### PR TITLE
Update bypass-review.yaml

### DIFF
--- a/.github/workflows/bypass-review.yaml
+++ b/.github/workflows/bypass-review.yaml
@@ -26,7 +26,7 @@ jobs:
           GH_TOKEN: ${{ secrets.ADMIN_PAT }}
         run: |
           AUTHOR=$(gh pr view ${{ github.event.pull_request.number }} --json author --jq '.author.login')
-          ADMIN_CHECK=$(gh api user/memberships/orgs/scidsg --jq '.role')
+          ADMIN_CHECK=$(gh api orgs/scidsg/members/$AUTHOR --jq '.role')
           if [ "$ADMIN_CHECK" != "admin" ]; then
             echo "User is not an admin or is not a public member of the organization. Exiting."
             exit 1


### PR DESCRIPTION
The orig command checks the token owner’s role. The new command checks the PR author’s role.