### PR TITLE
Change Branding tab order

### DIFF
--- a/hushline/templates/settings/index.html
+++ b/hushline/templates/settings/index.html
@@ -11,8 +11,8 @@
         ('aliases', 'Aliases', False),
         ('auth', 'Authentication', False),
         ('email', 'Email & Encryption', False),
-        ('advanced', 'Advanced', False),
         ('branding', 'Branding', True),
+        ('advanced', 'Advanced', False),
         ('admin', 'Admin', True)
       ] %}
         {% for (id, display, requires_admin) in buttons %}


### PR DESCRIPTION
This small PR moves the Branding tab before the Advanced tab.

![Screenshot 2024-10-01 at 9 45 22 AM](https://github.com/user-attachments/assets/0c13a898-759f-4518-b983-3c497cbb24b7)
