### PR TITLE
Replace is_personal_server flag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,12 @@ install:
 	poetry install
 
 .PHONY: run
-run: ## Run the app
-	. ./dev_env.sh && \
-	poetry run flask run --debug -h localhost -p 8080
+run: ## Run the app in a limited mode
+	docker compose up
+
+.PHONY: run-full
+run-full: ## Run the app with all features enabled
+	docker compose -f docker-compose.stripe.yaml up
 
 .PHONY: migrate-dev
 migrate-dev: ## Run dev env migrations

--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -16,6 +16,9 @@ services:
       SESSION_COOKIE_NAME: session
       NOTIFICATIONS_ADDRESS: notifications@hushline.app
       DIRECTORY_VERIFIED_TAB_ENABLED: "${DIRECTORY_VERIFIED_TAB_ENABLED:-true}"
+      SMTP_FORWARDING_MESSAGE_HTML: |
+        ✊ Email forwarding is powered by
+        <a href="https://riseup.net" target="_blank">Riseup.net</a>.
     env_file:
       - .env.stripe
     restart: always

--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -15,6 +15,7 @@ services:
       REGISTRATION_CODES_REQUIRED: False
       SESSION_COOKIE_NAME: session
       NOTIFICATIONS_ADDRESS: notifications@hushline.app
+      DIRECTORY_VERIFIED_TAB_ENABLED: "${DIRECTORY_VERIFIED_TAB_ENABLED:-true}"
     env_file:
       - .env.stripe
     restart: always

--- a/docker-compose.stripe.yaml
+++ b/docker-compose.stripe.yaml
@@ -16,6 +16,9 @@ services:
       SESSION_COOKIE_NAME: session
       NOTIFICATIONS_ADDRESS: notifications@hushline.app
       DIRECTORY_VERIFIED_TAB_ENABLED: "${DIRECTORY_VERIFIED_TAB_ENABLED:-true}"
+      SMTP_FORWARDING_MESSAGE_HTML: |
+        ✊ Email forwarding is powered by
+        <a href="https://riseup.net" target="_blank">Riseup.net</a>.
     env_file:
       - .env.stripe
     volumes:

--- a/docker-compose.stripe.yaml
+++ b/docker-compose.stripe.yaml
@@ -15,6 +15,7 @@ services:
       REGISTRATION_CODES_REQUIRED: False
       SESSION_COOKIE_NAME: session
       NOTIFICATIONS_ADDRESS: notifications@hushline.app
+      DIRECTORY_VERIFIED_TAB_ENABLED: "${DIRECTORY_VERIFIED_TAB_ENABLED:-true}"
     env_file:
       - .env.stripe
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,6 +16,9 @@ services:
       SESSION_COOKIE_NAME: session
       NOTIFICATIONS_ADDRESS: notifications@hushline.app
       DIRECTORY_VERIFIED_TAB_ENABLED: "${DIRECTORY_VERIFIED_TAB_ENABLED:-true}"
+      SMTP_FORWARDING_MESSAGE_HTML: |
+        ✊ Email forwarding is powered by
+        <a href="https://riseup.net" target="_blank">Riseup.net</a>.
     volumes:
       - ./:/app
     depends_on:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       REGISTRATION_CODES_REQUIRED: 'false'
       SESSION_COOKIE_NAME: session
       NOTIFICATIONS_ADDRESS: notifications@hushline.app
+      DIRECTORY_VERIFIED_TAB_ENABLED: "${DIRECTORY_VERIFIED_TAB_ENABLED:-true}"
     volumes:
       - ./:/app
     depends_on:

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,140 @@
+# Configuration
+
+Hush Line is configured via environment variables.
+The following env vars are available to configure the app.
+
+Note: There may be additional env vars the code uses, but if they are undocumented, their use is unsupported.
+
+<table>
+  <thead>
+    <tr>
+      <th>Env Var</th>
+      <th>Required</th>
+      <th>Type/Format</th>    
+      <th>Default</th>    
+      <th>Purpose</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <!-- Flask configs -->
+    <tr>
+      <td><code>SERVER_NAME</code></td>
+      <td>false</td>
+      <td>string</td>
+      <td></td>
+      <td>Set the server/host name in Flask</td>
+    </tr>
+    <!-- SqlAlchemy configs -->
+    <tr>
+      <td><code>SQLALCHEMY_DATABASE_URI</code></td>
+      <td>true</td>
+      <td>URL</td>
+      <td></td>
+      <td>SqlAlchemy database connection string</td>
+    </tr>
+    <!-- Hushline configs -->
+    <tr>
+      <td><code>DIRECTORY_VERIFIED_TAB_ENABLED</code></td>
+      <td>false</td>
+      <td>boolean</td>
+      <td><code>true</code></td>
+      <td>
+        Enable the "Verified" tab on the Hush Line directory.
+        When set to <code>true</code>, the directory shows only verified users with a second tab for all users.
+        When set to <code>false</code>, a single tab with all users is displayed.
+      </td>
+    </tr>
+    <tr>
+      <td><code>REGISTRATION_CODES_REQUIRED</code></td>
+      <td>false</td>
+      <td>boolean</td>
+      <td><code>true</code></td>
+      <td>Whether or not new user registrations require invite codes.</td>
+    </tr>
+    <tr>
+      <td><code>NOTIFICATIONS_ADDRESS</code></td>
+      <td>false</td>
+      <td>email address</td>
+      <td></td>
+      <td>Email address to use for sending message notifications</td>
+    </tr>
+    <tr>
+      <td><code>SMTP_FORWARDING_MESSAGE_HTML</code></td>
+      <td>false</td>
+      <td>HTML</td>
+      <td></td>
+      <td>Message to display on the Email settings page below the SMTP forwarding config.</td>
+    </tr>
+    <tr>
+      <td><code>SMTP_USERNAME</code></td>
+      <td>false</td>
+      <td>string</td>
+      <td></td>
+      <td>SMTP username for sending notifications</td>
+    </tr>
+    <tr>
+      <td><code>SMTP_PASSWORD</code></td>
+      <td>false</td>
+      <td>string</td>
+      <td></td>
+      <td>SMTP password for sending notifications</td>
+    </tr>
+    <tr>
+      <td><code>SMTP_SERVER</code></td>
+      <td>false</td>
+      <td>string</td>
+      <td></td>
+      <td>SMTP server for sending notifications</td>
+    </tr>
+    <tr>
+      <td><code>SMTP_PORT</code></td>
+      <td>false</td>
+      <td>integer</td>
+      <td></td>
+      <td>SMTP port for sending notifications</td>
+    </tr>
+    <tr>
+      <td><code>SMTP_ENCRYPTION</code></td>
+      <td>false</td>
+      <td>string</td>
+      <td>StartTLS</td>
+      <td>SMTP encryption method for sending notifications</td>
+    </tr>
+    <tr>
+      <td><code>REQUIRE_PGP</code></td>
+      <td>false</td>
+      <td>boolean</td>
+      <td><code>false</code></td>
+      <td>Whether users are required to use PGP to receive messages.</td>
+    </tr>
+    <tr>
+      <td><code>STRIPE_PUBLISHABLE_KEY</code></td>
+      <td>false</td>
+      <td>string</td>
+      <td></td>
+      <td><a href="https://docs.stripe.com/keys" target="_blank">Stripe publishable key</a> for enabling payments</td>
+    </tr>
+    <tr>
+      <td><code>STRIPE_SECRET_KEY</code></td>
+      <td>false</td>
+      <td>string</td>
+      <td></td>
+      <td><a href="https://docs.stripe.com/keys" target="_blank">Stripe secret key</a> for enabling payments</td>
+    </tr>
+    <tr>
+      <td><code>STRIPE_WEBHOOK_SECRET</code></td>
+      <td>false</td>
+      <td>string</td>
+      <td></td>
+      <td><a href="https://docs.stripe.com/webhooks#endpoint-secrets" target="_blank">Stripe webhook key</a> for enabling payments</td>
+    </tr>
+    <tr>
+      <td><code>ONION_HOSTNAME</code></td>
+      <td>false</td>
+      <td>string</td>
+      <td></td>
+      <td>Tor Onion Service host name that the Hush Line app is additionally available as.</td>
+    </tr>
+  </tbody>
+</table>

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -45,9 +45,6 @@ def create_app() -> Flask:
     app.config["VERSION"] = __version__
     app.config["ENCRYPTION_KEY"] = os.getenv("ENCRYPTION_KEY")
     app.config["ONION_HOSTNAME"] = os.environ.get("ONION_HOSTNAME", None)
