### PR TITLE
Add app contents to Dockerfile.dev to enable use in remote environments

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -22,3 +22,5 @@ ENV PYTHONPATH=/app
 COPY pyproject.toml poetry.lock .
 
 RUN poetry install
+
+COPY . /app


### PR DESCRIPTION
This PR adds the contents of the hushline repo to Dockerfile.dev to facilitate running tools/scripts in remove dev environments where we don't have volume mounts. 