### PR TITLE
Settings Nav Display Logic

### DIFF
--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -516,10 +516,7 @@
   /* Change background color of tabs on hover */
   .tab:hover,
   .subtab:hover {
-    background-color: oklch(
-      /* was rgba(255, 255, 255, 0.1) now with color */ from
-        var(--color-dark-bg) 0.15 calc(12 * c) h / 0.0675
-    );
+    background-color: var(--color-dark-bg-alt-1);
   }
 
   /* Create an active/current tablink class */

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -174,7 +174,7 @@
   /* Change background color of tabs on hover */
   .tab:hover,
   .subtab:hover,
-  .settings-main .settings-content .tab:hover{
+  .settings-main .settings-content .tab:hover {
     background-color: oklch(
       /* #fbf3ff */ from var(--color-brand-bg) 0.97 c h / 0.85
     );
@@ -2365,8 +2365,8 @@ p.bio + .extra-fields {
 }
 
 .settings-main .settings-content .tab-list li button:hover {
-  padding-left: .625rem;
-  transition: .3s;
+  padding-left: 0.625rem;
+  transition: 0.3s;
 }
 
 .settings-main .settings-content .settings-tabs {
@@ -2380,7 +2380,7 @@ p.bio + .extra-fields {
 .settings-main .settings-content .tab-list {
   display: flex;
   flex-direction: column;
-  padding-top: .5rem;
+  padding-top: 0.5rem;
 }
 
 .settings-main .settings-content .settings-tabs + div {
@@ -2427,13 +2427,12 @@ p.bio + .extra-fields {
 
   .settings-main .settings-content .tab-list li button {
     padding: 1rem 0.625rem;
-    
   }
 
   .settings-main .settings-content .tab-list {
     display: flex;
     flex-direction: row;
-    padding-top: .5rem;
+    padding-top: 0.5rem;
   }
 
   .settings-main .settings-content .settings-tabs + div {

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -2427,6 +2427,7 @@ p.bio + .extra-fields {
 
   .settings-main .settings-content .tab-list li button {
     padding: 1rem 0.625rem;
+    transition: none;
   }
 
   .settings-main .settings-content .tab-list {

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -583,12 +583,12 @@
       );
   }
 
-    @media (max-width: 640px) {
-      .settings-main .settings-content .tab.active,
-      .settings-main .settings-content .subtab.active {
-        box-shadow: 0 -2px 0 inset var(--color-brand-dark-min-saturation);
-        border-bottom: 1px solid var(--color-brand-dark-min-saturation);
-        border-left: none;
+  @media (max-width: 640px) {
+    .settings-main .settings-content .tab.active,
+    .settings-main .settings-content .subtab.active {
+      box-shadow: 0 -2px 0 inset var(--color-brand-dark-min-saturation);
+      border-bottom: 1px solid var(--color-brand-dark-min-saturation);
+      border-left: none;
     }
 
     .settings-main .settings-content .tab-list {

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -186,8 +186,8 @@
     border-bottom: 1px solid var(--color-brand);
   }
 
-  .settings-content .tab.active,
-  .settings-content .subtab.active {
+  .settings-main .settings-content .tab.active,
+  .settings-main .settings-content .subtab.active {
     box-shadow: none;
     border-left: none;
     border-bottom: none;
@@ -195,7 +195,7 @@
     border-left: 1px solid var(--color-brand);
   }
 
-  .settings-content .tab-list {
+  .settings-main .settings-content .tab-list {
     border-bottom: none;
   }
 
@@ -386,18 +386,18 @@
   }
 
   @media (max-width: 640px) {
-    .settings-content .tab.active,
-    .settings-content .subtab.active {
+    .settings-main .settings-content .tab.active,
+    .settings-main .settings-content .subtab.active {
       box-shadow: 0 -2px 0 inset var(--color-brand);
       border-bottom: 1px solid var(--color-brand);
       border-left: none;
     }
 
-    .settings-content .tab-list {
+    .settings-main .settings-content .tab-list {
       border-bottom: var(--border);
     }
   }
-  .settings-content .tab-list li button {
+  .settings-main .settings-content .tab-list li button {
     padding: 1rem;
   }
 
@@ -528,14 +528,14 @@
     border-bottom: 1px solid var(--color-brand-dark-min-saturation);
   }
 
-  .settings-content .tab.active,
-  .settings-content .subtab.active {
-    box-shadow: none;
-    border-left: none;
+  .settings-main .settings-content .tab.active,
+  .settings-main .settings-content .subtab.active {
     border-bottom: none;
+    box-shadow: 2px 0 0 inset var(--color-brand-dark-min-saturation);
+    border-left: 1px solid var(--color-brand-dark-min-saturation);
   }
 
-  .settings-content .tab-list {
+  .settings-main .settings-content .tab-list {
     border-bottom: none;
   }
 
@@ -581,6 +581,19 @@
         /* rgba(125, 37, 193, 0.25) */ from
           var(--color-brand-dark-max-saturation) l c h / 0.25
       );
+  }
+
+    @media (max-width: 640px) {
+      .settings-main .settings-content .tab.active,
+      .settings-main .settings-content .subtab.active {
+        box-shadow: 0 -2px 0 inset var(--color-brand-dark-min-saturation);
+        border-bottom: 1px solid var(--color-brand-dark-min-saturation);
+        border-left: none;
+    }
+
+    .settings-main .settings-content .tab-list {
+      border-bottom: var(--border-dark);
+    }
   }
 
   .formBody input[type="submit"]:hover,
@@ -2343,42 +2356,46 @@ p.bio + .extra-fields {
   align-self: center;
 }
 
-.settings-content {
+.settings-main .settings-content {
   display: flex;
   flex-direction: row;
   gap: 2rem;
   width: 100%;
 }
 
-.settings-content .tab-list li button:hover {
+.settings-main .settings-content .tab-list li button:hover {
   background-color: transparent;
   text-decoration: underline;
 }
 
-.settings-content .tab-list li button {
+.settings-main .settings-content .tab-list li button {
   padding: 0.75rem 0.75rem 0.75rem 0;
 }
 
-.settings-content .tab-list {
+.settings-main .settings-content .tab-list {
   display: flex;
   flex-direction: column;
 }
 
-.settings-content .settings-tabs + div {
+.settings-main .settings-content .settings-tabs + div {
+  width: 100%;
+}
+
+.settings-main .settings-main {
+  max-width: 960px;
+}
+
+.settings-main .settings-content .tab.active,
+.settings-main .settings-content .subtab.active {
+  padding: 0.75rem;
+}
+
+.settings-main .settings-content textarea {
   width: 100%;
 }
 
 .settings-main {
   max-width: 960px;
-}
-
-.settings-content .tab.active,
-.settings-content .subtab.active {
-  padding: 0.75rem;
-}
-
-.settings-content textarea {
-  width: 100%;
 }
 
 @media (max-width: 640px) {
@@ -2395,33 +2412,29 @@ p.bio + .extra-fields {
     flex-direction: column;
   }
 
-  .settings-content {
+  .settings-main .settings-content {
     display: flex;
     flex-direction: column;
     gap: 0;
     width: 100%;
   }
 
-  .settings-content .tab-list li button:hover {
+  .settings-main .settings-content .tab-list li button:hover {
     background-color: transparent;
     text-decoration: underline;
   }
 
-  .settings-content .tab-list li button {
+  .settings-main .settings-content .tab-list li button {
     padding: 1rem 0.5rem;
   }
 
-  .settings-content .tab-list {
+  .settings-main .settings-content .tab-list {
     display: flex;
     flex-direction: row;
   }
 
-  .settings-content .settings-tabs + div {
+  .settings-main .settings-content .settings-tabs + div {
     width: 100%;
-  }
-
-  .settings-main {
-    max-width: 960px;
   }
 }
 

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -186,6 +186,19 @@
     border-bottom: 1px solid var(--color-brand);
   }
 
+  .settings-content .tab.active,
+  .settings-content .subtab.active {
+    box-shadow: none;
+    border-left: none;
+    border-bottom: none;
+    box-shadow: 2px 0 0 inset var(--color-brand);
+    border-left: 1px solid var(--color-brand);
+  }
+
+  .settings-content .tab-list {
+    border-bottom: none;
+  }
+
   .user,
   #results > div {
     border: var(--border);
@@ -372,6 +385,22 @@
     }
   }
 
+  @media (max-width: 640px) {
+    .settings-content .tab.active,
+    .settings-content .subtab.active {
+      box-shadow: 0 -2px 0 inset var(--color-brand);
+      border-bottom: 1px solid var(--color-brand);
+      border-left: none;
+    }
+
+    .settings-content .tab-list {
+      border-bottom: var(--border);
+    }
+  }
+  .settings-content .tab-list li button {
+    padding: 1rem;
+  }
+
   .pgp-disabled-overlay {
     background-color: rgba(255, 255, 255, 0.7);
   }
@@ -497,6 +526,17 @@
   .subtab.active {
     box-shadow: 0 -2px 0 inset var(--color-brand-dark-min-saturation);
     border-bottom: 1px solid var(--color-brand-dark-min-saturation);
+  }
+
+  .settings-content .tab.active,
+  .settings-content .subtab.active {
+    box-shadow: none;
+    border-left: none;
+    border-bottom: none;
+  }
+
+  .settings-content .tab-list {
+    border-bottom: none;
   }
 
   .user,
@@ -1179,7 +1219,6 @@ textarea,
 select {
   display: flex;
   flex-direction: column;
-  max-width: 640px;
   width: 100%;
   padding: 0.75rem;
   font-size: var(--font-size-base);
@@ -2304,6 +2343,44 @@ p.bio + .extra-fields {
   align-self: center;
 }
 
+.settings-content {
+  display: flex;
+  flex-direction: row;
+  gap: 2rem;
+  width: 100%;
+}
+
+.settings-content .tab-list li button:hover {
+  background-color: transparent;
+  text-decoration: underline;
+}
+
+.settings-content .tab-list li button {
+  padding: 0.75rem 0.75rem 0.75rem 0;
+}
+
+.settings-content .tab-list {
+  display: flex;
+  flex-direction: column;
+}
+
+.settings-content .settings-tabs + div {
+  width: 100%;
+}
+
+.settings-main {
+  max-width: 960px;
+}
+
+.settings-content .tab.active,
+.settings-content .subtab.active {
+  padding: 0.75rem;
+}
+
+.settings-content textarea {
+  width: 100%;
+}
+
 @media (max-width: 640px) {
   .extra-fields {
     flex-direction: column;
@@ -2316,6 +2393,35 @@ p.bio + .extra-fields {
 
   #plan-wrapper {
     flex-direction: column;
+  }
+
+  .settings-content {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    width: 100%;
+  }
+
+  .settings-content .tab-list li button:hover {
+    background-color: transparent;
+    text-decoration: underline;
+  }
+
+  .settings-content .tab-list li button {
+    padding: 1rem 0.5rem;
+  }
+
+  .settings-content .tab-list {
+    display: flex;
+    flex-direction: row;
+  }
+
+  .settings-content .settings-tabs + div {
+    width: 100%;
+  }
+
+  .settings-main {
+    max-width: 960px;
   }
 }
 

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -173,7 +173,8 @@
 
   /* Change background color of tabs on hover */
   .tab:hover,
-  .subtab:hover {
+  .subtab:hover,
+  .settings-main .settings-content .tab:hover{
     background-color: oklch(
       /* #fbf3ff */ from var(--color-brand-bg) 0.97 c h / 0.85
     );
@@ -2364,30 +2365,35 @@ p.bio + .extra-fields {
 }
 
 .settings-main .settings-content .tab-list li button:hover {
-  background-color: transparent;
-  text-decoration: underline;
+  padding-left: .625rem;
+  transition: .3s;
+}
+
+.settings-main .settings-content .settings-tabs {
+  width: 240px;
 }
 
 .settings-main .settings-content .tab-list li button {
-  padding: 0.75rem 0.75rem 0.75rem 0;
+  padding: 1rem 0.625rem 1rem 0;
 }
 
 .settings-main .settings-content .tab-list {
   display: flex;
   flex-direction: column;
+  padding-top: .5rem;
 }
 
 .settings-main .settings-content .settings-tabs + div {
   width: 100%;
 }
 
-.settings-main .settings-main {
-  max-width: 960px;
+.settings-main {
+  max-width: 768px;
 }
 
 .settings-main .settings-content .tab.active,
 .settings-main .settings-content .subtab.active {
-  padding: 0.75rem;
+  padding: 1rem 0.625rem;
 }
 
 .settings-main .settings-content textarea {
@@ -2419,22 +2425,28 @@ p.bio + .extra-fields {
     width: 100%;
   }
 
-  .settings-main .settings-content .tab-list li button:hover {
-    background-color: transparent;
-    text-decoration: underline;
-  }
-
   .settings-main .settings-content .tab-list li button {
-    padding: 1rem 0.5rem;
+    padding: 1rem 0.625rem;
+    
   }
 
   .settings-main .settings-content .tab-list {
     display: flex;
     flex-direction: row;
+    padding-top: .5rem;
   }
 
   .settings-main .settings-content .settings-tabs + div {
     width: 100%;
+  }
+
+  .settings-main .settings-content .tab.active,
+  .settings-main .settings-content .subtab.active {
+    padding: 1rem 0.625rem;
+  }
+
+  .settings-main .settings-content .settings-tabs {
+    width: inherit;
   }
 }
 

--- a/hushline/static/js/settings.js
+++ b/hushline/static/js/settings.js
@@ -2,12 +2,18 @@ document.addEventListener("DOMContentLoaded", function () {
   const tabs = document.querySelectorAll(".tab");
   const tabPanels = document.querySelectorAll(".tab-content");
   const bioCountEl = document.querySelector(".bio-count");
+  const mainElement = document.querySelector("main");
+  const tabList = document.querySelectorAll(".tab-list .tab");
+
+  // Apply "settings-main" class if there are 5 or more tabs
+  if (tabList.length >= 5) {
+    mainElement.classList.add("settings-main");
+  }
 
   // Restore the active tab on page load
   function restoreActiveTab() {
     const activeTab = localStorage.getItem("activeTab");
     if (activeTab) {
-      // Deactivate all tabs and hide all tab contents
       tabs.forEach((tab) => {
         tab.classList.remove("active");
         tab.setAttribute("aria-selected", "false");
@@ -17,7 +23,6 @@ document.addEventListener("DOMContentLoaded", function () {
         panel.setAttribute("hidden", "true");
       });
 
-      // Activate the stored tab and show the corresponding content
       const activeTabElement = document.getElementById(`${activeTab}-tab`);
       const activePanelElement = document.getElementById(activeTab);
 
@@ -76,18 +81,15 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 
   if (document.getElementById("branding")) {
-    // Update color in real-time as they're being browsed & finalized
     const colorPicker = document.getElementById("brand-primary-color");
 
     for (const eventName of ["input", "change"]) {
       colorPicker.addEventListener(eventName, function (event) {
         const brandColor = `oklch(from ${event.target.value} l c h)`;
-        const cssVariable = ["--color-brand", brandColor];
-        document.documentElement.style.setProperty(...cssVariable);
+        document.documentElement.style.setProperty("--color-brand", brandColor);
       });
     }
 
-    // Update app name in real-time as it's being typed
     const appNameBox = document.getElementById("brand-app-name");
 
     appNameBox.addEventListener("input", function (event) {
@@ -95,48 +97,24 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
-  var forwarding_enabled = document.querySelector(
-    "input[id='forwarding_enabled']",
-  ).checked;
-  var forwarding_enabled_fieldset = document.querySelector(
-    "fieldset[id='forwarding_enabled_fields']",
-  );
+  var forwarding_enabled = document.querySelector("input[id='forwarding_enabled']").checked;
+  var forwarding_enabled_fieldset = document.querySelector("fieldset[id='forwarding_enabled_fields']");
   forwarding_enabled_fieldset.hidden = !forwarding_enabled;
 
-  document
-    .querySelector("input[id='forwarding_enabled']")
-    .addEventListener("change", function (e) {
-      // time out to let animation finish
-      setTimeout(() => {
-        var fieldset = document.querySelector(
-          "fieldset[id='forwarding_enabled_fields']",
-        );
-        fieldset.hidden = !e.target.checked;
+  document.querySelector("input[id='forwarding_enabled']").addEventListener("change", function (e) {
+    setTimeout(() => {
+      document.querySelector("fieldset[id='forwarding_enabled_fields']").hidden = !e.target.checked;
+      if (!e.target.checked) e.target.form.submit();
+    }, 200);
+  });
 
-        // If the toggle is turned off, submit the form automatically
-        if (!e.target.checked) {
-          e.target.form.submit();
-        }
-      }, 200);
-    });
-
-  var custom_smtp_settings = document.querySelector(
-    "input[id='custom_smtp_settings']",
-  ).checked;
-  var custom_smtp_settings_fields = document.querySelector(
-    "fieldset[id='custom_smtp_settings_fields']",
-  );
+  var custom_smtp_settings = document.querySelector("input[id='custom_smtp_settings']").checked;
+  var custom_smtp_settings_fields = document.querySelector("fieldset[id='custom_smtp_settings_fields']");
   custom_smtp_settings_fields.hidden = !custom_smtp_settings;
 
-  document
-    .querySelector("input[id='custom_smtp_settings']")
-    .addEventListener("change", function (e) {
-      // time out to let animation finish
-      setTimeout(() => {
-        var fieldset = document.querySelector(
-          "fieldset[id='custom_smtp_settings_fields']",
-        );
-        fieldset.hidden = !e.target.checked;
-      }, 200);
-    });
+  document.querySelector("input[id='custom_smtp_settings']").addEventListener("change", function (e) {
+    setTimeout(() => {
+      document.querySelector("fieldset[id='custom_smtp_settings_fields']").hidden = !e.target.checked;
+    }, 200);
+  });
 });

--- a/hushline/static/js/settings.js
+++ b/hushline/static/js/settings.js
@@ -97,24 +97,40 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
-  var forwarding_enabled = document.querySelector("input[id='forwarding_enabled']").checked;
-  var forwarding_enabled_fieldset = document.querySelector("fieldset[id='forwarding_enabled_fields']");
+  var forwarding_enabled = document.querySelector(
+    "input[id='forwarding_enabled']",
+  ).checked;
+  var forwarding_enabled_fieldset = document.querySelector(
+    "fieldset[id='forwarding_enabled_fields']",
+  );
   forwarding_enabled_fieldset.hidden = !forwarding_enabled;
 
-  document.querySelector("input[id='forwarding_enabled']").addEventListener("change", function (e) {
-    setTimeout(() => {
-      document.querySelector("fieldset[id='forwarding_enabled_fields']").hidden = !e.target.checked;
-      if (!e.target.checked) e.target.form.submit();
-    }, 200);
-  });
+  document
+    .querySelector("input[id='forwarding_enabled']")
+    .addEventListener("change", function (e) {
+      setTimeout(() => {
+        document.querySelector(
+          "fieldset[id='forwarding_enabled_fields']",
+        ).hidden = !e.target.checked;
+        if (!e.target.checked) e.target.form.submit();
+      }, 200);
+    });
 
-  var custom_smtp_settings = document.querySelector("input[id='custom_smtp_settings']").checked;
-  var custom_smtp_settings_fields = document.querySelector("fieldset[id='custom_smtp_settings_fields']");
+  var custom_smtp_settings = document.querySelector(
+    "input[id='custom_smtp_settings']",
+  ).checked;
+  var custom_smtp_settings_fields = document.querySelector(
+    "fieldset[id='custom_smtp_settings_fields']",
+  );
   custom_smtp_settings_fields.hidden = !custom_smtp_settings;
 
-  document.querySelector("input[id='custom_smtp_settings']").addEventListener("change", function (e) {
-    setTimeout(() => {
-      document.querySelector("fieldset[id='custom_smtp_settings_fields']").hidden = !e.target.checked;
-    }, 200);
-  });
+  document
+    .querySelector("input[id='custom_smtp_settings']")
+    .addEventListener("change", function (e) {
+      setTimeout(() => {
+        document.querySelector(
+          "fieldset[id='custom_smtp_settings_fields']",
+        ).hidden = !e.target.checked;
+      }, 200);
+    });
 });

--- a/hushline/templates/settings/index.html
+++ b/hushline/templates/settings/index.html
@@ -2,53 +2,57 @@
 
 {% block title %}Settings{% endblock %}
 
+{% block main_class %}settings-main{% endblock %}
 {% block content %}
   {% set aliases_enabled = alias_mode == AliasMode.ALWAYS or (alias_mode == AliasMode.PREMIUM and not user.is_free_tier) %}
   <h2>Settings</h2>
-  <div class="settings-tabs {% if user.is_admin %}is-admin{% endif %}">
-    <ul class="tab-list" role="tablist">
-      {% with buttons = [
-        ('profile', 'Profile', False, False),
-        ('aliases', 'Aliases', False, True),
-        ('auth', 'Authentication', False, False),
-        ('email', 'Email & Encryption', False, False),
-        ('branding', 'Branding', True, False),
-        ('advanced', 'Advanced', False, False),
-        ('admin', 'Admin', True, False)
-      ] %}
-        {% for (id, display, requires_admin, requires_paying_customer) in buttons %}
-          {% if (not requires_admin or user.is_admin) and (not requires_paying_customer or aliases_enabled) %}
-            <li role="presentation">
-              <button
-                type="button"
-                class="tab{% if loop.first %} active{% endif %}{% if requires_admin %} admin-only{% endif %}"
-                data-tab="{{ id }}"
-                role="tab"
-                aria-selected="{% if loop.first %}true{% else %}false{% endif %}"
-                aria-controls="{{ id }}"
-                id="{{ id }}-tab"
-              >
-                {{ display }}
-              </button>
-            </li>
-          {% endif %}
-        {% endfor %}
-      {% endwith %}
-    </ul>
+  <div class="settings-content">
+    <div class="settings-tabs {% if user.is_admin %}is-admin{% endif %}">
+      <ul class="tab-list" role="tablist">
+        {% with buttons = [
+          ('profile', 'Profile', False, False),
+          ('aliases', 'Aliases', False, True),
+          ('auth', 'Authentication', False, False),
+          ('email', 'Email & Encryption', False, False),
+          ('branding', 'Branding', True, False),
+          ('advanced', 'Advanced', False, False),
+          ('admin', 'Admin', True, False)
+        ] %}
+          {% for (id, display, requires_admin, requires_paying_customer) in buttons %}
+            {% if (not requires_admin or user.is_admin) and (not requires_paying_customer or aliases_enabled) %}
+              <li role="presentation">
+                <button
+                  type="button"
+                  class="tab{% if loop.first %} active{% endif %}{% if requires_admin %} admin-only{% endif %}"
+                  data-tab="{{ id }}"
+                  role="tab"
+                  aria-selected="{% if loop.first %}true{% else %}false{% endif %}"
+                  aria-controls="{{ id }}"
+                  id="{{ id }}-tab"
+                >
+                  {{ display }}
+                </button>
+              </li>
+            {% endif %}
+          {% endfor %}
+        {% endwith %}
+      </ul>
+    </div>
+    <div>
+      {% include "settings/profile.html" %}
+      {% if aliases_enabled %}
+        {% include "settings/aliases.html" %}
+      {% endif %}
+      {% include "settings/auth.html" %}
+      {% include "settings/email.html" %}
+      {% include "settings/advanced.html" %}
+      {% if user.is_admin %}
+        {% include "settings/branding.html" %}
+        {% include "settings/admin.html" %}
+      {% endif %}
+    </div>
   </div>
-  <div>
-    {% include "settings/profile.html" %}
-    {% if aliases_enabled %}
-      {% include "settings/aliases.html" %}
-    {% endif %}
-    {% include "settings/auth.html" %}
-    {% include "settings/email.html" %}
-    {% include "settings/advanced.html" %}
-    {% if user.is_admin %}
-      {% include "settings/branding.html" %}
-      {% include "settings/admin.html" %}
-    {% endif %}
-  </div>
+
 {% endblock %}
 
 {% block scripts %}

--- a/hushline/templates/settings/index.html
+++ b/hushline/templates/settings/index.html
@@ -2,7 +2,6 @@
 
 {% block title %}Settings{% endblock %}
 
-{% block main_class %}settings-main{% endblock %}
 {% block content %}
   {% set aliases_enabled = alias_mode == AliasMode.ALWAYS or (alias_mode == AliasMode.PREMIUM and not user.is_free_tier) %}
   <h2>Settings</h2>


### PR DESCRIPTION
When there are 5 or more items in the Settings nav tab set, the tabs display as a column instead of a row, and the settings content to the right rather than underneath.

At 640px, the display changes back to tabs as a row which are horizontally scrollable. 

![navupdate](https://github.com/user-attachments/assets/b7910b42-d00d-4fa7-8460-1aa64ad3ce04)
