### PR TITLE
Use url_for for a few /static/img paths we missed

### DIFF
--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -35,7 +35,7 @@
     {% if messages %}
     <div class="flash-messages" role="alert">
         {% for message in messages %}
-          <div class="flash-message">{{ message }}</div>
+        <div class="flash-message">{{ message }}</div>
         {% endfor %}
     </div>
     {% endif %}
@@ -55,14 +55,15 @@
                     <li><a href="{{ url_for('submit_message', username=session.username) }}">Submit Message</a></li>
                     <li class="dropdown">
                         <button type="button" aria-expanded="false" aria-controls="dropdown-content" class="dropbtn">
-                            @{{ session['username'] }} <img class="dropdown-icon" src="/static/img/app/dropdown.png" alt="Dropdown">
+                            @{{ session['username'] }} <img class="dropdown-icon"
+                                src="{{ url_for('static', filename='img/app/dropdown.png') }}" alt="Dropdown">
                         </button>
-                         <div id="dropdown-content" class="dropdown-content" hidden>
+                        <div id="dropdown-content" class="dropdown-content" hidden>
                             <ul>
                                 <li><a href="{{ url_for('settings.index') }}">Settings</a></li>
                                 <li><a href="{{ url_for('logout') }}">Logout</a></li>
                             </ul>
-                        </div> 
+                        </div>
                     </li>
                     {% else %}
                     <li><a href="{{ url_for('login') }}">Login</a></li>

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -8,20 +8,18 @@
 <div class="directory-tabs">
     <ul class="tab-list" role="tablist">
         <li role="presentation">
-            <button type="button" class="tab active" data-tab="verified" role="tab" aria-selected="true" aria-controls="verified" id="verified-tab" type="button">Verified</button>
+            <button type="button" class="tab active" data-tab="verified" role="tab" aria-selected="true"
+                aria-controls="verified" id="verified-tab" type="button">Verified</button>
         </li>
         <li role="presentation">
-            <button type="button" class="tab" data-tab="all" role="tab" aria-selected="false" aria-controls="all" id="all-tab" type="button">All</button>
+            <button type="button" class="tab" data-tab="all" role="tab" aria-selected="false" aria-controls="all"
+                id="all-tab" type="button">All</button>
         </li>
     </ul>
 </div>
 <div class="search-box">
-    <label
-        id="searchIcon"
-        for="searchInput"
-        aria-label="Search users"
-    >
-        <img src="../static/img/app/icon-search.png" alt="">
+    <label id="searchIcon" for="searchInput" aria-label="Search users">
+        <img src="{{ url_for('static', filename='img/app/icon-search.png') }}" alt="">
     </label>
     <input type="text" id="searchInput" placeholder="Search users...">
     <button id="clearIcon" type="button" style="cursor: pointer;" aria-label="Clear search field">&times;</button>


### PR DESCRIPTION
This is required for #407.

There were two static images in the templates that weren't using `url_for()`, resulting in broken images. This should fix it. (I also auto-formatted the HTML.)

![image](https://github.com/user-attachments/assets/cfadb481-a825-4254-90a7-6ff337bd3aba)
