### PR TITLE
Update style.css

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -689,6 +689,10 @@ img.upgrade {
     border-bottom: var(--border);
 }
 
+.tab-list li {
+    display: flex;
+}
+
 .tab-list::-webkit-scrollbar {
     display: none;
 }
@@ -697,7 +701,7 @@ img.upgrade {
 .tab  {
   min-height: 0px;
   min-width: auto;
-  padding: .75rem .625rem;
+  padding: 1rem .625rem;
   font-size: var(--font-size-base);
   font-family: var(--font-sans);
   white-space: nowrap;
@@ -721,7 +725,7 @@ img.upgrade {
 
 /* Create an active/current tablink class */
 .tab.active {
-    border-bottom: 3px solid var(--color-brand);
+    box-shadow: 0 -3px 0 inset var(--color-brand);
 }
 
 .tab.active  {


### PR DESCRIPTION
update CSS for better tab rendering.

Here you can see a gap under the tab on hover:
<img width="177" alt="Screenshot 2024-07-17 at 6 10 14 PM" src="https://github.com/user-attachments/assets/3611a7c2-bcdb-4bc5-b70c-8803b77f87cb">

Updated to take the full space and use an inset box shadow instead of a border-bottom.
<img width="161" alt="Screenshot 2024-07-17 at 6 10 05 PM" src="https://github.com/user-attachments/assets/c7a300d3-1edf-4378-9d01-f1c23d84e278">
