### PR TITLE
Use separate test databases, and stop deleting the dev database

### DIFF
--- a/hushline/generate_invite_codes.py
+++ b/hushline/generate_invite_codes.py
@@ -26,7 +26,6 @@ def create_invite_code() -> str:
         db.session.commit()
 
         # Return the generated code
-        print("Generated invite code:", code)
         return code
 
 

--- a/hushline/generate_invite_codes.py
+++ b/hushline/generate_invite_codes.py
@@ -1,7 +1,4 @@
 #!/usr/bin/env python
-import secrets
-from datetime import datetime, timedelta, timezone
-
 from hushline import create_app
 from hushline.db import db
 from hushline.model import InviteCode
@@ -12,21 +9,13 @@ def create_invite_code() -> str:
         # Ensure all tables are created
         db.create_all()
 
-        # Generate a unique invite code
-        code = secrets.token_urlsafe(16)
-
-        # Set the expiration date for the invite code to one year from now
-        expiration_date = datetime.now(timezone.utc) + timedelta(days=365)
-
         # Create a new InviteCode object
-        new_code = InviteCode(code=code, expiration_date=expiration_date)
-
-        # Add the new code to the session and commit it to the database
+        new_code = InviteCode()
         db.session.add(new_code)
         db.session.commit()
 
         # Return the generated code
-        return code
+        return new_code.code
 
 
 if __name__ == "__main__":

--- a/hushline/generate_invite_codes.py
+++ b/hushline/generate_invite_codes.py
@@ -26,6 +26,7 @@ def create_invite_code() -> str:
         db.session.commit()
 
         # Return the generated code
+        print("Generated invite code:", code)
         return code
 
 

--- a/hushline/model.py
+++ b/hushline/model.py
@@ -1,4 +1,5 @@
-from datetime import datetime
+import secrets
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from flask import current_app
@@ -180,10 +181,10 @@ class InviteCode(Model):
     code = db.Column(db.String(255), unique=True, nullable=False)
     expiration_date = db.Column(db.DateTime, nullable=False)
 
-    def __init__(self, code: str, expiration_date: datetime) -> None:
+    def __init__(self) -> None:
         super().__init__()
-        self.code = code
-        self.expiration_date = expiration_date
+        self.code = secrets.token_urlsafe(16)
+        self.expiration_date = datetime.now(timezone.utc) + timedelta(days=365)
 
     def __repr__(self) -> str:
         return f"<InviteCode {self.code}>"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,14 +21,15 @@ def _config(mocker: MockFixture) -> None:
 
 @pytest.fixture()
 def app(_config: None) -> Generator[Flask, None, None]:
+    os.environ["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
+    os.environ["SQLALCHEMY_TRACK_MODIFICATIONS"] = "False"
+    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+
     app = create_app()
     app.config["TESTING"] = True
-    app.config["SQLALCHEMY_DATABASE_URI"] = "sqlite:///:memory:"
     app.config["WTF_CSRF_ENABLED"] = False
-    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-    app.config["SERVER_NAME"] = "localhost:5000"
+    app.config["SERVER_NAME"] = "localhost:8080"
     app.config["PREFERRED_URL_SCHEME"] = "http"
-    app.config["REGISTRATION_CODES_REQUIRED"] = False
 
     with app.app_context():
         db.create_all()

--- a/tests/test_registration_and_login.py
+++ b/tests/test_registration_and_login.py
@@ -1,6 +1,4 @@
 import os
-import secrets
-from datetime import datetime, timedelta, timezone
 
 from flask.testing import FlaskClient
 
@@ -33,17 +31,15 @@ def test_user_registration_with_invite_code_enabled(client: FlaskClient) -> None
     os.environ["REGISTRATION_CODES_REQUIRED"] = "True"
 
     # Generate a valid invite code using the script
-    code = secrets.token_urlsafe(16)
-    expiration_date = datetime.now(timezone.utc) + timedelta(days=365)
-    new_code = InviteCode(code=code, expiration_date=expiration_date)
-    db.session.add(new_code)
+    code = InviteCode()
+    db.session.add(code)
     db.session.commit()
 
     # User registration data with valid invite code
     user_data = {
         "username": "newuser",
         "password": "SecurePassword123!",
-        "invite_code": code,
+        "invite_code": code.code,
     }
 
     # Post request to register a new user

--- a/tests/test_registration_and_login.py
+++ b/tests/test_registration_and_login.py
@@ -6,7 +6,7 @@ from flask.testing import FlaskClient
 
 # Import models and other modules
 from hushline import db
-from hushline.model import User, InviteCode
+from hushline.model import InviteCode, User
 
 
 def test_user_registration_with_invite_code_disabled(client: FlaskClient) -> None:


### PR DESCRIPTION
This fixes #373.

I fixed it by setting environment variables in `tests/conftest.py` _before_ running `app = create_app()`, so that when the `create_app()` function initializes the database, it initializes the in-memory sqlite database, instead of using the database from the actual environment.

This fixed most of the issue, but then I ran into a problem with the `test_user_registration_with_invite_code_enabled` test. This created the invite code by running a function in the `generate_invite_codes.py` script, but this is a standalone script and again was using the wrong database. So I fixed that by just creating an InviteCode object in the test directly.