### PR TITLE
Key UI

### DIFF
--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -63,7 +63,7 @@ class PGPProtonForm(FlaskForm):
 
 
 class PGPKeyForm(FlaskForm):
-    pgp_key = TextAreaField("PGP Key", validators=[Length(max=100000)])
+    pgp_key = TextAreaField("Or, Add Your Public PGP Key Manually", validators=[Length(max=100000)])
 
 
 class DisplayNameForm(FlaskForm):

--- a/hushline/settings.py
+++ b/hushline/settings.py
@@ -51,7 +51,15 @@ class SMTPSettingsForm(FlaskForm):
 
 
 class PGPProtonForm(FlaskForm):
-    email = StringField("Proton Email Address", validators=[DataRequired()])
+    email = StringField(
+        "",
+        validators=[DataRequired()],
+        render_kw={
+            "placeholder": "Search Proton email...",
+            "id": "proton_email",
+            "required": True,
+        },
+    )
 
 
 class PGPKeyForm(FlaskForm):

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -1505,6 +1505,22 @@ textarea#bio {
     margin: 0;
 }
 
+img.searchIcon {
+    width: 20px;
+    height: 20px;
+    position: absolute;
+    top: 21px;
+    left: 12px;
+}
+
+label.search {
+    position: relative;
+}
+
+label.search+input {
+    padding-left: 2.5rem;
+}
+
 #searchIcon img {
     width: 20px;
 }

