### PR TITLE
More strictly enforce authentication, and clean up routes

### DIFF
--- a/hushline/admin.py
+++ b/hushline/admin.py
@@ -1,21 +1,17 @@
-from flask import Blueprint, abort, flash, redirect, session, url_for
+from flask import Blueprint, abort, flash, redirect, url_for
 from werkzeug.wrappers.response import Response
 
 from .db import db
 from .model import User
-from .utils import require_2fa
+from .utils import admin_authentication_required
 
 
 def create_blueprint() -> Blueprint:
     bp = Blueprint("admin", __file__, url_prefix="/admin")
 
     @bp.route("/toggle_verified/<int:user_id>", methods=["POST"])
-    @require_2fa
+    @admin_authentication_required
     def toggle_verified(user_id: int) -> Response:
-        if not session.get("is_admin", False):
-            flash("Unauthorized access.", "error")
-            return redirect(url_for("settings.index"))
-
         user = db.session.get(User, user_id)
         if user is None:
             abort(404)
@@ -25,12 +21,8 @@ def create_blueprint() -> Blueprint:
         return redirect(url_for("settings.index"))
 
     @bp.route("/toggle_admin/<int:user_id>", methods=["POST"])
-    @require_2fa
+    @admin_authentication_required
     def toggle_admin(user_id: int) -> Response:
-        if not session.get("is_admin", False):
-            flash("Unauthorized access.", "error")
-            return redirect(url_for("settings.index"))
-
         user = db.session.get(User, user_id)
         if user is None:
             abort(404)

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -234,7 +234,7 @@ def init_app(app: Flask) -> None:
     @app.route("/register", methods=["GET", "POST"])
     def register() -> Response | str | tuple[Response | str, int]:
         user = db.session.get(User, session.get("user_id"))
-        if user:
+        if user and session.get("is_authenticated", False):
             flash("👉 You are already logged in.")
             return redirect(url_for("inbox"))
 

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -240,6 +240,11 @@ def init_app(app: Flask) -> None:
 
     @app.route("/register", methods=["GET", "POST"])
     def register() -> Response | str | tuple[Response | str, int]:
+        user = db.session.get(User, session["user_id"])
+        if user:
+            flash("👉 You are already logged in.")
+            return redirect(url_for("inbox", username=user.primary_username))
+
         require_invite_code = os.environ.get("REGISTRATION_CODES_REQUIRED", "True") == "True"
         form = RegistrationForm()
         if not require_invite_code:

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -303,6 +303,11 @@ def init_app(app: Flask) -> None:
 
     @app.route("/login", methods=["GET", "POST"])
     def login() -> Response | str:
+        user = db.session.get(User, session["user_id"])
+        if user:
+            flash("👉 You are already logged in.")
+            return redirect(url_for("inbox", username=user.primary_username))
+
         form = LoginForm()
         if request.method == "POST" and form.validate_on_submit():
             username = form.username.data.strip()

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -377,7 +377,7 @@ def create_blueprint() -> Blueprint:
         session.pop("is_setting_up_2fa", None)
         return redirect(url_for("logout"))
 
-    @bp.route("/update_pgp_key", methods=["GET", "POST"])
+    @bp.route("/update-pgp-key", methods=["POST"])
     @authentication_required
     def update_pgp_key() -> Response | str:
         user_id = session.get("user_id")
@@ -406,9 +406,10 @@ def create_blueprint() -> Blueprint:
             db.session.commit()
             flash("👍 PGP key updated successfully.")
             return redirect(url_for(".index"))
-        return render_template("settings.html", form=form)
 
-    @bp.route("/update_smtp_settings", methods=["GET", "POST"])
+        return redirect(url_for(".index"))
+
+    @bp.route("/update-smtp-settings", methods=["POST"])
     @authentication_required
     def update_smtp_settings() -> Response | str:
         user_id = session.get("user_id")
@@ -421,10 +422,7 @@ def create_blueprint() -> Blueprint:
             return redirect(url_for(".index"))
 
         # Initialize forms
-        change_password_form = ChangePasswordForm()
-        change_username_form = ChangeUsernameForm()
         smtp_settings_form = SMTPSettingsForm()
-        pgp_key_form = PGPKeyForm()
 
         # Handling SMTP settings form submission
         if smtp_settings_form.validate_on_submit():
@@ -439,23 +437,7 @@ def create_blueprint() -> Blueprint:
             flash("👍 SMTP settings updated successfully")
             return redirect(url_for(".index"))
 
