### PR TITLE
Publish to Docker Hub

### DIFF
--- a/.github/workflows/build-and-deploy-latest.yml
+++ b/.github/workflows/build-and-deploy-latest.yml
@@ -19,12 +19,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install doctl and authenticate
-        run: |
-          sudo snap install doctl jq
-          doctl auth init -t $DIGITALOCEAN_TOKEN
-        env:
-          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
+      - name: Log in to DockerHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: hub.docker.com
+          username: scidsg
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -33,7 +33,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/hushline:latest
-            registry.digitalocean.com/scidsg/hushline:latest
+            hub.docker.com/scidsg/hushline:latest
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-deploy-latest.yml
+++ b/.github/workflows/build-and-deploy-latest.yml
@@ -33,7 +33,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/${{ github.repository }}/hushline:latest
-            hub.docker.com/scidsg/hushline:latest
+            scidsg/hushline:latest
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-deploy-latest.yml
+++ b/.github/workflows/build-and-deploy-latest.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - dockerhub
 
 jobs:
   build-and-push:

--- a/.github/workflows/build-and-deploy-latest.yml
+++ b/.github/workflows/build-and-deploy-latest.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - dockerhub
 
 jobs:
   build-and-push:

--- a/.github/workflows/build-and-deploy-latest.yml
+++ b/.github/workflows/build-and-deploy-latest.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Log in to DockerHub Container Registry
         uses: docker/login-action@v3
         with:
-          registry: hub.docker.com
-          username: scidsg
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/build-and-deploy-release.yml
+++ b/.github/workflows/build-and-deploy-release.yml
@@ -28,11 +28,10 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Log in to DockerHub Container Registry
+      - name: Log in to DockerHub
         uses: docker/login-action@v3
         with:
-          registry: hub.docker.com
-          username: scidsg
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
@@ -43,8 +42,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/hushline:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}/hushline:release
-            hub.docker.com/scidsg/hushline:${{ github.ref_name }}
-            hub.docker.com/scidsg/hushline:release
+            scidsg/hushline:${{ github.ref_name }}
+            scidsg/hushline:release
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-and-deploy-release.yml
+++ b/.github/workflows/build-and-deploy-release.yml
@@ -28,12 +28,12 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Install doctl and authenticate
-        run: |
-          sudo snap install doctl jq
-          doctl auth init -t $DIGITALOCEAN_TOKEN
-        env:
-          DIGITALOCEAN_TOKEN: ${{ secrets.DIGITALOCEAN_TOKEN }}
+      - name: Log in to DockerHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: hub.docker.com
+          username: scidsg
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
@@ -43,8 +43,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/hushline:${{ github.ref_name }}
             ghcr.io/${{ github.repository }}/hushline:release
-            registry.digitalocean.com/scidsg/hushline:${{ github.ref_name }}
-            registry.digitalocean.com/scidsg/hushline:release
+            hub.docker.com/scidsg/hushline:${{ github.ref_name }}
+            hub.docker.com/scidsg/hushline:release
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
This stops trying to publish to DigitalOcean Container Registry, and instead publishes to Docker Hub here: https://hub.docker.com/r/scidsg/hushline

I tested it out by making build-and-deploy-latest.yml deploy `latest` on the `dockerhub` branch, rather than just the `main` branch, and it works. Here's the job where it pushed to Docker Hub: https://github.com/scidsg/hushline/actions/runs/11467211631/job/31909592576

You can pull the container from Docker Hub with: `docker pull scidsg/hushline:latest`