### PR TITLE
feat: add back button to settings/enable-2fa page to allow user to abort

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -21,7 +21,11 @@ RUN apt-get update && \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
 
-RUN pip install poetry
+RUN pip install poetry pytest-playwright
+
+# Playwright dependencies to run browsers
+RUN playwright install
+RUN playwright install-deps
 
 WORKDIR /app
 

--- a/Makefile
+++ b/Makefile
@@ -50,8 +50,13 @@ ifndef message
 endif
 	poetry run flask db revision -m "$(message)" --autogenerate
 
-TESTS ?= ./tests/
+TESTS ?= ./tests
 .PHONY: test
 test: ## Run the test suite
 	docker compose run --rm app \
 		poetry run pytest --cov hushline --cov-report term --cov-report html -vv $(PYTEST_ADDOPTS) $(TESTS)
+
+.PHONY: test/ui
+test/ui: # Only run the ui tests
+	docker compose run --rm app \
+		poetry run pytest --cov hushline --cov-report term --cov-report html -vv $(PYTEST_ADDOPTS) $(TESTS)/ui

--- a/hushline/templates/enable_2fa.html
+++ b/hushline/templates/enable_2fa.html
@@ -2,6 +2,7 @@
 {% block title %}Settings{% endblock %}
 
 {% block content %}
+  <a href="{{ url_for('.auth') }}" class="back-button"><span class="icon chevron back"></span> Back to Authentication</a>
   <h2>Enable Two-Factor Authentication</h2>
   <p>
     Scan the QR code with your 2FA app or enter the text code below to enable

--- a/poetry.lock
+++ b/poetry.lock
@@ -1290,6 +1290,26 @@ build-docs = ["cloud-sptheme (>=1.10.1)", "sphinx (>=1.6)", "sphinxcontrib-fullt
 totp = ["cryptography"]
 
 [[package]]
+name = "playwright"
+version = "1.49.0"
+description = "A high-level API to automate web browsers"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "playwright-1.49.0-py3-none-macosx_10_13_x86_64.whl", hash = "sha256:704532a2d8ba580ec9e1895bfeafddce2e3d52320d4eb8aa38e80376acc5cbb0"},
+    {file = "playwright-1.49.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e453f02c4e5cc2db7e9759c47e7425f32e50ac76c76b7eb17c69eed72f01c4d8"},
+    {file = "playwright-1.49.0-py3-none-macosx_11_0_universal2.whl", hash = "sha256:37ae985309184472946a6eb1a237e5d93c9e58a781fa73b75c8751325002a5d4"},
+    {file = "playwright-1.49.0-py3-none-manylinux1_x86_64.whl", hash = "sha256:68d94beffb3c9213e3ceaafa66171affd9a5d9162e0c8a3eed1b1132c2e57598"},
+    {file = "playwright-1.49.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7f12d2aecdb41fc25a624cb15f3e8391c252ebd81985e3d5c1c261fe93779345"},
+    {file = "playwright-1.49.0-py3-none-win32.whl", hash = "sha256:91103de52d470594ad375b512d7143fa95d6039111ae11a93eb4fe2f2b4a4858"},
+    {file = "playwright-1.49.0-py3-none-win_amd64.whl", hash = "sha256:34d28a2c2d46403368610be4339898dc9c34eb9f7c578207b4715c49743a072a"},
+]
+
+[package.dependencies]
+greenlet = "3.1.1"
+pyee = "12.0.0"
+
+[[package]]
 name = "pluggy"
 version = "1.5.0"
 description = "plugin and hook calling mechanisms for python"
@@ -1535,6 +1555,23 @@ files = [
 ]
 
 [[package]]
