### PR TITLE
Make postgresql database URIs use psycopg

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ services:
     ports:
       - "8080:8080"
     environment:
-      - SQLALCHEMY_DATABASE_URI=postgresql+psycopg://hushline:hushline@postgres:5432/hushline
+      - SQLALCHEMY_DATABASE_URI=postgresql://hushline:hushline@postgres:5432/hushline
       - FLASK_ENV=development
       - SECRET_KEY="cb3f4afde364bfb3956b97ca22ef4d2b593d9d980a4330686267cabcd2c0befd"
       - ENCRYPTION_KEY="bi5FDwhZGKfc4urLJ_ChGtIAaOPgxd3RDOhnvct10mw="

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -21,6 +21,12 @@ def create_app() -> Flask:
     app.config["SECRET_KEY"] = os.environ.get("SECRET_KEY")
     app.config["ENCRYPTION_KEY"] = os.getenv("ENCRYPTION_KEY")
     app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get("SQLALCHEMY_DATABASE_URI")
+    # if it's a Postgres URI, replace the scheme with `postgresql+psycopg`
+    # because we're using the psycopg driver
+    if app.config["SQLALCHEMY_DATABASE_URI"].startswith("postgresql://"):
+        app.config["SQLALCHEMY_DATABASE_URI"] = app.config["SQLALCHEMY_DATABASE_URI"].replace(
+            "postgresql://", "postgresql+psycopg://", 1
+        )
     app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
     app.config["SESSION_COOKIE_NAME"] = os.environ.get("SESSION_COOKIE_NAME", "__HOST-session")
     app.config["SESSION_COOKIE_SECURE"] = True


### PR DESCRIPTION
For PostgreSQL, we're using an adapter called [psycopg](https://pypi.org/project/psycopg/). In order to tell SQLAlchemy to use this adapter, the database URI needs to start with `postgresql+psycopg://`, not `postgresql://`, but otherwise it's the same.

This PR makes it so if the app is configured to use postgres, it always uses psycopg. If it's configured to use a different database (like sqlite), it doesn't change it.

This way, we can set `SQLALCHEMY_DATABASE_URI` to directly be the managed database connection string in prod.