### PR TITLE
ci: enable basic tests on all branches & the sharing of results

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,11 +3,6 @@ name: Run Tests
 
 on:
   push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
 
 jobs:
  run-lint-and-tests:


### PR DESCRIPTION
1. It would make sharing test results on PR branches easier if the basic test suite was enabled on all pushes to any branch.

2. The pull_request setting is redundant, since a push must occur for a branch to be viewable on GitHub, so that can be removed.

Sharing [test results](https://github.com/rmlibre/hushline/actions/runs/10049396828/job/27775340599) like these would be enabled by this change.