### PR TITLE
Update email tab label and PGP heading

### DIFF
--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -14,7 +14,7 @@
     <meta name="twitter:title" content="Hush Line">
     <meta name="twitter:description" content="A lightweight, secure, and anonymous tip line platform.">
     <meta name="twitter:image" content="https://hushline.app/design-system/images/social/social.png">
-    <title>{% block title %}{% endblock %} - Hushline</title>
+    <title>{% block title %}{% endblock %} - Hush Line</title>
     <link rel="apple-touch-icon" sizes="180x180"
         href="{{ url_for('static', filename='img/favicon/apple-touch-icon.png') }}">
     <link rel="icon" type="image/png" href="{{ url_for('static', filename='img/favicon/favicon-16x16.png') }}"

--- a/hushline/templates/settings.html
+++ b/hushline/templates/settings.html
@@ -16,7 +16,7 @@
         </li>
         <li role="presentation">
             <button type="button" class="tab" data-tab="email" role="tab" aria-selected="false" aria-controls="email" id="email-tab">
-                Email
+                Email &amp; Encryption
             </button>
         </li>
         <li role="presentation">
@@ -155,7 +155,10 @@
             <button type="submit">Update Settings</button>
         </form>
         <!-- PGP Key Section -->
-        <h3>Public PGP Key</h3>
+        <h3>Message Encryption</h3>
+        {% if not user.pgp_key %}
+        <p>🤔 Need help? <a href="https://github.com/scidsg/hushline/blob/main/docs/1-getting-started.md" rel="noopener noreferrer" target="_blank">Start with our docs.</a></p>
+        {% endif %}
         <form method="POST" action="{{ url_for('settings.update_pgp_key') }}">
             {{ pgp_key_form.hidden_tag() }}
             <label for="pgp_key">Public PGP Key</label>


### PR DESCRIPTION
- Update Email tab to read `Email & Encryption`.
- Add conditional help text for PGP linking to our getting started docs
- Fix global title formatting

https://github.com/user-attachments/assets/eb566055-9eae-4c5b-b995-a55a3d7aeac2

