### PR TITLE
reworked tab functions to be attached to window

### DIFF
--- a/hushline/static/js/directory.js
+++ b/hushline/static/js/directory.js
@@ -4,6 +4,7 @@ document.addEventListener('DOMContentLoaded', function () {
     // If it's /directory, then prefix is /
     const pathPrefix = window.location.pathname.split('/').slice(0, -1).join('/');
     const tabs = document.querySelectorAll('.tab');
+    const tabPanels = document.querySelectorAll('.tab-content');
     const searchInput = document.getElementById('searchInput');
     const clearIcon = document.getElementById('clearIcon');
     let userData = []; // Will hold the user data loaded from JSON
@@ -14,15 +15,6 @@ document.addEventListener('DOMContentLoaded', function () {
         searchInput.placeholder = `Search ${activeTab === 'verified' ? 'verified ' : ''}users...`;
     }
 
-    function searchUsers() {
-        const query = searchInput.value.trim().toLowerCase();
-        const tab = document.querySelector('.tab.active').getAttribute('data-tab');
-        const filteredUsers = userData.filter(user => {
-            const userText = `${user.primary_username} ${user.display_name || ''} ${user.bio || ''}`.toLowerCase();
-            return userText.includes(query) && (tab === 'all' || (user.is_verified && tab === 'verified'));
-        });
-        updateUsersList(filteredUsers);
-    }
 
     function loadData() {
         fetch(`${pathPrefix}/directory/users.json`)
@@ -127,14 +119,6 @@ document.addEventListener('DOMContentLoaded', function () {
         clearIcon.style.visibility = query.length ? 'visible' : 'hidden';
     }
 
-    tabs.forEach(tab => {
-        tab.addEventListener('click', function() {
-            setTimeout(function() {
-                handleSearchInput(); // Filter again when tab changes
-                updatePlaceholder();
-            })
-        });
-    });
 
     searchInput.addEventListener('input', handleSearchInput);
     clearIcon.addEventListener('click', function () {
@@ -143,6 +127,17 @@ document.addEventListener('DOMContentLoaded', function () {
         handleSearchInput();
     });
 
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', function(e) {
+            window.activateTab(e, tabs, tabPanels);
+            handleSearchInput(); // Filter again when tab changes
+            updatePlaceholder();
+        });
+        tab.addEventListener('keydown', function(e) {
+            window.handleKeydown(e)
+        });
+    });
 
 
     function createReportEventListeners(selector) {

--- a/hushline/static/js/global.js
+++ b/hushline/static/js/global.js
@@ -43,32 +43,10 @@ function navController() {
 }
 
 
-function tabController() {
-    const tabs = document.querySelectorAll('.tab');
 
-    if(!tabs) return; // Exit if no tabs found
-
-    function activateTab(event) {    
-        const selectedTab = event.target;
-        const targetPanel = document.getElementById(selectedTab.getAttribute('aria-controls'));
-
-        // Deselect all tabs and hide all panels
-        tabs.forEach(tab => {
-            tab.setAttribute('aria-selected', 'false');
-            tab.classList.remove('active');
-            const panel = document.getElementById(tab.getAttribute('aria-controls'));
-            panel.hidden = true;
-            panel.style.display = 'none';
-        });
-
-         // Select the clicked tab and show the corresponding panel
-         selectedTab.setAttribute('aria-selected', 'true');
-         selectedTab.classList.add('active');
-         targetPanel.hidden = false;
-         targetPanel.style.display = 'block';
-    }
-
-    function handleKeydown(event) {
+document.addEventListener('DOMContentLoaded', function() {
+    navController();
+    window.handleKeydown = function (event) {
         const { key } = event;
         const currentTab = event.target;
         let newTab;
@@ -97,13 +75,30 @@ function tabController() {
         }
     }
 
-    tabs.forEach(tab => {
-        tab.addEventListener('click', activateTab);
-        tab.addEventListener('keydown', handleKeydown);
-    });
-}
+    window.activateTab = function (event, tabs, tabPanels) {    
+        const selectedTab = event.target;
+        const targetPanel = document.getElementById(selectedTab.getAttribute('aria-controls'));
 
-document.addEventListener('DOMContentLoaded', function() {
-    navController();
-    tabController();
+        tabPanels.forEach(panel => {
+            panel.hidden = true;
+            panel.style.display = 'none';
+            panel.classList.remove('active');
+        });
+
+        // Deselect all tabs and hide all panels
+        tabs.forEach(tab => {
+            tab.setAttribute('aria-selected', 'false');
+            tab.classList.remove('active');
+            const panel = document.getElementById(tab.getAttribute('aria-controls'));
+            panel.hidden = true;
+            panel.style.display = 'none';
+        });
+
+         // Select the clicked tab and show the corresponding panel
+         selectedTab.setAttribute('aria-selected', 'true');
+         selectedTab.classList.add('active');
+         targetPanel.hidden = false;
+         targetPanel.style.display = 'block';
+         targetPanel.classList.add('active');
+    }
 });

--- a/hushline/static/js/settings.js
+++ b/hushline/static/js/settings.js
@@ -1,4 +1,6 @@
 document.addEventListener('DOMContentLoaded', function() {
+    const tabs = document.querySelectorAll('.tab');
+    const tabPanels = document.querySelectorAll('.tab-content');
     const bioCountEl = document.querySelector('.bio-count');
     // Deletion account confirmation logic
     document.getElementById('deleteAccountButton')?.addEventListener('click', function(event) {
@@ -17,5 +19,14 @@ document.addEventListener('DOMContentLoaded', function() {
 
     document.getElementById('bio').addEventListener('keyup', function(e) {
         bioCountEl.textContent = e.target.value.length;
+    });
+
+    tabs.forEach(tab => {
+        tab.addEventListener('click', function(e) {
+            window.activateTab(e, tabs, tabPanels);
+        });
+        tab.addEventListener('keydown', function(e) {
+            window.handleKeydown(e)
+        });
     });
 });


### PR DESCRIPTION
Resolved issue where if you were to go to the `All` tab the highlight functionality wouldn't work. 

In this added the tab functions to be attached to the `window` so we can call these functions in various JS files.

Example:  `directory.js` can call these  `tab functions` that live in `global.js` and also run other functions inside of these events like:  `handleSearchInput` and `updatePlaceholder`).

``` 
tabs.forEach(tab => {
        tab.addEventListener('click', function(e) {
            window.activateTab(e, tabs, tabPanels);
            handleSearchInput(); // Filter again when tab changes
            updatePlaceholder();
        });
        tab.addEventListener('keydown', function(e) {
            window.handleKeydown(e)
        });
});

```