### PR TITLE
use the gha docker build cache

### DIFF
--- a/.github/workflows/build-and-deploy-release.yml
+++ b/.github/workflows/build-and-deploy-release.yml
@@ -29,6 +29,8 @@ jobs:
             ghcr.io/${{ github.repository }}/hushline:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}/hushline:release
           platforms: linux/amd64,linux/arm64
+	  cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -27,3 +27,5 @@ jobs:
           push: true
           tags: ghcr.io/${{ github.repository }}/hushline:latest
           platforms: linux/amd64,linux/arm64
+	  cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
Docker builds currently take ~30 minutes across both architectures. Container builds benefit from caching as the lower layers rarely change.  This PR enables reading from and writing to the github actions.