### PR TITLE
Add some branding, make PGP optional, and separate email sender and receiver

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.formatting.provider": "none"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,12 @@ FROM python:3-alpine
 
 RUN apk --no-cache -U upgrade
 
-COPY . /app
 WORKDIR /app
 
+COPY requirements.txt /app
 RUN pip install -r requirements.txt
+
+COPY . /app
 
 EXPOSE 5000
 ENV FLASK_APP=app

--- a/app.py
+++ b/app.py
@@ -79,8 +79,6 @@ def save_message():
     if pgp_enabled:
         message = encrypt_message(message)
 
-    with open("messages.txt", "a") as f:
-        f.write(message + "\n\n")
     return jsonify(send_email_notification(message))
 
 

--- a/app.py
+++ b/app.py
@@ -16,18 +16,21 @@ log.info("Starting Hush Line")
 
 app = Flask(__name__)
 
-sender_email = os.environ.get("EMAIL", None)
-sender_password = os.environ.get("NOTIFY_PASSWORD", None)
-smtp_server = os.environ.get("NOTIFY_SMTP_SERVER", None)
-smtp_port = int(os.environ.get("NOTIFY_SMTP_PORT", 0))
-title = os.environ.get("HUSHLINE_TITLE", "🤫 Hush Line")
+recipient_name = os.environ.get("RECIPIENT_NAME", None)
+recipient_email = os.environ.get("RECIPIENT_EMAIL", None)
+sender_email = os.environ.get("SENDER_EMAIL", None)
+smtp_server = os.environ.get("SMTP_SERVER", None)
+smtp_port = int(os.environ.get("SMTP_PORT", 465))
+smtp_user = os.environ.get("SMTP_USER", None)
+smtp_password = os.environ.get("SMTP_PASSWORD", None)
+title = os.environ.get("TITLE", "🤫 Hush Line")
 close_app_link = os.environ.get(
-    "HUSHLINE_CLOSE_APP_LINK", "https://en.wikipedia.org/wiki/Tina_Turner"
+    "CLOSE_APP_LINK", "https://en.wikipedia.org/wiki/Tina_Turner"
 )
-pgp_enabled = os.environ.get("HUSHLINE_PGP_ENABLED", "true").lower() == "true"
-pgp_filename = os.environ.get("HUSHLINE_PGP_FILENAME", "public_key.asc")
+pgp_enabled = os.environ.get("PGP_ENABLED", "true").lower() == "true"
+pgp_filename = os.environ.get("PGP_FILENAME", "public_key.asc")
 
-if not sender_email or not sender_password or not smtp_server or not smtp_port:
+if not smtp_server or not smtp_port or not smtp_user or not smtp_password:
     log.warn(
         "Missing email notification configuration(s). Email notifications will not be sent."
     )
@@ -47,11 +50,26 @@ if pgp_enabled:
 
 @app.route("/")
 def index():
+    if pgp_enabled:
+        recipient = f"{PUBLIC_KEY.userids[0].name}\n<{PUBLIC_KEY.userids[0].email}>"
+        pgp_key_id = f"Key ID: {str(PUBLIC_KEY.fingerprint)[-8:]}"
+        if PUBLIC_KEY.expires_at is not None:
+            pgp_expires = f"Exp: {PUBLIC_KEY.expires_at.strftime('%Y-%m-%d')}"
+        else:
+            pgp_expires = f"Exp: never"
+    else:
+        recipient = f"{recipient_name} <{recipient_email}>"
+        pgp_key_id = None
+        pgp_expires = None
+
     return render_template(
         "index.html",
         title=title,
         close_app_link=close_app_link,
+        recipient=recipient,
         pgp_enabled=pgp_enabled,
+        pgp_key_id=pgp_key_id,
+        pgp_expires=pgp_expires,
     )
 
 
@@ -63,14 +81,13 @@ def save_message():
 
     with open("messages.txt", "a") as f:
         f.write(message + "\n\n")
-    send_email_notification(message)
-    return jsonify({"success": True})
+    return jsonify(send_email_notification(message))
 
 
 def send_email_notification(message):
     msg = MIMEMultipart()
     msg["From"] = sender_email
