### PR TITLE
fix: ensure new passwords are distinct

### DIFF
--- a/hushline/forms.py
+++ b/hushline/forms.py
@@ -1,4 +1,6 @@
 import re
+from hmac import compare_digest as bytes_are_equal
+from typing import Callable
 
 from flask_wtf import FlaskForm
 from wtforms import Field, Form, StringField
@@ -23,6 +25,16 @@ class ComplexPassword:
             and re.search("[^A-Za-z0-9]", password)
         ):
             raise ValidationError(self.message)
+
+
+def is_valid_password_swap(
+    *, check_password: Callable[[str], bool], old_password: str, new_password: str
+) -> bool:
+    # since the passwords can be of different lengths, the equality test must occur *iif*
+    # the correctness test passes, since timing differences leak length information
+    if check_password(old_password):
+        return not bytes_are_equal(old_password.encode(), new_password.encode())
+    return False
 
 
 class TwoFactorForm(FlaskForm):

--- a/hushline/forms.py
+++ b/hushline/forms.py
@@ -7,6 +7,10 @@ from wtforms import Field, Form, StringField
 from wtforms.validators import DataRequired, Length, ValidationError
 
 
+class WrongPassword(ValueError):
+    pass
+
+
 class ComplexPassword:
     def __init__(self, message: str | None = None) -> None:
         if not message:
@@ -34,7 +38,7 @@ def is_valid_password_swap(
     # the correctness test passes, since timing differences leak length information
     if check_password(old_password):
         return not bytes_are_equal(old_password.encode(), new_password.encode())
-    return False
+    raise WrongPassword
 
 
 class TwoFactorForm(FlaskForm):

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -183,9 +183,10 @@ def create_blueprint() -> Blueprint:
                 ):
                     user.password_hash = change_password_form.new_password.data
                     db.session.commit()
-                    flash("👍 Password changed successfully.")
-                else:
-                    flash("⛔️ Incorrect old password.")
+                    flash("👍 Password successfully changed. Please log in again.", "success")
+                    # Redirect to the login page for re-authentication
+                    return redirect(url_for("login"))
+                flash("⛔️ Incorrect old password.", "error")
                 return redirect(url_for("settings"))
 
             # Check if user is admin and add admin-specific data
@@ -260,7 +261,7 @@ def create_blueprint() -> Blueprint:
 
         change_password_form = ChangePasswordForm(request.form)
         if not change_password_form.validate_on_submit():
-            flash("New password is invalid.")
+            flash("⛔️ New password is invalid.", "error")
             return redirect(url_for("settings.index"))
 
         # Verify the old password
@@ -273,12 +274,10 @@ def create_blueprint() -> Blueprint:
             user.password_hash = change_password_form.new_password.data
             db.session.commit()
             session.clear()  # Clears the session, logging the user out
-            flash(
-                "👍 Password successfully changed. Please log in again.",
-                "success",
-            )
-            return redirect(url_for("login"))  # Redirect to the login page for re-authentication
-        flash("Incorrect old password.", "error")
+            flash("👍 Password successfully changed. Please log in again.", "success")
+            # Redirect to the login page for re-authentication
+            return redirect(url_for("login"))
+        flash("⛔️ Incorrect old password.", "error")
         return redirect(url_for("settings.index"))
 
     @bp.route("/change-username", methods=["POST"])

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -260,19 +260,18 @@ def create_blueprint() -> Blueprint:
             return redirect(url_for("settings.index"))
 
         # Verify the old password
-        if not user.check_password(change_password_form.old_password.data):
-            flash("Incorrect old password.", "error")
-            return redirect(url_for("settings.index"))
-
-        # Set the new password
-        user.password_hash = change_password_form.new_password.data
-        db.session.commit()
-        session.clear()  # Clears the session, logging the user out
-        flash(
-            "👍 Password successfully changed. Please log in again.",
-            "success",
-        )
-        return redirect(url_for("login"))  # Redirect to the login page for re-authentication
+        if user.check_password(change_password_form.old_password.data):
+            # Set the new password
+            user.password_hash = change_password_form.new_password.data
+            db.session.commit()
+            session.clear()  # Clears the session, logging the user out
+            flash(
+                "👍 Password successfully changed. Please log in again.",
+                "success",
+            )
+            return redirect(url_for("login"))  # Redirect to the login page for re-authentication
+        flash("Incorrect old password.", "error")
+        return redirect(url_for("settings.index"))
 
     @bp.route("/change-username", methods=["POST"])
     @require_2fa

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -21,7 +21,7 @@ from wtforms.validators import DataRequired, Length
 
 from .crypto import is_valid_pgp_key
 from .db import db
-from .forms import ComplexPassword, TwoFactorForm
+from .forms import ComplexPassword, TwoFactorForm, is_valid_password_swap
 from .model import Message, SecondaryUsername, User
 from .utils import require_2fa
 
@@ -176,7 +176,11 @@ def create_blueprint() -> Blueprint:
 
             # Handle Change Password Form Submission
             if change_password_form.validate_on_submit():
-                if user.check_password(change_password_form.old_password.data):
+                if is_valid_password_swap(
+                    check_password=user.check_password,
+                    old_password=change_password_form.old_password.data,
+                    new_password=change_password_form.new_password.data,
+                ):
                     user.password_hash = change_password_form.new_password.data
                     db.session.commit()
                     flash("👍 Password changed successfully.")
@@ -260,7 +264,11 @@ def create_blueprint() -> Blueprint:
             return redirect(url_for("settings.index"))
 
         # Verify the old password
-        if user.check_password(change_password_form.old_password.data):
+        if is_valid_password_swap(
+            check_password=user.check_password,
+            old_password=change_password_form.old_password.data,
+            new_password=change_password_form.new_password.data,
+        ):
             # Set the new password
             user.password_hash = change_password_form.new_password.data
             db.session.commit()

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -110,6 +110,20 @@ def test_change_password(client: FlaskClient) -> None:
     assert logged_in_user is not None
     assert user.id == logged_in_user.id
 
+    # Submit POST request to verify new password must be distinct from the previous
+    response = client.post(
+        "/settings/change-password",
+        data={
+            "old_password": original_password,
+            "new_password": original_password,
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "settings" in response.request.url
+    assert b"Incorrect old password" in response.data
+    assert b"Password successfully changed" not in response.data
+
     # Submit POST request to change the username & verify update was successful
     response = client.post(
         "/settings/change-password",

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -121,7 +121,7 @@ def test_change_password(client: FlaskClient) -> None:
     )
     assert response.status_code == 200
     assert "settings" in response.request.url
-    assert b"Incorrect old password" in response.data
+    assert b"New password is invalid" in response.data
     assert b"Password successfully changed" not in response.data
 
     # Submit POST request to change the username & verify update was successful


### PR DESCRIPTION
This PR ensures that the change password flow is consistent, safely & consistently flashes relevant error messages, and doesn't allow for a change to an identical password.


#### Passing Workflows:

- [x] [Run Linters & Tests](https://github.com/rmlibre/hushline/actions/runs/10187133104/job/28180490773) on (https://github.com/scidsg/hushline/pull/468/commits/9dfcdc5e7c84a8467b7d9260f004c8680098f3b2)