### PR TITLE
Visual Noise on Tabs and Buttons

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -720,7 +720,6 @@ img.upgrade {
   margin: 0;
   box-sizing: content-box;
   outline: none;
-  margin-bottom: -1px;
 }
 
 .tab:focus-within {
@@ -733,7 +732,8 @@ img.upgrade {
 
 /* Create an active/current tablink class */
 .tab.active {
-    box-shadow: 0 -3px 0 inset var(--color-brand);
+    box-shadow: 0 -2px 0 inset var(--color-brand);
+    border-bottom: 1px solid var(--color-brand);
 }
 
 .tab.active  {

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -713,13 +713,14 @@ img.upgrade {
   font-family: var(--font-sans);
   white-space: nowrap;
   border-radius: 0px;
-  border: 0px;
+  border: 1px solid transparent;
   background-color: transparent;
   color: var(--color-text);
   box-shadow: none;
   margin: 0;
   box-sizing: content-box;
   outline: none;
+  margin-bottom: -1px;
 }
 
 .tab:focus-within {

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -379,6 +379,7 @@ header nav ul {
     gap: 1.125rem;
     margin: 0;
     padding: 0;
+    align-items: center;
 }
 
 header nav li {
@@ -790,18 +791,19 @@ img.upgrade {
 .dropbtn {
   cursor: pointer;
   background: none;
-  padding: 0;
+  padding: .25rem 0;
   min-height: 0px;
   min-width: 0px;
   box-shadow: none;
   margin: 0;
   color: var(--color-text);
   font-family: var(--font-sans);
+  border: 1px solid transparent;
 }
 
 .dropbtn:focus-within {
     outline: none;
-    border: 2px solid var(--color-text);
+    border: 1px solid var(--color-brand);
 }
 
  .dropdown a {

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -846,6 +846,10 @@ a.dropbtn:hover {
     gap: 0;
 }
 
+.dropdown-content li {
+    width: 100%;
+}
+
 /* Change color of dropdown links on hover */
 .dropdown-content a:hover {background-color: #dfffff;}
 


### PR DESCRIPTION
All fixes are visual nits that occur during focus or hover states.

### Tabs
**Before:**
https://github.com/user-attachments/assets/c2917248-5c95-46a1-bfe2-15ba49738b9e

**After:**
https://github.com/user-attachments/assets/35b46f3b-462b-42d9-95f8-3f67c9716936

### Nav
**Before:**
https://github.com/user-attachments/assets/bce08be9-0881-414c-aeb9-bcfd1bba9a7f

**After:**
https://github.com/user-attachments/assets/a9252599-e0d5-42f5-93b3-2d07a9bf7fe9

### Dropdown Content
**Before:**
<img width="159" alt="Screenshot 2024-07-18 at 7 36 44 PM" src="https://github.com/user-attachments/assets/6859f4ae-e35d-4be1-b0ab-ee5dfa6c818d">

**After:**
<img width="133" alt="Screenshot 2024-07-18 at 7 50 59 PM" src="https://github.com/user-attachments/assets/aeadb934-c077-4fb9-9bee-39dd0d1a87a7">



