### PR TITLE
Renamed SecondaryUser to SecondaryUsername

### DIFF
--- a/admin.py
+++ b/admin.py
@@ -2,7 +2,7 @@
 
 import sys
 
-from hushline import SecondaryUser, User, app, db
+from hushline import SecondaryUsername, User, app, db
 
 
 def toggle_admin(username):
@@ -11,9 +11,9 @@ def toggle_admin(username):
 
     # If not found, try to find a secondary user
     if not user:
-        secondary_user = SecondaryUser.query.filter_by(username=username).first()
-        if secondary_user:
-            user = secondary_user.primary_user
+        secondary_username = SecondaryUsername.query.filter_by(username=username).first()
+        if secondary_username:
+            user = secondary_username.primary_user
         else:
             print("User not found.")
             return

--- a/hushline/model.py
+++ b/hushline/model.py
@@ -21,8 +21,8 @@ class User(db.Model):
     is_verified = db.Column(db.Boolean, default=False)
     is_admin = db.Column(db.Boolean, default=False)
     # Corrected the relationship and backref here
-    secondary_users = db.relationship(
-        "SecondaryUser", backref=db.backref("primary_user", lazy=True)
+    secondary_usernames = db.relationship(
+        "SecondaryUsername", backref=db.backref("primary_user", lazy=True)
     )
 
     @property
@@ -119,8 +119,8 @@ class User(db.Model):
             current_app.logger.error(f"Error updating username: {e}", exc_info=True)
 
 
-class SecondaryUser(db.Model):
-    __tablename__ = "secondary_user"
+class SecondaryUsername(db.Model):
+    __tablename__ = "secondary_username"
 
     id = db.Column(db.Integer, primary_key=True)
     username = db.Column(db.String(80), unique=True, nullable=False)
@@ -134,8 +134,8 @@ class Message(db.Model):
     _content = db.Column("content", db.Text, nullable=False)  # Encrypted content stored here
     user_id = db.Column(db.Integer, db.ForeignKey("user.id"), nullable=False)
     user = db.relationship("User", backref=db.backref("messages", lazy=True))
-    secondary_user_id = db.Column(db.Integer, db.ForeignKey("secondary_user.id"), nullable=True)
-    secondary_user = db.relationship("SecondaryUser", backref="messages")
+    secondary_user_id = db.Column(db.Integer, db.ForeignKey("secondary_username.id"), nullable=True)
+    secondary_username = db.relationship("SecondaryUsername", backref="messages")
 
     @property
     def content(self):

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -11,7 +11,7 @@ from .crypto import encrypt_message, get_email_from_pgp_key
 from .db import db
 from .ext import bcrypt, limiter
 from .forms import ComplexPassword
-from .model import InviteCode, Message, SecondaryUser, User
+from .model import InviteCode, Message, SecondaryUsername, User
 from .utils import require_2fa, send_email
 
 
@@ -81,15 +81,15 @@ def init_app(app: Flask) -> None:
         messages = (
             Message.query.filter_by(user_id=primary_user.id).order_by(Message.id.desc()).all()
         )
-        secondary_users_dict = {su.id: su for su in primary_user.secondary_users}
+        secondary_users_dict = {su.id: su for su in primary_user.secondary_usernames}
 
         return render_template(
             "inbox.html",
             user=primary_user,
-            secondary_user=None,
+            secondary_username=None,
             messages=messages,
             is_secondary=False,
-            secondary_users=secondary_users_dict,
+            secondary_usernames=secondary_users_dict,
         )
 
     @app.route("/submit_message/<username>", methods=["GET", "POST"])
@@ -98,7 +98,7 @@ def init_app(app: Flask) -> None:
         form = MessageForm()
 
         user = None
-        secondary_user = None
+        secondary_username = None
         display_name_or_username = ""
 
         primary_user = User.query.filter_by(primary_username=username).first()
@@ -106,10 +106,12 @@ def init_app(app: Flask) -> None:
             user = primary_user
             display_name_or_username = primary_user.display_name or primary_user.primary_username
         else:
-            secondary_user = SecondaryUser.query.filter_by(username=username).first()
-            if secondary_user:
-                user = secondary_user.primary_user
-                display_name_or_username = secondary_user.display_name or secondary_user.username
+            secondary_username = SecondaryUsername.query.filter_by(username=username).first()
+            if secondary_username:
+                user = secondary_username.primary_user
+                display_name_or_username = (
+                    secondary_username.display_name or secondary_username.username
+                )
                 return redirect(url_for("settings"))
 
         if not user:
@@ -142,7 +144,7 @@ def init_app(app: Flask) -> None:
             new_message = Message(
                 content=email_content,
                 user_id=user.id,
-                secondary_user_id=secondary_user.id if secondary_user else None,
+                secondary_user_id=secondary_username.id if secondary_username else None,
             )
             db.session.add(new_message)
             db.session.commit()
@@ -182,7 +184,7 @@ def init_app(app: Flask) -> None:
             "submit_message.html",
             form=form,
             user=user,
-            secondary_user=secondary_user if secondary_user else None,
+            secondary_username=secondary_username if secondary_username else None,
             username=username,
             display_name_or_username=display_name_or_username,
             current_user_id=session.get("user_id"),

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -22,7 +22,7 @@ from .crypto import is_valid_pgp_key
 from .db import db
 from .ext import bcrypt, limiter
 from .forms import ComplexPassword, TwoFactorForm
-from .model import Message, SecondaryUser, User
+from .model import Message, SecondaryUsername, User
 from .utils import require_2fa
 
 
@@ -74,7 +74,7 @@ def create_blueprint() -> Blueprint:
             return redirect(url_for("login"))
 
         # Fetch all secondary usernames for the current user
-        secondary_usernames = SecondaryUser.query.filter_by(user_id=user.id).all()
+        secondary_usernames = SecondaryUsername.query.filter_by(user_id=user.id).all()
 
         # Initialize forms
         change_password_form = ChangePasswordForm()
@@ -171,9 +171,9 @@ def create_blueprint() -> Blueprint:
                 two_fa_percentage = (two_fa_count / user_count * 100) if user_count else 0
                 pgp_key_percentage = (pgp_key_count / user_count * 100) if user_count else 0
             else:
-                user_count = two_fa_count = pgp_key_count = two_fa_percentage = (
-                    pgp_key_percentage
-                ) = None
+                user_count = (
+                    two_fa_count
+                ) = pgp_key_count = two_fa_percentage = pgp_key_percentage = None
 
         # Prepopulate form fields
         smtp_settings_form.smtp_server.data = user.smtp_server
@@ -509,7 +509,7 @@ def create_blueprint() -> Blueprint:
             Message.query.filter_by(user_id=user.id).delete()
 
             # Explicitly delete secondary users if necessary
-            SecondaryUser.query.filter_by(user_id=user.id).delete()
+            SecondaryUsername.query.filter_by(user_id=user.id).delete()
 
             # Now delete the user
             db.session.delete(user)

--- a/hushline/templates/inbox.html
+++ b/hushline/templates/inbox.html
@@ -8,9 +8,9 @@
             <div class="message{% if 'BEGIN PGP MESSAGE' in message.content %} encrypted{% endif %}" data-encrypted-content="{{ message.content | safe }}">
                 {% if not is_secondary %}
                     {% if message.secondary_user_id %}
-                        {% set sender_info = secondary_users[message.secondary_user_id] %}
+                        {% set sender_info = secondary_usernames[message.secondary_user_id] %}
                         <p class="message-label">📥 {{ sender_info.display_name or sender_info.username }}</p>
-                    {% elif secondary_users|length > 0 %}
+                    {% elif secondary_usernames|length > 0 %}
                         <p class="message-label">📥 {{ user.display_name or user.primary_username }}</p>
                     {% endif %}
                 {% endif %}

--- a/hushline/templates/secondary_user_settings.html
+++ b/hushline/templates/secondary_user_settings.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
 {% block content %}
-<h2>Settings for {{ secondary_user.display_name or secondary_user.username }}</h2>
+<h2>Settings for {{ secondary_username.display_name or secondary_username.username }}</h2>
 
 <form method="POST">
     <label for="display_name">Display Name</label>
-    <input type="text" id="display_name" name="display_name" value="{{ secondary_user.display_name or '' }}" placeholder="Display Name">
+    <input type="text" id="display_name" name="display_name" value="{{ secondary_username.display_name or '' }}" placeholder="Display Name">
     <button type="submit">Update</button>
 </form>
 {% endblock %}

--- a/hushline/templates/submit_message.html
+++ b/hushline/templates/submit_message.html
@@ -11,7 +11,7 @@
     <p class="badge">⚙️ Admin</p>
     {% endif %}
 </div>
-{% if current_user_id == user.id or (secondary_user and current_user_id == secondary_user.primary_user_id) %}
+{% if current_user_id == user.id or (secondary_username and current_user_id == secondary_username.primary_user_id) %}
     <p class="instr">Only visible to you: This is your public tip line. Share the address on your social media profiles, your website, or email signature. Ensuring that someone submitting a message trusts this form belongs to you is critical!</p>
     {% if user.pgp_key %}
         <p class="info">🔐 Your message will be encrypted and only readable by you.</p>


### PR DESCRIPTION
## What's Changed
Renamed the `SecondaryUser` model to `SecondaryUsername`. This is to make it clearer what the model is about. It's not about users; it's about their usernames.

## Specific Changes
- Renamed the class from `SecondaryUser` to `SecondaryUsername`.
- Updated the table name in the DB from `secondary_user` to `secondary_username`.
- Fixed all references to this model in the code, including relationships and foreign keys. Wherever we had `secondary_users`, it's now `secondary_usernames`.
- Updated foreign keys in the `Message` model to link to `secondary_username.id` instead of `secondary_user.id`.
- Adjusted the backref in the `User` model to match the new naming.

## Why
The old name was misleading. This change makes our model names match what they actually represent.

## Next Steps
- Test the parts of the app that use this model to make sure nothing broke.