-    msg["To"] = sender_email
+    msg["To"] = f"{recipient_name} <{recipient_email}>"
     msg["Subject"] = "🤫 New Hush Line Message Received"
 
     body = f"{message}"
@@ -78,24 +95,12 @@ def send_email_notification(message):
 
     try:
         with smtplib.SMTP_SSL(smtp_server, smtp_port) as server:
-            server.login(sender_email, sender_password)
-            server.sendmail(sender_email, sender_email, msg.as_string())
+            server.login(smtp_user, smtp_password)
+            server.sendmail(sender_email, recipient_email, msg.as_string())
+        return {"success": True}
     except Exception as e:
         log.error(f"Error sending email notification: {e}")
-
-
-@app.route("/pgp_owner_info")
-def pgp_owner_info():
-    if pgp_enabled:
-        owner = f"{PUBLIC_KEY.userids[0].name}\n{PUBLIC_KEY.userids[0].email}"
-        key_id = f"Key ID: {str(PUBLIC_KEY.fingerprint)[-8:]}"
-        if PUBLIC_KEY.expires_at is not None:
-            expires = f"Exp: {PUBLIC_KEY.expires_at.strftime('%Y-%m-%d')}"
-        else:
-            expires = f"Exp: never"
-        return jsonify({"owner_info": owner, "key_id": key_id, "expires": expires})
-    else:
-        return jsonify(False)
+        return {"success": False, "error": str(e)}
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -20,43 +20,50 @@ sender_email = os.environ.get("EMAIL", None)
 sender_password = os.environ.get("NOTIFY_PASSWORD", None)
 smtp_server = os.environ.get("NOTIFY_SMTP_SERVER", None)
 smtp_port = int(os.environ.get("NOTIFY_SMTP_PORT", 0))
