### PR TITLE
Fix the fix

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -701,10 +701,6 @@ img.upgrade {
     display: flex;
 }
 
-.tab-list li:first-of-type {
-    margin-left: -1px;
-}
-
 .tab-list::-webkit-scrollbar {
     display: none;
 }
@@ -717,7 +713,7 @@ img.upgrade {
   font-size: var(--font-size-base);
   font-family: var(--font-sans);
   white-space: nowrap;
-  border-radius: 0px;
+  border-radius: 0em;
   border: 1px solid transparent;
   background-color: transparent;
   color: var(--color-text);


### PR DESCRIPTION
Okay, correcting the fix from before. Basically, the 0px border-radius on the tab wasn't having the same effect as using 0em or 0rem. The gap that I tried fixing before is now more uniformly addressed.

![Screenshot 2024-07-19 at 4 50 41 PM](https://github.com/user-attachments/assets/5967898e-ecf8-4f92-907e-7db023e04ab9)
