### PR TITLE
remove "Wait for deployment to finish" step from deploy job

### DIFF
--- a/.github/workflows/build-and-deploy-release.yml
+++ b/.github/workflows/build-and-deploy-release.yml
@@ -43,12 +43,6 @@ jobs:
 
       - name: Trigger deployment on DigitalOcean App Platform
         run: |
-          doctl apps create-deployment $DIGITALOCEAN_APP_ID --force-rebuild
-        env:
-          DIGITALOCEAN_APP_ID: ${{ secrets.DIGITALOCEAN_APP_ID }}
-
-      - name: Wait for deployment to finish
-        run: |
-          doctl apps wait $DIGITALOCEAN_APP_ID
+          doctl apps create-deployment $DIGITALOCEAN_APP_ID --force-rebuild --wait
         env:
           DIGITALOCEAN_APP_ID: ${{ secrets.DIGITALOCEAN_APP_ID }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,13 +3,9 @@ name: Run Tests
 
 on:
   push:
-    paths-ignore:
-      - .github/**
     branches:
       - main
   pull_request:
-    paths-ignore:
-      - .github/**
     branches:
       - main
 


### PR DESCRIPTION
The deploy job has a step that is supposed to wait for a deployment to complete before completing, but the command it runs doesn't exist in doctl. This PR updates the job to pass the `--wait` flag to the command which initiates the deployment.