### PR TITLE
Close App links to random Wikipedia page

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -21,7 +21,7 @@
     <header>
         <div class="wrapper">
             <h1>🤫 Hush Line</h1>
-            <a href="https://en.wikipedia.org/wiki/Tina_Turner" class="btn" rel="noopener noreferrer">Close App</a>
+            <a href="https://en.wikipedia.org/wiki/Special:Random" class="btn" rel="noopener noreferrer">Close App</a>
         </div>
     </header>
     <div id="pgp-owner-info" class="card mt-3">


### PR DESCRIPTION
No disrespect to the "Queen of Rock 'n' Roll", but rather than hard-code the "Close App" button to [Tina Turner's Wikipedia page](https://en.wikipedia.org/wiki/Tina_Turner), this instead links to [https://en.wikipedia.org/wiki/Special:Random](https://en.wikipedia.org/wiki/Special:Random), which, as I understand it, takes users to a random Wikipedia page.

I don't know if either stance matters much -- just thought I propose this to start a discussion/offer another slightly less arbitrary solution. I guess theoretically investigators could look for visit's to Tina Turner's Wikipedia page as a piece of metadata?  