### PR TITLE
Modify Close App button link to main Wikipedia page

### DIFF
--- a/assets/scripts/install-public-plus-tor.sh
+++ b/assets/scripts/install-public-plus-tor.sh
@@ -281,7 +281,7 @@ cat >$HOME/hushline/templates/info.html <<EOL
     <header>
         <div class="wrapper">
             <h1><a href="/">🤫 Hush Line</a></h1>
-            <a href="https://en.wikipedia.org/wiki/Special:Random" class="btn" rel="noopener noreferrer">Close App</a>
+            <a href="https://www.wikipedia.org" class="btn" rel="noopener noreferrer">Close App</a>
         </div>
     </header>
     <section>

--- a/assets/scripts/install-tor-only.sh
+++ b/assets/scripts/install-tor-only.sh
@@ -249,7 +249,7 @@ cat >$HOME/hushline/templates/info.html <<EOL
     <header>
         <div class="wrapper">
             <h1><a href="/">🤫 Hush Line</a></h1>
-            <a href="https://en.wikipedia.org/wiki/Special:Random" class="btn" rel="noopener noreferrer">Close App</a>
+            <a href="https://www.wikipedia.org" class="btn" rel="noopener noreferrer">Close App</a>
         </div>
     </header>
     <section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -22,7 +22,7 @@
         <div class="wrapper">
             <h1>🤫 Hush Line</h1>
              <nav>
-                <li><a href="https://en.wikipedia.org/wiki/Special:Random" class="btn" aria-label="Close this app in case of emergency" rel="noopener noreferrer">Close App</a></li>
+                <li><a href="https://www.wikipedia.org" class="btn" aria-label="Close this app in case of emergency" rel="noopener noreferrer">Close App</a></li>
             </nav>
         </div>
     </header>


### PR DESCRIPTION
Proposition to change the link redirection on the "Close App" button from a random Wikipedia topic page to the main Wikipedia start page: https://www.wikipedia.org 

This would reduce the risk of an "unlucky roll" where a user might get a random Wikipedia page topic that in context might be inappropriate or even dangerous to the situation. 

It is a relatively low risk and the randomness was a creative feature but it would likely be safer to keep the redirection result constant.