-        # Prepopulate SMTP settings form fields
-        smtp_settings_form.email.data = user.email
-        smtp_settings_form.smtp_server.data = user.smtp_server
-        smtp_settings_form.smtp_port.data = user.smtp_port
-        smtp_settings_form.smtp_username.data = user.smtp_username
-        # Note: Password fields are typically not prepopulated for security reasons
-
-        pgp_key_form.pgp_key.data = user.pgp_key
-
-        return render_template(
-            "settings.html",
-            user=user,
-            smtp_settings_form=smtp_settings_form,
-            change_password_form=change_password_form,
-            change_username_form=change_username_form,
-            pgp_key_form=pgp_key_form,
-        )
+        return redirect(url_for(".index"))
 
     @bp.route("/delete-account", methods=["POST"])
     @authentication_required

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -408,33 +408,6 @@ def create_blueprint() -> Blueprint:
     def confirm_disable_2fa() -> Response | str:
         return render_template("confirm_disable_2fa.html")
 
-    @bp.route("/show-qr-code")
-    @authentication_required
-    def show_qr_code() -> Response | str:
-        user = db.session.get(User, session["user_id"])
-        if not user or not user.totp_secret:
-            return redirect(url_for(".enable_2fa"))
-
-        form = TwoFactorForm()
-
-        totp_uri = pyotp.totp.TOTP(user.totp_secret).provisioning_uri(
-            name=user.primary_username, issuer_name="Hush Line"
-        )
-        img = qrcode.make(totp_uri)
-
-        # Convert QR code to a data URI
-        buffered = io.BytesIO()
-        img.save(buffered)
-        img_str = base64.b64encode(buffered.getvalue()).decode()
-        qr_code_img = f"data:image/png;base64,{img_str}"
-
-        return render_template(
-            "show_qr_code.html",
-            form=form,
-            qr_code_img=qr_code_img,
-            user_secret=user.totp_secret,
-        )
-
     @bp.route("/verify-2fa-setup", methods=["POST"])
     @authentication_required
     def verify_2fa_setup() -> Response | str:

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -346,11 +346,7 @@ def create_blueprint() -> Blueprint:
     @bp.route("/enable-2fa", methods=["GET", "POST"])
     @authentication_required
     def enable_2fa() -> Response | str:
-        user_id = session.get("user_id")
-        if not user_id:
-            return redirect(url_for("login"))
-
-        user = db.session.get(User, user_id)
+        user = db.session.get(User, session.get("user_id"))
         form = TwoFactorForm()
 
         if form.validate_on_submit():

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -23,7 +23,7 @@ from .crypto import is_valid_pgp_key
 from .db import db
 from .forms import ComplexPassword, TwoFactorForm
 from .model import Message, SecondaryUsername, User
-from .utils import require_2fa
+from .utils import authentication_required
 
 
 class ChangePasswordForm(FlaskForm):
@@ -73,7 +73,7 @@ def create_blueprint() -> Blueprint:
     bp = Blueprint("settings", __file__, url_prefix="/settings")
 
     @bp.route("/", methods=["GET", "POST"])
-    @require_2fa
+    @authentication_required
     def index() -> str | Response:  # noqa: PLR0911, PLR0912
         user_id = session.get("user_id")
         if not user_id:
@@ -246,6 +246,7 @@ def create_blueprint() -> Blueprint:
         )
 
     @bp.route("/toggle-2fa", methods=["POST"])
+    @authentication_required
     def toggle_2fa() -> Response:
         user_id = session.get("user_id")
         if not user_id:
@@ -258,7 +259,7 @@ def create_blueprint() -> Blueprint:
         return redirect(url_for(".enable_2fa"))
 
     @bp.route("/change-password", methods=["POST"])
-    @require_2fa
+    @authentication_required
     def change_password() -> str | Response:
         user_id = session.get("user_id")
         if not user_id:
@@ -291,7 +292,7 @@ def create_blueprint() -> Blueprint:
         return redirect(url_for("login"))  # Redirect to the login page for re-authentication
 
     @bp.route("/change-username", methods=["POST"])
-    @require_2fa
+    @authentication_required
     def change_username() -> Response | str:
         user_id = session.get("user_id")
         if not user_id:
@@ -343,7 +344,7 @@ def create_blueprint() -> Blueprint:
         return redirect(url_for(".settings"))
 
     @bp.route("/enable-2fa", methods=["GET", "POST"])
