### PR TITLE
Adopt sql alchemy session api

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,4 +42,4 @@ endif
 .PHONY: test
 test: ## Run the test suite
 	. ./dev_env.sh && \
-	poetry run pytest -vv tests -p no:warnings
+	poetry run pytest -vv tests

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -54,7 +54,7 @@ def create_app() -> Flask:
     @app.context_processor
     def inject_user() -> dict[str, Any]:
         if "user_id" in session:
-            user = User.query.get(session["user_id"])
+            user = db.session.get(User, session["user_id"])
             return {"user": user}
         return {}
 

--- a/hushline/admin.py
+++ b/hushline/admin.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, flash, redirect, session, url_for
+from flask import Blueprint, abort, flash, redirect, session, url_for
 from werkzeug.wrappers.response import Response
 
 from .db import db
@@ -16,7 +16,9 @@ def create_blueprint() -> Blueprint:
             flash("Unauthorized access.", "error")
             return redirect(url_for("settings.index"))
 
-        user = User.query.get_or_404(user_id)
+        user = db.session.get(User, user_id)
+        if user is None:
+            abort(404)
         user.is_verified = not user.is_verified
         db.session.commit()
         flash("✅ User verification status toggled.", "success")
@@ -29,7 +31,9 @@ def create_blueprint() -> Blueprint:
             flash("Unauthorized access.", "error")
             return redirect(url_for("settings.index"))
 
-        user = User.query.get_or_404(user_id)
+        user = db.session.get(User, user_id)
+        if user is None:
+            abort(404)
         user.is_admin = not user.is_admin
         db.session.commit()
         flash("✅ User admin status toggled.", "success")

--- a/hushline/make_admin.py
+++ b/hushline/make_admin.py
@@ -9,11 +9,13 @@ from hushline.model import SecondaryUsername, User
 
 def toggle_admin(username: str) -> None:
     # First, try to find a primary user
-    user = User.query.filter_by(primary_username=username).first()
+    user = db.session.scalars(db.select(User).filter_by(primary_username=username).limit(1)).first()
 
     # If not found, try to find a secondary user
     if not user:
-        secondary_username = SecondaryUsername.query.filter_by(username=username).first()
+        secondary_username = db.session.scalars(
+            db.select(SecondaryUsername).filter_by(username=username).limit(1)
+        ).first()
         if secondary_username:
             user = secondary_username.primary_user
         else:

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -104,7 +104,7 @@ def init_app(app: Flask) -> None:
             messages = db.session.scalars(
                 db.select(Message).filter_by(user_id=logged_in_user.id).order_by(Message.id.desc())
             ).all()