+name = "pyee"
+version = "12.0.0"
+description = "A rough port of Node.js's EventEmitter to Python with a few tricks of its own"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pyee-12.0.0-py3-none-any.whl", hash = "sha256:7b14b74320600049ccc7d0e0b1becd3b4bd0a03c745758225e31a59f4095c990"},
+    {file = "pyee-12.0.0.tar.gz", hash = "sha256:c480603f4aa2927d4766eb41fa82793fe60a82cbfdb8d688e0d08c55a534e145"},
+]
+
+[package.dependencies]
+typing-extensions = "*"
+
+[package.extras]
+dev = ["black", "build", "flake8", "flake8-black", "isort", "jupyter-console", "mkdocs", "mkdocs-include-markdown-plugin", "mkdocstrings[python]", "pytest", "pytest-asyncio", "pytest-trio", "sphinx", "toml", "tox", "trio", "trio", "trio-typing", "twine", "twisted", "validate-pyproject[all]"]
+
+[[package]]
 name = "pyotp"
 version = "2.9.0"
 description = "Python One Time Password Library"
@@ -1612,6 +1649,24 @@ pluggy = ">=1.5,<2"
 dev = ["argcomplete", "attrs (>=19.2)", "hypothesis (>=3.56)", "mock", "pygments (>=2.7.2)", "requests", "setuptools", "xmlschema"]
 
 [[package]]
+name = "pytest-base-url"
+version = "2.1.0"
+description = "pytest plugin for URL based testing"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "pytest_base_url-2.1.0-py3-none-any.whl", hash = "sha256:3ad15611778764d451927b2a53240c1a7a591b521ea44cebfe45849d2d2812e6"},
+    {file = "pytest_base_url-2.1.0.tar.gz", hash = "sha256:02748589a54f9e63fcbe62301d6b0496da0d10231b753e950c63e03aee745d45"},
+]
+
+[package.dependencies]
+pytest = ">=7.0.0"
+requests = ">=2.9"
+
+[package.extras]
+test = ["black (>=22.1.0)", "flake8 (>=4.0.1)", "pre-commit (>=2.17.0)", "pytest-localserver (>=0.7.1)", "tox (>=3.24.5)"]
+
+[[package]]
 name = "pytest-cov"
 version = "5.0.0"
 description = "Pytest plugin for measuring coverage."
@@ -1647,6 +1702,23 @@ pytest = ">=6.2.5"
 dev = ["pre-commit", "pytest-asyncio", "tox"]
 
 [[package]]
+name = "pytest-playwright"
+version = "0.6.2"
+description = "A pytest wrapper with fixtures for Playwright to automate web browsers"
+optional = false
+python-versions = ">=3.9"
+files = [
+    {file = "pytest_playwright-0.6.2-py3-none-any.whl", hash = "sha256:0eff73bebe497b0158befed91e2f5fe94cfa17181f8b3acf575beed84e7e9043"},
+    {file = "pytest_playwright-0.6.2.tar.gz", hash = "sha256:ff4054b19aa05df096ac6f74f0572591566aaf0f6d97f6cb9674db8a4d4ed06c"},
+]
+
+[package.dependencies]
+playwright = ">=1.18"
+pytest = ">=6.2.4,<9.0.0"
+pytest-base-url = ">=1.0.0,<3.0.0"
+python-slugify = ">=6.0.0,<9.0.0"
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 description = "Extensions to the standard Python datetime module"
@@ -1659,6 +1731,23 @@ files = [
 
 [package.dependencies]
 six = ">=1.5"
+
+[[package]]
+name = "python-slugify"
+version = "8.0.4"
+description = "A Python slugify application that also handles Unicode"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "python-slugify-8.0.4.tar.gz", hash = "sha256:59202371d1d05b54a9e7720c5e038f928f45daaffe41dd10822f3907b937c856"},
+    {file = "python_slugify-8.0.4-py2.py3-none-any.whl", hash = "sha256:276540b79961052b66b7d116620b36518847f52d5fd9e3a70164fc8c50faa6b8"},
+]
+
+[package.dependencies]
+text-unidecode = ">=1.3"
+
+[package.extras]
+unidecode = ["Unidecode (>=1.1.1)"]
 
 [[package]]
 name = "qrcode"
