### PR TITLE
install the hushline app after installing dependencies

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -24,6 +24,8 @@ RUN poetry install --no-root
 # Copy the rest of the application
 COPY . /app
 
+RUN poetry install
+
 # Expose port 8080
 EXPOSE 8080
 


### PR DESCRIPTION
This is an alternative to https://github.com/scidsg/hushline/pull/599. This installs the current application into the poetry venv allowing execution of scripts which import packages from `hushline`. In this case, it's `scripts/dev_data.py` which imports from `hushline` but isn't part of the `hushline` package.