### PR TITLE
fix: use app logic to avoid broken migration & apply DRY #622

### DIFF
--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -6,7 +6,6 @@ from typing import Any
 from flask import Flask, flash, redirect, request, session, url_for
 from flask_migrate import Migrate
 from jinja2 import StrictUndefined
-from sqlalchemy.exc import ProgrammingError
 from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.wrappers.response import Response
 
@@ -93,7 +92,10 @@ def create_app() -> Flask:
 
     @app.context_processor
     def inject_host() -> dict[str, HostOrganization]:
-        return dict(host_org=HostOrganization.fetch_or_default())
+        if (host_org := HostOrganization.fetch()) is None:
+            db.session.add(host_org := HostOrganization())
+            db.session.commit()
+        return dict(host_org=host_org)
 
     @app.context_processor
     def inject_is_personal_server() -> dict[str, Any]:
@@ -108,18 +110,5 @@ def create_app() -> Flask:
                 f"http://{app.config['ONION_HOSTNAME']}{request.path}"
             )
             return response
-
-    # we can't
-    if app.config.get("FLASK_ENV", None) != "development":
-        with app.app_context():
-            try:
-                host_org = HostOrganization.fetch()
-            except ProgrammingError:
-                app.logger.warning(
-                    "Could not check for existence of HostOrganization", exc_info=True
-                )
-            else:
-                if host_org is None:
-                    app.logger.warning("HostOrganization data not found in database.")
 
     return app

--- a/migrations/versions/5410668e15ad_add_host_organization_table.py
+++ b/migrations/versions/5410668e15ad_add_host_organization_table.py
@@ -26,11 +26,6 @@ def upgrade() -> None:
         sa.PrimaryKeyConstraint("id", name=op.f("pk_host_organization")),
     )
 
-    op.execute(
-        "INSERT INTO host_organization (id, brand_app_name, brand_primary_hex_color) "
-        "VALUES (1, '🤫 Hush Line', '#7d25c1')"
-    )
-
 
 def downgrade() -> None:
     op.drop_table("host_organization")


### PR DESCRIPTION
When running ``make migrate-dev`` there's an error with the new 'host_organization' table migration. Filling & committing the default record on app startup if it's missing:

- removes the error 
- reduces repetition of magic constants which were given variable names in the app 
- keeps application & migration logic separate 
- and, avoids an incomplete DB state which breaks rendering of CSS from jinja db inserts.

Partial reversion of (https://github.com/scidsg/hushline/pull/622/commits/9cad57194ee0ac72a8a56a53d950bb2da2b64d1e, https://github.com/scidsg/hushline/pull/622/commits/9674b1e06e1dab58fec0f44fa2bc5a04d59c2de3)

Suggested in review https://github.com/scidsg/hushline/pull/622#discussion_r1780064725

For Roadmap Item #533


---


### Extended Error Message Fixed by This PR:

```bash
    poetry run ./scripts/dev_migrations.py
    2024-09-29 17:51:17,772:WARNING:Could not check for existence of HostOrganization
    Traceback (most recent call last):
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
        self.dialect.do_execute(
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 941, in do_execute
        cursor.execute(statement, parameters)
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/psycopg/cursor.py", line 97, in execute
        raise ex.with_traceback(None)
    psycopg.errors.UndefinedTable: relation "host_organization" does not exist
    LINE 2: FROM host_organization
                 ^

    The above exception was the direct cause of the following exception:

    Traceback (most recent call last):
      File "~/hushline/hushline/__init__.py", line 116, in create_app
        host_org = HostOrganization.fetch()
                   ^^^^^^^^^^^^^^^^^^^^^^^^
      File "~/hushline/hushline/model.py", line 46, in fetch
        return db.session.get(cls, cls._DEFAULT_ID)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/orm/scoping.py", line 1060, in get
        return self._proxied.get(
               ^^^^^^^^^^^^^^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 3693, in get
        return self._get_impl(
               ^^^^^^^^^^^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 3873, in _get_impl
        return db_load_fn(
               ^^^^^^^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/orm/loading.py", line 694, in load_on_pk_identity
        session.execute(
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2362, in execute
        return self._execute_internal(
               ^^^^^^^^^^^^^^^^^^^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/orm/session.py", line 2247, in _execute_internal
        result: Result[Any] = compile_state_cls.orm_execute_statement(
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/orm/context.py", line 305, in orm_execute_statement
        result = conn.execute(
                 ^^^^^^^^^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1418, in execute
        return meth(
               ^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/sql/elements.py", line 515, in _execute_on_connection
        return connection._execute_clauseelement(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1640, in _execute_clauseelement
        ret = self._execute_context(
              ^^^^^^^^^^^^^^^^^^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1846, in _execute_context
        return self._exec_single_context(
               ^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1986, in _exec_single_context
        self._handle_dbapi_exception(
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 2355, in _handle_dbapi_exception
        raise sqlalchemy_exception.with_traceback(exc_info[2]) from e
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/engine/base.py", line 1967, in _exec_single_context
        self.dialect.do_execute(
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/sqlalchemy/engine/default.py", line 941, in do_execute
        cursor.execute(statement, parameters)
      File "~/.cache/pypoetry/virtualenvs/hushline-syl4zbji-py3.12/lib/python3.12/site-packages/psycopg/cursor.py", line 97, in execute
        raise ex.with_traceback(None)
    sqlalchemy.exc.ProgrammingError: (psycopg.errors.UndefinedTable) relation "host_organization" does not exist
    LINE 2: FROM host_organization
                 ^
    [SQL: SELECT host_organization.id AS host_organization_id, host_organization.brand_app_name AS host_organization_brand_app_name, host_organization.brand_primary_hex_color AS host_organization_brand_primary_hex_color
    FROM host_organization
    WHERE host_organization.id = %(pk_1)s::INTEGER]
    [parameters: {'pk_1': 1}]
    (Background on this error at: https://sqlalche.me/e/20/f405)
```


---


### Actions Passing:

- [x] https://github.com/rmlibre/hushline/actions/runs/11093540275/job/30819945877