-    @require_2fa
+    @authentication_required
     def enable_2fa() -> Response | str:
         user_id = session.get("user_id")
         if not user_id:
@@ -393,7 +394,7 @@ def create_blueprint() -> Blueprint:
         )
 
     @bp.route("/disable-2fa", methods=["POST"])
-    @require_2fa
+    @authentication_required
     def disable_2fa() -> Response | str:
         user_id = session.get("user_id")
         if not user_id:
@@ -407,11 +408,12 @@ def create_blueprint() -> Blueprint:
         return redirect(url_for(".index"))
 
     @bp.route("/confirm-disable-2fa", methods=["GET"])
+    @authentication_required
     def confirm_disable_2fa() -> Response | str:
         return render_template("confirm_disable_2fa.html")
 
     @bp.route("/show-qr-code")
-    @require_2fa
+    @authentication_required
     def show_qr_code() -> Response | str:
         user = db.session.get(User, session["user_id"])
         if not user or not user.totp_secret:
@@ -438,6 +440,7 @@ def create_blueprint() -> Blueprint:
         )
 
     @bp.route("/verify-2fa-setup", methods=["POST"])
+    @authentication_required
     def verify_2fa_setup() -> Response | str:
         user = db.session.get(User, session["user_id"])
         if not user:
@@ -458,7 +461,7 @@ def create_blueprint() -> Blueprint:
         return redirect(url_for("logout"))
 
     @bp.route("/update_pgp_key", methods=["GET", "POST"])
-    @require_2fa
+    @authentication_required
     def update_pgp_key() -> Response | str:
         user_id = session.get("user_id")
         if not user_id:
@@ -489,7 +492,7 @@ def create_blueprint() -> Blueprint:
         return render_template("settings.html", form=form)
 
     @bp.route("/update_smtp_settings", methods=["GET", "POST"])
-    @require_2fa
+    @authentication_required
     def update_smtp_settings() -> Response | str:
         user_id = session.get("user_id")
         if not user_id:
@@ -538,7 +541,7 @@ def create_blueprint() -> Blueprint:
         )
 
     @bp.route("/delete-account", methods=["POST"])
-    @require_2fa
+    @authentication_required
     def delete_account() -> Response | str:
         user_id = session.get("user_id")
         if not user_id:

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -57,8 +57,7 @@
                     {% if not is_personal_server %}
                     <li><a href="{{ url_for('vision') }}">Vision</a></li>
                     {% endif %}
-                    {% if 'user_id' in session and (('2fa_required' not in session or not session['2fa_required']) or
-                    ('2fa_verified' in session and session['2fa_verified'])) %}
+                    {% if 'user_id' in session and (session.get('is_authenticated', False)) %}
                     <li><a href="{{ url_for('inbox', username=session.username) }}">Inbox</a></li>
                     <li><a href="{{ url_for('submit_message', username=session.username) }}">Submit Message</a></li>
                     <li class="dropdown">

--- a/hushline/templates/verify_2fa_login.html
+++ b/hushline/templates/verify_2fa_login.html
@@ -14,5 +14,6 @@
         {% endif %}
     </div>
     <button type="submit">Verify</button>
+    <p><a href="{{ url_for('logout') }}">Cancel</a></p>
 </form>
 {% endblock %}

--- a/hushline/utils.py
+++ b/hushline/utils.py
@@ -4,7 +4,7 @@ from email.mime.text import MIMEText
 from functools import wraps
 from typing import Any, Callable
 
-from flask import current_app, flash, redirect, session, url_for
+from flask import abort, current_app, flash, redirect, session, url_for
 
 from hushline.model import User
 
