### PR TITLE
Modifications to flash messages

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -235,7 +235,7 @@ img.empty {
     max-width: 78vw;
     text-align: center;
     opacity: 0;
-    visibility: hidden;
+    z-index: 10;
     animation: fadeInDown 0.5s ease forwards, fadeOutUp 0.5s ease 5s forwards;
 }
 
@@ -259,7 +259,7 @@ img.empty {
     }
 
     100% {
-        transform: translateX(50%) translateY(4.5em);
+        transform: translateX(50%) translateY(1em);
         opacity: 1;
         visibility: visible;
     }
@@ -267,7 +267,7 @@ img.empty {
 
 @keyframes fadeOutUp {
     0% {
-        transform: translateX(50%) translateY(4.5em);
+        transform: translateX(50%) translateY(1em);
         opacity: 1;
         visibility: visible;
     }

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -225,7 +225,7 @@ img.empty {
     position: fixed;
     top: 1rem;
     right: 50%;
-    transform: translateX(50%);
+    transform: translateX(50%) translateY(0%);
     background-color: white;
     border: var(--border);
     padding: 1.25rem 2rem;
@@ -235,8 +235,8 @@ img.empty {
     max-width: 78vw;
     text-align: center;
     opacity: 0;
+    visibility: hidden;
     animation: fadeInDown 0.5s ease forwards, fadeOutUp 0.5s ease 5s forwards;
-    z-index: 99;
 }
 
 .message .message-label,
@@ -253,30 +253,34 @@ img.empty {
 
 @keyframes fadeInDown {
     0% {
-        top: 0px;
+        transform: translateX(50%) translateY(0%);
         opacity: 0;
+        visibility: hidden;
     }
 
     100% {
-        top: 1rem;
+        transform: translateX(50%) translateY(4.5em);
         opacity: 1;
+        visibility: visible;
     }
 }
 
 @keyframes fadeOutUp {
     0% {
-        top: 1rem;
+        transform: translateX(50%) translateY(4.5em);
         opacity: 1;
+        visibility: visible;
     }
 
     99% {
-        top: 0;
+        transform: translateX(50%) translateY(0%);
         opacity: 0;
+        visibility: hidden; 
     }
 
     100% {
         opacity: 0;
-        z-index: -999;
+        visibility: hidden;
     }
 
 }

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -24,16 +24,15 @@
 </head>
 <body>
 
-
-  {% with messages = get_flashed_messages() %}
-    {% if messages %}
-      <div class="flash-messages">
-        {% for message in messages %}
-          <div class="flash-message">{{ message }}</div>
-        {% endfor %}
-      </div>
-    {% endif %}
-  {% endwith %}
+    {% with messages = get_flashed_messages() %}
+      {% if messages %}
+        <div class="flash-messages">
+          {% for message in messages %}
+            <div class="flash-message">{{ message }}</div>
+          {% endfor %}
+        </div>
+      {% endif %}
+    {% endwith %}
 
     <header>
         <!-- Navigation bar, logo, etc. -->

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -24,9 +24,10 @@
 </head>
 <body>
 
+
   {% with messages = get_flashed_messages() %}
     {% if messages %}
-      <div class="flash-messages" aria-live="polite" role="alert">
+      <div class="flash-messages" >
         {% for message in messages %}
           <div class="flash-message">{{ message }}</div>
         {% endfor %}

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -27,7 +27,7 @@
 
   {% with messages = get_flashed_messages() %}
     {% if messages %}
-      <div class="flash-messages" >
+      <div class="flash-messages">
         {% for message in messages %}
           <div class="flash-message">{{ message }}</div>
         {% endfor %}

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -23,6 +23,17 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
 <body>
+
+  {% with messages = get_flashed_messages() %}
+    {% if messages %}
+      <div class="flash-messages" aria-live="polite" role="alert">
+        {% for message in messages %}
+          <div class="flash-message">{{ message }}</div>
+        {% endfor %}
+      </div>
+    {% endif %}
+  {% endwith %}
+
     <header>
         <!-- Navigation bar, logo, etc. -->
         <h1>🤫 Hush Line</h1>
@@ -53,15 +64,7 @@
         </nav>
     </header>
 
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        <div class="flash-messages">
-          {% for message in messages %}
-            <div class="flash-message">{{ message }}</div>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
+
 
     <main>
         <div class="container">


### PR DESCRIPTION
1. Removed `z-index` property from styles. Edit: Added `z-index: 10` without altering index value on show/hide
2. Using `transform` instead of `top` for smoother transitions.
3. Updated the hierarchy of the messaging element so it's top level for the screen reader to announce first once it appears on the page.


https://github.com/scidsg/hushline/assets/15894356/09eda57c-f6d8-495f-8507-8cf9f96b1736


**Update screenshots:**

<img width="832" alt="Screenshot 2024-07-08 at 2 13 07 PM" src="https://github.com/scidsg/hushline/assets/15894356/26e592aa-66dc-46fb-86c7-d5bf2fb5d116">
<img width="1281" alt="Screenshot 2024-07-08 at 2 12 31 PM" src="https://github.com/scidsg/hushline/assets/15894356/b005a180-3b4a-407d-bdba-aa11c251e24a">