-    app.config["IS_PERSONAL_SERVER"] = (
-        os.environ.get("IS_PERSONAL_SERVER", "False").lower() == "true"
-    )
     app.config["DIRECTORY_VERIFIED_TAB_ENABLED"] = (
         os.environ.get("DIRECTORY_VERIFIED_TAB_ENABLED", "true").lower() == "true"
     )
@@ -113,7 +110,6 @@ def create_app() -> Flask:
     def inject_variables() -> dict[str, Any]:
         data = {
             "host_org": HostOrganization.fetch_or_default(),
-            "is_personal_server": app.config["IS_PERSONAL_SERVER"],
             "is_premium_enabled": bool(app.config.get("STRIPE_SECRET_KEY", False)),
             "is_onion_service": request.host.lower().endswith(".onion"),
         }

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -108,6 +108,7 @@ def create_app() -> Flask:
             "host_org": HostOrganization.fetch_or_default(),
             "is_personal_server": app.config["IS_PERSONAL_SERVER"],
             "is_premium_enabled": bool(app.config.get("STRIPE_SECRET_KEY", False)),
+            "is_onion_service": request.host.lower().endswith(".onion"),
         }
         if "user_id" in session:
             data["user"] = db.session.get(User, session["user_id"])

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -7,7 +7,6 @@ from typing import Any
 from flask import Flask, flash, redirect, request, session, url_for
 from flask.cli import AppGroup
 from jinja2 import StrictUndefined
-from werkzeug.middleware.proxy_fix import ProxyFix
 from werkzeug.wrappers.response import Response
 
 from . import admin, premium, routes, settings
@@ -65,12 +64,6 @@ def create_app() -> Flask:
     # Handle the tips domain for profile verification
     app.config["SERVER_NAME"] = os.getenv("SERVER_NAME")
     app.config["PREFERRED_URL_SCHEME"] = "https" if os.getenv("SERVER_NAME") is not None else "http"
-
-    if not app.config["IS_PERSONAL_SERVER"]:
-        # if were running the managed service, we are behind a proxy
-        app.wsgi_app = ProxyFix(  # type: ignore[method-assign]
-            app.wsgi_app, x_for=2, x_proto=1, x_host=0, x_port=0, x_prefix=0
-        )
 
     # jinja configs
     if app.config.get("FLASK_ENV", None) == "development":

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -91,23 +91,15 @@ def create_app() -> Flask:
         return redirect(url_for("index"))
 
     @app.context_processor
-    def inject_user() -> dict[str, Any]:
+    def inject_variables() -> dict[str, Any]:
+        data = {
+            "host_org": HostOrganization.fetch_or_default(),
+            "is_personal_server": app.config["IS_PERSONAL_SERVER"],
+            "is_premium_enabled": bool(app.config.get("STRIPE_SECRET_KEY", False)),
+        }
         if "user_id" in session:
-            user = db.session.get(User, session["user_id"])
-            return {"user": user}
-        return {}
-
-    @app.context_processor
-    def inject_host() -> dict[str, HostOrganization]:
-        return dict(host_org=HostOrganization.fetch_or_default())
-
-    @app.context_processor
-    def inject_is_personal_server() -> dict[str, Any]:
-        return {"is_personal_server": app.config["IS_PERSONAL_SERVER"]}
-
-    @app.context_processor
-    def inject_is_premium_enabled() -> dict[str, Any]:
-        return {"is_premium_enabled": bool(app.config.get("STRIPE_SECRET_KEY", False))}
+            data["user"] = db.session.get(User, session["user_id"])
+        return data
 
     # Add Onion-Location header to all responses
     if app.config["ONION_HOSTNAME"]:

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -56,9 +56,9 @@ def create_app() -> Flask:
     )
     app.config["NOTIFICATIONS_ADDRESS"] = os.environ.get("NOTIFICATIONS_ADDRESS", None)
     app.config["SMTP_USERNAME"] = os.environ.get("SMTP_USERNAME", None)
+    app.config["SMTP_PASSWORD"] = os.environ.get("SMTP_PASSWORD", None)
     app.config["SMTP_SERVER"] = os.environ.get("SMTP_SERVER", None)
     app.config["SMTP_PORT"] = int(os.environ.get("SMTP_PORT", 0))
-    app.config["SMTP_PASSWORD"] = os.environ.get("SMTP_PASSWORD", None)
     app.config["SMTP_ENCRYPTION"] = os.environ.get("SMTP_ENCRYPTION", "StartTLS")
     app.config["REQUIRE_PGP"] = os.environ.get("REQUIRE_PGP", "False").lower() == "true"
     app.config["STRIPE_PUBLISHABLE_KEY"] = os.environ.get("STRIPE_PUBLISHABLE_KEY", None)

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -7,6 +7,7 @@ from typing import Any
 from flask import Flask, flash, redirect, request, session, url_for
 from flask.cli import AppGroup
 from jinja2 import StrictUndefined
+from markupsafe import Markup
 from werkzeug.wrappers.response import Response
 
 from . import admin, premium, routes, settings
@@ -50,6 +51,9 @@ def create_app() -> Flask:
     app.config["DIRECTORY_VERIFIED_TAB_ENABLED"] = (
         os.environ.get("DIRECTORY_VERIFIED_TAB_ENABLED", "true").lower() == "true"
     )
