### PR TITLE
run prettier via docker container

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,16 +28,8 @@ jobs:
           python-version: "3.12"
           cache: "poetry"
 
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: "npm"
-
       - name: Install Python dependencies
         run: poetry install
-
-      - name: Install Node dependencies
-        run: npm install
 
       - name: Lint
         run: poetry run make lint

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,11 +6,17 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends \
         build-essential \
         libffi-dev \
-        libpq-dev
+        libpq-dev \
+        npm
 
 RUN pip install poetry
 
 WORKDIR /app
+
+COPY package.json package-lock.json .
+
+RUN npm install
+
 ENV PYTHONPATH=/app
 
 COPY pyproject.toml poetry.lock .

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ lint: ## Lint the code
 	poetry run ruff format --check && \
 	poetry run ruff check && \
 	poetry run mypy .
-	docker compose run --rm -v $(shell pwd):/work app npx prettier --check ./*.md ./docs ./.github/workflows/* ./hushline
+	docker compose run --rm app npx prettier --check ./*.md ./docs ./.github/workflows/* ./hushline
 
 .PHONY: fix
 fix: ## Format the code
 	poetry run ruff format && \
 	poetry run ruff check --fix
-	docker compose run --rm -v $(shell pwd):/work app npx prettier --write ./*.md ./docs ./.github/workflows/* ./hushline
+	docker compose run --rm app npx prettier --write ./*.md ./docs ./.github/workflows/* ./hushline
 
 .PHONY: revision
 revision: migrate-prod ## Create a new migration

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ help: ## Print the help message
 .PHONY: install
 install:
 	poetry install
-	npm install
 
 .PHONY: run
 run: ## Run the app
@@ -26,16 +25,18 @@ migrate-prod: ## Run prod env (alembic) migrations
 
 .PHONY: lint
 lint: ## Lint the code
+	docker compose run --rm app \
 	poetry run ruff format --check && \
 	poetry run ruff check && \
 	poetry run mypy .
-	npx prettier --check .
+	docker run --rm -v $(shell pwd):/work tmknom/prettier:3.2.5 --check ./*.md ./docs ./.github/workflows/* ./hushline
 
 .PHONY: fix
 fix: ## Format the code
+	docker compose run --rm app \
 	poetry run ruff format && \
 	poetry run ruff check --fix
-	npx prettier --write .
+	docker run --rm -v $(shell pwd):/work tmknom/prettier:3.2.5 --write ./*.md ./docs ./.github/workflows/* ./hushline
 
 .PHONY: revision
 revision: migrate-prod ## Create a new migration

--- a/Makefile
+++ b/Makefile
@@ -28,13 +28,13 @@ lint: ## Lint the code
 	poetry run ruff format --check && \
 	poetry run ruff check && \
 	poetry run mypy .
-	docker run --rm -v $(shell pwd):/work tmknom/prettier:3.2.5 --check ./*.md ./docs ./.github/workflows/* ./hushline
+	docker compose run --rm -v $(shell pwd):/work app npx prettier --check ./*.md ./docs ./.github/workflows/* ./hushline
 
 .PHONY: fix
 fix: ## Format the code
 	poetry run ruff format && \
 	poetry run ruff check --fix
-	docker run --rm -v $(shell pwd):/work tmknom/prettier:3.2.5 --write ./*.md ./docs ./.github/workflows/* ./hushline
+	docker compose run --rm -v $(shell pwd):/work app npx prettier --write ./*.md ./docs ./.github/workflows/* ./hushline
 
 .PHONY: revision
 revision: migrate-prod ## Create a new migration

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,6 @@ migrate-prod: ## Run prod env (alembic) migrations
 
 .PHONY: lint
 lint: ## Lint the code
-	docker compose run --rm app \
 	poetry run ruff format --check && \
 	poetry run ruff check && \
 	poetry run mypy .
@@ -33,7 +32,6 @@ lint: ## Lint the code
 
 .PHONY: fix
 fix: ## Format the code
-	docker compose run --rm app \
 	poetry run ruff format && \
 	poetry run ruff check --fix
 	docker run --rm -v $(shell pwd):/work tmknom/prettier:3.2.5 --write ./*.md ./docs ./.github/workflows/* ./hushline

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "hushline",
+  "name": "app",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {


### PR DESCRIPTION
This change runs prettier via docker container. It also defines the scope of prettier to `.md` files in the repo root, github actions workflows, docs, and the hushline directory.