### PR TITLE
Remove HostOrganization check in create_app()

### DIFF
--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -132,19 +132,6 @@ def create_app() -> Flask:
     # Register custom CLI commands
     register_commands(app)
 
-    # we can't
-    if app.config.get("FLASK_ENV", None) != "development":
-        with app.app_context():
-            try:
-                host_org = HostOrganization.fetch()
-            except ProgrammingError:
-                app.logger.warning(
-                    "Could not check for existence of HostOrganization", exc_info=True
-                )
-            else:
-                if host_org is None:
-                    app.logger.warning("HostOrganization data not found in database.")
-
     return app
 
 


### PR DESCRIPTION
The HostOrganization check doesn't seem to actually do anything except write log messages, and I think it may be getting in the way of running migrations in prod mode.

In order to run migrations, create_app is called, which means the create_app function will throw exceptions and not return the app any SQL queries are called -- this is why, for Stripe integration, I ended up moving SQL stuff into a flask command that's run separately.

My hope is by removing this, the migrations will successfully run on staging.