### PR TITLE
Remove list_keys()

### DIFF
--- a/app.py
+++ b/app.py
@@ -775,8 +775,13 @@ def list_keys():
         app.logger.error(f"Error listing keys: {e}")
 
 
-# Call this function after key import or during troubleshooting
-list_keys()
+@app.cli.command("debug-list-keys")
+def debug_list_keys():
+    """List GPG keys for debugging purposes."""
+    if os.getenv("HUSHLINE_DEBUG_OPTS") == "1":
+        list_keys()
+    else:
+        print("Debugging options are not enabled. Set HUSHLINE_DEBUG_OPTS=1 to enable.")
 
 
 @app.route("/delete_message/<int:message_id>", methods=["POST"])

--- a/install.sh
+++ b/install.sh
@@ -262,12 +262,15 @@ poetry install
 SECRET_KEY=$(python3 -c 'import os; print(os.urandom(64).hex())')
 ENCRYPTION_KEY=$(python3 -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())')
 
-# Store in .env file
-echo "ENCRYPTION_KEY=$ENCRYPTION_KEY" > .env
-echo "DB_NAME=$DB_NAME" >> .env  
-echo "DB_USER=$DB_USER" >> .env
-echo "DB_PASS=$DB_PASS" >> .env
-echo "SECRET_KEY=$SECRET_KEY" >> .env
+# Store in .env file more efficiently
+{
+echo "ENCRYPTION_KEY=$ENCRYPTION_KEY"
+echo "DB_NAME=$DB_NAME"
+echo "DB_USER=$DB_USER"
+echo "DB_PASS=$DB_PASS"
+echo "SECRET_KEY=$SECRET_KEY"
+echo "HUSHLINE_DEBUG_OPTS=0"
+} > .env
 
 # Ask the user if registration should require codes and directly update the .env file
 if whiptail --title "Require Registration Codes" --yesno "Do you want to require registration codes for new users?" 8 78; then


### PR DESCRIPTION
## Implement Debug Command for GPG Key Listing

### Changes
- Introduced a Flask CLI command `debug-list-keys` to list GPG keys, improving debuggability.
- Command execution depends on `HUSHLINE_DEBUG_OPTS` env var to ensure controlled use.
- Removed direct invocation of `list_keys()` to enhance security and operational control.

### Rationale
Shifted GPG key listing to a debug command to prevent unintentional exposure of sensitive info and provide a deliberate tool for debugging GPG configurations.

### Impact
- Secures GPG key listing by making it an intentional action.
- Offers a controlled debugging tool for developers.
- Aligns cryptographic key management with security best practices.
