### PR TITLE
ci: run basic required tests on 'main' when PRs target it

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -3,6 +3,9 @@ name: Run Tests
 
 on:
   push:
+  pull_request:
+    branches:
+      - main
 
 jobs:
  run-lint-and-tests:


### PR DESCRIPTION
Add the 'pull_request' event trigger in 'tests.yml' for PRs which target 'main' to automatically cause the required basic tests to run.


#### Passing workflows:

- [x] [Run Linters & Tests](https://github.com/rmlibre/hushline/actions/runs/10167849272/job/28121122738) on (https://github.com/scidsg/hushline/pull/467/commits/2cafb61c7f03ed8c3d3180b7b0b27718cdb53f83)