### PR TITLE
Use `raspi-config` CLI to enable SPI

### DIFF
--- a/scripts/waveshare-2_13in_eink-display.sh
+++ b/scripts/waveshare-2_13in_eink-display.sh
@@ -22,9 +22,10 @@ apt update
 apt-get -y dist-upgrade
 apt-get install -y python3-pip whiptail
 
-# Welcome Prompt
-whiptail --title "E-Ink Display Setup" --msgbox "The e-paper hat communicates with the Raspberry Pi using the SPI interface, so you need to enable it.\n\nNavigate to \"Interface Options\" > \"SPI\" and select \"Yes\" to enable the SPI interface." 12 64
-sudo raspi-config
+# Enable SPI interface
+# 0 for enable; 1 to disable
+# See: https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint
+sudo raspi-config nonint do_spi 0
 
 # Install Waveshare e-Paper library
 git clone https://github.com/waveshare/e-Paper.git

--- a/scripts/waveshare-2_7in-eink-display-v1.sh
+++ b/scripts/waveshare-2_7in-eink-display-v1.sh
@@ -22,9 +22,10 @@ apt update
 apt-get -y dist-upgrade
 apt-get install -y python3-pip whiptail
 
-# Welcome Prompt
-whiptail --title "E-Ink Display Setup" --msgbox "The e-paper hat communicates with the Raspberry Pi using the SPI interface, so you need to enable it.\n\nNavigate to \"Interface Options\" > \"SPI\" and select \"Yes\" to enable the SPI interface." 12 64
-sudo raspi-config
+# Enable SPI interface
+# 0 for enable; 1 to disable
+# See: https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint
+sudo raspi-config nonint do_spi 0
 
 # Install Waveshare e-Paper library
 git clone https://github.com/waveshare/e-Paper.git

--- a/scripts/waveshare-2_7in-eink-display.sh
+++ b/scripts/waveshare-2_7in-eink-display.sh
@@ -22,9 +22,10 @@ apt update
 apt-get -y dist-upgrade
 apt-get install -y python3-pip whiptail
 
-# Welcome Prompt
-whiptail --title "E-Ink Display Setup" --msgbox "The e-paper hat communicates with the Raspberry Pi using the SPI interface, so you need to enable it.\n\nNavigate to \"Interface Options\" > \"SPI\" and select \"Yes\" to enable the SPI interface." 12 64
-sudo raspi-config
+# Enable SPI interface
+# 0 for enable; 1 to disable
+# See: https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint
+sudo raspi-config nonint do_spi 0
 
 # Install Waveshare e-Paper library
 git clone https://github.com/waveshare/e-Paper.git


### PR DESCRIPTION
In all 3 waveshare e-ink display scripts, use the [`raspi-config` Command Line Interface](https://www.raspberrypi.com/documentation/computers/configuration.html#raspi-config-cli) to enable the Pi's SPI interface rather than tossing the user into the raspi-config TUI with instructions. 

Note: Perhaps counterintuitively, [`0` is to enable and `1` is to disable](https://www.raspberrypi.com/documentation/computers/configuration.html#spi-nonint).

This change seems to work well for Blackbox. See [Blackbox PR #16](https://github.com/scidsg/blackbox/pull/16) for more info.