### PR TITLE
Fix username validation

### DIFF
--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -29,8 +29,8 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(mess
 
 
 def valid_username(form: Form, field: Field) -> None:
-    # Regex pattern with length constraint (3 to 20 characters) and no special characters at the start or end
-    if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{4,20}[a-zA-Z0-9]$", field.data):
+    # Corrected regex pattern with length constraint (4 to 20 characters)
+    if not re.match(r"^[a-zA-Z0-9]([a-zA-Z0-9_-]{2,18}[a-zA-Z0-9])?$", field.data):
         raise ValidationError(
             "Username must contain only letters, numbers, underscores, or hyphens, "
             "and be between 4 and 20 characters long, without starting or ending with special characters."

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -30,7 +30,7 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(mess
 
 def valid_username(form: Form, field: Field) -> None:
     # Corrected regex pattern with length constraint (4 to 20 characters)
-    if not re.match(r"^[a-zA-Z0-9]([a-zA-Z0-9_-]{2,18}[a-zA-Z0-9])?$", field.data):
+    if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{2,18}[a-zA-Z0-9]$", field.data):
         raise ValidationError(
             "Username must contain only letters, numbers, underscores, or hyphens, "
             "and be between 4 and 20 characters long, without starting or ending with "

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -33,7 +33,8 @@ def valid_username(form: Form, field: Field) -> None:
     if not re.match(r"^[a-zA-Z0-9]([a-zA-Z0-9_-]{2,18}[a-zA-Z0-9])?$", field.data):
         raise ValidationError(
             "Username must contain only letters, numbers, underscores, or hyphens, "
-            "and be between 4 and 20 characters long, without starting or ending with special characters."
+            "and be between 4 and 20 characters long, without starting or ending with "
+            "special characters."
         )
 
 

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -29,9 +29,11 @@ logging.basicConfig(level=logging.INFO, format="%(asctime)s:%(levelname)s:%(mess
 
 
 def valid_username(form: Form, field: Field) -> None:
-    if not re.match(r"^[a-zA-Z0-9_-]+$", field.data):
+    # Regex pattern with length constraint (3 to 20 characters) and no special characters at the start or end
+    if not re.match(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{4,20}[a-zA-Z0-9]$", field.data):
         raise ValidationError(
-            "Username must contain only letters, numbers, underscores, or hyphens."
+            "Username must contain only letters, numbers, underscores, or hyphens, "
+            "and be between 4 and 20 characters long, without starting or ending with special characters."
         )
 
 


### PR DESCRIPTION
Updated the Regex for username validation to avoid emoji and other non-standard patterns.

**New Rules:**
- Usernames must begin and end with an alphanumeric character.
- Usernames can contain alphanumeric characters, hyphens, and underscores.
- Usernames cannot contain emojis or other non-standard characters.
- Length of the username must be between 4 and 20 characters.

### Regex Pattern:
```regex
^[a-zA-Z0-9]([a-zA-Z0-9_-]{2,18}[a-zA-Z0-9])?$
```

![Screenshot 2024-07-10 at 1 29 44 PM](https://github.com/scidsg/hushline/assets/28545431/1533e3b2-b665-4688-bef5-7e9bdb439a26)
![Screenshot 2024-07-10 at 1 30 17 PM](https://github.com/scidsg/hushline/assets/28545431/05347c94-9499-4d79-b8a3-3c7f1c3641ae)
![Screenshot 2024-07-10 at 1 34 18 PM](https://github.com/scidsg/hushline/assets/28545431/b5b4c83f-d13a-42a1-a88b-2288428682c3)