### PR TITLE
brings srcripts README up-to-date

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,23 +1,22 @@
 # Scripts
 
-## Waveshare 2.7" v2 e-Paper Display
-```
-curl -sSL https://raw.githubusercontent.com/scidsg/hushline/main/scripts/waveshare-2_7in-eink-display.sh | bash
+This directory contains shell scripts that aid in the installation and maintenance of Hush Line. 
+
+## Installing optional e-paper display
+
+Depending on which e-paper display you have, run one of the following commands.
+
+### Waveshare 2.7" v2 e-Paper Display
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/scidsg/hushline/main/scripts/waveshare-2_7in-eink-display.sh | bash
 ```
 
-## Waveshare 2.7" v1 e-Paper Display
-```
-curl -sSL https://raw.githubusercontent.com/scidsg/hushline/main/scripts/waveshare-2_7in-eink-display-v1.sh | bash
-```
-
-## Waveshare 2.13" v3 e-Paper Display
-```
-curl -sSL https://raw.githubusercontent.com/scidsg/hushline/main/scripts/waveshare-2_13in_eink-display.sh | bash
+### Waveshare 2.7" v1 e-Paper Display
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/scidsg/hushline/main/scripts/waveshare-2_7in-eink-display-v1.sh | bash
 ```
 
-## QR Beta Installer
+### Waveshare 2.13" v3 e-Paper Display
+```bash
+curl --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/scidsg/hushline/main/scripts/waveshare-2_13in_eink-display.sh | bash
 ```
-curl -sSL https://raw.githubusercontent.com/scidsg/hushline/main/scripts/qr-installer-beta.sh | bash
-```
-
-


### PR DESCRIPTION
Kind of forgot we had a little README in the `scripts/` directory. 

I added a note at the top, removed the command for a now-deleted script, and updated the `curl` flags for the remaining commands (I don't think they need the `-L` flag). 