+    app.config["SMTP_FORWARDING_MESSAGE_HTML"] = (
+        Markup(os.environ.get("SMTP_FORWARDING_MESSAGE_HTML", "")) or None
+    )
     app.config["REGISTRATION_CODES_REQUIRED"] = (
         os.environ.get("REGISTRATION_CODES_REQUIRED", "true").lower() == "true"
     )
@@ -79,6 +83,9 @@ def create_app() -> Flask:
 
     # always pop the config to avoid accidentally dumping all our secrets to the user
     app.jinja_env.globals.pop("config", None)
+    app.jinja_env.globals["smtp_forwarding_message_html"] = app.config[
+        "SMTP_FORWARDING_MESSAGE_HTML"
+    ]
     if onion_hostname := app.config.get("ONION_HOSTNAME", None):
         app.jinja_env.globals["onion_hostname"] = onion_hostname
 

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -66,9 +66,16 @@ def create_app() -> Flask:
     app.config["PREFERRED_URL_SCHEME"] = "https" if os.getenv("SERVER_NAME") is not None else "http"
 
     # jinja configs
+    app.jinja_env.globals["hushline_version"] = __version__
+
     if app.config.get("FLASK_ENV", None) == "development":
         app.logger.info("Development environment detected, enabling jinja2.StrictUndefined")
         app.jinja_env.undefined = StrictUndefined
+
+    # always pop the config to avoid accidentally dumping all our secrets to the user
+    app.jinja_env.globals.pop("config", None)
+    if onion_hostname := app.config.get("ONION_HOSTNAME", None):
+        app.jinja_env.globals["onion_hostname"] = onion_hostname
 
     db.init_app(app)
     migrate.init_app(app, db)

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -47,6 +47,9 @@ def create_app() -> Flask:
     app.config["IS_PERSONAL_SERVER"] = (
         os.environ.get("IS_PERSONAL_SERVER", "False").lower() == "true"
     )
+    app.config["DIRECTORY_VERIFIED_TAB_ENABLED"] = (
+        os.environ.get("DIRECTORY_VERIFIED_TAB_ENABLED", "true").lower() == "true"
+    )
     app.config["REGISTRATION_CODES_REQUIRED"] = (
         os.environ.get("REGISTRATION_CODES_REQUIRED", "true").lower() == "true"
     )
@@ -67,7 +70,9 @@ def create_app() -> Flask:
 
     # jinja configs
     app.jinja_env.globals["hushline_version"] = __version__
-
+    app.jinja_env.globals["directory_verified_tab_enabled"] = app.config[
+        "DIRECTORY_VERIFIED_TAB_ENABLED"
+    ]
     if app.config.get("FLASK_ENV", None) == "development":
         app.logger.info("Development environment detected, enabling jinja2.StrictUndefined")
         app.jinja_env.undefined = StrictUndefined

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -536,10 +536,8 @@ def init_app(app: Flask) -> None:
         return render_template("vision.html")
 
     @app.route("/info")
-    def personal_server_info() -> Response | str:
-        if app.config.get("IS_PERSONAL_SERVER"):
-            return render_template("personal_server_info.html", ip_address=get_ip_address())
-        return Response(status=404)
+    def server_info() -> Response | str:
+        return render_template("server_info.html", ip_address=get_ip_address())
 
     @app.route("/health.json")
     def health() -> dict[str, str]:

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -10,7 +10,6 @@ from flask import (
     Flask,
     current_app,
     flash,
-    make_response,
     redirect,
     render_template,
     request,
@@ -120,11 +119,7 @@ def init_app(app: Flask) -> None:
             flash("👉 Please log in to access your inbox.")
             return redirect(url_for("login"))
 
-        return render_template(
-            "inbox.html",
-            user=user,
-            is_personal_server=app.config["IS_PERSONAL_SERVER"],
-        )
+        return render_template("inbox.html", user=user)
 
     @app.route("/to/<username>", methods=["GET"])
     def profile(username: str) -> Response | str:
@@ -169,7 +164,6 @@ def init_app(app: Flask) -> None:
             display_name_or_username=uname.display_name or uname.username,
             current_user_id=session.get("user_id"),
             public_key=uname.user.pgp_key,
-            is_personal_server=app.config["IS_PERSONAL_SERVER"],
             require_pgp=app.config["REQUIRE_PGP"],
             math_problem=math_problem,
         )
@@ -374,7 +368,6 @@ def init_app(app: Flask) -> None:
             "register.html",
             form=form,
             require_invite_code=require_invite_code,
-            is_personal_server=app.config["IS_PERSONAL_SERVER"],
         )
 
     @app.route("/login", methods=["GET", "POST"])
@@ -412,11 +405,7 @@ def init_app(app: Flask) -> None:
                 return redirect(url_for("inbox"))
 
             flash("⛔️ Invalid username or password")
-        return render_template(
-            "login.html",
-            form=form,
-            is_personal_server=app.config["IS_PERSONAL_SERVER"],
-        )
+        return render_template("login.html", form=form)
 
     @app.route("/verify-2fa-login", methods=["GET", "POST"])
     def verify_2fa_login() -> Response | str | tuple[Response | str, int]:
@@ -497,9 +486,7 @@ def init_app(app: Flask) -> None:
             flash("⛔️ Invalid 2FA code. Please try again.")
             return render_template("verify_2fa_login.html", form=form), 401
 
-        return render_template(
-            "verify_2fa_login.html", form=form, is_personal_server=app.config["IS_PERSONAL_SERVER"]
-        )
+        return render_template("verify_2fa_login.html", form=form)
 
     @app.route("/logout")
     @authentication_required
@@ -520,12 +507,10 @@ def init_app(app: Flask) -> None:
     @app.route("/directory")
     def directory() -> Response | str:
         logged_in = "user_id" in session
-        is_personal_server = app.config["IS_PERSONAL_SERVER"]
         return render_template(
             "directory.html",
             usernames=get_directory_usernames(),
             logged_in=logged_in,
-            is_personal_server=is_personal_server,
         )
 
     @app.route("/directory/get-session-user.json")
@@ -551,14 +536,9 @@ def init_app(app: Flask) -> None:
         return render_template("vision.html")
 
     @app.route("/info")
-    def personal_server_info() -> Response:
+    def personal_server_info() -> Response | str:
         if app.config.get("IS_PERSONAL_SERVER"):
-            ip_address = get_ip_address()
-            return make_response(
-                render_template(
-                    "personal_server_info.html", is_personal_server=True, ip_address=ip_address
-                )
-            )
+            return render_template("personal_server_info.html", ip_address=get_ip_address())
         return Response(status=404)
 
     @app.route("/health.json")