-hushline_title = os.environ.get("HUSHLINE_TITLE", "🤫 Hush Line")
-hushline_close_app_link = os.environ.get(
+title = os.environ.get("HUSHLINE_TITLE", "🤫 Hush Line")
+close_app_link = os.environ.get(
     "HUSHLINE_CLOSE_APP_LINK", "https://en.wikipedia.org/wiki/Tina_Turner"
 )
+pgp_enabled = os.environ.get("HUSHLINE_PGP_ENABLED", "true").lower() == "true"
+pgp_filename = os.environ.get("HUSHLINE_PGP_FILENAME", "public_key.asc")
 
 if not sender_email or not sender_password or not smtp_server or not smtp_port:
     log.warn(
         "Missing email notification configuration(s). Email notifications will not be sent."
     )
 
-# Load the public key into memory on startup
-with open("public_key.asc", "r") as key_file:
-    key_data = key_file.read()
-    PUBLIC_KEY, _ = pgpy.PGPKey.from_blob(key_data)  # Extract the key from the tuple
+if pgp_enabled:
+    # Load the public key into memory on startup
+    with open(pgp_filename, "r") as key_file:
+        key_data = key_file.read()
+        PUBLIC_KEY, _ = pgpy.PGPKey.from_blob(
+            key_data
+        )  # Extract the key from the tuple
 
-
-def encrypt_message(message):
-    encrypted_message = str(PUBLIC_KEY.encrypt(pgpy.PGPMessage.new(message)))
-    return encrypted_message
+    def encrypt_message(message):
+        encrypted_message = str(PUBLIC_KEY.encrypt(pgpy.PGPMessage.new(message)))
+        return encrypted_message
 
 
 @app.route("/")
 def index():
     return render_template(
         "index.html",
-        title=hushline_title,
-        close_app_link=hushline_close_app_link,
+        title=title,
+        close_app_link=close_app_link,
+        pgp_enabled=pgp_enabled,
     )
 
 
 @app.route("/save_message", methods=["POST"])
 def save_message():
     message = request.form["message"]
-    encrypted_message = encrypt_message(message)
+    if pgp_enabled:
+        message = encrypt_message(message)
+
     with open("messages.txt", "a") as f:
-        f.write(encrypted_message + "\n\n")
-    send_email_notification(encrypted_message)
+        f.write(message + "\n\n")
+    send_email_notification(message)
     return jsonify({"success": True})
 
 
@@ -79,13 +86,16 @@ def send_email_notification(message):
 
 @app.route("/pgp_owner_info")
 def pgp_owner_info():
-    owner = f"{PUBLIC_KEY.userids[0].name}\n{PUBLIC_KEY.userids[0].email}"
-    key_id = f"Key ID: {str(PUBLIC_KEY.fingerprint)[-8:]}"
-    if PUBLIC_KEY.expires_at is not None:
-        expires = f"Exp: {PUBLIC_KEY.expires_at.strftime('%Y-%m-%d')}"
+    if pgp_enabled:
+        owner = f"{PUBLIC_KEY.userids[0].name}\n{PUBLIC_KEY.userids[0].email}"
+        key_id = f"Key ID: {str(PUBLIC_KEY.fingerprint)[-8:]}"
+        if PUBLIC_KEY.expires_at is not None:
+            expires = f"Exp: {PUBLIC_KEY.expires_at.strftime('%Y-%m-%d')}"
+        else:
+            expires = f"Exp: never"
+        return jsonify({"owner_info": owner, "key_id": key_id, "expires": expires})
     else:
-        expires = f"Exp: never"
-    return jsonify({"owner_info": owner, "key_id": key_id, "expires": expires})
+        return jsonify(False)
 
 
 if __name__ == "__main__":

--- a/app.py
+++ b/app.py
@@ -20,6 +20,10 @@ sender_email = os.environ.get("EMAIL", None)
 sender_password = os.environ.get("NOTIFY_PASSWORD", None)
 smtp_server = os.environ.get("NOTIFY_SMTP_SERVER", None)
 smtp_port = int(os.environ.get("NOTIFY_SMTP_PORT", 0))
+hushline_title = os.environ.get("HUSHLINE_TITLE", "🤫 Hush Line")
+hushline_close_app_link = os.environ.get(
+    "HUSHLINE_CLOSE_APP_LINK", "https://en.wikipedia.org/wiki/Tina_Turner"
+)
 
 if not sender_email or not sender_password or not smtp_server or not smtp_port:
     log.warn(
@@ -39,7 +43,11 @@ def encrypt_message(message):
 
 @app.route("/")
 def index():
-    return render_template("index.html")
+    return render_template(
+        "index.html",
+        title=hushline_title,
+        close_app_link=hushline_close_app_link,
+    )
 
 
 @app.route("/save_message", methods=["POST"])

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -12,3 +12,5 @@ services:
       - NOTIFY_SMTP_SERVER=smtp.gmail.com
       - NOTIFY_SMTP_PORT=465
       - NOTIFY_PASSWORD=yourpassword
+      - HUSHLINE_PGP_ENABLED=true
+      - HUSHLINE_PGP_FILENAME=public_key.asc

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -8,9 +8,12 @@ services:
     volumes:
       - ./public_key.asc:/app/public_key.asc:ro
     environment:
-      - EMAIL=email@example.com
-      - NOTIFY_SMTP_SERVER=smtp.gmail.com
-      - NOTIFY_SMTP_PORT=465
-      - NOTIFY_PASSWORD=yourpassword
-      - HUSHLINE_PGP_ENABLED=true
-      - HUSHLINE_PGP_FILENAME=public_key.asc
+      - RECIPIENT_NAME=Your Name
+      - RECIPIENT_EMAIL=recipient@example.com
+      - SENDER_EMAIL=sender@example.com
+      - SMTP_SERVER=smtp.gmail.com
+      - SMTP_PORT=465
+      - SMTP_USER=username@example.com
+      - SMTP_PASSWORD=yourpassword
+      - PGP_ENABLED=true
+      - PGP_FILENAME=public_key.asc

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -15,5 +15,7 @@ services:
       - SMTP_PORT=465
       - SMTP_USER=username@example.com
       - SMTP_PASSWORD=yourpassword
+      - TITLE=🤫 Hush Line
+      - CLOSE_APP_LINK=https://en.wikipedia.org/wiki/Tina_Turner
       - PGP_ENABLED=true
       - PGP_FILENAME=public_key.asc

--- a/docker-compose.example.yaml
+++ b/docker-compose.example.yaml
@@ -12,4 +12,3 @@ services:
       - NOTIFY_SMTP_SERVER=smtp.gmail.com
       - NOTIFY_SMTP_PORT=465
       - NOTIFY_PASSWORD=yourpassword
-      - PGP_KEY_ADDRESS=https://example.com/key.asc

--- a/static/main.js
+++ b/static/main.js
@@ -44,6 +44,12 @@ document.addEventListener("DOMContentLoaded", function () {
     xhr.onload = function () {
       if (xhr.status === 200) {
         const result = JSON.parse(xhr.responseText);
+        // If result is false
+        if (!result) {
+          console.error("No PGP owner info.");
+          return;
+        }
+
         const pgpOwner = document.getElementById("pgp-owner");
         const pgpKeyId = document.getElementById("pgp-key-id");
         const pgpExpires = document.getElementById("pgp-expires");

--- a/static/main.js
+++ b/static/main.js
@@ -24,7 +24,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const result = JSON.parse(responseText);
 
     if (result.success) {
-      alert("Your message has been successfully encrypted and submitted.");
+      alert("Your message has been successfully submitted.");
       form.reset();
     } else {
       alert("An error occurred. Please try again.");
@@ -34,45 +34,4 @@ document.addEventListener("DOMContentLoaded", function () {
     spinner.style.display = 'none';
     submitButton.classList.remove("button-text-hidden");
   });
-
-  const pgpOwnerInfo = document.getElementById("pgp-owner-info");
-
-  // Fetch the PGP info when the page loads
-  const fetchPGPInfo = async () => {
-    const xhr = new XMLHttpRequest();
-    xhr.open("GET", "/pgp_owner_info");
-    xhr.onload = function () {
-      if (xhr.status === 200) {
-        const result = JSON.parse(xhr.responseText);
-        // If result is false
-        if (!result) {
-          console.error("No PGP owner info.");
-          return;
-        }
-
-        const pgpOwner = document.getElementById("pgp-owner");
-        const pgpKeyId = document.getElementById("pgp-key-id");
-        const pgpExpires = document.getElementById("pgp-expires");
-
-        // Add angle brackets around the email
-        const emailRegex = /([\w.-]+@[\w.-]+\.\w+)/;
-        const modifiedOwnerInfo = result.owner_info.replace(emailRegex, '<$1>');
-        pgpOwner.textContent = modifiedOwnerInfo;
-        pgpKeyId.textContent = result.key_id;
-        pgpExpires.textContent = result.expires;
-
-        // Display the PGP owner info right away
-        pgpOwnerInfo.style.display = "block";
-        pgpOwnerInfo.style.maxHeight = pgpOwnerInfo.scrollHeight + "px";
-      } else {
-        console.error(xhr.statusText);
-      }
-    };
-    xhr.onerror = function () {
-      console.error(xhr.statusText);
-    };
-    xhr.send();
-  };
-
-  fetchPGPInfo();
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="utf-8">
     <meta name="author" content="Glenn Sorrentino, Science & Design, Inc.">
@@ -7,21 +8,27 @@
     <meta name="description" content="A reasonably private and secure personal tip line.">
     <meta name="theme-color" content="#7D25C1">
 
-    <title>Hush Line</title>
+    <title>{{ title }}</title>
 
-    <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', filename='favicon/apple-touch-icon.png') }}">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/favicon-32x32.png') }}" sizes="32x32">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/favicon-16x16.png') }}" sizes="16x16">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/android-chrome-192x192.png') }}" sizes="192x192">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/android-chrome-512x512.png') }}" sizes="512x512">
+    <link rel="apple-touch-icon" sizes="180x180"
+        href="{{ url_for('static', filename='favicon/apple-touch-icon.png') }}">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/favicon-32x32.png') }}"
+        sizes="32x32">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/favicon-16x16.png') }}"
+        sizes="16x16">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/android-chrome-192x192.png') }}"
+        sizes="192x192">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='favicon/android-chrome-512x512.png') }}"
+        sizes="512x512">
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='favicon/favicon.ico') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
+
 <body>
     <header>
         <div class="wrapper">
