### PR TITLE
tab indexing on settings

### DIFF
--- a/hushline/templates/settings.html
+++ b/hushline/templates/settings.html
@@ -4,12 +4,32 @@
 <h2>Settings</h2>
 <div class="settings-tabs {% if user.is_admin %}is-admin{% endif %}">
     <ul class="tab-list">
-        <li class="tab active" data-tab="profile">Profile</li>
-        <li class="tab" data-tab="auth">Authentication</li>
-        <li class="tab" data-tab="email">Email & PGP</li>
-        <li class="tab" data-tab="advanced">Advanced</li>
+        <li>
+            <button type="button" class="tab active" data-tab="profile">
+                Profile
+            </button>
+        </li>
+        <li>
+            <button type="button" class="tab" data-tab="auth">
+                Authentication
+            </button>
+        </li>
+        <li>
+            <button type="button" class="tab" data-tab="email">
+                Email
+            </button>
+        </li>
+        <li>
+            <button type="button" class="tab" data-tab="advanced">
+                Advanced
+            </button>
+        </li>
         {% if user.is_admin %}
-            <li class="tab admin-only" data-tab="admin">Admin</li>
+            <li>
+                <button type="button" class="tab admin-only" data-tab="admin">
+                    Admin
+                </button>
+            </li>
         {% endif %}
     </ul>
 </div>


### PR DESCRIPTION
Converted tabs into `button` elements to get native tabbing. Allows keyboard only users to set active tabs 

Example:

https://github.com/user-attachments/assets/722eedd7-b585-4244-9797-71a6faa9f8be