--- a/hushline/static/js/directory.js
+++ b/hushline/static/js/directory.js
@@ -52,7 +52,7 @@ document.addEventListener("DOMContentLoaded", function () {
   function reportUser(username, bio) {
     const messageContent = `Reported user: ${username}\n\nBio: ${bio}\n\nReason:`;
     const encodedMessage = encodeURIComponent(messageContent);
-    const submissionUrl = `${pathPrefix}/profile/admin?prefill=${encodedMessage}`;
+    const submissionUrl = `${pathPrefix}/to/admin?prefill=${encodedMessage}`;
     window.location.href = submissionUrl;
   }
 
@@ -96,7 +96,7 @@ document.addEventListener("DOMContentLoaded", function () {
                     <div class="badgeContainer">${badgeContainer}</div>
                     ${bioHighlighted ? `<p class="bio">${bioHighlighted}</p>` : ""}
                     <div class="user-actions">
-                        <a href="${pathPrefix}/profile/${user.primary_username}">Send a Message</a>
+                        <a href="${pathPrefix}/to/${user.primary_username}">Send a Message</a>
                         ${isSessionUser ? `<a href="#" class="report-link" data-username="${user.primary_username}" data-display-name="${user.display_name || user.primary_username}" data-bio="${user.bio ?? "No bio"}">Report Account</a>` : ``}
                     </div>
                 `;

--- a/hushline/static/js/directory.js
+++ b/hushline/static/js/directory.js
@@ -1,76 +1,63 @@
 document.addEventListener("DOMContentLoaded", function () {
-  // Get the path prefix
-  // If window.location.pathname is /tips/directory, then prefix is /tips
-  // If it's /directory, then prefix is /
   const pathPrefix = window.location.pathname.split("/").slice(0, -1).join("/");
-  const tabs = document.querySelectorAll(".tab");
-  const tabPanels = document.querySelectorAll(".tab-content");
   const searchInput = document.getElementById("searchInput");
   const clearIcon = document.getElementById("clearIcon");
-  let userData = []; // Will hold the user data loaded from JSON
+  let userData = [];
   let isSessionUser = false;
-
-  function updatePlaceholder() {
-    const activeTab = document
-      .querySelector(".tab.active")
-      .getAttribute("data-tab");
-    searchInput.placeholder = `Search ${activeTab === "verified" ? "verified " : ""}users...`;
-  }
 
   function loadData() {
     fetch(`${pathPrefix}/directory/users.json`)
-      .then((response) => response.json())
+      .then((response) => {
+        if (!response.ok) {
+          throw new Error("Network response was not ok");
+        }
+        return response.json();
+      })
       .then((data) => {
         userData = data;
-        handleSearchInput(); // Initial display after data is loaded
+        handleSearchInput();
       })
       .catch((error) => console.error("Failed to load user data:", error));
   }
 
   async function checkIfSessionUser() {
-    const response = await fetch(
-      `${pathPrefix}/directory/get-session-user.json`,
-    );
-    const { logged_in } = await response.json();
-    isSessionUser = logged_in;
+    try {
+      const response = await fetch(
+        `${pathPrefix}/directory/get-session-user.json`,
+      );
+      if (!response.ok) {
+        throw new Error("Network response was not ok");
+      }
+      const { logged_in } = await response.json();
+      isSessionUser = logged_in;
+    } catch (error) {
+      console.error("Failed to check session user:", error);
+    }
   }
 
   function filterUsers(query) {
-    const tab = document.querySelector(".tab.active").getAttribute("data-tab");
     return userData.filter((user) => {
       const searchText =
         `${user.primary_username} ${user.display_name} ${user.bio}`.toLowerCase();
-      const matchesTab =
-        tab === "all" || (tab === "verified" && user.is_verified);
-      return searchText.includes(query.toLowerCase()) && matchesTab;
+      return searchText.includes(query.toLowerCase());
     });
   }
 
   function highlightMatch(text, query) {
-    if (!query) return text; // If no query, return the text unmodified
-    const regex = new RegExp(`(${query})`, "gi"); // Case-insensitive matching
+    if (!query) return text;
+    const regex = new RegExp(`(${query})`, "gi");
     return text.replace(regex, '<mark class="search-highlight">$1</mark>');
   }
 
   function reportUser(username, bio) {
-    // Construct the message content with explicit line breaks
     const messageContent = `Reported user: ${username}\n\nBio: ${bio}\n\nReason:`;
-
-    // Encode the message content to ensure line breaks and other special characters are correctly handled
     const encodedMessage = encodeURIComponent(messageContent);
-
-    // Redirect to the message submission form for the admin with the pre-filled content
-    const submissionUrl = `${pathPrefix}/to/admin?prefill=${encodedMessage}`;
+    const submissionUrl = `${pathPrefix}/profile/admin?prefill=${encodedMessage}`;
     window.location.href = submissionUrl;
   }
 
   function displayUsers(users, query) {
-    const userListContainer = document.querySelector(
-      ".tab-content.active .user-list",
-    );
-    const activeTab = document
-      .querySelector(".tab.active")
-      .getAttribute("data-tab");
+    const userListContainer = document.querySelector(".user-list");
     userListContainer.innerHTML = "";
 
     if (users.length > 0) {
@@ -86,18 +73,10 @@ document.addEventListener("DOMContentLoaded", function () {
         const bioHighlighted = user.bio ? highlightMatch(user.bio, query) : "";
 
         let badgeContainer = "";
-
         if (user.is_admin) {
           badgeContainer += '<p class="badge">⚙️ Admin</p>';
         }
-
-        // Include the "Verified" badge if the "all" tab is active
-        if (activeTab === "all" && user.is_verified) {
-          badgeContainer += '<p class="badge">⭐️ Verified</p>';
-        }
-
-        // Include the "Verified" badge if the "verified" tab is active
-        if (activeTab === "verified" && user.is_verified) {
+        if (user.is_verified) {
           badgeContainer += '<p class="badge">⭐️ Verified</p>';
         }
 
@@ -117,14 +96,14 @@ document.addEventListener("DOMContentLoaded", function () {
                     <div class="badgeContainer">${badgeContainer}</div>
                     ${bioHighlighted ? `<p class="bio">${bioHighlighted}</p>` : ""}
                     <div class="user-actions">
-                        <a href="${pathPrefix}/to/${user.primary_username}">View Profile</a>
+                        <a href="${pathPrefix}/profile/${user.primary_username}">Send a Message</a>
                         ${isSessionUser ? `<a href="#" class="report-link" data-username="${user.primary_username}" data-display-name="${user.display_name || user.primary_username}" data-bio="${user.bio ?? "No bio"}">Report Account</a>` : ``}
                     </div>
                 `;
         userListContainer.appendChild(userDiv);
       });
 
-      createReportEventListeners(".tab-content.active .user-list");
+      createReportEventListeners(".user-list");
     } else {
       userListContainer.innerHTML =
         '<p class="empty-message"><span class="emoji-message">🫥</span><br>No users found.</p>';
@@ -145,17 +124,6 @@ document.addEventListener("DOMContentLoaded", function () {
     handleSearchInput();
   });
 
-  tabs.forEach((tab) => {
-    tab.addEventListener("click", function (e) {
-      window.activateTab(e, tabs, tabPanels);
-      handleSearchInput(); // Filter again when tab changes
-      updatePlaceholder();
-    });
-    tab.addEventListener("keydown", function (e) {
-      window.handleKeydown(e);
-    });
-  });
-
   function createReportEventListeners(selector) {
     document
       .querySelector(selector)
@@ -169,7 +137,8 @@ document.addEventListener("DOMContentLoaded", function () {
         }
       });
   }
-  checkIfSessionUser();
-  updatePlaceholder(); // Initialize placeholder text
-  loadData();
+
+  checkIfSessionUser().then(() => {
+    loadData();
+  });
 });

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -115,9 +115,7 @@
               {% endif %}
             {% endif %}
             <li><a href="{{ url_for('directory') }}">Directory</a></li>
