### PR TITLE
Wait for migrations before starting worker

### DIFF
--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -1,0 +1,35 @@
+---
+services:
+  app: &app_env
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
+    ports:
+      - 127.0.0.1:8080:8080
+    environment:
+      FLASK_APP: hushline
+      FLASK_ENV: production
+      ENCRYPTION_KEY: bi5FDwhZGKfc4urLJ_ChGtIAaOPgxd3RDOhnvct10mw=
+      SECRET_KEY: cb3f4afde364bfb3956b97ca22ef4d2b593d9d980a4330686267cabcd2c0befd
+      SQLALCHEMY_DATABASE_URI: postgresql://hushline:hushline@postgres:5432/hushline
+      REGISTRATION_CODES_REQUIRED: False
+      SESSION_COOKIE_NAME: session
+      NOTIFICATIONS_ADDRESS: notifications@hushline.app
+    env_file:
+      - .env.stripe
+    restart: always
+
+  worker:
+    <<: *app_env
+    ports: []
+    restart: always
+    command: poetry run flask stripe start-worker
+
+  postgres:
+    image: postgres:16.4-alpine3.20
+    environment:
+      POSTGRES_USER: hushline
+      POSTGRES_PASSWORD: hushline
+      POSTGRES_DB: hushline
+    ports:
+      - 127.0.0.1:5432:5432

--- a/scripts/prod_start.sh
+++ b/scripts/prod_start.sh
@@ -1,10 +1,13 @@
 #!/bin/bash
 
 # Run migrations
+echo "> Running migrations"
 poetry run flask db upgrade
 
 # Configure Stripe and tiers
+echo "> Configuring Stripe"
 poetry run flask stripe configure
 
 # Start the server
+echo "> Starting the server"
 poetry run gunicorn "hushline:create_app()" -b 0.0.0.0:8080


### PR DESCRIPTION
Should help with #657.

I still haven't pinned down exactly why staging releases weren't working (and the latest PR that merged into main did work), but this PR should at least help. I think the issue is in part related to the containers in the staging environment not have any dependencies, so they all start up in a random order.

The worker container was crashing because it was starting before migrations happened, so this waits for migrations to finish before actually starting the worker. I also added a new docker-compose.yaml file which starts the containers in production mode, to more closely resemble what happens on staging and prod, to be able to test locally.