### PR TITLE
Add Bio to Submit Message Page

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -93,6 +93,11 @@ h2.submit + p {
     margin-top: 1rem;
 }
 
+h2.submit ~ .instr {
+    margin-bottom: .5rem;
+    margin-top: .5rem
+}
+
 h3 {
     font-size: var(--font-size-3);
 }

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -98,6 +98,10 @@ h2.submit ~ .instr {
     margin-top: .5rem
 }
 
+h2.submit ~ .bio {
+    margin: .75rem 0 1rem 0;
+}
+
 h3 {
     font-size: var(--font-size-3);
 }

--- a/hushline/templates/submit_message.html
+++ b/hushline/templates/submit_message.html
@@ -14,25 +14,13 @@
     {% endif %}
 </div>
 {% endif %}
+{% if user.bio %}
+<p class="bio">{{ user.bio }}</p>
+{% endif %}
 {% if current_user_id == user.id or (secondary_username and current_user_id == secondary_username.primary_user_id) %}
 <p class="instr">Only visible to you: This is your public tip line. Share the address on your social media profiles,
     your website, or email signature. Ensuring that someone submitting a message trusts this form belongs to you is
     critical!</p>
-{% if user.pgp_key %}
-<p class="helper">🔐 Your message will be encrypted and only readable by you.</p>
-{% else %}
-<p class="helper">⚠️ Your messages will NOT be encrypted. If you expect messages to contain sensitive information,
-    please <a href="https://github.com/scidsg/hushline/blob/main/docs/1-getting-started.md" target="_blank"
-        rel="noopener noreferrer">add a public PGP key</a>.</p>
-{% endif %}
-{% else %}
-{% if user.pgp_key %}
-<p class="helper">🔐 Your message will be encrypted and only readable by {{ display_name_or_username }}.</p>
-{% else %}
-<p class="helper">⚠️ Your message will NOT be encrypted. If this message is sensitive, ask {{ display_name_or_username
-    }} to add a public PGP key. <a href="https://github.com/scidsg/hushline/blob/main/docs/1-getting-started.md"
-        target="_blank" rel="noopener noreferrer">Here's how they can do it</a>.</p>
-{% endif %}
 {% endif %}
 <form method="POST" action="{{ url_for('submit_message', username=username) }}" id="messageForm">
     {{ form.hidden_tag() }}
@@ -46,6 +34,23 @@
     <input type="hidden" id="publicKey" value="{{ user.pgp_key }}" />
     <!-- Hidden field to indicate if the message was encrypted client-side -->
     <input type="hidden" name="client_side_encrypted" id="clientSideEncrypted" value="false">
+    {% if current_user_id == user.id or (secondary_username and current_user_id == secondary_username.primary_user_id) %}
+{% if user.pgp_key %}
+<p class="helper meta">🔐 Your message will be encrypted and only readable by you.</p>
+{% else %}
+<p class="helper meta">⚠️ Your messages will NOT be encrypted. If you expect messages to contain sensitive information,
+    please <a href="https://github.com/scidsg/hushline/blob/main/docs/1-getting-started.md" target="_blank"
+        rel="noopener noreferrer">add a public PGP key</a>.</p>
+{% endif %}
+{% else %}
+{% if user.pgp_key %}
+<p class="helper meta">🔐 Your message will be encrypted and only readable by {{ display_name_or_username }}.</p>
+{% else %}
+<p class="helper meta">⚠️ Your message will NOT be encrypted. If this message is sensitive, ask {{ display_name_or_username
+    }} to add a public PGP key. <a href="https://github.com/scidsg/hushline/blob/main/docs/1-getting-started.md"
+        target="_blank" rel="noopener noreferrer">Here's how they can do it</a>.</p>
+{% endif %}
+{% endif %}
     <button type="submit" id="submitBtn">Send Message</button>
 </form>
 {% endblock %}


### PR DESCRIPTION
Changes include:
- Add bio to submit message page
- Move encryption status above submit button

<img width="667" alt="Screenshot 2024-07-21 at 10 23 35 PM" src="https://github.com/user-attachments/assets/5c47aca4-53da-4d8a-ade9-941d95dcfa89">