-            {% if not is_personal_server %}
-              <li><a href="{{ url_for('vision') }}">Vision</a></li>
-            {% endif %}
+            <li><a href="{{ url_for('vision') }}">Vision</a></li>
             {% if 'user_id' in session and (session.get('is_authenticated', False)) %}
               <li>
                 <a href="{{ url_for('inbox', username=session.username) }}"

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -162,7 +162,7 @@
       </nav>
     </header>
 
-    <main>
+    <main class="{% block main_class %}{% endblock %}">
       <div class="container">
         {% block content %}
           <!-- This block will be filled with page-specific content -->

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -83,7 +83,7 @@
       {% endif %}
     {% endwith %}
 
-    {% if not is_personal_server %}
+    {% if not is_onion_service %}
       <div class="banner">
         <p>
           🧅 Use

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -195,7 +195,7 @@
           href="https://github.com/scidsg/hushline"
           target="_blank"
           rel="noopener noreferrer"
-          >v{{ config.VERSION }}</a
+          >v{{ hushline_version }}</a
         >
       </p>
     </footer>

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -114,9 +114,6 @@
               </li>
               {% endif %}
             {% endif %}
-            {% if is_personal_server %}
-              <li><a href="{{ url_for('personal_server_info') }}">Info</a></li>
-            {% endif %}
             <li><a href="{{ url_for('directory') }}">Directory</a></li>
             {% if not is_personal_server %}
               <li><a href="{{ url_for('vision') }}">Vision</a></li>

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -4,7 +4,7 @@
 
 {% block content %}
   <h2>User Directory</h2>
-  {% if not is_personal_server %}
+  {% if directory_verified_tab_enabled %}
     {% if not logged_in %}
       <p class="helper section-intro">
         👋 Hush Line connects whistleblowers with lawyers, journalists, business
@@ -60,7 +60,7 @@
       &times;
     </button>
   </div>
-  {% if not is_personal_server %}
+  {% if directory_verified_tab_enabled %}
     <div
       id="verified"
       class="tab-content active"
@@ -128,7 +128,7 @@
   {% endif %}
   <div
     id="all"
-    class="tab-content {% if is_personal_server %}active{% endif %}"
+    class="tab-content {% if not directory_verified_tab_enabled %}active{% endif %}"
     role="tabpanel"
     aria-labelledby="all-users-tab"
   >
@@ -180,8 +180,8 @@
 {% endblock %}
 
 {% block scripts %}
-  {% if is_personal_server %}
-    <script src="{{ url_for('static', filename='js/directory_personal_server.js') }}"></script>
+  {% if directory_verified_tab_enabled %}
+    <script src="{{ url_for('static', filename='js/directory_verified.js') }}"></script>
   {% else %}
     <script src="{{ url_for('static', filename='js/directory.js') }}"></script>
   {% endif %}

--- a/hushline/templates/personal_server_info.html
+++ b/hushline/templates/personal_server_info.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+
 {% block title %}Hush Line Personal Server{% endblock %}
 
 {% block content %}
@@ -21,7 +22,7 @@
     with the following URL:
   </p>
 
-  <pre>http://{{ config.ONION_HOSTNAME }}</pre>
+  <pre>http://{{ onion_hostname }}</pre>
 
   <p>
     Or, you can access the service from the network the device is connected to
@@ -41,7 +42,4 @@
       >https://hushline.app</a
     >.
   </p>
-{% endblock %}
-
-{% block scripts %}
 {% endblock %}

--- a/hushline/templates/premium-select-tier.html
+++ b/hushline/templates/premium-select-tier.html
@@ -1,227 +1,33 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="theme-color" content="#7D25C1" id="theme-color" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="og:title" content="Hush Line" />
-    <meta
-      property="og:description"
-      content="An open-source whistleblowing platform for organizations and individuals."
-    />
-    <meta property="og:url" content="https://hushline.app" />
-    <meta
-      property="og:image"
-      content="https://hushline.app/assets/img/social/social.png"
-    />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@scidsg" />
-    <meta name="twitter:title" content="Hush Line" />
-    <meta
-      name="twitter:description"
-      content="An open-source whistleblowing platform for organizations and individuals."
-    />
-    <meta
-      name="twitter:image"
-      content="https://hushline.app/assets/img/social/social.png"
-    />
-    <title>Select a Tier - Hush Line</title>
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="{{ url_for('static', filename='img/favicon/apple-touch-icon.png') }}"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="{{ url_for('static', filename='img/favicon/favicon-16x16.png') }}"
-      sizes="16x16"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="{{ url_for('static', filename='img/favicon/favicon-32x32.png') }}"
-      sizes="32x32"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="{{ url_for('static', filename='img/favicon/android-chrome-192x192.png') }}"
-      sizes="192x192"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="{{ url_for('static', filename='img/favicon/android-chrome-512x512.png') }}"
-      sizes="512x512"
-    />
-    <link
-      rel="icon"
-      type="image/x-icon"
-      href="{{ url_for('static', filename='img/favicon/favicon.ico') }}"
-    />
-    <link
-      rel="stylesheet"
-      href="{{ url_for('static', filename='css/style.css') }}"
-    />
-    <!-- prettier-ignore -->
-    <style>
-      :root {
-        --color-brand: oklch(from {{ host_org.brand_primary_hex_color }} l c h);
-      }
-    </style>
-  </head>
+{% extends "base.html" %}
 
-  <body>
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        <div class="flash-messages" role="alert">
-          {% for message in messages %}
-            <div class="flash-message">{{ message }}</div>
-          {% endfor %}
-        </div>
-      {% endif %}
-    {% endwith %}
+{% block title %}Select a Tier{% endblock %}
+{% block main_class %}tier-select{% endblock %}
 
-    {% if not is_personal_server %}
-      <div class="banner">
-        <p>
-          🧅 Use
-          <a
-            href="https://www.torproject.org/download/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Use Tor Browser for increased anonymity. This link opens a new browser tab."
-            >Tor Browser</a
-          >
-          for increased anonymity.
-        </p>
-      </div>
-    {% endif %}
+{% block content %}
+  <h2 class="centered-heading">Choose a Hush&nbsp;Line&nbsp;Plan</h2>
 
