### PR TITLE
Allow lots of requests to /health.json

### DIFF
--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -385,6 +385,7 @@ def init_app(app: Flask) -> None:
         current_app.logger.info("Triggering JSON regeneration due to user update/insert")
         generate_user_directory_json()
 
+    @limiter.limit("120 per minute")
     @app.route("/health.json")
     def health() -> dict[str, str]:
         return {"status": "ok"}


### PR DESCRIPTION
The default flask-limiter limits are `["200 per day", "50 per hour"]`, but the Digital Ocean health check route gets hit way more frequently than that. This PR fixes this.

However, #369 also fixes that by just removing the limits. So if we decide to merge that PR, then we can go ahead and close this one. If we're not sure, we should merge this PR first just to fix the immediate problem.