### PR TITLE
Fixed Poetry package inclusion for hushline directory in `pyproject.toml`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,9 @@ pytest = "^8.1.1"
 pytest-mock = "^3.12.0"
 types-flask-migrate = "^4.0.0.20240311"
 
+[[tool.poetry.packages]]
+include = "hushline"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
Updated `pyproject.toml` to correctly include the hushline directory under package definitions. This change fixes the issue where Poetry could not find the package files, ensuring the project is correctly installed and dependencies are managed.

Error addressed:
```
(venv) glennsorrentino@m1 hushline % poetry install
Installing dependencies from lock file

No dependencies to install or update

Installing the current project: Hush Line (0.0.1)
Warning: The current project could not be installed: No file/folder found for package hush line
If you do not want to install the current project use --no-root.
If you want to use Poetry only for dependency management but not for packaging, you can disable package mode by setting package-mode = false in your pyproject.toml file.
In a future version of Poetry this warning will become an error!
```