@@ -1878,6 +1967,32 @@ files = [
 [package.dependencies]
 requests = {version = ">=2.20", markers = "python_version >= \"3.0\""}
 typing-extensions = {version = ">=4.5.0", markers = "python_version >= \"3.7\""}
+
+[[package]]
+name = "tenacity"
+version = "9.0.0"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539"},
+    {file = "tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
+name = "text-unidecode"
+version = "1.3"
+description = "The most basic Text::Unidecode port"
+optional = false
+python-versions = "*"
+files = [
+    {file = "text-unidecode-1.3.tar.gz", hash = "sha256:bad6603bb14d279193107714b288be206cac565dfa49aa5b105294dd5c4aab93"},
+    {file = "text_unidecode-1.3-py2.py3-none-any.whl", hash = "sha256:1311f10e8b895935241623731c2ba64f4c455287888b18189350b67134a822e8"},
+]
 
 [[package]]
 name = "types-bleach"
@@ -2138,4 +2253,4 @@ propcache = ">=0.2.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "588879f99b2ad09277b8567f4e0e34dc2fe1f0c454d97ddf14806f721fd1ad27"
+content-hash = "76a0ef8aad10388a7c2b18f4d1f504a6aef960f9183a3151be4501e7f9a653c0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ stripe = "^10.9.0"
 types-requests = "^2.32.0.20240712"
 types-setuptools = "^71.1.0.20240813"
 python = "^3.11"
+pytest-playwright = "^0.6.2"
+tenacity = "^9.0.0"
 
 [tool.poetry.group.dev.dependencies]
 beautifulsoup4 = "^4.12.3"

--- a/tests/ui/test_settings_enable_2fa.py
+++ b/tests/ui/test_settings_enable_2fa.py
@@ -1,0 +1,43 @@
+import re
+
+from playwright.sync_api import Page, expect
+from tenacity import RetryCallState, retry, stop_after_attempt, wait_random_exponential
+
+BASE_URL = "http://127.0.0.1:8080"
+
+
+def log_retry_error(retry_state: RetryCallState) -> None:
+    if retry_state is None or retry_state.outcome is None:
+        return
+    print(f"Retrying due to error: {retry_state.outcome.exception()}")
+
+
+@retry(
+    wait=wait_random_exponential(min=1, max=60),
+    stop=stop_after_attempt(3),
+    retry_error_callback=log_retry_error,
+)
+def test_enable_2fa_has_back_button(page: Page, user_password: str) -> None:
+    page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded")
+    page.get_by_label("Username").fill("test")
+    page.get_by_label("Password").fill(user_password)
+    page.get_by_role("button", name="Login").click()
+
+    page.goto(f"{BASE_URL}/settings/enable-2fa", wait_until="domcontentloaded")
+    expect(page.get_by_text("Back to Authentication")).to_be_visible()
+
+
+@retry(
+    wait=wait_random_exponential(min=1, max=60),
+    stop=stop_after_attempt(3),
+    retry_error_callback=log_retry_error,
+)
+def test_enable_2fa_back_button_returns(page: Page, user_password: str) -> None:
+    page.goto(f"{BASE_URL}/login", wait_until="domcontentloaded")
+    page.get_by_label("Username").fill("test")
+    page.get_by_label("Password").fill(user_password)
+    page.get_by_role("button", name="Login").click()
+
+    page.goto(f"{BASE_URL}/settings/enable-2fa", wait_until="domcontentloaded")
+    page.get_by_text("Back to Authentication").click()
+    expect(page).to_have_url(re.compile(".*auth"))


### PR DESCRIPTION
Closes #761 

## What  and How 🛠️ 

This PR introduces a back button in the `settings/enable-2fa` view. The button is added via the `<a>` element in the page's template file.

## Why 🤷 

The new link serves as a an escape hatch, allowing users to return to the authentication settings page.

## Testing 🧪 

To validate the existence and usage of the `<a>` element representing the back button, I've leveraged [Playwright](https://playwright.dev/python/docs/intro)'s browser testing. The test cases live in a `ui` subdirectory so they can be run independently with a new target, namely `make test/ui`, or alongside all the the tests via `make test`.

Locally, you can pull this branch and run `make test/ui` to validate.

## Anything else 💭 

I chose Playwright here instead of Selenium because it seems to spin up faster and perhaps less overhead -- did require installing some dependencies (see `Dockerfile.dev`).  Open to discussing this choice more since sets a precedent for e2e browser testing