### PR TITLE
generate pseudo-random username for each 2fa test

### DIFF
--- a/tests/test_2fa.py
+++ b/tests/test_2fa.py
@@ -10,14 +10,21 @@ from flask.testing import FlaskClient
 
 LoginData: TypeAlias = dict[str, str]
 
+
 @pytest.fixture()
-def nonce(len: int = 15) -> str:
-  return ''.join(random.choices(string.ascii_lowercase +  # noqa: S311
-                             string.digits, k=len))
+def nonce(length: int = 15) -> str:
+    return "".join(
+        random.choices(  # noqa: S311
+            string.ascii_lowercase + string.digits,
+            k=length,
+        )
+    )
+
 
 @pytest.fixture()
 def login_data(nonce: str) -> LoginData:
-  return {"username": "test_user_" + nonce, "password": "SecurePassword123!"}
+    return {"username": "test_user_" + nonce, "password": "SecurePassword123!"}
+
 
 def test_enable_2fa(client: FlaskClient) -> None:
     user, totp_secret = register_user_2fa(client, "test_user", "SecurePassword123!")

--- a/tests/test_2fa.py
+++ b/tests/test_2fa.py
@@ -11,13 +11,13 @@ from flask.testing import FlaskClient
 LoginData: TypeAlias = dict[str, str]
 
 @pytest.fixture()
-def nonce(len: int = 7) -> str:
+def nonce(len: int = 15) -> str:
   return ''.join(random.choices(string.ascii_lowercase +  # noqa: S311
                              string.digits, k=len))
 
 @pytest.fixture()
 def login_data(nonce: str) -> LoginData:
-  return {"username": "test_user" + nonce, "password": "SecurePassword123!"}
+  return {"username": "test_user_" + nonce, "password": "SecurePassword123!"}
 
 def test_enable_2fa(client: FlaskClient) -> None:
     user, totp_secret = register_user_2fa(client, "test_user", "SecurePassword123!")

--- a/tests/test_2fa.py
+++ b/tests/test_2fa.py
@@ -1,16 +1,29 @@
+import random
 import secrets
+import string
+from typing import TypeAlias
 
 import pyotp
+import pytest
 from auth_helper import register_user_2fa
 from flask.testing import FlaskClient
 
+LoginData: TypeAlias = dict[str, str]
+
+@pytest.fixture()
+def nonce(len: int = 7) -> str:
+  return ''.join(random.choices(string.ascii_lowercase +  # noqa: S311
+                             string.digits, k=len))
+
+@pytest.fixture()
+def login_data(nonce: str) -> LoginData:
+  return {"username": "test_user" + nonce, "password": "SecurePassword123!"}
 
 def test_enable_2fa(client: FlaskClient) -> None:
     user, totp_secret = register_user_2fa(client, "test_user", "SecurePassword123!")
 
 
-def test_valid_2fa_should_login(client: FlaskClient) -> None:
-    login_data = {"username": "test_user", "password": "SecurePassword123!"}
+def test_valid_2fa_should_login(client: FlaskClient, login_data: LoginData) -> None:
     user, totp_secret = register_user_2fa(client, login_data["username"], login_data["password"])
 
     # Logging in should now require 2FA
@@ -28,8 +41,7 @@ def test_valid_2fa_should_login(client: FlaskClient) -> None:
     assert valid_2fa_response.status_code == 200
 
 
-def test_invalid_2fa_should_not_login(client: FlaskClient) -> None:
-    login_data = {"username": "test_user", "password": "SecurePassword123!"}
+def test_invalid_2fa_should_not_login(client: FlaskClient, login_data: LoginData) -> None:
     user, totp_secret = register_user_2fa(client, login_data["username"], login_data["password"])
 
     # Start logging in
@@ -54,8 +66,7 @@ def test_invalid_2fa_should_not_login(client: FlaskClient) -> None:
     assert "Invalid 2FA code" in invalid_2fa_response.text
 
 
-def test_reuse_of_2fa_code_should_fail(client: FlaskClient) -> None:
-    login_data = {"username": "test_user", "password": "SecurePassword123!"}
+def test_reuse_of_2fa_code_should_fail(client: FlaskClient, login_data: LoginData) -> None:
     user, totp_secret = register_user_2fa(client, login_data["username"], login_data["password"])
 
     # Make sure we have a valid verification code
@@ -85,8 +96,7 @@ def test_reuse_of_2fa_code_should_fail(client: FlaskClient) -> None:
     assert valid_2fa_response.status_code == 429
 
 
-def test_limit_invalid_2fa_guesses(client: FlaskClient) -> None:
-    login_data = {"username": "test_user", "password": "SecurePassword123!"}
+def test_limit_invalid_2fa_guesses(client: FlaskClient, login_data: LoginData) -> None:
     user, totp_secret = register_user_2fa(client, login_data["username"], login_data["password"])
 
     # Make sure we have a valid verification code


### PR DESCRIPTION
2fa tests were all using the same test user which seems to occasionally cause issues related to unintended otp rate-limiting. This PR passes a login_data fixture to each test with a pseudo-random username to improve isolation between the tests and avoid accidental rate-limiting.