### PR TITLE
Fix double period punctuation 

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -1026,7 +1026,7 @@ p.helper {
 
     .container {
         min-width: initial;
-        padding: 2rem 1.5rem;
+        padding: 2rem 1.25rem;
     }
 
     header nav ul {

--- a/hushline/static/js/submit-message.js
+++ b/hushline/static/js/submit-message.js
@@ -1,0 +1,15 @@
+document.addEventListener("DOMContentLoaded", function() {
+    // Function to correct double periods at the end of sentences
+    function correctDoublePeriods() {
+        let elements = document.querySelectorAll('.helper');
+        elements.forEach(element => {
+            let text = element.innerHTML;
+            // Replace double periods at the end of sentences with a single period
+            text = text.replace(/\.{2,}/g, '.');
+            element.innerHTML = text;
+        });
+    }
+
+    // Run the function to correct double periods
+    correctDoublePeriods();
+});

--- a/hushline/templates/submit_message.html
+++ b/hushline/templates/submit_message.html
@@ -42,4 +42,5 @@
 {% block scripts %}
 <script src="{{ url_for('static', filename='vendor/openpgp-5.11.1.min.js') }}"></script>
 <script src="{{ url_for('static', filename='js/client-side-encryption.js') }}"></script>
+<script src="{{ url_for('static', filename='js/submit-message.js') }}"></script>
 {% endblock %}


### PR DESCRIPTION
If a display name uses an abbreviation, like Science & Design, Inc. does, the helper text on the submit message page renders with two periods. This fix uses JS to find instances of two periods in any text with the `.helper` class and renders with one.

Live example on https://tips.hushline.app/submit_message/scidsg
<img width="594" alt="Screenshot 2024-07-08 at 8 31 16 PM" src="https://github.com/scidsg/hushline/assets/28545431/48818eb0-bc4e-4706-91df-b3adccda2b03">

The updated rendering:
<img width="601" alt="Screenshot 2024-07-08 at 8 31 02 PM" src="https://github.com/scidsg/hushline/assets/28545431/900acf3f-e80f-444a-bdd2-6cf438f344d1">