-    <header>
-      <!-- Navigation bar, logo, etc. -->
-      <h1>{{ host_org.brand_app_name }}</h1>
-      <nav>
-        <div class="navGroup">
-          <a class="mobileNav btnIcon" aria-label="Navigation menu">Menu</a>
-          <ul>
-            {% if 'user_id' in session and (session.get('is_authenticated', False)) %}
-              {% if is_premium_enabled and user.is_free_tier %}
-              <li>
-                <span class="nav-emoji">⭐️&nbsp;</span>
-                <a href="{{ url_for('premium.index') }}">Upgrade</a>
-              </li>
-              {% endif %}
-            {% endif %}
-            {% if is_personal_server %}
-              <li><a href="{{ url_for('personal_server_info') }}">Info</a></li>
-            {% endif %}
-            <li><a href="{{ url_for('directory') }}">Directory</a></li>
-            {% if not is_personal_server %}
-              <li><a href="{{ url_for('vision') }}">Vision</a></li>
-            {% endif %}
-            {% if 'user_id' in session and (session.get('is_authenticated', False)) %}
-              <li>
-                <a href="{{ url_for('inbox', username=session.username) }}"
-                  >Inbox</a
-                >
-              </li>
-              <li>
-                <a href="{{ url_for('profile', username=session.username) }}"
-                  >Profile</a
-                >
-              </li>
-              <li class="dropdown">
-                <button
-                  type="button"
-                  aria-expanded="false"
-                  aria-controls="dropdown-content"
-                  class="dropbtn"
-                >
-                  @{{ session['username'] }}
-                  <img
-                    class="dropdown-icon"
-                    src="{{ url_for('static', filename='img/app/dropdown.png') }}"
-                    alt="Dropdown"
-                  />
-                </button>
-                <div id="dropdown-content" class="dropdown-content" hidden>
-                  <ul>
-                    <li>
-                      <a href="{{ url_for('settings.index') }}">Settings</a>
-                    </li>
-                    <li><a href="{{ url_for('logout') }}">Logout</a></li>
-                  </ul>
-                </div>
-              </li>
-            {% else %}
-              <li><a href="{{ url_for('login') }}">Login</a></li>
-              <li><a href="{{ url_for('register') }}">Register</a></li>
-            {% endif %}
-          </ul>
-          <a class="btn" href="https://opencollective.com/scidsg/"
-            ><span class="emoji">❤️</span> Donate</a
-          >
-        </div>
-      </nav>
-    </header>
-
-    <main class="tier-select">
-      <div class="container">
-        <h2 class="centered-heading">Choose a Hush&nbsp;Line&nbsp;Plan</h2>
-
-        <div id="plan-wrapper">
-          <div class="plan">
-            <p class="plan-status badge">👍 Great for Individuals</p>
-            {% include "premium/free-features.html" %}
-            <form
-              id="free-form"
-              action="{{ url_for('premium.select_free') }}"
-              method="post"
-            >
-              <button class="btn">Use Free Plan</button>
-            </form>
-          </div>
-          <div class="plan plan-recommended">
-            <p class="plan-status badge">⭐️ Recommended for Businesses</p>
-            {% include "premium/business-features.html" %}
-            <form
-              id="upgrade-form"
-              action="{{ url_for('premium.upgrade') }}"
-              method="post"
-            >
-              <button class="btn">Upgrade to Super User</button>
-            </form>
-          </div>
-        </div>
-      </div>
-    </main>
-
-    <footer>
-      <p>
-        <a
-          href="https://github.com/scidsg/hushline/blob/main/docs/PRIVACY.md"
-          target="_blank"
-          rel="noopener noreferrer"
-          >Privacy Policy</a
-        >
-        |
-        <a
-          href="https://github.com/scidsg/hushline/blob/main/docs/TERMS.md"
-          target="_blank"
-          rel="noopener noreferrer"
-          >Terms of Service</a
-        >
-        |
-        <a
-          href="https://github.com/scidsg/hushline"
-          target="_blank"
-          rel="noopener noreferrer"
-          >v{{ config.VERSION }}</a
-        >
-      </p>
-    </footer>
-    <script src="{{ url_for('static', filename='js/global.js') }}"></script>
-  </body>
-</html>
+  <div id="plan-wrapper">
+    <div class="plan">
+      <p class="plan-status badge">👍 Great for Individuals</p>
+      {% include "premium/free-features.html" %}
+      <form
+        id="free-form"
+        action="{{ url_for('premium.select_free') }}"
+        method="post"
+      >
+        <button class="btn">Use Free Plan</button>
+      </form>
+    </div>
+    <div class="plan plan-recommended">
+      <p class="plan-status badge">⭐️ Recommended for Businesses</p>
+      {% include "premium/business-features.html" %}
+      <form
+        id="upgrade-form"
+        action="{{ url_for('premium.upgrade') }}"
+        method="post"
+      >
+        <button class="btn">Upgrade to Super User</button>
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/hushline/templates/premium.html
+++ b/hushline/templates/premium.html
@@ -1,289 +1,92 @@
-<!doctype html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="theme-color" content="#7D25C1" id="theme-color" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta property="og:title" content="Hush Line" />
-    <meta
-      property="og:description"
-      content="An open-source whistleblowing platform for organizations and individuals."
-    />
-    <meta property="og:url" content="https://hushline.app" />
-    <meta
-      property="og:image"
-      content="https://hushline.app/assets/img/social/social.png"
-    />
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:site" content="@scidsg" />
-    <meta name="twitter:title" content="Hush Line" />
-    <meta
-      name="twitter:description"
-      content="An open-source whistleblowing platform for organizations and individuals."
-    />
-    <meta
-      name="twitter:image"
-      content="https://hushline.app/assets/img/social/social.png"
-    />
-    <title>Select a Tier - Hush Line</title>
-    <link
-      rel="apple-touch-icon"
-      sizes="180x180"
-      href="{{ url_for('static', filename='img/favicon/apple-touch-icon.png') }}"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="{{ url_for('static', filename='img/favicon/favicon-16x16.png') }}"
-      sizes="16x16"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="{{ url_for('static', filename='img/favicon/favicon-32x32.png') }}"
-      sizes="32x32"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="{{ url_for('static', filename='img/favicon/android-chrome-192x192.png') }}"
-      sizes="192x192"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      href="{{ url_for('static', filename='img/favicon/android-chrome-512x512.png') }}"
-      sizes="512x512"
-    />
-    <link
-      rel="icon"
-      type="image/x-icon"
-      href="{{ url_for('static', filename='img/favicon/favicon.ico') }}"
-    />
-    <link
-      rel="stylesheet"
-      href="{{ url_for('static', filename='css/style.css') }}"
-    />
-    <!-- prettier-ignore -->
-    <style>
-      :root {
-        --color-brand: oklch(from {{ host_org.brand_primary_hex_color }} l c h);
-      }
-    </style>
-  </head>
+{% extends "base.html" %}
 
