### PR TITLE
Update curl flags in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ## Easy Install:
 
 ```bash
-curl -sSL https://install.hushline.app | bash
+curl --proto '=https' --tlsv1.2 -sSfL https://install.hushline.app | bash
 ```
 
 Still need help? Check out our [documentation](https://scidsg.github.io/hushline-docs/book/intro.html) for more information.


### PR DESCRIPTION
Now reads `curl --proto '=https' --tlsv1.2 -sSfL https://install.hushline.app | bash`, matching [documentation](https://scidsg.github.io/hushline-docs/book/installation/tor-only.html#1-run-the-installer).