### PR TITLE
Formats app.py Python code using Python formatter Black

### DIFF
--- a/app.py
+++ b/app.py
@@ -8,52 +8,58 @@ import logging
 
 # setup a logger
 log = logging.getLogger(__name__)
-log.setLevel(os.environ.get('LOG_LEVEL', 'INFO').upper())
+log.setLevel(os.environ.get("LOG_LEVEL", "INFO").upper())
 handler = logging.StreamHandler()
-handler.setFormatter(logging.Formatter('%(asctime)s - %(levelname)s - %(message)s'))
+handler.setFormatter(logging.Formatter("%(asctime)s - %(levelname)s - %(message)s"))
 log.addHandler(handler)
-log.info('Starting Hush Line')
+log.info("Starting Hush Line")
 
 app = Flask(__name__)
 
-sender_email = os.environ.get('EMAIL', None)
-sender_password = os.environ.get('NOTIFY_PASSWORD', None)
-smtp_server = os.environ.get('NOTIFY_SMTP_SERVER', None)
-smtp_port = int(os.environ.get('NOTIFY_SMTP_PORT', 0))
+sender_email = os.environ.get("EMAIL", None)
+sender_password = os.environ.get("NOTIFY_PASSWORD", None)
+smtp_server = os.environ.get("NOTIFY_SMTP_SERVER", None)
+smtp_port = int(os.environ.get("NOTIFY_SMTP_PORT", 0))
 
 if not sender_email or not sender_password or not smtp_server or not smtp_port:
-    log.warn('Missing email notification configuration(s). Email notifications will not be sent.')
+    log.warn(
+        "Missing email notification configuration(s). Email notifications will not be sent."
+    )
 
 # Load the public key into memory on startup
-with open('public_key.asc', 'r') as key_file:
+with open("public_key.asc", "r") as key_file:
     key_data = key_file.read()
-    PUBLIC_KEY, _ = pgpy.PGPKey.from_blob(key_data) # Extract the key from the tuple
+    PUBLIC_KEY, _ = pgpy.PGPKey.from_blob(key_data)  # Extract the key from the tuple
+
 
 def encrypt_message(message):
     encrypted_message = str(PUBLIC_KEY.encrypt(pgpy.PGPMessage.new(message)))
     return encrypted_message
 
-@app.route('/')
-def index():
-    return render_template('index.html')
 
-@app.route('/save_message', methods=['POST'])
+@app.route("/")
+def index():
+    return render_template("index.html")
+
+
+@app.route("/save_message", methods=["POST"])
 def save_message():
-    message = request.form['message']
+    message = request.form["message"]
     encrypted_message = encrypt_message(message)
-    with open('messages.txt', 'a') as f:
-        f.write(encrypted_message + '\n\n')
+    with open("messages.txt", "a") as f:
+        f.write(encrypted_message + "\n\n")
     send_email_notification(encrypted_message)
-    return jsonify({'success': True})
+    return jsonify({"success": True})
+
 
 def send_email_notification(message):
     msg = MIMEMultipart()
-    msg['From'] = sender_email
-    msg['To'] = sender_email
-    msg['Subject'] = "🤫 New Hush Line Message Received"
+    msg["From"] = sender_email
+    msg["To"] = sender_email
+    msg["Subject"] = "🤫 New Hush Line Message Received"
 
     body = f"{message}"
-    msg.attach(MIMEText(body, 'plain'))
+    msg.attach(MIMEText(body, "plain"))
 
     try:
         with smtplib.SMTP_SSL(smtp_server, smtp_port) as server:
@@ -62,7 +68,8 @@ def send_email_notification(message):
     except Exception as e:
         log.error(f"Error sending email notification: {e}")
 
-@app.route('/pgp_owner_info')
+
+@app.route("/pgp_owner_info")
 def pgp_owner_info():
     owner = f"{PUBLIC_KEY.userids[0].name}\n{PUBLIC_KEY.userids[0].email}"
     key_id = f"Key ID: {str(PUBLIC_KEY.fingerprint)[-8:]}"
@@ -70,7 +77,8 @@ def pgp_owner_info():
         expires = f"Exp: {PUBLIC_KEY.expires_at.strftime('%Y-%m-%d')}"
     else:
         expires = f"Exp: Never"
-    return jsonify({'owner_info': owner, 'key_id': key_id, 'expires': expires})
+    return jsonify({"owner_info": owner, "key_id": key_id, "expires": expires})
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     app.run()


### PR DESCRIPTION
Formats `app.py` with [Black](https://github.com/psf/black/), a popular and opinionated Python formatter. 

## What Black did to the Python code in `app.py`
It seems to have mostly changed some single quotes to double quotes and tweaks number of blank lines between some methods. I don't think anything that will break anything.

## A one-time shot
I just ran `app.py` through the `black` command-line tool as a one-time thing for this PR. If we all want to [set up Black in our text editors, that's possible](https://black.readthedocs.io/en/stable/integrations/index.html).

## Inspiration
I noticed that [Micah did this in his PR](https://github.com/scidsg/hushline/commit/d28e552bfbf562ceb54fc22a13b586571b8bf017) that later got reverted. Pretty sure it wasn't for the Black formatting.