### PR TITLE
update dockerfile so pysequoia installs on linux/amd64

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,13 +1,25 @@
 # vim: set syntax=dockerfile :
 FROM python:3.12.6-slim-bookworm
 
+# libffi-dev for Python C extensions
+# libpq-dev for `psycopg` Python packge
+# curl for installing `cargo`
+# clang, pkg-config, libpscsclite-dev, nettle-dev for `pysequoia`
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
+        curl \
         build-essential \
+        clang \
+        pkg-config \
         libffi-dev \
         libpq-dev \
+        libpcsclite-dev \
+        nettle-dev \
         npm
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}"
 
 RUN pip install poetry
 


### PR DESCRIPTION
According to the PySequoia v0.1.24 PyPI page, there are no amd64 wheel builds, so we need to compile from source. This changes the requirements, so we need `cargo` for Rust, a whole bunch of .so and header files, and extra build tools.

fixes #620