--- a/hushline/static/js/settings.js
+++ b/hushline/static/js/settings.js
@@ -2,6 +2,42 @@ document.addEventListener('DOMContentLoaded', function () {
     const tabs = document.querySelectorAll('.tab');
     const tabPanels = document.querySelectorAll('.tab-content');
     const bioCountEl = document.querySelector('.bio-count');
+
+    // Restore the active tab on page load
+    function restoreActiveTab() {
+        const activeTab = localStorage.getItem('activeTab');
+        if (activeTab) {
+            // Deactivate all tabs and hide all tab contents
+            tabs.forEach(tab => {
+                tab.classList.remove('active');
+                tab.setAttribute('aria-selected', 'false');
+            });
+            tabPanels.forEach(panel => {
+                panel.classList.remove('active');
+                panel.setAttribute('hidden', 'true');
+            });
+
+            // Activate the stored tab and show the corresponding content
+            const activeTabElement = document.getElementById(`${activeTab}-tab`);
+            const activePanelElement = document.getElementById(activeTab);
+
+            if (activeTabElement && activePanelElement) {
+                activeTabElement.classList.add('active');
+                activeTabElement.setAttribute('aria-selected', 'true');
+                activePanelElement.classList.add('active');
+                activePanelElement.removeAttribute('hidden');
+            }
+        }
+    }
+
+    // Save the active tab to localStorage
+    function setActiveTab(tabName) {
+        localStorage.setItem('activeTab', tabName);
+    }
+
+    // Initialize the page with the restored tab
+    restoreActiveTab();
+
     // Deletion account confirmation logic
     document.getElementById('deleteAccountButton')?.addEventListener('click', function (event) {
         const confirmed = confirm('Are you sure you want to delete your account? This cannot be undone.');
@@ -14,7 +50,7 @@ document.addEventListener('DOMContentLoaded', function () {
         // time out to let animation finish
         setTimeout(() => {
             document.querySelector("button[name='update_directory_visibility']").click();
-        }, 200)
+        }, 200);
     });
 
     document.getElementById('bio').addEventListener('keyup', function (e) {
@@ -24,39 +60,10 @@ document.addEventListener('DOMContentLoaded', function () {
     tabs.forEach(tab => {
         tab.addEventListener('click', function (e) {
             window.activateTab(e, tabs, tabPanels);
+            setActiveTab(this.getAttribute('data-tab'));
         });
         tab.addEventListener('keydown', function (e) {
-            window.handleKeydown(e)
+            window.handleKeydown(e);
         });
     });
-
-    // PGP subtabs
-    const pgpProtonTab = document.querySelector('.subtab-pgp-proton');
-    const pgpProtonTabContent = document.getElementById('pgp-proton');
-    const pgpPublicKeyTab = document.querySelector('.subtab-pgp-public-key');
-    const pgpPublicKeyTabContent = document.getElementById('pgp-public-key');
-
-    pgpProtonTab.addEventListener('click', function (e) {
-        pgpProtonTab.classList.add('active');
-        pgpProtonTabContent.classList.add('active');
-        pgpProtonTabContent.hidden = false;
-
-        pgpPublicKeyTab.classList.remove('active');
-        pgpPublicKeyTabContent.classList.remove('active');
-        pgpPublicKeyTabContent.hidden = true;
-    });
-    pgpPublicKeyTab.addEventListener('click', function (e) {
-        pgpPublicKeyTab.classList.add('active');
-        pgpPublicKeyTabContent.classList.add('active');
-        pgpPublicKeyTabContent.hidden = false;
-
-        pgpProtonTab.classList.remove('active');
-        pgpProtonTabContent.classList.remove('active');
-        pgpProtonTabContent.hidden = true;
-    });
-
-    // If there's a PGP key set, show the public key tab
-    if (document.getElementById('pgp_key').value != "") {
-        pgpPublicKeyTab.click();
-    }
 });

--- a/hushline/templates/settings.html
+++ b/hushline/templates/settings.html
@@ -166,48 +166,28 @@
                 rel="noopener noreferrer" target="_blank"
                 aria-label="Need help setting up message encryption? Start with our docs.">Start with our docs.</a></p>
         {% endif %}
-
-        <div class="pgp-tabs">
-            <ul class="tab-list" role="tablist">
-                <li role="presentation">
-                    <button type="button" class="subtab subtab-pgp-proton active" data-tab="pgp-proton" role="tab"
-                        aria-selected="true" aria-controls="pgp-proton" id="pgp-proton-tab">
-                        Proton Mail
-                    </button>
-                </li>
-                <li role="presentation">
-                    <button type="button" class="subtab subtab-pgp-public-key" data-tab="pgp-public-key" role="tab"
-                        aria-selected="false" aria-controls="pgp-public-key" id="pgp-public-key-tab">
-                        PGP Public Key
-                    </button>
-                </li>
-            </ul>
-        </div>
-
-        <div id="pgp-proton" class="subtab-content active" role="tabpanel" aria-labelledby="pgp-proton-tab">
-            <p class="meta">🔒 Do you use Proton Mail? We can automatically retrieve your PGP key from Proton's key
-                server.
-            </p>
-            <form method="POST" action="{{ url_for('settings.update_pgp_key_proton') }}" class="formBody">
-                {{ pgp_proton_form.hidden_tag() }}
-                <label for="proton_email">Proton Mail Email Address</label>
-                <input type="email" name="email" id="proton_email" required>
-                <button type="submit">Search Proton's Key Server</button>
-            </form>
-        </div>
-        <div id="pgp-public-key" class="subtab-content" role="tabpanel" aria-labelledby="pgp-public-key-tab" hidden>
-            <form method="POST" action="{{ url_for('settings.update_pgp_key') }}" class="formBody">
-                {{ pgp_key_form.hidden_tag() }}
-                <label for="pgp_key">Public PGP Key</label>
-                {{ pgp_key_form.pgp_key(id='pgp_key') }}
-                {% if pgp_key_form.pgp_key.errors %}
-                {% for error in pgp_key_form.pgp_key.errors %}
-                <span class="error">{{ error }}</span>
-                {% endfor %}
-                {% endif %}
-                <button type="submit">Update PGP Key</button>
-            </form>
-        </div>
+        <p>🔒 Do you use Proton Mail? We can automatically retrieve your PGP key from Proton's key
+            server.
+        </p>
+        <form method="POST" action="{{ url_for('settings.update_pgp_key_proton') }}" class="formBody">
+            {{ pgp_proton_form.hidden_tag() }}
+            <label class="search" for="proton_email">
+                <img class="searchIcon" src="/static/img/app/icon-search.png" alt="">
+            </label>
+            <input type="email" name="email" id="proton_email" placeholder="Search Proton email..." required>
+            <button type="submit">Search Proton</button>
+        </form>
+        <form method="POST" action="{{ url_for('settings.update_pgp_key') }}" class="formBody">
+            {{ pgp_key_form.hidden_tag() }}
+            <label for="pgp_key">Or, Add Your Public PGP Key Manually</label>
+            {{ pgp_key_form.pgp_key(id='pgp_key') }}
+            {% if pgp_key_form.pgp_key.errors %}
+            {% for error in pgp_key_form.pgp_key.errors %}
+            <span class="error">{{ error }}</span>
+            {% endfor %}
+            {% endif %}
+            <button type="submit">Update PGP Key</button>
+        </form>
     </div>
 
     <div id="advanced" class="tab-content" role="tabpanel" aria-labelledby="advanced-tab" hidden>


### PR DESCRIPTION
- Removed subtabs
- Updated the input to include a search icon
- Added placeholder text
- Updated button for a shorter value
- Updated label for PGP key
- Persistence for active tab after save

Open question: @micahflee I updated the label for the PGP textarea - do we need to update the sanitization for the PGP search? 

```python
class PGPProtonForm(FlaskForm):
    email = StringField(
        "",
        validators=[DataRequired()],
        render_kw={
            "placeholder": "Search Proton email...",
            "id": "proton_email",
            "required": True,
        },
    )
```

Updated UI:
<img width="638" alt="Screenshot 2024-08-16 at 9 15 37 PM" src="https://github.com/user-attachments/assets/180b5a03-4a72-4708-8b48-9cb776c4cbd6">
