### PR TITLE
Start packaging in a Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+docker-compose.yaml
+public_key.asc

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM python:3-alpine
+
+RUN apk --no-cache -U upgrade
+
+COPY . /app
+WORKDIR /app
+
+RUN pip install -r requirements.txt
+
+EXPOSE 5000
+ENV FLASK_APP=app
+CMD ["flask", "run", "-h", "0.0.0.0", "-p", "80"]

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -1,0 +1,15 @@
+version: "3.9"
+
+services:
+  app:
+    build: .
+    ports:
+      - "5000:80"
+    volumes:
+      - ./public_key.asc:/app/public_key.asc:ro
+    environment:
+      - EMAIL=email@example.com
+      - NOTIFY_SMTP_SERVER=smtp.gmail.com
+      - NOTIFY_SMTP_PORT=465
+      - NOTIFY_PASSWORD=yourpassword
+      - PGP_KEY_ADDRESS=https://example.com/key.asc


### PR DESCRIPTION
This begins to package Hush Line using Docker containers. Here's how to test it:

- Make sure you have [Docker Desktop](https://www.docker.com/products/docker-desktop/) installed.
- Save a copy of `docker-compose.example.yaml` as `docker-compose.yaml` and edit it to add your correct settings.
- Put a copy of your PGP public key in the file `public_key.asc`.
- Run: `docker-compose up`

It should start a Hush Line server which you can load at http://localhost:5000/.

(This isn't quite done yet-- I need to add Tor onion service support.)