### PR TITLE
Refactor User model to use Passlib for secure password hashing

### DIFF
--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -12,7 +12,7 @@ from werkzeug.middleware.proxy_fix import ProxyFix
 
 from . import admin, routes, settings
 from .db import db
-from .ext import bcrypt, limiter
+from .ext import limiter
 from .model import User
 from .crypto import list_keys
 
@@ -42,7 +42,6 @@ def create_app() -> Flask:
     db.init_app(app)
     _ = Migrate(app, db)
     limiter.init_app(app)
-    bcrypt.init_app(app)
 
     file_handler = RotatingFileHandler("flask.log", maxBytes=1024 * 1024 * 100, backupCount=20)
     file_handler.setLevel(logging.DEBUG)

--- a/hushline/ext.py
+++ b/hushline/ext.py
@@ -1,8 +1,5 @@
-from flask_bcrypt import Bcrypt
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
-
-bcrypt = Bcrypt()
 
 limiter = Limiter(
     key_func=get_remote_address,

--- a/hushline/model.py
+++ b/hushline/model.py
@@ -1,7 +1,10 @@
 from flask import current_app
 
+from passlib.context import CryptContext
 from .crypto import decrypt_field, encrypt_field
 from .db import db
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
 
 
 class User(db.Model):
@@ -27,11 +30,18 @@ class User(db.Model):
 
     @property
     def password_hash(self):
-        return decrypt_field(self._password_hash)
+        decrypted_hash = decrypt_field(self._password_hash)
+        return decrypted_hash
 
     @password_hash.setter
-    def password_hash(self, value):
-        self._password_hash = encrypt_field(value)
+    def password_hash(self, plaintext_password):
+        hashed_password = pwd_context.hash(plaintext_password)
+        self._password_hash = encrypt_field(hashed_password)
+
+    def verify_password(self, plaintext_password):
+    decrypted_hash = decrypt_field(self._password_hash)
+    return pwd_context.verify(plaintext_password, decrypted_hash)
+
 
     @property
     def totp_secret(self):

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -9,7 +9,7 @@ from wtforms.validators import DataRequired, Length
 
 from .crypto import encrypt_message, get_email_from_pgp_key
 from .db import db
-from .ext import bcrypt, limiter
+from .ext import limiter
 from .forms import ComplexPassword
 from .model import InviteCode, Message, SecondaryUser, User
 from .utils import require_2fa, send_email
@@ -239,7 +239,7 @@ def init_app(app: Flask) -> None:
                 flash("💔 Username already taken.", "error")
                 return redirect(url_for("register"))
 
-            password_hash = bcrypt.generate_password_hash(password).decode("utf-8")
+            password_hash = pwd_context.hash(password).decode("utf-8")
             new_user = User(primary_username=username, password_hash=password_hash)
             db.session.add(new_user)
             db.session.commit()
@@ -260,7 +260,7 @@ def init_app(app: Flask) -> None:
             # Use primary_username for filter_by
             user = User.query.filter_by(primary_username=username).first()
 
-            if user and bcrypt.check_password_hash(user.password_hash, password):
+            if user and pwd_context.verify(password, user.password_hash):
                 session.permanent = (
                     True  # Make the session permanent so it uses the configured lifetime
                 )

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -20,7 +20,7 @@ from wtforms.validators import DataRequired, Length
 
 from .crypto import is_valid_pgp_key
 from .db import db
-from .ext import bcrypt, limiter
+from .ext import limiter
 from .forms import ComplexPassword, TwoFactorForm
 from .model import Message, SecondaryUser, User
 from .utils import require_2fa
@@ -148,10 +148,8 @@ def create_blueprint() -> Blueprint:
 
             # Handle Change Password Form Submission
             elif change_password_form.validate_on_submit():
-                if bcrypt.check_password_hash(
-                    user.password_hash, change_password_form.old_password.data
-                ):
-                    user.password_hash = bcrypt.generate_password_hash(
+                if pwd_context.verify(user.password_hash, change_password_form.old_password.data):
+                    user.password_hash = pwd_context.hash(
                         change_password_form.new_password.data
                     ).decode("utf-8")
                     db.session.commit()
@@ -171,9 +169,9 @@ def create_blueprint() -> Blueprint:
                 two_fa_percentage = (two_fa_count / user_count * 100) if user_count else 0
                 pgp_key_percentage = (pgp_key_count / user_count * 100) if user_count else 0
             else:
-                user_count = two_fa_count = pgp_key_count = two_fa_percentage = (
-                    pgp_key_percentage
-                ) = None
+                user_count = (
+                    two_fa_count
+                ) = pgp_key_count = two_fa_percentage = pgp_key_percentage = None
 
         # Prepopulate form fields
         smtp_settings_form.smtp_server.data = user.smtp_server
@@ -234,8 +232,8 @@ def create_blueprint() -> Blueprint:
             old_password = change_password_form.old_password.data
             new_password = change_password_form.new_password.data
 
-            if bcrypt.check_password_hash(user.password_hash, old_password):
-                user.password_hash = bcrypt.generate_password_hash(new_password).decode("utf-8")
+            if pwd_context.verify(user.password_hash, old_password):
+                user.password_hash = pwd_context.hash(new_password).decode("utf-8")
                 db.session.commit()
                 session.clear()  # Clears the session, logging the user out
                 flash(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,12 +16,12 @@ flask-migrate = "^4.0.7"
 flask-sqlalchemy = "^3.1.1"
 flask-wtf = "^1.2.1"
 gnupg = "^2.3.1"
+passlib = "^1.7.4"
 pymysql = "^1.1.0"
 pyotp = "^2.9.0"
 python-dotenv = "^1.0.1"
 qrcode = "^7.4.2"
 redis = "^5.0.3"
-passlib = "^1.7.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ pyotp = "^2.9.0"
 python-dotenv = "^1.0.1"
 qrcode = "^7.4.2"
 redis = "^5.0.3"
+passlib = "^1.7.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.3.0"


### PR DESCRIPTION
- Introduced Passlib's CryptContext for hashing passwords using bcrypt scheme. Ensured backward compatibility by marking bcrypt as the default scheme and enabling auto deprecation for future upgrades.
- Modified the `password_hash` property setter in the User model to hash plaintext passwords with Passlib before encrypting and storing the hash. This ensures that passwords are securely managed and stored in an encrypted and hashed format, enhancing security.
- Added a `verify_password` method to the `User` model for decrypting and verifying password hashes against plaintext passwords using Passlib. This method supports secure password verification during user authentication processes.
