### PR TITLE
fix intro gap for unauth directory

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -1023,6 +1023,10 @@ p.helper {
     margin-top: .5rem
 }
 
+p.section-intro {
+    margin-bottom: .75rem;
+}
+
 h2 + p.helper:not(h2 + .badgeContainer + p.helper) {
     margin-top: .125rem;
 }

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -3,7 +3,7 @@
 {% block content %}
 <h2>User Directory</h2>
 {% if not logged_in %}
-<p class="helper">👋 Welcome to Hush Line! Find users who've opted into being listed below.</p>
+<p class="helper section-intro">👋 Welcome to Hush Line! Find users who've opted into being listed below.</p>
 {% endif %}
 <div class="directory-tabs">
     <ul class="tab-list" role="tablist">


### PR DESCRIPTION
minimizes margin-bottom on directory intro.

before:
![Screenshot 2024-07-19 at 6 19 59 PM](https://github.com/user-attachments/assets/bc9dc970-8245-4e9f-bf66-ca6a0f685d17)


after:
![Screenshot 2024-07-19 at 6 23 41 PM](https://github.com/user-attachments/assets/4b0fc79b-7041-4ccc-81e4-c96a150bb06f)