@@ -25,15 +25,11 @@ def authentication_required(f: Callable[..., Any]) -> Callable[..., Any]:
 
 def admin_authentication_required(f: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(f)
+    @authentication_required
     def decorated_function(*args: Any, **kwargs: Any) -> Any:
-        if "user_id" not in session or not session.get("is_authenticated", False):
-            return redirect(url_for("login"))
-
         user = db.session.query(User).get(session["user_id"])
         if not user or not user.is_admin:
-            flash("Unauthorized access.", "error")
-            return redirect(url_for("index"))
-
+            abort(403)
         return f(*args, **kwargs)
 
     return decorated_function

--- a/hushline/utils.py
+++ b/hushline/utils.py
@@ -14,9 +14,12 @@ from .db import db
 def authentication_required(f: Callable[..., Any]) -> Callable[..., Any]:
     @wraps(f)
     def decorated_function(*args: Any, **kwargs: Any) -> Any:
-        if "user_id" not in session or not session.get("is_authenticated", False):
+        if "user_id" not in session:
             flash("👉 Please complete authentication.")
             return redirect(url_for("login"))
+
+        if not session.get("is_authenticated", False):
+            return redirect(url_for("verify_2fa_login"))
 
         return f(*args, **kwargs)
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -167,7 +167,7 @@ def test_add_pgp_key(client: FlaskClient) -> None:
 
     # Submit POST request to add the PGP key
     response = client.post(
-        "/settings/update_pgp_key",
+        "/settings/update-pgp-key",
         data={"pgp_key": new_pgp_key},
         follow_redirects=True,
     )
@@ -196,7 +196,7 @@ def test_add_invalid_pgp_key(client: FlaskClient) -> None:
 
     # Submit POST request to add the invalid PGP key
     response = client.post(
-        "/settings/update_pgp_key",  # Adjust to your app's correct endpoint
+        "/settings/update-pgp-key",
         data={"pgp_key": invalid_pgp_key},
         follow_redirects=True,
     )
@@ -232,7 +232,7 @@ def test_update_smtp_settings(client: FlaskClient) -> None:
 
     # Submit POST request to update SMTP settings
     response = client.post(
-        "/settings/update_smtp_settings",  # Adjust to your app's correct endpoint
+        "/settings/update-smtp-settings",
         data=new_smtp_settings,
         follow_redirects=True,
     )


### PR DESCRIPTION
While implementing an unrelated feature I discovered a bunch of problems and inconsistencies with the routes, as they're defined. This PR tries to fix as many of them as possible. It does the following:

# Updated authentication

Many of the routes included the confusingly-named `@require_2fa` decorator, even routes that were unrelated to 2FA. What this route actually did was ensure that the user was logged in, with extra logic to ensure that 2FA was verified if it's enabled. This was all too complicated.

I deleted the `@require_2fa` decorator and made two new ones, `@authentication_required` and `@admin_authentication_required`. If `user_id` is set in the session and `is_authenticated` in the session is true, then the user is logged in. I moved all of the 2FA logic into the login flow itself.

Before, during login the code set the values `2fa_required`, `2fa_verified`, and `is_admin` to the session. This PR removes these from the session. Instead it works like this:

- When you start the login process, is sets `user_id` to your user ID. If you have 2FA, it sets `is_authenticated` to false and redirects to the `verify_2fa_login` route, and otherwise it sets `is_authenticated` to true.
- From the `verify_2fa_login` route, if you verify 2FA, it sets `is_authenticated` to true.
- The one bit of code that used `is_admin` now figures out if the user is admin by checking the database and not the session.

# Required authentication everywhere it should be required

This adds the `@authentication_required` decorator to a bunch of routes that didn't require authentication before, when they should have, including:

- `/verify-2fa-login`
- `/settings/update_directory_visibility`
- `/settings/toggle-2fa`
- `/settings/confirm_disable_2fa`
- `/settings/verify-2fa-setup`

These routes mostly seemed to expect `user_id` to be in the session to work, but it's entirely possible there are code paths that could be exploited. For example, here I am not logged into an account at all, but looking at the disable 2FA page:

![image](https://github.com/user-attachments/assets/86765350-814b-4743-83e8-32bb3199b453)

# Fixed the `/inbox` route to not take the username as client-side input

Before, `/inbox` required a `username` URL parameter (like http://localhost:8080/inbox?username=user), and if you try loading it without it (like http://localhost:8080/inbox), the browser gets stuck an in infinite redirect loop:

![image](https://github.com/user-attachments/assets/e00e8ffe-d906-4edd-b298-49125404afbf)

There's no need to ask the user to provider the username of what inbox they're looking at, and then confirm that it matches what's in the database. It's much simpler to just pull this data from the database directly.

# Deleted completely unused routes

I deleted these routes because they weren't being used, and the code was duplicated in different places:

- `/show-qr-code`, because the QR code logic is actually handled in `/enable-2fa`
- `/settings/change-username`, because this POST request is handled in `/settings` instead

I don't know how these ended up there, but it's good to delete unused code as it could have bugs that could some day get exploited.

# Small fixes

- Prevents logged-in users from registering an account (`/register`, GET and POST).
- Prevents logged-in users from trying to login again (`/login`, GET and POST).