-            <h1>🤫 Hush Line</h1>
-            <a href="https://en.wikipedia.org/wiki/Tina_Turner" class="btn" rel="noopener noreferrer">Close App</a>
+            <h1>{{ title }}</h1>
+            <a href="{{ close_app_link }}" class="btn" rel="noopener noreferrer">Close App</a>
         </div>
     </header>
     <div id="pgp-owner-info" class="card mt-3">
@@ -37,14 +44,17 @@
         </div>
     </div>
     <form id="message-form" action="/save_message" method="POST">
-        <textarea name="message" rows="10" cols="60" required placeholder="Please leave a contact method if you'd like a response..."></textarea>
-        <p>🔒 Your message will be encrypted and only readable by the owner of the address above. <a href="https://hushline.app" target="_blank" rel="noopener noreferrer">Learn&nbsp;more</a>.</p>
+        <textarea name="message" rows="10" cols="60" required
+            placeholder="Please leave a contact method if you'd like a response..."></textarea>
+        <p>🔒 Your message will be encrypted and only readable by the owner of the address above. <a
+                href="https://hushline.app" target="_blank" rel="noopener noreferrer">Learn&nbsp;more</a>.</p>
         <div class="button-container">
-          <button type="submit" id="submit-button">Submit</button>
-          <span class="spinner hidden"></span>
+            <button type="submit" id="submit-button">Submit</button>
+            <span class="spinner hidden"></span>
         </div>
     </form>
     <script src="{{ url_for('static', filename='jquery-min.js') }}"></script>
     <script src="{{ url_for('static', filename='main.js') }}"></script>
 </body>