-  <body>
-    {% with messages = get_flashed_messages() %}
-      {% if messages %}
-        <div class="flash-messages" role="alert">
-          {% for message in messages %}
-            <div class="flash-message">{{ message }}</div>
-          {% endfor %}
-        </div>
+{% block title %}Select a Tier{% endblock %}
+{% block main_class %}tier-select{% endblock %}
+
+{% block content %}
+  <h2 class="centered-heading">Choose a Hush&nbsp;Line&nbsp;Plan</h2>
+  <div id="plan-wrapper">
+    <div class="plan">
+      {% if user.is_free_tier %}
+        <p class="plan-status badge">📍 Current Plan</p>
+      {% elif user.is_business_tier %}
+        <p class="plan-status badge">👇 Fewer Features</p>
       {% endif %}
-    {% endwith %}
-
-    {% if not is_personal_server %}
-      <div class="banner">
-        <p>
-          🧅 Use
-          <a
-            href="https://www.torproject.org/download/"
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="Use Tor Browser for increased anonymity. This link opens a new browser tab."
-            >Tor Browser</a
+      {% include "premium/free-features.html" %}
+    </div>
+    <div class="plan plan-recommended">
+      {% if user.is_free_tier %}
+        <p class="plan-status badge">⭐️ Recommended for Businesses</p>
+      {% elif user.is_business_tier %}
+        <p class="plan-status badge">📍 Current Plan</p>
+      {% endif %}
+      {% include "premium/business-features.html" %}
+      {% if user.is_free_tier %}
+        <form
+          id="upgrade-form"
+          action="{{ url_for('premium.upgrade') }}"
+          method="post"
+        >
+          <button id="upgrade">Upgrade Now</button>
+        </form>
+      {% endif %}
+      {% if user.is_business_tier %}
+        {% if user.stripe_subscription_cancel_at_period_end %}
+          <p class="meta sub-info">⚠️ Your subscription will expire on {{ user.stripe_subscription_current_period_end.strftime('%B %d, %Y') }}.</p>
+          <form
+            id="enable-autorenew-form"
+            action="{{ url_for('premium.disable_autorenew') }}"
+            method="post"
           >
-          for increased anonymity.
-        </p>
-      </div>
-    {% endif %}
-
-    <header>
-      <!-- Navigation bar, logo, etc. -->
-      <h1>{{ host_org.brand_app_name }}</h1>
-      <nav>
-        <div class="navGroup">
-          <a class="mobileNav btnIcon" aria-label="Navigation menu">Menu</a>
-          <ul>
-            {% if 'user_id' in session and (session.get('is_authenticated', False)) %}
-              {% if is_premium_enabled and user.is_free_tier %}
-              <li>
-                <span class="nav-emoji">⭐️&nbsp;</span>
-                <a href="{{ url_for('premium.index') }}">Upgrade</a>
-              </li>
-              {% endif %}
-            {% endif %}
-            {% if is_personal_server %}
-              <li><a href="{{ url_for('personal_server_info') }}">Info</a></li>
-            {% endif %}
-            <li><a href="{{ url_for('directory') }}">Directory</a></li>
-            {% if not is_personal_server %}
-              <li><a href="{{ url_for('vision') }}">Vision</a></li>
-            {% endif %}
-            {% if 'user_id' in session and (session.get('is_authenticated', False)) %}
-              <li>
-                <a href="{{ url_for('inbox', username=session.username) }}"
-                  >Inbox</a
-                >
-              </li>
-              <li>
-                <a href="{{ url_for('profile', username=session.username) }}"
-                  >Profile</a
-                >
-              </li>
-              <li class="dropdown">
-                <button
-                  type="button"
-                  aria-expanded="false"
-                  aria-controls="dropdown-content"
-                  class="dropbtn"
-                >
-                  @{{ session['username'] }}
-                  <img
-                    class="dropdown-icon"
-                    src="{{ url_for('static', filename='img/app/dropdown.png') }}"
-                    alt="Dropdown"
-                  />
-                </button>
-                <div id="dropdown-content" class="dropdown-content" hidden>
-                  <ul>
-                    <li>
-                      <a href="{{ url_for('settings.index') }}">Settings</a>
-                    </li>
-                    <li><a href="{{ url_for('logout') }}">Logout</a></li>
-                  </ul>
-                </div>
-              </li>
-            {% else %}
-              <li><a href="{{ url_for('login') }}">Login</a></li>
-              <li><a href="{{ url_for('register') }}">Register</a></li>
-            {% endif %}
-          </ul>
-          <a class="btn" href="https://opencollective.com/scidsg/"
-            ><span class="emoji">❤️</span> Donate</a
+            <button id="enable-autorenew">Automatically Renew</button>
+          </form>
+          <form
+            id="cancel-form"
+            action="{{ url_for('premium.disable_autorenew') }}"
+            method="post"
           >
-        </div>
-      </nav>
-    </header>
-
-    <main class="tier-select">
-      <div class="container">
-        <h2 class="centered-heading">Choose a Hush&nbsp;Line&nbsp;Plan</h2>
-        <div id="plan-wrapper">
-          <div class="plan">
-            {% if user.is_free_tier %}
-              <p class="plan-status badge">📍 Current Plan</p>
-            {% endif %}
-            {% if user.is_business_tier %}
-              <p class="plan-status badge">👇 Fewer Features</p>
-            {% endif %}
-            {% include "premium/free-features.html" %}
-          </div>
-          <div class="plan plan-recommended">
-            {% if user.is_free_tier %}
-              <p class="plan-status badge">⭐️ Recommended for Businesses</p>
-            {% endif %}
-            {% if user.is_business_tier %}
-              <p class="plan-status badge">📍 Current Plan</p>
-            {% endif %}
-            {% include "premium/business-features.html" %}
-            {% if user.is_free_tier %}
-              <form
-                id="upgrade-form"
-                action="{{ url_for('premium.upgrade') }}"
-                method="post"
-              >
-                <button id="upgrade">Upgrade Now</button>
-              </form>
-            {% endif %}
-            {% if user.is_business_tier %}
-              {% if user.stripe_subscription_cancel_at_period_end %}
-                <p class="meta sub-info">⚠️ Your subscription will expire on {{ user.stripe_subscription_current_period_end.strftime('%B %d, %Y') }}.</p>
-                <form
-                  id="enable-autorenew-form"
-                  action="{{ url_for('premium.disable_autorenew') }}"
-                  method="post"
-                >
-                  <button id="enable-autorenew">Automatically Renew</button>
-                </form>
-                <form
-                  id="cancel-form"
-                  action="{{ url_for('premium.disable_autorenew') }}"
-                  method="post"
-                >
-                  <button id="cancel" class="btn">Cancel Now</button>
-                </form>
-              {% else %}
-                <form
-                  id="disable-autorenew-form"
-                  action="{{ url_for('premium.disable_autorenew') }}"
-                  method="post"
-                >
-                  <button class="btn" id="disable-autorenew">Don't Renew</button>
-                </form>
-              {% endif %}
-            {% endif %}
-          </div>
-        </div>
-
-        {% if invoices %}
-        <div id="invoice-wrapper">
-            <h3>Invoices</h3>
-            <table class="table">
-              <thead>
-                <tr>
-                  <th>Date</th>
-                  <th>Amount Paid</th>
-                  <th>Status</th>
-                  <th>Receipt</th>
-                </tr>
-              </thead>
-              <tbody>
-                {% for invoice in invoices %}
-                  <tr>
-                    <td>{{ invoice.created_at.strftime('%Y-%m-%d') }}</td>
-                    <td>${{ invoice.total / 100 }}</td>
-                    <td>{{ invoice.status.value }}</td>
-                    <td>
-                      <a href="{{ invoice.hosted_invoice_url }}" target="_blank">
-                        Receipt
-                      </a>
-                    </td>
-                  </tr>
-                {% endfor %}
-              </tbody>
-            </table>
-        </div>
+            <button id="cancel" class="btn">Cancel Now</button>
+          </form>
+        {% else %}
+          <form
+            id="disable-autorenew-form"
+            action="{{ url_for('premium.disable_autorenew') }}"
+            method="post"
+          >
+            <button class="btn" id="disable-autorenew">Don't Renew</button>
+          </form>
         {% endif %}
