### PR TITLE
Automatically publish container images to GitHub Container Registry

### DIFF
--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -1,0 +1,32 @@
+name: Publish container image
+
+on:
+  push:
+    branches:
+      - main
+      - ghcr
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ghcr.io/${{ github.repository }}/hushline:latest

--- a/.github/workflows/publish_container.yml
+++ b/.github/workflows/publish_container.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ghcr
 
 jobs:
   build-and-push:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,4 +99,4 @@ no_implicit_optional = true
 disallow_untyped_defs = true
 disallow_incomplete_defs = true
 warn_unused_configs = true
-exclude = '^migrations/env\.py$|^migrations/versions/.*\.py$'
+exclude = '^migrations/env\.py$|^migrations/versions/.*\.py$|^volumes/.*'


### PR DESCRIPTION
There are various ways to deploy on Digital Ocean App Platform, but the simplest seems to be from a container image hosted on a container registry. This PR adds a GitHub Action workflow to automatically build new container images on every push to the `main` branch, and publish them to the GitHub Container Registry.

This works, but right now the package visibility is private and it can only be accessed with authentication. Making it public would be simpler for deployment (I don't need to store GHCR credentials in Digital Ocean) and it also means others will be able to use the container image that gets built here.

@glenn-sorrentino can you help make it public? Here's the package settings: https://github.com/orgs/scidsg/packages/container/hushline%2Fhushline/settings. Can you scroll down to the Danger Zone at the bottom and click "Change visibility" and then make it public?

![image](https://github.com/scidsg/hushline/assets/156128/1e1c6f90-85c2-4fb7-a056-22dd5178719f)

Once this is public, I can make DO App Platform pull from the container image. Every time any PR is merged into `main`, the dev server will automatically switch to the latest container image.