### PR TITLE
Style updates

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -560,9 +560,9 @@
 
   .btn-danger,
   .formBody .btn-danger {
-    background-color: darkred;
-    color: white;
-    border: 1px solid oklch(1 0 0 / 0.15);
+    background-color: transparent;
+    color: pink;
+    border: 1px solid pink;
     box-shadow: 0px 4px 8px -4px oklch(1 0 0 / 0.25);
   }
 
@@ -1019,6 +1019,7 @@ img.empty {
   padding: 1.125rem;
   border-radius: 0.25rem;
   margin: 0.5rem 0;
+  position: relative;
 }
 
 .message:last-of-type {
@@ -1285,7 +1286,7 @@ a.logoutLink {
 
 .message.encrypted p {
   font-family: var(--font-mono);
-  font-size: calc(var(--font-size-smaller) * 1.0625);
+  font-size: var(--font-size-smaller);
   white-space: break-spaces;
   margin-top: 0.25rem;
 }
@@ -1293,7 +1294,11 @@ a.logoutLink {
 .message p.badge {
   font-family: var(--font-sans-bold);
   font-size: var(--font-size-smaller); 
-  margin-bottom: 1.25rem;
+  position: absolute;
+  right: 1.125rem;
+  top: 0.825rem;
+  filter: saturate(0) opacity(.6);
+  transform: scale(.9); 
 }
 
 footer {

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -1293,12 +1293,12 @@ a.logoutLink {
 
 .message p.badge {
   font-family: var(--font-sans-bold);
-  font-size: var(--font-size-smaller); 
+  font-size: var(--font-size-smaller);
   position: absolute;
   right: 1.125rem;
   top: 0.825rem;
-  filter: saturate(0) opacity(.6);
-  transform: scale(.9); 
+  filter: saturate(0) opacity(0.6);
+  transform: scale(0.9);
 }
 
 footer {

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -1290,6 +1290,12 @@ a.logoutLink {
   margin-top: 0.25rem;
 }
 
+.message p.badge {
+  font-family: var(--font-sans-bold);
+  font-size: var(--font-size-smaller); 
+  margin-bottom: 1.25rem;
+}
+
 footer {
   position: fixed;
   bottom: 0;

--- a/hushline/templates/inbox.html
+++ b/hushline/templates/inbox.html
@@ -10,7 +10,7 @@
         data-encrypted-content="{{ message.content }}"
         aria-label="Message with {{ message.user.primary_username or message.user.display_name }}"
       >
-        <p>To: @{{ message.username.username }}</p>
+        <p class="badge">📥 @{{ message.username.username }}</p>
         <p class="decrypted-content">{{ message.content }}</p>
         <div
           class="mailvelope-decryption-container"

--- a/hushline/templates/inbox.html
+++ b/hushline/templates/inbox.html
@@ -10,7 +10,7 @@
         data-encrypted-content="{{ message.content }}"
         aria-label="Message with {{ message.user.primary_username or message.user.display_name }}"
       >
-        <p class="badge">📥 @{{ message.username.username }}</p>
+        <p>To: @{{ message.username.username }}</p>
         <p class="decrypted-content">{{ message.content }}</p>
         <div
           class="mailvelope-decryption-container"


### PR DESCRIPTION
- Smaller encrypted text
- Fix dark mode destructive colors

<img width="336" alt="Screenshot 2024-10-05 at 12 29 34 PM" src="https://github.com/user-attachments/assets/111c54d7-ffec-4874-9d16-f22daddef8d6">

**Before:**
<img width="337" alt="Screenshot 2024-10-05 at 12 29 40 PM" src="https://github.com/user-attachments/assets/5f01c223-65b5-4a65-af0a-6ae2139ec354">
