### PR TITLE
Add Environment Variable for Intro Text on Directory Page

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -17,6 +17,12 @@ services:
       SESSION_COOKIE_NAME: session
       NOTIFICATIONS_ADDRESS: notifications@hushline.app
       DIRECTORY_VERIFIED_TAB_ENABLED: "${DIRECTORY_VERIFIED_TAB_ENABLED:-true}"
+      HUSHLINE_INTRO_TEXT: | 
+        👋 
+        <a href="https://hushline.app" target="_blank">Hush Line</a>
+        connects whistleblowers with lawyers, journalists, business leaders, and more.
+        We advise speaking to a legal professional before taking any confidential
+        information from your workplace.
       SMTP_FORWARDING_MESSAGE_HTML: |
         ✊ Email forwarding is powered by
         <a href="https://riseup.net" target="_blank">Riseup.net</a>.

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -526,7 +526,7 @@ def init_app(app: Flask) -> None:
                 "connects whistleblowers with lawyers, journalists, business leaders, and more. "
                 "We advise speaking to a legal professional before taking any confidential "
                 "information from your workplace."
-            )
+            ),
         )
         return render_template(
             "directory.html",

--- a/hushline/routes.py
+++ b/hushline/routes.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import re
 import secrets
 import socket
@@ -518,10 +519,20 @@ def init_app(app: Flask) -> None:
     @app.route("/directory")
     def directory() -> Response | str:
         logged_in = "user_id" in session
+        hushline_intro_text = os.getenv(
+            "HUSHLINE_INTRO_TEXT",
+            (
+                "👋 <a href='https://hushline.app' target='_blank'>Hush Line</a> "
+                "connects whistleblowers with lawyers, journalists, business leaders, and more. "
+                "We advise speaking to a legal professional before taking any confidential "
+                "information from your workplace."
+            )
+        )
         return render_template(
             "directory.html",
             usernames=get_directory_usernames(),
             logged_in=logged_in,
+            HUSHLINE_INTRO_TEXT=hushline_intro_text,
         )
 
     @app.route("/directory/get-session-user.json")

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -1,15 +1,14 @@
-{% extends "base.html" %} {% block title %}Directory{% endblock %} {% block
-content %}
+{% extends "base.html" %}
+{% block title %}Directory{% endblock %}
+{% block content %}
 <h2>User Directory</h2>
-{% if directory_verified_tab_enabled %} {% if not logged_in %}
+
+{% if not logged_in %}
 <p class="helper section-intro">
-  👋
-  <a href="https://hushline.app" target="_blank">Hush Line</a>
-  connects whistleblowers with lawyers, journalists, business leaders, and more.
-  We advise speaking to a legal professional before taking any confidential
-  information from your workplace.
+  {{ HUSHLINE_INTRO_TEXT | safe }}
 </p>
 {% endif %}
+
 <div class="directory-tabs">
   <ul class="tab-list" role="tablist">
     <li role="presentation">
@@ -40,7 +39,7 @@ content %}
     </li>
   </ul>
 </div>
-{% endif %}
+
 <div class="search-box">
   <label id="searchIcon" for="searchInput" aria-label="Search users">
     <img
@@ -58,6 +57,7 @@ content %}
     &times;
   </button>
 </div>
+
 {% if directory_verified_tab_enabled %}
 <div
   id="verified"
@@ -78,40 +78,44 @@ content %}
   </p>
   {% endif %}
   <div class="user-list">
-    {% for username in usernames %} {% if username.is_verified and
-    username.show_in_directory %}
-    <article class="user">
-      <h3>{{ username.display_name or username.username }}</h3>
-      {% if username.username %}
-      <p class="meta">@{{ username.username }}</p>
-      {% endif %} {% if username.is_verified or useranme.user.is_admin %}
-      <div class="badgeContainer">
-        {% if username.user.is_admin %}
-        <p class="badge">⚙️ Admin</p>
-        {% endif %} {% if username.is_verified %}
-        <p class="badge">⭐️ Verified</p>
+    {% for username in usernames %}
+      {% if username.is_verified and username.show_in_directory %}
+      <article class="user">
+        <h3>{{ username.display_name or username.username }}</h3>
+        {% if username.username %}
+        <p class="meta">@{{ username.username }}</p>
         {% endif %}
-      </div>
-      {% endif %} {% if username.bio %}
-      <p class="bio">{{ username.bio }}</p>
+        {% if username.is_verified or username.user.is_admin %}
+        <div class="badgeContainer">
+          {% if username.user.is_admin %}
+          <p class="badge">⚙️ Admin</p>
+          {% endif %}
+          {% if username.is_verified %}
+          <p class="badge">⭐️ Verified</p>
+          {% endif %}
+        </div>
+        {% endif %}
+        {% if username.bio %}
+        <p class="bio">{{ username.bio }}</p>
+        {% endif %}
+        <div class="user-actions">
+          <a href="{{ url_for('profile', username=username.username) }}"
+            >View Profile</a
+          >
+          {% if logged_in %}
+          <a
+            href="#"
+            class="report-link"
+            data-username="{{ username.username }}"
+            data-display-name="{{ username.display_name or username.username }}"
+            data-bio="{{ username.bio }}"
+            >Report Account</a
+          >
+          {% endif %}
+        </div>
+      </article>
       {% endif %}