+
 </html>

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,15 +35,15 @@
         <div class="card-header">
             <h3 class="card-title">To:</h3>
         </div>
-        {% if pgp_enabled %}
         <div class="card-body">
-            <p id="pgp-owner"></p>
+            <p id="recipient">{{ recipient }}</p>
+            {% if pgp_enabled %}
             <div class="pgp-meta">
-                <p id="pgp-key-id"></p>
-                <p id="pgp-expires"></p>
+                <p id="pgp-key-id">{{ pgp_key_id }}</p>
+                <p id="pgp-expires">{{ pgp_expires }}</p>
             </div>
+            {% endif %}
         </div>
-        {% endif %}
     </div>
     <form id="message-form" action="/save_message" method="POST">
         <textarea name="message" rows="10" cols="60" required

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,7 @@
         <div class="card-header">
             <h3 class="card-title">To:</h3>
         </div>
+        {% if pgp_enabled %}
         <div class="card-body">
             <p id="pgp-owner"></p>
             <div class="pgp-meta">
@@ -42,12 +43,18 @@
                 <p id="pgp-expires"></p>
             </div>
         </div>
+        {% endif %}
     </div>
     <form id="message-form" action="/save_message" method="POST">
         <textarea name="message" rows="10" cols="60" required
             placeholder="Please leave a contact method if you'd like a response..."></textarea>
+        {% if pgp_enabled %}
         <p>🔒 Your message will be encrypted and only readable by the owner of the address above. <a
                 href="https://hushline.app" target="_blank" rel="noopener noreferrer">Learn&nbsp;more</a>.</p>
+        {% else %}
+        <p>🔒 Your message will be anonymously emailed to the address above. <a href="https://hushline.app"
+                target="_blank" rel="noopener noreferrer">Learn&nbsp;more</a>.</p>
+        {% endif %}
         <div class="button-container">
             <button type="submit" id="submit-button">Submit</button>
             <span class="spinner hidden"></span>


### PR DESCRIPTION
This single PR changes several things. Sorry about doing it all at once, but it just seemed simpler this way.

Since #108, now you can define all of the Hush Line settings directly in a `docker-compose.yaml` file. Here's the example docker-compose file:

