### PR TITLE
use shorter DO app names, they are limited to a max of 32 charaters

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -11,7 +11,7 @@ env:
   WORKSPACE_NAME: hushline-dev-${{ github.head_ref }}
   TF_PROJECT_HUSH_LINE_DEV: prj-iEruEQFmaNTCRAtA
   DEV_TF_PATH: terraform/dev
-  DO_APP_NAME: hushline-dev-${{ github.head_ref }}
+  DO_APP_NAME: dev-${{ github.head_ref }}
   HUSHLINE_INFRA_REPO: scidsg/hushline-infra
   HUSHLINE_INFRA_REF: main
 


### PR DESCRIPTION
A dev deploy failed with the error message:
```
Error: expected length of spec.0.name to be in the range (2 - 32), got hushline-dev-proton-key-discovery
```