### PR TITLE
Update templates to use url_for()

### DIFF
--- a/hushline/static/js/directory.js
+++ b/hushline/static/js/directory.js
@@ -102,7 +102,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     <div class="badgeContainer">${badgeContainer}</div>
                     ${bioHighlighted ? `<p class="bio">${bioHighlighted}</p>` : ''}
                     <div class="user-actions">
-                        <a href="/submit_message/${user.primary_username}">Send a Message</a>
+                        <a href="${pathPrefix}/submit_message/${user.primary_username}">Send a Message</a>
                         ${isSessionUser ? `<a href="#" class="report-link" data-username="${user.primary_username}" data-display-name="${user.display_name || user.primary_username}" data-bio="${user.bio ?? "No bio"}">Report Account</a>` : ``}
                     </div>
                 `;

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <meta name="theme-color" content="#7D25C1">
@@ -14,24 +15,30 @@
     <meta name="twitter:description" content="A lightweight, secure, and anonymous tip line platform.">
     <meta name="twitter:image" content="https://hushline.app/design-system/images/social/social.png">
     <title>{% block title %}{% endblock %} - Hushline</title>
-    <link rel="apple-touch-icon" sizes="180x180" href="{{ url_for('static', filename='img/favicon/apple-touch-icon.png') }}">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/favicon/favicon-16x16.png') }}" sizes="16x16">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/favicon/favicon-32x32.png') }}" sizes="32x32">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/favicon/android-chrome-192x192.png') }}" sizes="192x192">
-    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/favicon/android-chrome-512x512.png') }}" sizes="512x512">
+    <link rel="apple-touch-icon" sizes="180x180"
+        href="{{ url_for('static', filename='img/favicon/apple-touch-icon.png') }}">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/favicon/favicon-16x16.png') }}"
+        sizes="16x16">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/favicon/favicon-32x32.png') }}"
+        sizes="32x32">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/favicon/android-chrome-192x192.png') }}"
+        sizes="192x192">
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/favicon/android-chrome-512x512.png') }}"
+        sizes="512x512">
     <link rel="icon" type="image/x-icon" href="{{ url_for('static', filename='img/favicon/favicon.ico') }}">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/style.css') }}">
 </head>
+
 <body>
 
     {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        <div class="flash-messages">
-          {% for message in messages %}
-            <div class="flash-message">{{ message }}</div>
-          {% endfor %}
-        </div>
-      {% endif %}
+    {% if messages %}
+    <div class="flash-messages">
+        {% for message in messages %}
+        <div class="flash-message">{{ message }}</div>
+        {% endfor %}
+    </div>
+    {% endif %}
     {% endwith %}
 
     <header>
@@ -42,21 +49,23 @@
                 <a class="mobileNav btnIcon" aria-label="Navigation menu">Menu</a>
                 <ul>
                     <li><a href="{{ url_for('directory') }}">Directory</a></li>
-                    {% if 'user_id' in session and (('2fa_required' not in session or not session['2fa_required']) or ('2fa_verified' in session and session['2fa_verified'])) %}
-                        <li><a href="{{ url_for('inbox', username=session.username) }}">Inbox</a></li>
-                        <li><a href="{{ url_for('submit_message', username=session.username) }}">Submit Message</a></li>
-                        <li class="dropdown">
-                            <a href="#" class="dropbtn">@{{ session['username'] }} <img class="dropdown-icon" src="{{ url_for('static', filename='img/app/dropdown.png') }}" alt="Dropdown"></a>
-                            <div class="dropdown-content">
-                                <ul>
-                                    <li><a href="{{ url_for('settings.index') }}">Settings</a></li>
-                                    <li><a href="{{ url_for('logout') }}">Logout</a></li>
-                                </ul>
-                            </div>
-                        </li>
+                    {% if 'user_id' in session and (('2fa_required' not in session or not session['2fa_required']) or
+                    ('2fa_verified' in session and session['2fa_verified'])) %}
+                    <li><a href="{{ url_for('inbox', username=session.username) }}">Inbox</a></li>
+                    <li><a href="{{ url_for('submit_message', username=session.username) }}">Submit Message</a></li>
+                    <li class="dropdown">
+                        <a href="#" class="dropbtn">@{{ session['username'] }} <img class="dropdown-icon"
+                                src="{{ url_for('static', filename='img/app/dropdown.png') }}" alt="Dropdown"></a>
+                        <div class="dropdown-content">
+                            <ul>
+                                <li><a href="{{ url_for('settings.index') }}">Settings</a></li>
+                                <li><a href="{{ url_for('logout') }}">Logout</a></li>
+                            </ul>
+                        </div>
+                    </li>
                     {% else %}
-                        <li><a href="{{ url_for('login') }}">Login</a></li>
-                        <li><a href="{{ url_for('register') }}">Register</a></li>
+                    <li><a href="{{ url_for('login') }}">Login</a></li>
+                    <li><a href="{{ url_for('register') }}">Register</a></li>
                     {% endif %}
                 </ul>
                 <a class="btn" href="https://opencollective.com/scidsg/"><span class="emoji">❤️</span> Donate</a>
@@ -76,8 +85,10 @@
 
     <footer>
         <p>
-            <a href="https://github.com/scidsg/hushline/blob/main/docs/PRIVACY.md" target="_blank" rel="noopener noreferrer">Privacy Policy</a> |
-            <a href="https://github.com/scidsg/hushline/blob/main/docs/TERMS.md" target="_blank" rel="noopener noreferrer">Terms of Service</a>
+            <a href="https://github.com/scidsg/hushline/blob/main/docs/PRIVACY.md" target="_blank"
+                rel="noopener noreferrer">Privacy Policy</a> |
+            <a href="https://github.com/scidsg/hushline/blob/main/docs/TERMS.md" target="_blank"
+                rel="noopener noreferrer">Terms of Service</a>
         </p>
     </footer>
     {% block scripts %}
@@ -85,4 +96,5 @@
     <script src="{{ url_for('static', filename='js/nav.js') }}"></script>
 
 </body>
+
 </html>

--- a/hushline/templates/confirm_disable_2fa.html
+++ b/hushline/templates/confirm_disable_2fa.html
@@ -2,10 +2,10 @@
 {% block title %}Settings{% endblock %}
 
 {% block content %}
-    <h2>Disable Two-Factor Authentication</h2>
-    <p>Are you sure you want to disable 2FA?</p>
-    <form method="POST" action="{{ url_for('settings.disable_2fa') }}">
-        <button type="submit">Yes, Disable 2FA</button>
-    </form>
-    <a href="{{ url_for('settings.index') }}">Cancel</a>
+<h2>Disable Two-Factor Authentication</h2>
+<p>Are you sure you want to disable 2FA?</p>
+<form method="POST" action="{{ url_for('settings.disable_2fa') }}">
+    <button type="submit">Yes, Disable 2FA</button>
+</form>
+<a href="{{ url_for('settings.index') }}">Cancel</a>
 {% endblock %}

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -43,7 +43,7 @@
             <p class="bio">{{ user.bio }}</p>
             {% endif %}
             <div class="user-actions">
-                <a href="/submit_message/{{ user.primary_username }}">Send a Message</a>
+                <a href="{{ url_for('submit_message', username=user.primary_username) }}">Send a Message</a>
                 {% if logged_in %}
                 <a href="#" class="report-link" data-username="{{ user.primary_username }}"
                     data-display-name="{{ user.display_name or user.primary_username }}"
@@ -80,7 +80,7 @@
             <p class="bio">{{ user.bio }}</p>
             {% endif %}
             <div class="user-actions">
-                <a href="/submit_message/{{ user.primary_username }}">Send a Message</a>
+                <a href="{{ url_for('submit_message', username=user.primary_username) }}">Send a Message</a>
                 {% if logged_in %}
                 <a href="#" class="report-link" data-username="{{ user.primary_username }}"
                     data-display-name="{{ user.display_name or user.primary_username }}"

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -3,15 +3,15 @@
 {% block content %}
 <h2>User Directory</h2>
 {% if not logged_in %}
-    <p class="helper">👋 Welcome to Hush Line! Find users who've opted into being listed below.</p>
+<p class="helper">👋 Welcome to Hush Line! Find users who've opted into being listed below.</p>
 {% endif %}
 <div class="directory-tabs">
     <ul class="tab-list">
         <li>
-          <button class="tab active" data-tab="verified" type="button">Verified</button>
+            <button class="tab active" data-tab="verified" type="button">Verified</button>
         </li>
         <li>
-          <button class="tab" data-tab="all"type="button">All</button>
+            <button class="tab" data-tab="all" type="button">All</button>
         </li>
     </ul>
 </div>
@@ -21,69 +21,76 @@
 </div>
 <div id="verified" class="tab-content active">
     {% if not logged_in %}
-        <p class="meta dirMeta">⭐️ Verified accounts are offered to journalists, businesses, and other public figures and have manually verified their identities with a member of our staff. <a href="https://github.com/scidsg/hushline/blob/main/docs/3-managed-service.md#verified-accounts" target="_blank" rel="noopener noreferrer">Learn more about our verification process</a>.</p>
+    <p class="meta dirMeta">⭐️ Verified accounts are offered to journalists, businesses, and other public figures and
+        have manually verified their identities with a member of our staff. <a
+            href="https://github.com/scidsg/hushline/blob/main/docs/3-managed-service.md#verified-accounts"
+            target="_blank" rel="noopener noreferrer">Learn more about our verification process</a>.</p>
     {% endif %}
     <div class="user-list">
         {% for user in users %}
-            {% if user.is_verified and user.show_in_directory %}
-                <div class="user">
-                    <h3>{{ user.display_name or user.primary_username }}</h3>
-                    {% if user.primary_username %}
-                        <p class="meta">@{{ user.primary_username }}</p>
-                    {% endif %}
-                    {% if user.is_admin %}
-                    <div class="badgeContainer">
-                        <p class="badge">⚙️ Admin</p>
-                    </div>
-                    {% endif %}
-                    {% if user.bio %}
-                        <p class="bio">{{ user.bio }}</p>
-                    {% endif %}
-                    <div class="user-actions">
-                        <a href="/submit_message/{{ user.primary_username }}">Send a Message</a>
-                        {% if logged_in %}
-                            <a href="#" class="report-link" data-username="{{ user.primary_username }}" data-display-name="{{ user.display_name or user.primary_username }}" data-bio="{{ user.bio }}">Report Account</a>
-                        {% endif %}
-                    </div>
-                </div>
+        {% if user.is_verified and user.show_in_directory %}
+        <div class="user">
+            <h3>{{ user.display_name or user.primary_username }}</h3>
+            {% if user.primary_username %}
+            <p class="meta">@{{ user.primary_username }}</p>
             {% endif %}
+            {% if user.is_admin %}
+            <div class="badgeContainer">
+                <p class="badge">⚙️ Admin</p>
+            </div>
+            {% endif %}
+            {% if user.bio %}
+            <p class="bio">{{ user.bio }}</p>
+            {% endif %}
+            <div class="user-actions">
+                <a href="/submit_message/{{ user.primary_username }}">Send a Message</a>
+                {% if logged_in %}
+                <a href="#" class="report-link" data-username="{{ user.primary_username }}"
+                    data-display-name="{{ user.display_name or user.primary_username }}"
+                    data-bio="{{ user.bio }}">Report Account</a>
+                {% endif %}
+            </div>
+        </div>
+        {% endif %}
         {% else %}
-            <p class="empty-message"><span class="emoji-message">🙈</span><br>Nothing to see here...</p>
+        <p class="empty-message"><span class="emoji-message">🙈</span><br>Nothing to see here...</p>
         {% endfor %}
     </div>
 </div>
 <div id="all" class="tab-content">
     <div class="user-list">
         {% for user in users %}
-            {% if user.show_in_directory %}
-                <div class="user">
-                    <h3>{{ user.display_name or user.primary_username }}</h3>
-                    {% if user.primary_username %}
-                        <p class="meta">@{{ user.primary_username }}</p>
-                    {% endif %}
-                    {% if user.is_verified or user.is_admin %}
-                    <div class="badgeContainer">
-                        {% if user.is_verified %}
-                        <p class="badge">⭐️ Verified</p>
-                        {% endif %}
-                        {% if user.is_admin %}
-                        <p class="badge">⚙️ Admin</p>
-                        {% endif %}
-                    </div>
-                    {% endif %}
-                    {% if user.bio %}
-                        <p class="bio">{{ user.bio }}</p>
-                    {% endif %}
-                    <div class="user-actions">
-                        <a href="/submit_message/{{ user.primary_username }}">Send a Message</a>
-                        {% if logged_in %}
-                            <a href="#" class="report-link" data-username="{{ user.primary_username }}" data-display-name="{{ user.display_name or user.primary_username }}" data-bio="{{ user.bio }}">Report Account</a>
-                        {% endif %}
-                    </div>
-                </div>
+        {% if user.show_in_directory %}
+        <div class="user">
+            <h3>{{ user.display_name or user.primary_username }}</h3>
+            {% if user.primary_username %}
+            <p class="meta">@{{ user.primary_username }}</p>
             {% endif %}
+            {% if user.is_verified or user.is_admin %}
+            <div class="badgeContainer">
+                {% if user.is_verified %}
+                <p class="badge">⭐️ Verified</p>
+                {% endif %}
+                {% if user.is_admin %}
+                <p class="badge">⚙️ Admin</p>
+                {% endif %}
+            </div>
+            {% endif %}
+            {% if user.bio %}
+            <p class="bio">{{ user.bio }}</p>
+            {% endif %}
+            <div class="user-actions">
+                <a href="/submit_message/{{ user.primary_username }}">Send a Message</a>
+                {% if logged_in %}
+                <a href="#" class="report-link" data-username="{{ user.primary_username }}"
+                    data-display-name="{{ user.display_name or user.primary_username }}"
+                    data-bio="{{ user.bio }}">Report Account</a>
+                {% endif %}
+            </div>
+        </div>
+        {% endif %}
         {% else %}
-            <p class="empty-message"><span class="emoji-message">🙈</span><br>Nothing to see here...</p>
+        <p class="empty-message"><span class="emoji-message">🙈</span><br>Nothing to see here...</p>
         {% endfor %}
     </div>
 </div>

--- a/hushline/templates/inbox.html
+++ b/hushline/templates/inbox.html
@@ -2,32 +2,33 @@
 {% block title %}Inbox{% endblock %}
 
 {% block content %}
-    {% if messages %}
-        <h2>Inbox for {{ user.display_name or user.primary_username }}</h2>
-        {% for message in messages %}
-            <div class="message{% if 'BEGIN PGP MESSAGE' in message.content %} encrypted{% endif %}" data-encrypted-content="{{ message.content }}">
-                {% if not is_secondary %}
-                    {% if message.secondary_user_id %}
-                        {% set sender_info = secondary_usernames[message.secondary_user_id] %}
-                        <p class="message-label">📥 {{ sender_info.display_name or sender_info.username }}</p>
-                    {% elif secondary_usernames|length > 0 %}
-                        <p class="message-label">📥 {{ user.display_name or user.primary_username }}</p>
-                    {% endif %}
-                {% endif %}
-                <p class="decrypted-content">{{ message.content }}</p>
-                <div class="mailvelope-decryption-container" id="decryption-container-{{ message.id }}"></div>
-                <form action="{{ url_for('delete_message', message_id=message.id) }}" method="POST">
-                    <button type="submit" class="btn btn-danger" id="deleteMessageButton">Delete</button>
-                </form>
-            </div>
-        {% endfor %}
-    {% else %}
-        <div class="emptyState">
-            <img class="empty" src="{{ url_for('static', filename='img/app/empty.png') }}" alt="Empty Inbox">
-            <h1>Nothing to see here...</h1>
-            <p>No messages yet.</p>
-        </div>
+{% if messages %}
+<h2>Inbox for {{ user.display_name or user.primary_username }}</h2>
+{% for message in messages %}
+<div class="message{% if 'BEGIN PGP MESSAGE' in message.content %} encrypted{% endif %}"
+    data-encrypted-content="{{ message.content }}">
+    {% if not is_secondary %}
+    {% if message.secondary_user_id %}
+    {% set sender_info = secondary_usernames[message.secondary_user_id] %}
+    <p class="message-label">📥 {{ sender_info.display_name or sender_info.username }}</p>
+    {% elif secondary_usernames|length > 0 %}
+    <p class="message-label">📥 {{ user.display_name or user.primary_username }}</p>
     {% endif %}
+    {% endif %}
+    <p class="decrypted-content">{{ message.content }}</p>
+    <div class="mailvelope-decryption-container" id="decryption-container-{{ message.id }}"></div>
+    <form action="{{ url_for('delete_message', message_id=message.id) }}" method="POST">
+        <button type="submit" class="btn btn-danger" id="deleteMessageButton">Delete</button>
+    </form>
+</div>
+{% endfor %}
+{% else %}
+<div class="emptyState">
+    <img class="empty" src="{{ url_for('static', filename='img/app/empty.png') }}" alt="Empty Inbox">
+    <h1>Nothing to see here...</h1>
+    <p>No messages yet.</p>
+</div>
+{% endif %}
 {% endblock %}
 
 {% block scripts %}

--- a/hushline/templates/login.html
+++ b/hushline/templates/login.html
@@ -2,18 +2,18 @@
 {% block title %}Login{% endblock %}
 
 {% block content %}
-    <h2>Login</h2>
-    <form method="POST" action="/login">
-        {{ form.hidden_tag() }}
-        <div>
-            {{ form.username.label(for="username") }}
-            {{ form.username(id="username", required=True) }}
-        </div>
-        <div>
-            {{ form.password.label(for="password") }}
-            {{ form.password(id="password", required=True) }}
-        </div>
-        <button type="submit">Login</button>
-    </form>
-    <p>Don't have an account? <a href="/register">Register here</a></p>
+<h2>Login</h2>
+<form method="POST" action="/login">
+    {{ form.hidden_tag() }}
+    <div>
+        {{ form.username.label(for="username") }}
+        {{ form.username(id="username", required=True) }}
+    </div>
+    <div>
+        {{ form.password.label(for="password") }}
+        {{ form.password(id="password", required=True) }}
+    </div>
+    <button type="submit">Login</button>
+</form>
+<p>Don't have an account? <a href="/register">Register here</a></p>
 {% endblock %}

--- a/hushline/templates/login.html
+++ b/hushline/templates/login.html
@@ -15,5 +15,5 @@
 </div>
 <button type="submit">Login</button>
 </form>
-<p>Don't have an account? <a href="/register">Register here</a></p>
+<p>Don't have an account? <a href="{{ url_for('register') }}">Register here</a></p>
 {% endblock %}

--- a/hushline/templates/login.html
+++ b/hushline/templates/login.html
@@ -3,17 +3,17 @@
 
 {% block content %}
 <h2>Login</h2>
-<form method="POST" action="{{ url_for('login') }}"></form>
-{{ form.hidden_tag() }}
-<div>
-    {{ form.username.label(for="username") }}
-    {{ form.username(id="username", required=True) }}
-</div>
-<div>
-    {{ form.password.label(for="password") }}
-    {{ form.password(id="password", required=True) }}
-</div>
-<button type="submit">Login</button>
+<form method="POST" action="{{ url_for('login') }}">
+    {{ form.hidden_tag() }}
+    <div>
+        {{ form.username.label(for="username") }}
+        {{ form.username(id="username", required=True) }}
+    </div>
+    <div>
+        {{ form.password.label(for="password") }}
+        {{ form.password(id="password", required=True) }}
+    </div>
+    <button type="submit">Login</button>
 </form>
 <p>Don't have an account? <a href="{{ url_for('register') }}">Register here</a></p>
 {% endblock %}

--- a/hushline/templates/login.html
+++ b/hushline/templates/login.html
@@ -3,17 +3,17 @@
 
 {% block content %}
 <h2>Login</h2>
-<form method="POST" action="/login">
-    {{ form.hidden_tag() }}
-    <div>
-        {{ form.username.label(for="username") }}
-        {{ form.username(id="username", required=True) }}
-    </div>
-    <div>
-        {{ form.password.label(for="password") }}
-        {{ form.password(id="password", required=True) }}
-    </div>
-    <button type="submit">Login</button>
+<form method="POST" action="{{ url_for('login') }}"></form>
+{{ form.hidden_tag() }}
+<div>
+    {{ form.username.label(for="username") }}
+    {{ form.username(id="username", required=True) }}
+</div>
+<div>
+    {{ form.password.label(for="password") }}
+    {{ form.password(id="password", required=True) }}
+</div>
+<button type="submit">Login</button>
 </form>
 <p>Don't have an account? <a href="/register">Register here</a></p>
 {% endblock %}

--- a/hushline/templates/rate_limit_exceeded.html
+++ b/hushline/templates/rate_limit_exceeded.html
@@ -5,7 +5,7 @@
     <img class="empty" src="{{ url_for('static', filename='img/app/rate-limit.png') }}" alt="Rate Limit Exceeded">
     <h2>Rate Limit Exceeded</h2>
     <p>Light pierces shadows,<br>
-    Brave voice sparks hope's resurgence,<br>
-    New dawn from truth's stand.</p>
+        Brave voice sparks hope's resurgence,<br>
+        New dawn from truth's stand.</p>
 </div>
 {% endblock %}

--- a/hushline/templates/register.html
+++ b/hushline/templates/register.html
@@ -2,35 +2,35 @@
 {% block title %}Register{% endblock %}
 
 {% block content %}
-    <h2>Register</h2>
-    <form method="POST" action="/register">
-        {{ form.hidden_tag() }}
-        <div>
-            {{ form.username.label(for="username") }}
-            {{ form.username(id="username") }}
-            {% if form.username.errors %}
-                <span class="error">{{ form.username.errors[0] }}</span>
-            {% endif %}
-        </div>
-        <div>
-            {{ form.password.label(for="password") }}
-            {{ form.password(id="password") }}
-            {% if form.password.errors %}
-                {% for error in form.password.errors %}
-                    <span class="error">{{ error }}</li>
-                {% endfor %}
-            {% endif %}
-        </div>
-        {% if require_invite_code %}
-        <div>
-            {{ form.invite_code.label }}
-            {{ form.invite_code(size=32) }}
-            {% for error in form.invite_code.errors %}
-                <span>{{ error }}</span>
-            {% endfor %}
-        </div>
+<h2>Register</h2>
+<form method="POST" action="/register">
+    {{ form.hidden_tag() }}
+    <div>
+        {{ form.username.label(for="username") }}
+        {{ form.username(id="username") }}
+        {% if form.username.errors %}
+        <span class="error">{{ form.username.errors[0] }}</span>
         {% endif %}
-        <button type="submit">Register</button>
-    </form>
-    <p>Already have an account? <a href="/login">Login here</a></p>
+    </div>
+    <div>
+        {{ form.password.label(for="password") }}
+        {{ form.password(id="password") }}
+        {% if form.password.errors %}
+        {% for error in form.password.errors %}
+        <span class="error">{{ error }}</li>
+            {% endfor %}
+            {% endif %}
+    </div>
+    {% if require_invite_code %}
+    <div>
+        {{ form.invite_code.label }}
+        {{ form.invite_code(size=32) }}
+        {% for error in form.invite_code.errors %}
+        <span>{{ error }}</span>
+        {% endfor %}
+    </div>
+    {% endif %}
+    <button type="submit">Register</button>
+</form>
+<p>Already have an account? <a href="/login">Login here</a></p>
 {% endblock %}

--- a/hushline/templates/register.html
+++ b/hushline/templates/register.html
@@ -3,7 +3,7 @@
 
 {% block content %}
 <h2>Register</h2>
-<form method="POST" action="/register">
+<form method="POST" action="{{ url_for('register') }}">
     {{ form.hidden_tag() }}
     <div>
         {{ form.username.label(for="username") }}

--- a/hushline/templates/register.html
+++ b/hushline/templates/register.html
@@ -32,5 +32,5 @@
     {% endif %}
     <button type="submit">Register</button>
 </form>
-<p>Already have an account? <a href="/login">Login here</a></p>
+<p>Already have an account? <a href="{{ url_for('login') }}">Login here</a></p>
 {% endblock %}

--- a/hushline/templates/secondary_user_settings.html
+++ b/hushline/templates/secondary_user_settings.html
@@ -5,7 +5,8 @@
 
 <form method="POST">
     <label for="display_name">Display Name</label>
-    <input type="text" id="display_name" name="display_name" value="{{ secondary_username.display_name or '' }}" placeholder="Display Name">
+    <input type="text" id="display_name" name="display_name" value="{{ secondary_username.display_name or '' }}"
+        placeholder="Display Name">
     <button type="submit">Update</button>
 </form>
 {% endblock %}

--- a/hushline/templates/settings.html
+++ b/hushline/templates/settings.html
@@ -25,11 +25,11 @@
             </button>
         </li>
         {% if user.is_admin %}
-            <li>
-                <button type="button" class="tab admin-only" data-tab="admin">
-                    Admin
-                </button>
-            </li>
+        <li>
+            <button type="button" class="tab admin-only" data-tab="admin">
+                Admin
+            </button>
+        </li>
         {% endif %}
     </ul>
 </div>
@@ -44,16 +44,16 @@
 
         <h3>Update Display Name</h3>
         {% if user.is_verified %}
-            <p>⚠️ Changing your display name will result in losing your verification status.</p>
+        <p>⚠️ Changing your display name will result in losing your verification status.</p>
         {% endif %}
         <form method="POST" action="{{ url_for('settings.index') }}">
             {{ display_name_form.hidden_tag() }}
-                <label for="display_name">Display Name</label>
+            <label for="display_name">Display Name</label>
             {{ display_name_form.display_name(id='display_name') }}
             {% if display_name_form.display_name.errors %}
-                {% for error in display_name_form.display_name.errors %}
-                    <span class="error">{{ error }}</span>
-                {% endfor %}
+            {% for error in display_name_form.display_name.errors %}
+            <span class="error">{{ error }}</span>
+            {% endfor %}
             {% endif %}
             <button type="submit" name="update_display_name">Update Display Name</button>
         </form>
@@ -62,7 +62,7 @@
         <form method="POST" action="{{ url_for('settings.index') }}">
             {{ directory_visibility_form.hidden_tag() }}
             <div class="checkbox-group toggle-ui">
-                {{ directory_visibility_form.show_in_directory() }}    
+                {{ directory_visibility_form.show_in_directory() }}
                 <label for="show_in_directory" class="toggle-label">
                     Show on public directory
                     <div class="toggle">
@@ -90,16 +90,16 @@
         <!-- Change Username Section -->
         <h3>Change Username</h3>
         {% if user.is_verified %}
-            <p>⚠️ Changing your username will result in losing your verification status.</p>
+        <p>⚠️ Changing your username will result in losing your verification status.</p>
         {% endif %}
         <form method="POST" action="{{ url_for('settings.index') }}">
             {{ change_username_form.hidden_tag() }}
             <label for="new_username">Username</label>
             {{ change_username_form.new_username(id='new_username', value=session['username']) }}
             {% if change_username_form.new_username.errors %}
-                {% for error in change_username_form.new_username.errors %}
-                    <span class="error">{{ error }}</span>
-                {% endfor %}
+            {% for error in change_username_form.new_username.errors %}
+            <span class="error">{{ error }}</span>
+            {% endfor %}
             {% endif %}
             <button type="submit" name="change_username">Change Username</button>
         </form>
@@ -107,10 +107,10 @@
         <!-- Two-Factor Authentication Section -->
         <h3>Two-Factor Authentication</h3>
         {% if user.totp_secret %}
-            <!-- If 2FA is enabled, show the Disable 2FA button -->
-            <form method="GET" action="{{ url_for('settings.confirm_disable_2fa') }}">
-                <button type="submit">Disable 2FA</button>
-            </form>
+        <!-- If 2FA is enabled, show the Disable 2FA button -->
+        <form method="GET" action="{{ url_for('settings.confirm_disable_2fa') }}">
+            <button type="submit">Disable 2FA</button>
+        </form>
         {% else %}
         <!-- If 2FA is disabled, show the Enable 2FA button -->
         <form method="POST" action="{{ url_for('settings.toggle_2fa') }}">
@@ -121,19 +121,19 @@
         <h3>Change Password</h3>
         <form method="POST" action="{{ url_for('settings.change_password') }}">
             {{ change_password_form.hidden_tag() }}
-                <label for="old_password">Old Password</label>
+            <label for="old_password">Old Password</label>
             {{ change_password_form.old_password(id='old_password') }}
             {% if change_password_form.old_password.errors %}
-                {% for error in change_password_form.old_password.errors %}
-                    <span class="error">{{ error }}</span>
-                {% endfor %}
+            {% for error in change_password_form.old_password.errors %}
+            <span class="error">{{ error }}</span>
+            {% endfor %}
             {% endif %}
             <label for="new_password">New Password</label>
             {{ change_password_form.new_password(id="new_password") }}
             {% if change_password_form.new_password.errors %}
-                {% for error in change_password_form.new_password.errors %}
-                    <span class="error">{{ error }}</span>
-                {% endfor %}
+            {% for error in change_password_form.new_password.errors %}
+            <span class="error">{{ error }}</span>
+            {% endfor %}
             {% endif %}
             <button type="submit">Change Password</button>
         </form>
@@ -161,9 +161,9 @@
             <label for="pgp_key">Public PGP Key</label>
             {{ pgp_key_form.pgp_key(id='pgp_key') }}
             {% if pgp_key_form.pgp_key.errors %}
-                {% for error in pgp_key_form.pgp_key.errors %}
-                    <span class="error">{{ error }}</span>
-                {% endfor %}
+            {% for error in pgp_key_form.pgp_key.errors %}
+            <span class="error">{{ error }}</span>
+            {% endfor %}
             {% endif %}
             <button type="submit">Update PGP Key</button>
         </form>
@@ -179,47 +179,47 @@
     </div>
 
     {% if user.is_admin %}
-        <div id="admin" class="tab-content admin-only">
-            <div class="admin-highlights">
-                <div class="metric">
-                    <p>Users</p>
-                    <p>{{ user_count }}</p>
-                </div>
-                <div class="metric">
-                    <p>2FA Enabled</p>
-                    <p>{{ two_fa_count }}</p>
-                    <p>{{ two_fa_percentage | round(2) }}%</p>
-                </div>
-                <div class="metric">
-                    <p>PGP Enabled</p>
-                    <p>{{ pgp_key_count }}</p>
-                    <p>{{ pgp_key_percentage | round(2) }}%</p>
-                </div>
+    <div id="admin" class="tab-content admin-only">
+        <div class="admin-highlights">
+            <div class="metric">
+                <p>Users</p>
+                <p>{{ user_count }}</p>
             </div>
-            <h3>All Users</h3>
-            {% if all_users %}
-                {% for user in all_users %}
-                    <div class="user">
-                        <h4>{{ user.primary_username }}</h4>
-                        <p class="meta">Display Name: {{ user.display_name or 'No display name' }}</p>
-                        <p class="meta">Verified: {{ "✅ Yes" if user.is_verified else "👎 No" }}</p>
-                        <p class="meta">Admin: {{ "✅ Yes" if user.is_admin else "👎 No" }}</p>
-                        <div class="tableActions">
-                            <form action="/admin/toggle_verified/{{ user.id }}" method="POST">
-                                <button type="submit">Toggle Verified</button>
-                            </form>
-                            <form action="/admin/toggle_admin/{{ user.id }}" method="POST">
-                                <button type="submit">Toggle Admin</button>
-                            </form>
-                        </div>
-                    </div>
-                {% endfor %}
-                {% else %}
-                    <p>No users found.</p>
-            {% endif %}
+            <div class="metric">
+                <p>2FA Enabled</p>
+                <p>{{ two_fa_count }}</p>
+                <p>{{ two_fa_percentage | round(2) }}%</p>
+            </div>
+            <div class="metric">
+                <p>PGP Enabled</p>
+                <p>{{ pgp_key_count }}</p>
+                <p>{{ pgp_key_percentage | round(2) }}%</p>
+            </div>
         </div>
+        <h3>All Users</h3>
+        {% if all_users %}
+        {% for user in all_users %}
+        <div class="user">
+            <h4>{{ user.primary_username }}</h4>
+            <p class="meta">Display Name: {{ user.display_name or 'No display name' }}</p>
+            <p class="meta">Verified: {{ "✅ Yes" if user.is_verified else "👎 No" }}</p>
+            <p class="meta">Admin: {{ "✅ Yes" if user.is_admin else "👎 No" }}</p>
+            <div class="tableActions">
+                <form action="/admin/toggle_verified/{{ user.id }}" method="POST">
+                    <button type="submit">Toggle Verified</button>
+                </form>
+                <form action="/admin/toggle_admin/{{ user.id }}" method="POST">
+                    <button type="submit">Toggle Admin</button>
+                </form>
+            </div>
+        </div>
+        {% endfor %}
+        {% else %}
+        <p>No users found.</p>
         {% endif %}
     </div>
+    {% endif %}
+</div>
 {% endblock %}
 
 {% block scripts %}

--- a/hushline/templates/settings.html
+++ b/hushline/templates/settings.html
@@ -205,10 +205,10 @@
             <p class="meta">Verified: {{ "✅ Yes" if user.is_verified else "👎 No" }}</p>
             <p class="meta">Admin: {{ "✅ Yes" if user.is_admin else "👎 No" }}</p>
             <div class="tableActions">
-                <form action="/admin/toggle_verified/{{ user.id }}" method="POST">
+                <form action="{{ url_for('admin.toggle_verified', user_id=user.id) }}" method="POST">
                     <button type="submit">Toggle Verified</button>
                 </form>
-                <form action="/admin/toggle_admin/{{ user.id }}" method="POST">
+                <form action="{{ url_for('admin.toggle_admin', user_id=user.id) }}" method="POST">
                     <button type="submit">Toggle Admin</button>
                 </form>
             </div>

--- a/hushline/templates/show_qr_code.html
+++ b/hushline/templates/show_qr_code.html
@@ -2,17 +2,17 @@
 {% block title %}Settings{% endblock %}
 
 {% block content %}
-    <h2>Scan this QR Code with your 2FA app and enter the code</h2>
-    <img class="qr" src="{{ qr_code_img }}" alt="QR Code">
-    <p class="mono">Your pairing code: {{ user_secret }}</p>
-    <form method="POST" action="{{ url_for('settings.verify_2fa_setup') }}">
-        {{ form.hidden_tag() }}
-        <div>
-            {{ form.verification_code(size=6) }}
-            {% if form.verification_code.errors %}
-                <div class="error">{{ form.verification_code.errors[0] }}</div>
-            {% endif %}
-        </div>
-        <button type="submit">Verify Setup</button>
-    </form>
+<h2>Scan this QR Code with your 2FA app and enter the code</h2>
+<img class="qr" src="{{ qr_code_img }}" alt="QR Code">
+<p class="mono">Your pairing code: {{ user_secret }}</p>
+<form method="POST" action="{{ url_for('settings.verify_2fa_setup') }}">
+    {{ form.hidden_tag() }}
+    <div>
+        {{ form.verification_code(size=6) }}
+        {% if form.verification_code.errors %}
+        <div class="error">{{ form.verification_code.errors[0] }}</div>
+        {% endif %}
+    </div>
+    <button type="submit">Verify Setup</button>
+</form>
 {% endblock %}

--- a/hushline/templates/submit_message.html
+++ b/hushline/templates/submit_message.html
@@ -31,7 +31,7 @@
         target="_blank" rel="noopener noreferrer">Here's how they can do it</a>.</p>
 {% endif %}
 {% endif %}
-<form method="POST" action="/submit_message/{{ username }}" id="messageForm">
+<form method="POST" action="{{ url_for('submit_message', username=username) }}" id="messageForm">
     {{ form.hidden_tag() }}
     <label for="contact_method">Contact Method (Optional)</label>
     <input type="text" id="contact_method" name="contact_method"

--- a/hushline/templates/submit_message.html
+++ b/hushline/templates/submit_message.html
@@ -12,25 +12,33 @@
     {% endif %}
 </div>
 {% if current_user_id == user.id or (secondary_username and current_user_id == secondary_username.primary_user_id) %}
-    <p class="instr">Only visible to you: This is your public tip line. Share the address on your social media profiles, your website, or email signature. Ensuring that someone submitting a message trusts this form belongs to you is critical!</p>
-    {% if user.pgp_key %}
-        <p class="helper">🔐 Your message will be encrypted and only readable by you.</p>
-    {% else %}
-        <p class="helper">⚠️ Your messages will NOT be encrypted. If you expect messages to contain sensitive information, please <a href="https://github.com/scidsg/hushline/blob/main/docs/1-getting-started.md" target="_blank" rel="noopener noreferrer">add a public PGP key</a>.</p>
-    {% endif %}
+<p class="instr">Only visible to you: This is your public tip line. Share the address on your social media profiles,
+    your website, or email signature. Ensuring that someone submitting a message trusts this form belongs to you is
+    critical!</p>
+{% if user.pgp_key %}
+<p class="helper">🔐 Your message will be encrypted and only readable by you.</p>
 {% else %}
-    {% if user.pgp_key %}
-        <p class="helper">🔐 Your message will be encrypted and only readable by {{ display_name_or_username }}.</p>
-    {% else %}
-        <p class="helper">⚠️ Your message will NOT be encrypted. If this message is sensitive, ask {{ display_name_or_username }} to add a public PGP key. <a href="https://github.com/scidsg/hushline/blob/main/docs/1-getting-started.md" target="_blank" rel="noopener noreferrer">Here's how they can do it</a>.</p>
-    {% endif %}
+<p class="helper">⚠️ Your messages will NOT be encrypted. If you expect messages to contain sensitive information,
+    please <a href="https://github.com/scidsg/hushline/blob/main/docs/1-getting-started.md" target="_blank"
+        rel="noopener noreferrer">add a public PGP key</a>.</p>
+{% endif %}
+{% else %}
+{% if user.pgp_key %}
+<p class="helper">🔐 Your message will be encrypted and only readable by {{ display_name_or_username }}.</p>
+{% else %}
+<p class="helper">⚠️ Your message will NOT be encrypted. If this message is sensitive, ask {{ display_name_or_username
+    }} to add a public PGP key. <a href="https://github.com/scidsg/hushline/blob/main/docs/1-getting-started.md"
+        target="_blank" rel="noopener noreferrer">Here's how they can do it</a>.</p>
+{% endif %}
 {% endif %}
 <form method="POST" action="/submit_message/{{ username }}" id="messageForm">
     {{ form.hidden_tag() }}
     <label for="contact_method">Contact Method (Optional)</label>
-    <input type="text" id="contact_method" name="contact_method" value="{{ form.contact_method.data if form.contact_method.data is not none else '' }}">
+    <input type="text" id="contact_method" name="contact_method"
+        value="{{ form.contact_method.data if form.contact_method.data is not none else '' }}">
     <label for="content">Message</label>
-    <textarea id="content" maxlength="10000" name="content" required="" spellcheck="true">{{ form.content.data if form.content.data is not none else '' }}</textarea>
+    <textarea id="content" maxlength="10000" name="content" required=""
+        spellcheck="true">{{ form.content.data if form.content.data is not none else '' }}</textarea>
     <!-- Hidden field for public PGP key -->
     <input type="hidden" id="publicKey" value="{{ user.pgp_key }}" />
     <!-- Hidden field to indicate if the message was encrypted client-side -->

--- a/hushline/templates/verify_2fa_login.html
+++ b/hushline/templates/verify_2fa_login.html
@@ -2,17 +2,17 @@
 {% block title %}Enter 2FA Code{% endblock %}
 
 {% block content %}
-    <h2>Enter your 2FA Code</h2>
-    <p>🔑 Enter the six-digit code from your authenticator app.</p>
-    <form method="POST" action="{{ url_for('verify_2fa_login') }}">
-        {{ form.hidden_tag() }}
-        <div>
-            {{ form.verification_code.label }}
-            {{ form.verification_code(size=6) }}
-            {% if form.verification_code.errors %}
-                <div class="error">{{ form.verification_code.errors[0] }}</div>
-            {% endif %}
-        </div>
-        <button type="submit">Verify</button>
-    </form>
+<h2>Enter your 2FA Code</h2>
+<p>🔑 Enter the six-digit code from your authenticator app.</p>
+<form method="POST" action="{{ url_for('verify_2fa_login') }}">
+    {{ form.hidden_tag() }}
+    <div>
+        {{ form.verification_code.label }}
+        {{ form.verification_code(size=6) }}
+        {% if form.verification_code.errors %}
+        <div class="error">{{ form.verification_code.errors[0] }}</div>
+        {% endif %}
+    </div>
+    <button type="submit">Verify</button>
+</form>
 {% endblock %}


### PR DESCRIPTION
This is required for #407.

There are several links to routes that were hard-coded instead of using `url_for()`, which makes all of those links broken when there's a URL prefix. This fixes them all.

Also, it formats all of the HTML using the default Visual Studio Code HTML formatter.