### PR TITLE
Adds parenthesis to be more explicit in public install script

### DIFF
--- a/scripts/install-public-plus-tor.sh
+++ b/scripts/install-public-plus-tor.sh
@@ -160,7 +160,7 @@ if [ -e "/etc/nginx/sites-enabled/default" ]; then
     rm /etc/nginx/sites-enabled/default
 fi
 ln -sf /etc/nginx/sites-available/hush-line.nginx /etc/nginx/sites-enabled/
-nginx -t && systemctl restart nginx || error_exit
+(nginx -t && systemctl restart nginx) || error_exit
 
 SERVER_IP=$(curl -s ifconfig.me)
 WIDTH=$(tput cols)


### PR DESCRIPTION
Fixing the other instance of this code. See #132 .