### PR TITLE
Adjusting Line Height for Measured Letterform Height

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -125,7 +125,7 @@ a {
 p {
     word-break: break-word;
     margin: 1rem 0;
-    line-height: 1.5;
+    line-height: 1.40625;
 }
 
 p.instr {
@@ -405,7 +405,7 @@ label {
 p.meta {
     font-size: var(--font-size-small);
     color: var(--color-text-light);
-    line-height: 1.5;
+    line-height: 1.40625;
 }
 
 h3 + p.meta {

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -23,6 +23,7 @@
   --font-size-3: 1.5rem;
   --font-size-4: 1.125rem;
 
+  --line-height-base: 1.40625;
 }
 
 @font-face {
@@ -125,7 +126,7 @@ a {
 p {
     word-break: break-word;
     margin: 1rem 0;
-    line-height: 1.40625;
+    line-height: var(--line-height-base);
 }
 
 p.instr {
@@ -405,7 +406,7 @@ label {
 p.meta {
     font-size: var(--font-size-small);
     color: var(--color-text-light);
-    line-height: 1.40625;
+    line-height: var(--line-height-base)
 }
 
 h3 + p.meta {


### PR DESCRIPTION
While the base font size is 1rem, which should be 16px, measuring the actual letterforms shows that the size is actually 15px. With accessibility standards calling for line-height to be 1.5/150% of the letterform, the adjusted line-height is 22.5px. not 24px. Instead of multiplying at 1.5, the real line-height should be 1.40625rem, which is set as a new css variable. 

<img width="962" alt="Screenshot 2024-07-22 at 9 21 14 PM" src="https://github.com/user-attachments/assets/ccf8017c-b16c-4fb5-87c7-35a4db1fd18d">

