### PR TITLE
Fixed accessibility for directory tabs 

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -667,10 +667,11 @@ img.upgrade {
 .tab-list {
     list-style-type: none;
     margin: 0 0 1.75rem 0;
-    padding: 0;
+    padding: 0.5rem 0 0 0;
     overflow-x: auto;
     display: flex;
     overflow-y: hidden;
+    gap: 10px;
     -ms-overflow-style: none;
     scrollbar-width: none;
     border-bottom: var(--border);
@@ -681,31 +682,25 @@ img.upgrade {
 }
 
 /* Tab button styling */
-.tab {
-    border: none;
-    outline: none;
-    cursor: pointer;
-    padding: .75rem .625rem;
-    font-size: var(--font-size-base);
-    white-space: nowrap;
-}
-
-.tab button {
+.tab  {
   min-height: 0px;
   min-width: auto;
+  padding: .75rem .625rem;
   font-size: var(--font-size-base);
   font-family: var(--font-sans);
+  white-space: nowrap;
   border-radius: 0px;
   border: 0px;
   background-color: transparent;
   color: var(--color-text);
   box-shadow: none;
-  padding: 0px;
+  margin: 0;
+  box-sizing: content-box;
+  outline: none;
 }
 
-.tab button:focus-within {
-  outline: 2px solid var(--color-brand);
-  outline-offset: 4px;
+.tab:focus-within {
+  outline: none;
 }
 /* Change background color of tabs on hover */
 .tab:hover {
@@ -717,7 +712,7 @@ img.upgrade {
     border-bottom: 3px solid var(--color-brand);
 }
 
-.tab.active button {
+.tab.active  {
   font-family: var(--font-sans-bold);
 }
 

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -690,6 +690,23 @@ img.upgrade {
     white-space: nowrap;
 }
 
+.tab button {
+  min-height: 0px;
+  min-width: auto;
+  font-size: var(--font-size-base);
+  font-family: var(--font-sans);
+  border-radius: 0px;
+  border: 0px;
+  background-color: transparent;
+  color: var(--color-text);
+  box-shadow: none;
+  padding: 0px;
+}
+
+.tab button:focus-within {
+  outline: 2px solid var(--color-brand);
+  outline-offset: 4px;
+}
 /* Change background color of tabs on hover */
 .tab:hover {
     background-color: #fbf3ff;
@@ -698,8 +715,12 @@ img.upgrade {
 /* Create an active/current tablink class */
 .tab.active {
     border-bottom: 3px solid var(--color-brand);
-    font-family: var(--font-sans-bold);
 }
+
+.tab.active button {
+  font-family: var(--font-sans-bold);
+}
+
 
 /* Style the tab content (and hide it by default) */
 .tab-content {

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -7,8 +7,12 @@
 {% endif %}
 <div class="directory-tabs">
     <ul class="tab-list">
-        <li class="tab active" data-tab="verified">Verified</li>
-        <li class="tab" data-tab="all">All</li>
+        <li class="tab active" data-tab="verified">
+          <button type="button">Verified</button>
+        </li>
+        <li class="tab" data-tab="all">
+          <button type="button">All</button>
+        </li>
     </ul>
 </div>
 <div class="search-box">

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -7,11 +7,11 @@
 {% endif %}
 <div class="directory-tabs">
     <ul class="tab-list">
-        <li class="tab active" data-tab="verified">
-          <button type="button">Verified</button>
+        <li>
+          <button class="tab active" data-tab="verified" type="button">Verified</button>
         </li>
-        <li class="tab" data-tab="all">
-          <button type="button">All</button>
+        <li>
+          <button class="tab" data-tab="all"type="button">All</button>
         </li>
     </ul>
 </div>


### PR DESCRIPTION
Allowing tabs to be in the tab order and using `button` elements instead

Example below is shown using keyboard (tabbing) only:


https://github.com/scidsg/hushline/assets/15894356/eefb9bbc-b2f5-4449-a5a4-8aae10b801c3

