### PR TITLE
Fix Forwarding UI When No PGP Key Present

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -1681,6 +1681,14 @@ input#captcha_answer {
     margin-top: 2.25rem;
 }
 
+#email .forwarding {
+    margin-bottom: 0;
+}
+
+#email .forwarding+.meta {
+    margin-bottom: 1rem;
+}
+
 @media only screen and (max-width: 768px) {
 
     .container {

--- a/hushline/templates/settings.html
+++ b/hushline/templates/settings.html
@@ -140,18 +140,15 @@
     <div id="email" class="tab-content" role="tabpanel" aria-labelledby="email-tab" hidden>
         <!-- SMTP Settings Section -->
         <h3>Email Forwarding</h3>
-        {% if not is_personal_server and default_forwarding_enabled %}
-        <p class="meta">✊ Email forwarding is powered by <a href="https://riseup.net" target="_blank"
-                rel="noopener noreferrer">Riseup.net</a>.</p>
-        {% endif %}
         {% if not user.pgp_key %}
         <p class="info">Add a PGP key to enable email forwarding. <a
                 href="https://github.com/scidsg/hushline/blob/main/docs/1-getting-started.md#2-mailvelope">Here's
                 how.</a></p>
         {% endif %}
         <form method="POST" action="{{ url_for('settings.update_smtp_settings') }}" class="formBody">
+            {% if user.pgp_key %}
             {{ email_forwarding_form.hidden_tag() }}
-            <div class="checkbox-group toggle-ui">
+            <div class="checkbox-group toggle-ui forwarding">
                 {{ email_forwarding_form.forwarding_enabled() }}
                 <label for="forwarding_enabled" class="toggle-label">
                     {{ email_forwarding_form.forwarding_enabled.label }}
@@ -160,6 +157,10 @@
                     </div>
                 </label>
             </div>
+            {% if not is_personal_server and default_forwarding_enabled %}
+            <p class="meta">✊ Email forwarding is powered by <a href="https://riseup.net" target="_blank"
+                    rel="noopener noreferrer">Riseup.net</a>.</p>
+            {% endif %}
             <fieldset id="forwarding_enabled_fields">
                 {{ email_forwarding_form.email_address.label }}
                 {{ email_forwarding_form.email_address }}
@@ -190,6 +191,7 @@
                 </fieldset>
                 <button type="submit">Update Email Forwarding</button>
             </fieldset>
+            {% endif %}
         </form>
         <!-- PGP Key Section -->
         <h3>Message Encryption</h3>


### PR DESCRIPTION
Fixes a messy layout when a PGP key hasn't been uploaded

Before:
![Screenshot 2024-08-21 at 2 34 43 PM](https://github.com/user-attachments/assets/bbc36021-5607-4ee8-ac11-a17bcb50bdb3)


After:
![Screenshot 2024-08-21 at 2 33 00 PM](https://github.com/user-attachments/assets/c2328f24-c7e5-407c-b7f3-12167970ca00)

![Screenshot 2024-08-21 at 2 32 52 PM](https://github.com/user-attachments/assets/ee72a83d-f0e2-442c-9adc-4c1690328b24)

