### PR TITLE
delete auth logs when deleting a user

### DIFF
--- a/hushline/settings/__init__.py
+++ b/hushline/settings/__init__.py
@@ -26,7 +26,15 @@ from wtforms import Field
 from ..crypto import is_valid_pgp_key
 from ..db import db
 from ..forms import TwoFactorForm
-from ..model import HostOrganization, Message, SMTPEncryption, Tier, User, Username
+from ..model import (
+    AuthenticationLog,
+    HostOrganization,
+    Message,
+    SMTPEncryption,
+    Tier,
+    User,
+    Username,
+)
 from ..utils import (
     admin_authentication_required,
     authentication_required,
@@ -676,6 +684,7 @@ def create_blueprint() -> Blueprint:
                     Message.username_id.in_(db.select(Username.id).filter_by(user_id=user.id))
                 )
             )
+            db.session.execute(db.delete(AuthenticationLog).filter_by(user_id=user.id))
             db.session.execute(db.delete(Username).filter_by(user_id=user.id))
             db.session.delete(user)
             db.session.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,7 +18,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from hushline import create_app
 from hushline.crypto import _SCRYPT_PARAMS
 from hushline.db import db
-from hushline.model import Message, Tier, User, Username
+from hushline.model import AuthenticationLog, Message, Tier, User, Username
 
 if TYPE_CHECKING:
     from _pytest.config.argparsing import Parser
@@ -260,3 +260,11 @@ def message(app: Flask, user: User) -> Message:
     db.session.add(msg)
     db.session.commit()
     return msg
+
+
+@pytest.fixture()
+def authentication_log(app: Flask, user: User) -> AuthenticationLog:
+    log = AuthenticationLog(user_id=user.id, successful=True)
+    db.session.add(log)
+    db.session.commit()
+    return log

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,7 +7,14 @@ from flask import url_for
 from flask.testing import FlaskClient
 
 from hushline.db import db
-from hushline.model import HostOrganization, Message, SMTPEncryption, User, Username
+from hushline.model import (
+    AuthenticationLog,
+    HostOrganization,
+    Message,
+    SMTPEncryption,
+    User,
+    Username,
+)
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -351,7 +358,9 @@ def test_alias_page_loads(client: FlaskClient, user: User, user_alias: Username)
 
 
 @pytest.mark.usefixtures("_authenticated_user")
-def test_delete_account(client: FlaskClient, user: User, message: Message) -> None:
+def test_delete_account(
+    client: FlaskClient, user: User, message: Message, authentication_log: AuthenticationLog
+) -> None:
     # save these because SqlAlchemy is too smart about nullifying them on deletion
     user_id = user.id
     username_id = user.primary_username.id


### PR DESCRIPTION
Fixes #660 in the simplest way possible without changing the overall logic/structuring of the app.

Follow up ticket: #661