### PR TITLE
Add link to alias tip line

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -2194,7 +2194,7 @@ p.bio + .extra-fields {
 .alias-heading + .meta,
 .alias-heading + a {
   margin-bottom: 2rem;
-  margin-top: .25rem;
+  margin-top: 0.25rem;
 }
 
 .icon.back {
@@ -2210,8 +2210,8 @@ p.bio + .extra-fields {
 }
 
 .alias-heading {
-  margin-bottom: .25rem;
-  margin-top: .5rem;
+  margin-bottom: 0.25rem;
+  margin-top: 0.5rem;
 }
 
 .drill-in {

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -2191,6 +2191,12 @@ p.bio + .extra-fields {
   background-repeat: no-repeat;
 }
 
+.alias-heading + .meta,
+.alias-heading + a {
+  margin-bottom: 2rem;
+  margin-top: .25rem;
+}
+
 .icon.back {
   transform: rotate(180deg);
   display: inline-block;
@@ -2204,7 +2210,8 @@ p.bio + .extra-fields {
 }
 
 .alias-heading {
-  margin-bottom: 1rem;
+  margin-bottom: .25rem;
+  margin-top: .5rem;
 }
 
 .drill-in {

--- a/hushline/templates/settings/alias.html
+++ b/hushline/templates/settings/alias.html
@@ -6,6 +6,7 @@
 <div class="drill-in">
   <a href="{{ url_for('.index') }}" class="back-button"><span class="icon chevron back"></span> Back to Settings</a>
   <h2 class="alias-heading">{{ alias.display_name or alias.username }}</h2>
+  <a href="{{ url_for('profile', username=alias.username) }}">Alias tip line</a>
 
   {# TODO: much of this is copy/pasted from "settings/profile.html" and will need to be synced with updates there #}
   <h3>Update Display Name</h3>


### PR DESCRIPTION
Before we didn't have a way to link to the tip line for an alias if it wasn't already in the directory. This PR addresses that by adding a link on the `alias.html` page under the page heading.