### PR TITLE
Add the Onion-Location header to HTTP responses

### DIFF
--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -3,7 +3,7 @@ import os
 from datetime import timedelta
 from typing import Any
 
-from flask import Flask, flash, redirect, session, url_for, request
+from flask import Flask, flash, redirect, request, session, url_for
 from flask_migrate import Migrate
 from werkzeug.wrappers.response import Response
 

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -3,7 +3,7 @@ import os
 from datetime import timedelta
 from typing import Any
 
-from flask import Flask, flash, redirect, session, url_for
+from flask import Flask, flash, redirect, session, url_for, request
 from flask_migrate import Migrate
 from werkzeug.wrappers.response import Response
 
@@ -53,5 +53,14 @@ def create_app() -> Flask:
             user = User.query.get(session["user_id"])
             return {"user": user}
         return {}
+
+    # Add Onion-Location header to all responses
+    onion_hostname: str | None = os.environ.get("ONION_HOSTNAME", None)
+    if onion_hostname:
+
+        @app.after_request
+        def add_onion_location_header(response: Response) -> Response:
+            response.headers["Onion-Location"] = f"http://{onion_hostname}{request.path}"
+            return response
 
     return app

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -33,6 +33,7 @@ def create_app() -> Flask:
     app.config["SESSION_COOKIE_HTTPONLY"] = True
     app.config["SESSION_COOKIE_SAMESITE"] = "Lax"
     app.config["PERMANENT_SESSION_LIFETIME"] = timedelta(minutes=30)
+    app.config["ONION_HOSTNAME"] = os.environ.get("ONION_HOSTNAME", None)
 
     # Run migrations
     db.init_app(app)
@@ -55,12 +56,13 @@ def create_app() -> Flask:
         return {}
 
     # Add Onion-Location header to all responses
-    onion_hostname: str | None = os.environ.get("ONION_HOSTNAME", None)
-    if onion_hostname:
+    if app.config["ONION_HOSTNAME"]:
 
         @app.after_request
         def add_onion_location_header(response: Response) -> Response:
-            response.headers["Onion-Location"] = f"http://{onion_hostname}{request.path}"
+            response.headers["Onion-Location"] = (
+                f"http://{app.config['ONION_HOSTNAME']}{request.path}"
+            )
             return response
 
     return app


### PR DESCRIPTION
If there's an environment variable `ONION_HOSTNAME`, this adds the [Onion-Location](https://community.torproject.org/onion-services/advanced/onion-location/) HTTP response header to every request. But if `ONION_HOSTNAME` is not set, then it doesn't add the extra header.

Onion-Location tells Tor Browser that there's an onion site version of the website, and it shows a ".onion available" button in the address bar. If the user clicks it, it redirects to the onion site specified in Onion-Location.

This PR takes into account what page the user is at right now. So if they're at `/directory`, the Onion-Location header will bring them to the `/directory` page of the onion site.