### PR TITLE
Push container images to DigitalOcean Container Registry

### DIFF
--- a/.github/workflows/build-and-deploy-latest.yml
+++ b/.github/workflows/build-and-deploy-latest.yml
@@ -19,13 +19,21 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install doctl and authenticate
+        run: |
+          sudo snap install doctl jq
+          doctl auth init -t $DIGITALOCEAN_TOKEN
+        env:
+          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
           context: .
           file: ./Dockerfile.prod
           push: true
-          tags: ghcr.io/${{ github.repository }}/hushline:latest
+          tags: |
+            ghcr.io/${{ github.repository }}/hushline:latest
+            registry.digitalocean.com/scidsg/hushline:latest
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-deploy-release.yml
+++ b/.github/workflows/build-and-deploy-release.yml
@@ -28,6 +28,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install doctl and authenticate
+        run: |
+          sudo snap install doctl jq
+          doctl auth init -t $DIGITALOCEAN_TOKEN
+        env:
+          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -37,6 +43,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/hushline:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}/hushline:release
+            registry.digitalocean.com/scidsg/hushline:${{ github.ref_name }}
+            registry.digitalocean.com/scidsg/hushline:release
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
When building a `latest` or `release` docker image, this pushes the image to a private DigitalOcean Container Registry as well as the public GitHub Container Registry.

Note: I haven't tried running this in GitHub Actions, but I have manually authenticated to DOCR using a DO token and pushed images to this container registry using the same commands, so I expect it will work.