### PR TITLE
chore: runs tests on PRs and pushes to main; run tests and linters in parallel

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,14 +1,16 @@
 ---
-name: Run Tests
+name: Run Linter and Tests
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
 
 jobs:
-  run-lint-and-tests:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -27,8 +29,18 @@ jobs:
       - name: Lint
         run: poetry run make lint
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
       - name: Test
         run: make test
+
+  test-with-alembic:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
 
       - name: Test with alembic
         run: make test


### PR DESCRIPTION
Closes #623 

## Description

This PR limits the runs of the `tests` on `push` events; only pushes to `main` will trigger the workflow (in addition to pull_request events).

In addition, this PR teases out the test-related steps to separate jobs so they can be run in parallel as they are not dependent on each other (afict) with the goal of reducing total runtime of the workflow and creating a quicker feedback loop as we cannot get test results in CI until the linters run on the codebase. If we look at the latest run vs previous in https://github.com/scidsg/hushline/actions/workflows/tests.yml , seems we can reduce by at least a minute.