### PR TITLE
remove messages.txt file

### DIFF
--- a/messages.txt
+++ b/messages.txt
@@ -1,2 +1,0 @@
-👇 Encrypted messages will appear here after they're submitted.
-


### PR DESCRIPTION
Guessing this `./messages.txt` file was a hold-over from an older system for Hush Line where messages would be decrypted to a text file? 