### PR TITLE
Upgrade button tweaks

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -1098,7 +1098,7 @@ header nav li {
 
 .nav-emoji {
   position: absolute;
-  transform: translateY(-.325rem) translateX(-1.5rem); 
+  transform: translateY(-0.325rem) translateX(-1.5rem);
 }
 
 header nav a {
@@ -1951,7 +1951,7 @@ input#captcha_answer {
 
   .nav-emoji {
     position: absolute;
-    transform: translateY(-.325rem) translateX(3.75rem); 
+    transform: translateY(-0.325rem) translateX(3.75rem);
   }
 }
 

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -1096,6 +1096,11 @@ header nav li {
   font-size: 0.875rem;
 }
 
+.nav-emoji {
+  position: absolute;
+  transform: translateY(-.325rem) translateX(-1.5rem); 
+}
+
 header nav a {
   text-decoration: none;
 }
@@ -1942,6 +1947,11 @@ input#captcha_answer {
 
   .admin-highlights {
     gap: 0.5rem;
+  }
+
+  .nav-emoji {
+    position: absolute;
+    transform: translateY(-.325rem) translateX(3.75rem); 
   }
 }
 

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -109,7 +109,8 @@
             {% if 'user_id' in session and (session.get('is_authenticated', False)) %}
               {% if is_premium_enabled and user.is_free_tier %}
               <li>
-                  <a href="{{ url_for('premium.index') }}">⭐️ Upgrade</a>
+                <span class="nav-emoji">⭐️&nbsp;</span>
+                <a href="{{ url_for('premium.index') }}">Upgrade</a>
               </li>
               {% endif %}
             {% endif %}


### PR DESCRIPTION
The emoji was causing the Upgrade label to be misaligned. This fix moves the emoji outside of the anchor, and positions it absolutely to force alignment of just the text label.

Before:
![Screenshot 2024-10-04 at 10 56 17 AM](https://github.com/user-attachments/assets/dc56087f-dce5-4ab2-b164-ca0095523b6f)

After:
![Screenshot 2024-10-04 at 10 56 07 AM](https://github.com/user-attachments/assets/3d0c727a-83c7-4ae9-a058-020b683a9769)