```yaml
version: "3.9"

services:
  app:
    build: .
    ports:
      - "5000:80"
    volumes:
      - ./public_key.asc:/app/public_key.asc:ro
    environment:
      - RECIPIENT_NAME=Your Name
      - RECIPIENT_EMAIL=recipient@example.com
      - SENDER_EMAIL=sender@example.com
      - SMTP_SERVER=smtp.gmail.com
      - SMTP_PORT=465
      - SMTP_USER=username@example.com
      - SMTP_PASSWORD=yourpassword
      - TITLE=🤫 Hush Line
      - CLOSE_APP_LINK=https://en.wikipedia.org/wiki/Tina_Turner
      - PGP_ENABLED=true
      - PGP_FILENAME=public_key.asc
```

# Branding

The `TITLE` and `CLOSE_APP_LINK` environment variables let you change how the Hush Line page looks. For example, here's where I set it to these:

```yaml
- TITLE=Micah's Anonymous Suggestion Box
- CLOSE_APP_LINK=https://en.wikipedia.org/wiki/Lise_Meitner
```

![Screenshot from 2023-09-21 15-41-01](https://github.com/scidsg/hushline/assets/156128/48cb325d-b2df-457a-9892-35fb02f51957)

# Optional PGP

I also introduced two new environment variables, `PGP_ENABLED` (either `true` or `false`) and `PGP_FILENAME` (the path to the PGP public key file, instead of always assuming it's `public_key.asc`). Now you can disable PGP by setting:

```yaml
- PGP_ENABLED=false
```

![Screenshot from 2023-09-21 15-43-15](https://github.com/scidsg/hushline/assets/156128/e5c0dc5f-3c04-44ff-9ee3-05c41d4da7e1)

This also required making some other changes. Before, the `To:` name and email was pulled out of the PGP key, but if you aren't using a PGP key you just need to specify them with these environment variables:

```yaml
- RECIPIENT_NAME=Micah Lee
- RECIPIENT_EMAIL=micah@micahflee.com
```

Also, while I was at it, I simplified it a bit by ripping out the `/pgp_owner_info` ajax request. Instead, all of the relevant information is passed into the `index.html` template when it's being rendered, so it doesn't need to make an extra request with javascript. If PGP is enabled, it pulls out the relevant info from the PGP key. If it's disabled, it uses these environment variables.

Finally, if PGP is disabled, then it just emails the message without encrypting it first.

# Separating email sender and receiver

This one I think is especially useful. When you submit the form, Hush Line sends an email to an email address. Before, it was connecting using SMTP to a mail server and sending the email to the same account that was receiving it. Now, I've separated these using these environment variables:

```yaml
- RECIPIENT_NAME=Your Name
- RECIPIENT_EMAIL=recipient@example.com
- SENDER_EMAIL=sender@example.com
- SMTP_SERVER=smtp.gmail.com
- SMTP_PORT=465
- SMTP_USER=username@example.com
- SMTP_PASSWORD=yourpassword
```

The `RECIPIENT_NAME` and `RECIPIENT_EMAIL` variables are used to populate the `To` header, and `SENDER_EMAIL` is used to populate the `From` header. Then, the all of the SMTP variables are used to connect to an SMTP server to actually send the email.

When I was testing this out, I set up my `SENDER_EMAIL` to be a riseup.net address, and specified the correct SMTP info for Riseup and for this user. And then I set `RECIPIENT_EMAIL` to be micah@micahflee.com, which is hosted by Proton Mail. When submitting the form, my Riseup account sends the email to micah@micahflee.com -- this way, I don't need to store credentials to my actual email account within Hush Line.

(And on another note, I also managed to get it to send an encrypted email to my Proton Mail account, using my Proton Mail PGP public key, making it way more usable to receive encrypted emails.)

# Doesn't write message.txt to disk

I noticed that the code before saved the message in the file `message.txt`, but then never actually used it. I deleted that code, so now it doesn't write any files to disk when submitting messages.

# Requires some other changes

Before merging this PR, here are a few things to keep in mind:

- I renamed some of the environment variables! I changed `NOTIFY_SMTP_SERVER` to just `SMTP_SERVER`, and so on. This means that existing Hush Line servers out there can't simply upgrade, they also need to re-setup these environment variables.
- I didn't touch any of the installation scripts, so they're still out-of-date. When using Docker I'm not actually using the installation scripts, so you'll need to update those separately to account for all of these new environment variables.