### PR TITLE
Fix Empty Badge Container

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -701,6 +701,10 @@ img.upgrade {
     display: flex;
 }
 
+.tab-list li:first-of-type {
+    margin-left: -1px;
+}
+
 .tab-list::-webkit-scrollbar {
     display: none;
 }

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -80,7 +80,7 @@ h2 {
 }
 
 h1+p:not(.instr):not(.message):not(.badge):not(.landing-message),
-h2+p:not(.instr):not(.message):not(.badge):not(.landing-message) {
+h2+p:not(.instr):not(.message):not(.badge):not(.landing-message):not(.helper) {
     margin-top: .5rem;
     margin-bottom: 1rem;
 }
@@ -1020,6 +1020,10 @@ textarea#bio {
 p.helper {
     margin-bottom: 1.325rem;
     margin-top: .5rem
+}
+
+h2 + p.helper:not(h2 + .badgeContainer + p.helper) {
+    margin-top: .125rem;
 }
 
 .user-actions {

--- a/hushline/templates/submit_message.html
+++ b/hushline/templates/submit_message.html
@@ -3,6 +3,7 @@
 
 {% block content %}
 <h2 class="submit">Submit a message to {{ display_name_or_username }}</h2>
+{% if user.is_admin or user.is_verified %}
 <div class="badgeContainer">
     {% if user.is_admin %}
     <p class="badge">⚙️&nbsp;Admin</p>
@@ -12,6 +13,7 @@
     <a class="meta" href="https://github.com/scidsg/hushline/blob/main/docs/3-managed-service.md#verified-accounts" target="_blank" rel="noopener noreferrer" aria-label="Learn more about verified accounts.">Learn more</a>
     {% endif %}
 </div>
+{% endif %}
 {% if current_user_id == user.id or (secondary_username and current_user_id == secondary_username.primary_user_id) %}
 <p class="instr">Only visible to you: This is your public tip line. Share the address on your social media profiles,
     your website, or email signature. Ensuring that someone submitting a message trusts this form belongs to you is


### PR DESCRIPTION
Closes #427 

Removes the badge container div if the user is not an admin or verified + some spacing tweaks.