### PR TITLE
Update mobile nav alignment

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -1138,6 +1138,7 @@ p.helper {
         border-radius: .25rem;
         outline: var(--border);
         min-width: 140px;
+        align-items: start;
     }
 
     header nav .dropbtn {


### PR DESCRIPTION
the mobile nav menu's alignment was centered - updated to `start`.

**Before:**
![Screenshot 2024-07-19 at 1 31 32 PM](https://github.com/user-attachments/assets/04559462-5bfd-4032-9eeb-948e58352ece)
![Screenshot 2024-07-19 at 1 31 43 PM](https://github.com/user-attachments/assets/e2a435aa-b929-451d-bcb4-a8b1a2208a9f)

**After:**
![Screenshot 2024-07-19 at 1 31 57 PM](https://github.com/user-attachments/assets/640ef62d-40fe-48e6-b8b1-6b9d5f01d8e1)
![Screenshot 2024-07-19 at 1 32 03 PM](https://github.com/user-attachments/assets/538cca22-6c3b-4377-baaf-4bdd6297be39)