-      </div>
-    </main>
+      {% endif %}
+    </div>
+  </div>
 
-    <footer>
-      <p>
-        <a
-          href="https://github.com/scidsg/hushline/blob/main/docs/PRIVACY.md"
-          target="_blank"
-          rel="noopener noreferrer"
-          >Privacy Policy</a
-        >
-        |
-        <a
-          href="https://github.com/scidsg/hushline/blob/main/docs/TERMS.md"
-          target="_blank"
-          rel="noopener noreferrer"
-          >Terms of Service</a
-        >
-        |
-        <a
-          href="https://github.com/scidsg/hushline"
-          target="_blank"
-          rel="noopener noreferrer"
-          >v{{ config.VERSION }}</a
-        >
-      </p>
-    </footer>
-    <script src="{{ url_for('static', filename='js/global.js') }}"></script>
-    <script src="{{ url_for('static', filename='js/premium.js') }}"></script>
-  </body>
-</html>
+  {% if invoices %}
+    <div id="invoice-wrapper">
+        <h3>Invoices</h3>
+        <table class="table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Amount Paid</th>
+              <th>Status</th>
+              <th>Receipt</th>
+            </tr>
+          </thead>
+          <tbody>
+            {% for invoice in invoices %}
+              <tr>
+                <td>{{ invoice.created_at.strftime('%Y-%m-%d') }}</td>
+                <td>${{ invoice.total / 100 }}</td>
+                <td>{{ invoice.status.value }}</td>
+                <td>
+                  <a href="{{ invoice.hosted_invoice_url }}" target="_blank">
+                    Receipt
+                  </a>
+                </td>
+              </tr>
+            {% endfor %}
+          </tbody>
+        </table>
+    </div>
+  {% endif %}
+{% endblock %}

--- a/hushline/templates/server_info.html
+++ b/hushline/templates/server_info.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Hush Line Personal Server{% endblock %}
+{% block title %}Hush Line Server Info{% endblock %}
 
 {% block content %}
   <h1>Welcome to Hush Line</h1>

--- a/hushline/templates/settings/email.html
+++ b/hushline/templates/settings/email.html
@@ -32,15 +32,9 @@
           </div>
         </label>
       </div>
-      {% if not is_personal_server and default_forwarding_enabled %}
+      {% if default_forwarding_enabled and smtp_forwarding_message_html %}
         <p class="meta">
-          ✊ Email forwarding is powered by
-          <a
-            href="https://riseup.net"
-            target="_blank"
-            rel="noopener noreferrer"
-            >Riseup.net</a
-          >.
+          {{ smtp_forwarding_message_html }}
         </p>
       {% endif %}
       <fieldset id="forwarding_enabled_fields">

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -1,9 +1,21 @@
+import os
+from typing import Callable
+
+import pytest
 from flask import Flask, url_for
+from pytest_mock import MockFixture
+
+
+@pytest.fixture()
+def env_var_modifier(mocker: MockFixture) -> Callable[[MockFixture], None]:
+    def modifier(mocker: MockFixture) -> None:
+        mocker.patch.dict(os.environ, {"ONION_HOSTNAME": "example.onion"})
+
+    return modifier
 
 
 def test_info_available_on_personal_server(app: Flask) -> None:
     app.config["IS_PERSONAL_SERVER"] = True
-    app.config["ONION_HOSTNAME"] = "example.onion"
 
     with app.test_client() as client:
         response = client.get(url_for("personal_server_info"))
@@ -14,7 +26,6 @@ def test_info_available_on_personal_server(app: Flask) -> None:
 
 def test_info_not_available_by_default(app: Flask) -> None:
     app.config["IS_PERSONAL_SERVER"] = False
-    app.config["ONION_HOSTNAME"] = "example.onion"
 
     with app.test_client() as client:
         response = client.get(url_for("personal_server_info"))

--- a/tests/test_info.py
+++ b/tests/test_info.py
@@ -14,19 +14,9 @@ def env_var_modifier(mocker: MockFixture) -> Callable[[MockFixture], None]:
     return modifier
 
 
-def test_info_available_on_personal_server(app: Flask) -> None:
-    app.config["IS_PERSONAL_SERVER"] = True
-
+def test_info_available(app: Flask) -> None:
     with app.test_client() as client:
-        response = client.get(url_for("personal_server_info"))
+        response = client.get(url_for("server_info"))
         assert response.status_code == 200
-        assert "Hush Line Personal Server" in response.get_data(as_text=True)
+        assert "Hush Line Server Info" in response.get_data(as_text=True)
         assert "example.onion" in response.get_data(as_text=True)
-
-
-def test_info_not_available_by_default(app: Flask) -> None:
-    app.config["IS_PERSONAL_SERVER"] = False
-
-    with app.test_client() as client:
-        response = client.get(url_for("personal_server_info"))
-        assert response.status_code == 404


### PR DESCRIPTION
fixes #646
fixes #626 

- Removes `IS_PERSONAL_SERVER` flag and `is_personal_server` jinja var
- Removes hardcoded riseup.net text and replaces with `SMTP_FORWARDING_MESSAGE_HTML` env var
- Changes logic for `/directory` route to use `DIRECTORY_VERIFIED_TAB_ENABLED` env var instead of `IS_PERSONAL_SERVER`
- Removes `ProxyFix` that has dubiously correct settings with unused results
- Detects "personal server / Tor" via `request.host`
- renamed JS files (didn't change them, but the diff thinks I did)
- adds docs for all currently supported configs (others exist, but they're purposely undocumented so we don't have to support them)