-      <div class="user-actions">
-        <a href="{{ url_for('profile', username=username.username) }}"
-          >View Profile</a
-        >
-        {% if logged_in %}
-        <a
-          href="#"
-          class="report-link"
-          data-username="{{ username.username }}"
-          data-display-name="{{ username.display_name or username.username }}"
-          data-bio="{{ username.bio }}"
-          >Report Account</a
-        >
-        {% endif %}
-      </div>
-    </article>
-    {% endif %} {% else %}
+    {% else %}
     <p class="empty-message">
       <span class="emoji-message">🙈</span><br />Nothing to see here...
     </p>
@@ -119,6 +123,7 @@ content %}
   </div>
 </div>
 {% endif %}
+
 <div
   id="all"
   class="tab-content {% if not directory_verified_tab_enabled %}active{% endif %}"
@@ -126,47 +131,56 @@ content %}
   aria-labelledby="all-users-tab"
 >
   <div class="user-list">
-    {% for username in usernames %} {% if username.show_in_directory %}
-    <article class="user">
-      <h3>{{ username.display_name or username.username }}</h3>
-      {% if username.username %}
-      <p class="meta">@{{ username.username }}</p>
-      {% endif %} {% if username.is_verified or username.user.is_admin %}
-      <div class="badgeContainer">
-        {% if username.user.is_admin %}
-        <p class="badge">⚙️ Admin</p>
-        {% endif %} {% if username.is_verified %}
-        <p class="badge">⭐️ Verified</p>
+    {% for username in usernames %}
+      {% if username.show_in_directory %}
+      <article class="user">
+        <h3>{{ username.display_name or username.username }}</h3>
+        {% if username.username %}
+        <p class="meta">@{{ username.username }}</p>
         {% endif %}
-      </div>
-      {% endif %} {% if username.bio %}
-      <p class="bio">{{ username.bio }}</p>
+        {% if username.is_verified or username.user.is_admin %}
+        <div class="badgeContainer">
+          {% if username.user.is_admin %}
+          <p class="badge">⚙️ Admin</p>
+          {% endif %}
+          {% if username.is_verified %}
+          <p class="badge">⭐️ Verified</p>
+          {% endif %}
+        </div>
+        {% endif %}
+        {% if username.bio %}
+        <p class="bio">{{ username.bio }}</p>
+        {% endif %}
+        <div class="user-actions">
+          <a href="{{ url_for('profile', username=username.username) }}"
+            >View Profile</a
+          >
+          {% if logged_in %}
+          <a
+            href="#"
+            class="report-link"
+            data-username="{{ username.username }}"
+            data-display-name="{{ username.display_name or username.username }}"
+            data-bio="{{ username.bio }}"
+            >Report Account</a
+          >
+          {% endif %}
+        </div>
+      </article>
       {% endif %}
-      <div class="user-actions">
-        <a href="{{ url_for('profile', username=username.username) }}"
-          >View Profile</a
-        >
-        {% if logged_in %}
-        <a
-          href="#"
-          class="report-link"
-          data-username="{{ username.username }}"
-          data-display-name="{{ username.display_name or username.username }}"
-          data-bio="{{ username.bio }}"
-          >Report Account</a
-        >
-        {% endif %}
-      </div>
-    </article>
-    {% endif %} {% else %}
+    {% else %}
     <p class="empty-message">
       <span class="emoji-message">🙈</span><br />Nothing to see here...
     </p>
     {% endfor %}
   </div>
 </div>
-{% endblock %} {% block scripts %} {% if directory_verified_tab_enabled %}
+{% endblock %}
+
+{% block scripts %}
+{% if directory_verified_tab_enabled %}
 <script src="{{ url_for('static', filename='js/directory_verified.js') }}"></script>
 {% else %}
 <script src="{{ url_for('static', filename='js/directory.js') }}"></script>
-{% endif %} {% endblock %}
+{% endif %}
+{% endblock %}


### PR DESCRIPTION
1. Environment Variable for Intro Text:
	    • Introduced a new environment variable, `HUSHLINE_INTRO_TEXT`, in docker-compose.yaml. This variable allows administrators to set a custom intro paragraph for the Directory page directly from the environment configuration.
	    • Default text is provided in the route to ensure a fallback message if `HUSHLINE_INTRO_TEXT` is undefined.
2. Template Update:
	    • Updated directory.html to render `HUSHLINE_INTRO_TEXT` using the Jinja `|safe` filter, ensuring the variable’s HTML content displays correctly without being escaped.
            • Removed the outer `{% if directory_verified_tab_enabled %}` conditional around the intro text, simplifying the logic to only check `{% if not logged_in %}`.
3. Route Update:
	    • Modified the directory route to fetch `HUSHLINE_INTRO_TEXT` from the environment and pass it to the template. If the environment variable is not set, the route defaults to a predefined message.