### PR TITLE
Add "PGP key received" message for user peace of mind

### DIFF
--- a/scripts/install-tor-only.sh
+++ b/scripts/install-tor-only.sh
@@ -85,6 +85,8 @@ while IFS= read -r LINE < /dev/tty; do
     [[ $LINE == "-----END PGP PUBLIC KEY BLOCK-----" ]] && break
 done
 
+echo "Public PGP key received.\nContinuing with installation process..."
+
 export DOMAIN
 export EMAIL
 export NOTIFY_PASSWORD


### PR DESCRIPTION
I found the lack of immediate feedback after entering/submitting the public PGP key through the terminal a little worrisome as a user. This PR adds a short `echo` message immediately after the prompt for the key, just to tell the user that they submitted their key correctly (we hope) and that the script has moved on to other tasks (and that they can just chill and don't have to provide more information at the moment).

**I haven't tested this** 