### PR TITLE
Fix field wrapping

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -1937,7 +1937,7 @@ p.bio+.extra-fields {
     flex: 1;
     flex-direction: row;
     display: flex;
-    width: 48%;
+    min-width: 45%;
 }
 
 .extra-fields .extra-field-label {


### PR DESCRIPTION
Adding min-width to `.extra-field` instead of width fixes a wrapping problem when fields are short.

Before:
<img width="689" alt="Screenshot 2024-08-26 at 2 09 16 PM" src="https://github.com/user-attachments/assets/a095ee50-3788-4531-9c97-e25c39e3f66e">

After:
<img width="688" alt="Screenshot 2024-08-26 at 2 13 08 PM" src="https://github.com/user-attachments/assets/1f2dc5ec-640c-47e3-b4c7-63ad34a983fb">
