### PR TITLE
`reset` terminal window before first whiptail prompt

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -44,6 +44,9 @@ else
     cd $HOME # return to HOME for next steps
 fi
 
+# "reset" the terminal window before running first whiptail prompt
+reset
+
 # Welcome Prompt
 whiptail --title "🤫 Hush Line Installation" --msgbox "Hush Line provides a simple way to receive secure messages from sources, colleagues, clients, or patients.\n\nAfter installation, you'll have a private tip line hosted on your own server, secured with PGP, HTTPS, and available on a .onion address so anyone can message you, even from locations where the internet is censored.\n\nIf deploying to a public website, ensure your DNS settings point to this server." 16 64
 


### PR DESCRIPTION
This change fixes a bug I was experiencing on my Pi (Bookworm) in which the Hush Line install script would get "stuck" on the first whiptail prompt (I was unable to get past it by hitting enter). 

Running the simple `reset` command, with its default flags, before the first whiptail call appears to fix the issue for me. 

I don't think the command will have any adverse side effects for users who were not having my issue with the whiptail prompt(s).