-            secondary_users_dict = {su.id: su for su in list(logged_in_user.secondary_usernames)}
+            secondary_users_dict = {su.id: su for su in logged_in_user.secondary_usernames}
 
         return render_template(
             "inbox.html",
@@ -453,7 +453,7 @@ def init_app(app: Flask) -> None:
         return {"logged_in": logged_in}
 
     @app.route("/directory/users.json")
-    def directory_users() -> list[dict[str, str]]:
+    def directory_users() -> list[dict[str, str | bool | None]]:
         return [
             {
                 "primary_username": user.primary_username,

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -2,7 +2,7 @@ import logging
 import os
 import re
 import socket
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import pyotp
 from flask import (
@@ -231,7 +231,9 @@ def init_app(app: Flask) -> None:
                 invite_code = db.session.scalars(
                     select(InviteCode).filter_by(code=invite_code_input).limit(1)
                 ).first()
-                if not invite_code or invite_code.expiration_date < datetime.utcnow():
+                if not invite_code or invite_code.expiration_date.replace(
+                    tzinfo=UTC
+                ) < datetime.now(UTC):
                     flash("⛔️ Invalid or expired invite code.", "error")
                     return (
                         render_template(

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -88,7 +88,7 @@ def create_blueprint() -> Blueprint:
             show_in_directory=user.show_in_directory
         )
         secondary_usernames = db.session.scalars(
-            select(SecondaryUsername).filter_by(user_id=user.id)
+            db.select(SecondaryUsername).filter_by(user_id=user.id)
         ).all()
         change_password_form = ChangePasswordForm()
         change_username_form = ChangeUsernameForm()
@@ -119,20 +119,20 @@ def create_blueprint() -> Blueprint:
 
         # Check if user is admin and add admin-specific data
         if user.is_admin:
-            user_count = db.session.scalar(func.count(User.id))
+            user_count = db.session.scalar(db.func.count(User.id))
             two_fa_count = db.session.scalar(
-                select(func.count(User.id).filter(User._totp_secret.isnot(None)))
+                db.select(db.func.count(User.id).filter(User._totp_secret.isnot(None)))
             )
             pgp_key_count = db.session.scalar(
-                select(
-                    func.count(User.id)
+                db.select(
+                    db.func.count(User.id)
                     .filter(User._pgp_key.isnot(None))
                     .filter(User._pgp_key != "")
                 )
             )
             two_fa_percentage = (two_fa_count / user_count * 100) if user_count else 0
             pgp_key_percentage = (pgp_key_count / user_count * 100) if user_count else 0
-            all_users = list(db.session.scalars(select(User)).all())  # Fetch all users for admin
+            all_users = list(db.session.scalars(db.select(User)).all())  # Fetch all users for admin
 
         # Handle form submissions
         if request.method == "POST":
@@ -151,7 +151,7 @@ def create_blueprint() -> Blueprint:
             if "change_username" in request.form and change_username_form.validate_on_submit():
                 new_username = change_username_form.new_username.data
                 existing_user = db.session.scalars(
-                    select(User).filter_by(primary_username=new_username).limit(1)
+                    db.select(User).filter_by(primary_username=new_username).limit(1)
                 ).first()
                 if existing_user:
                     flash("💔 This username is already taken.")
@@ -197,13 +197,13 @@ def create_blueprint() -> Blueprint:
             # Check if user is admin and add admin-specific data
             is_admin = user.is_admin
             if is_admin:
-                user_count = db.session.scalar(func.count(User.id))
+                user_count = db.session.scalar(db.func.count(User.id))
                 two_fa_count = db.session.scalar(
-                    select(func.count(User.id).filter(User._totp_secret.isnot(None)))
+                    db.select(db.func.count(User.id).filter(User._totp_secret.isnot(None)))
                 )
                 pgp_key_count = db.session.scalar(
-                    select(
-                        func.count(User.id)
+                    db.select(
+                        db.func.count(User.id)
                         .filter(User._pgp_key.isnot(None))
                         .filter(User._pgp_key != "")
                     )
@@ -315,7 +315,7 @@ def create_blueprint() -> Blueprint:
             return redirect(url_for(".settings"))
 
         existing_user = db.session.scalars(
-            select(User).filter_by(primary_username=new_username)
+            db.select(User).filter_by(primary_username=new_username)
         ).first()
         if existing_user:
             flash("This username is already taken.", "error")

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -1,6 +1,6 @@
 import base64
 import io
-from datetime import datetime
+from datetime import UTC, datetime
 
 import pyotp
 import qrcode
@@ -225,7 +225,7 @@ def create_blueprint() -> Blueprint:
 
         return render_template(
             "settings.html",
-            now=datetime.utcnow(),
+            now=datetime.now(UTC),
             user=user,
             secondary_usernames=secondary_usernames,
             all_users=all_users,  # Pass to the template for admin view

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -79,7 +79,7 @@ def create_blueprint() -> Blueprint:
         if not user_id:
             return redirect(url_for("login"))
 
-        user = User.query.get(user_id)
+        user = db.session.get(User, user_id)
         if not user:
             flash("🫥 User not found.")
             return redirect(url_for("login"))
@@ -87,7 +87,9 @@ def create_blueprint() -> Blueprint:
         directory_visibility_form = DirectoryVisibilityForm(
             show_in_directory=user.show_in_directory
         )
-        secondary_usernames = SecondaryUsername.query.filter_by(user_id=user.id).all()
+        secondary_usernames = db.session.scalars(
+            select(SecondaryUsername).filter_by(user_id=user.id)
+        ).all()
         change_password_form = ChangePasswordForm()
         change_username_form = ChangeUsernameForm()
         smtp_settings_form = SMTPSettingsForm()
@@ -117,14 +119,20 @@ def create_blueprint() -> Blueprint:
 
         # Check if user is admin and add admin-specific data
         if user.is_admin:
-            user_count = User.query.count()
-            two_fa_count = User.query.filter(User._totp_secret.isnot(None)).count()
-            pgp_key_count = (
-                User.query.filter(User._pgp_key.isnot(None)).filter(User._pgp_key != "").count()
+            user_count = db.session.scalar(func.count(User.id))
+            two_fa_count = db.session.scalar(
+                select(func.count(User.id).filter(User._totp_secret.isnot(None)))
+            )
+            pgp_key_count = db.session.scalar(
+                select(
+                    func.count(User.id)
+                    .filter(User._pgp_key.isnot(None))
+                    .filter(User._pgp_key != "")
+                )
             )
             two_fa_percentage = (two_fa_count / user_count * 100) if user_count else 0
             pgp_key_percentage = (pgp_key_count / user_count * 100) if user_count else 0
-            all_users = User.query.all()  # Fetch all users for admin
+            all_users = list(db.session.scalars(select(User)).all())  # Fetch all users for admin
 
         # Handle form submissions
         if request.method == "POST":
@@ -142,7 +150,9 @@ def create_blueprint() -> Blueprint:
             # Handle Change Username Form Submission
             if "change_username" in request.form and change_username_form.validate_on_submit():
                 new_username = change_username_form.new_username.data
-                existing_user = User.query.filter_by(primary_username=new_username).first()
+                existing_user = db.session.scalars(
+                    select(User).filter_by(primary_username=new_username).limit(1)
+                ).first()
                 if existing_user:
                     flash("💔 This username is already taken.")
                 else:
@@ -187,10 +197,16 @@ def create_blueprint() -> Blueprint:
             # Check if user is admin and add admin-specific data
             is_admin = user.is_admin
             if is_admin:
-                user_count = User.query.count()
-                two_fa_count = User.query.filter(User._totp_secret.isnot(None)).count()
-                pgp_key_count = (
-                    User.query.filter(User._pgp_key.isnot(None)).filter(User._pgp_key != "").count()
+                user_count = db.session.scalar(func.count(User.id))
+                two_fa_count = db.session.scalar(
+                    select(func.count(User.id).filter(User._totp_secret.isnot(None)))
+                )
+                pgp_key_count = db.session.scalar(
+                    select(
+                        func.count(User.id)
+                        .filter(User._pgp_key.isnot(None))
+                        .filter(User._pgp_key != "")
+                    )
                 )
                 two_fa_percentage = (two_fa_count / user_count * 100) if user_count else 0
                 pgp_key_percentage = (pgp_key_count / user_count * 100) if user_count else 0
@@ -235,7 +251,7 @@ def create_blueprint() -> Blueprint:
         if not user_id:
             return redirect(url_for("login"))
 
-        user = db.session.query(User).get(user_id)
+        user = db.session.get(User, user_id)
         if user and user.totp_secret:
             return redirect(url_for(".disable_2fa"))
 
@@ -249,7 +265,7 @@ def create_blueprint() -> Blueprint:
             flash("Session expired, please log in again.", "info")
             return redirect(url_for("login"))
 
-        user = User.query.get(user_id)
+        user = db.session.get(User, user_id)
         if not user:
             flash("User not found.", "error")
             return redirect(url_for("login"))
@@ -289,7 +305,7 @@ def create_blueprint() -> Blueprint:
 
         new_username = new_username.strip()
 
-        user = User.query.get(user_id)
+        user = db.session.get(User, user_id)
         if not user:
             flash("User not found.", "error")
             return redirect(url_for("login"))
@@ -298,7 +314,9 @@ def create_blueprint() -> Blueprint:
             flash("New username is the same as the current username.", "info")
             return redirect(url_for(".settings"))
 
-        existing_user = User.query.filter_by(primary_username=new_username).first()
+        existing_user = db.session.scalars(
+            select(User).filter_by(primary_username=new_username)
+        ).first()
         if existing_user:
             flash("This username is already taken.", "error")
             return redirect(url_for(".settings"))
@@ -331,7 +349,7 @@ def create_blueprint() -> Blueprint:
         if not user_id:
             return redirect(url_for("login"))
 
-        user = User.query.get(user_id)
+        user = db.session.get(User, user_id)
         form = TwoFactorForm()
 
         if form.validate_on_submit():
@@ -381,7 +399,7 @@ def create_blueprint() -> Blueprint:
         if not user_id:
             return redirect(url_for("login"))
 
-        user = db.session.query(User).get(user_id)
+        user = db.session.get(User, user_id)
         if user:
             user.totp_secret = None
         db.session.commit()
@@ -395,7 +413,7 @@ def create_blueprint() -> Blueprint:
     @bp.route("/show-qr-code")
     @require_2fa
     def show_qr_code() -> Response | str:
-        user = User.query.get(session["user_id"])
+        user = db.session.get(User, session["user_id"])
         if not user or not user.totp_secret:
             return redirect(url_for(".enable_2fa"))
 
@@ -421,19 +439,23 @@ def create_blueprint() -> Blueprint:
 
     @bp.route("/verify-2fa-setup", methods=["POST"])
     def verify_2fa_setup() -> Response | str:
-        user = User.query.get(session["user_id"])
+        user = db.session.get(User, session["user_id"])
         if not user:
             return redirect(url_for("login"))
 
+        if not user.totp_secret:
+            flash("⛔️ 2FA setup failed. Please try again.")
+            return redirect(url_for("show_qr_code"))
+
         verification_code = request.form["verification_code"]
         totp = pyotp.TOTP(user.totp_secret)
-        if totp.verify(verification_code):
-            flash("👍 2FA setup successful. Please log in again.")
-            session.pop("is_setting_up_2fa", None)
-            return redirect(url_for("logout"))
+        if not totp.verify(verification_code):
+            flash("⛔️ Invalid 2FA code. Please try again.")
+            return redirect(url_for("show_qr_code"))
 
-        flash("⛔️ Invalid 2FA code. Please try again.")
-        return redirect(url_for("show_qr_code"))
+        flash("👍 2FA setup successful. Please log in again.")
+        session.pop("is_setting_up_2fa", None)
+        return redirect(url_for("logout"))
 
     @bp.route("/update_pgp_key", methods=["GET", "POST"])
     @require_2fa
@@ -443,7 +465,7 @@ def create_blueprint() -> Blueprint:
             flash("⛔️ User not authenticated.")
             return redirect(url_for("login"))
 
-        user = db.session.query(User).get(user_id)
+        user = db.session.get(User, user_id)
         form = PGPKeyForm()
         if form.validate_on_submit():
             pgp_key = form.pgp_key.data
@@ -473,7 +495,7 @@ def create_blueprint() -> Blueprint:
         if not user_id:
             return redirect(url_for("login"))
 
-        user = db.session.query(User).get(user_id)
+        user = db.session.get(User, user_id)
         if not user:
             flash("⛔️ User not found")
             return redirect(url_for(".index"))
@@ -523,13 +545,13 @@ def create_blueprint() -> Blueprint:
             flash("Please log in to continue.")
             return redirect(url_for("login"))
 
-        user = User.query.get(user_id)
+        user = db.session.get(User, user_id)
         if user:
             # Explicitly delete messages for the user
-            Message.query.filter_by(user_id=user.id).delete()
+            db.session.execute(db.delete(Message).filter_by(user_id=user.id))
 
             # Explicitly delete secondary users if necessary
-            SecondaryUsername.query.filter_by(user_id=user.id).delete()
+            db.session.execute(db.delete(SecondaryUsername).filter_by(user_id=user.id))
 
             # Now delete the user
             db.session.delete(user)

--- a/hushline/templates/inbox.html
+++ b/hushline/templates/inbox.html
@@ -7,13 +7,11 @@
 {% for message in messages %}
 <article class="message{% if 'BEGIN PGP MESSAGE' in message.content %} encrypted{% endif %}" data-encrypted-content="{{ message.content }}"
             aria-label="Message with {{message.user.primary_username or message.user.display_name}}">
-    {% if not is_secondary %}
     {% if message.secondary_user_id %}
     {% set sender_info = secondary_usernames[message.secondary_user_id] %}
     <p class="message-label">📥 {{ sender_info.display_name or sender_info.username }}</p>
     {% elif secondary_usernames|length > 0 %}
     <p class="message-label">📥 {{ user.display_name or user.primary_username }}</p>
-    {% endif %}
     {% endif %}
     <p class="decrypted-content">{{ message.content }}</p>
     <div class="mailvelope-decryption-container" id="decryption-container-{{ message.id }}"></div>

--- a/tests/test_registration_and_login.py
+++ b/tests/test_registration_and_login.py
@@ -21,7 +21,9 @@ def test_user_registration_with_invite_code_disabled(client: FlaskClient) -> Non
     assert "Registration successful!" in response.text
 
     # Verify user is added to the database
-    user = User.query.filter_by(primary_username="test_user").first()
+    user = db.session.scalars(
+        db.select(User).filter_by(primary_username="test_user").limit(1)
+    ).first()
     assert user is not None
     assert user.primary_username == "test_user"
 
@@ -50,7 +52,9 @@ def test_user_registration_with_invite_code_enabled(client: FlaskClient) -> None
     assert "Registration successful!" in response.text
 
     # Verify user is added to the database
-    user = User.query.filter_by(primary_username="newuser").first()
+    user = db.session.scalars(
+        db.select(User).filter_by(primary_username="newuser").limit(1)
+    ).first()
     assert user is not None
     assert user.primary_username == "newuser"
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -3,6 +3,7 @@ from secrets import token_urlsafe
 from auth_helper import login_user, register_user
 from flask.testing import FlaskClient
 
+from hushline.db import db
 from hushline.model import User
 
 
@@ -44,7 +45,9 @@ def test_change_display_name(client: FlaskClient) -> None:
     assert response.status_code == 200, "Failed to update display name"
 
     # Fetch updated user info from the database to confirm change
-    updated_user = User.query.filter_by(primary_username="testuser_settings").first()
+    updated_user = db.session.scalars(
+        db.select(User).filter_by(primary_username="testuser_settings").limit(1)
+    ).first()
     assert updated_user is not None, "User was not found after update attempt"
     assert updated_user.display_name == new_display_name, "Display name was not updated correctly"
 
@@ -78,7 +81,9 @@ def test_change_username(client: FlaskClient) -> None:
     assert response.status_code == 200, "Failed to update username"
 
     # Fetch updated user info from the database to confirm change
-    updated_user = User.query.filter_by(primary_username=new_username).first()
+    updated_user = db.session.scalars(
+        db.select(User).filter_by(primary_username=new_username).limit(1)
+    ).first()
     assert updated_user is not None, "Username was not updated correctly in the database"
     assert (
         updated_user.primary_username == new_username
@@ -169,7 +174,9 @@ def test_add_pgp_key(client: FlaskClient) -> None:
 
     # Check successful update
     assert response.status_code == 200, "Failed to update PGP key"
-    updated_user = User.query.filter_by(primary_username="user_with_pgp").first()
+    updated_user = db.session.scalars(
+        db.select(User).filter_by(primary_username="user_with_pgp").limit(1)
+    ).first()
     assert updated_user is not None, "User was not found after update attempt"
     assert updated_user.pgp_key == new_pgp_key, "PGP key was not updated correctly"
 

--- a/tests/test_submit_message.py
+++ b/tests/test_submit_message.py
@@ -1,6 +1,7 @@
 from auth_helper import login_user, register_user
 from flask.testing import FlaskClient
 
+from hushline.db import db
 from hushline.model import Message
 
 
@@ -60,7 +61,7 @@ def test_submit_message(client: FlaskClient) -> None:
     assert b"Message submitted successfully." in response.data
 
     # Verify that the message is saved in the database
-    message = Message.query.filter_by(user_id=user.id).first()
+    message = db.session.scalars(db.select(Message).filter_by(user_id=user.id).limit(1)).first()
     assert message is not None
     assert message.content == "This is a test message."
 
@@ -104,7 +105,7 @@ def test_submit_message_with_contact_method(client: FlaskClient) -> None:
     assert b"Message submitted successfully." in response.data
 
     # Verify that the message is saved in the database
-    message = Message.query.filter_by(user_id=user.id).first()
+    message = db.session.scalars(db.select(Message).filter_by(user_id=user.id).limit(1)).first()
     assert message is not None
 
     # Check if the message content includes the concatenated contact method


### PR DESCRIPTION
The PR refactors the hushline codebase onto sqlalchemy's new session API. This interface ends up looking much more like the sql that it generates and should reduce the "magic" of the query builder. Along with this, I've updated the models to use the new declarative definition, with the main result being improved type-checking.

At the same time, this refactors the deprecated use of `datetime.utcnow()` in favor of `datetime.now(datetime.UTC)`

 In the process of refactoring, a few issues were highlighted related to 2fa validation if it doesn't get setup correctly.