### PR TITLE
Fix Message Debouncing

### DIFF
--- a/hushline/static/js/submit-message.js
+++ b/hushline/static/js/submit-message.js
@@ -22,4 +22,8 @@ document.addEventListener("DOMContentLoaded", function() {
     // Run the function to correct double periods
     correctDoublePeriods();
     prefillMessage();
+
+    document.getElementById('messageForm').addEventListener('submit', function() {
+        document.getElementById('submitBtn').disabled = true;
+    });
 });


### PR DESCRIPTION
Right now in Hush Line when submitting a message it's possible to click "Send Message" and then a second later click it again, which ends up sending two messages. This fix makes it so that when the user clicks submit and the form starts processing the button becomes disabled.

Added js:
```js
document.addEventListener("DOMContentLoaded", function() {
...
    document.getElementById('messageForm').addEventListener('submit', function() {
        document.getElementById('submitBtn').disabled = true;
    });
});
```