### PR TITLE
fernet encrypted sessions

### DIFF
--- a/docker-compose.staging.yaml
+++ b/docker-compose.staging.yaml
@@ -11,6 +11,7 @@ services:
       FLASK_ENV: production
       ENCRYPTION_KEY: bi5FDwhZGKfc4urLJ_ChGtIAaOPgxd3RDOhnvct10mw=
       SECRET_KEY: cb3f4afde364bfb3956b97ca22ef4d2b593d9d980a4330686267cabcd2c0befd
+      SESSION_FERNET_KEY: jY0gDbATEOQolx2SGj46YnkkbN6HQBB4YCABzwl1H1A=
       SQLALCHEMY_DATABASE_URI: postgresql://hushline:hushline@postgres:5432/hushline
       REGISTRATION_CODES_REQUIRED: "false"
       ALIAS_MODE: always

--- a/docker-compose.stripe.yaml
+++ b/docker-compose.stripe.yaml
@@ -11,6 +11,7 @@ services:
       FLASK_ENV: development
       ENCRYPTION_KEY: bi5FDwhZGKfc4urLJ_ChGtIAaOPgxd3RDOhnvct10mw=
       SECRET_KEY: cb3f4afde364bfb3956b97ca22ef4d2b593d9d980a4330686267cabcd2c0befd
+      SESSION_FERNET_KEY: jY0gDbATEOQolx2SGj46YnkkbN6HQBB4YCABzwl1H1A=
       SQLALCHEMY_DATABASE_URI: postgresql://hushline:hushline@postgres:5432/hushline
       REGISTRATION_CODES_REQUIRED: "false"
       ALIAS_MODE: premium

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,7 @@ services:
       FLASK_ENV: development
       ENCRYPTION_KEY: bi5FDwhZGKfc4urLJ_ChGtIAaOPgxd3RDOhnvct10mw=
       SECRET_KEY: cb3f4afde364bfb3956b97ca22ef4d2b593d9d980a4330686267cabcd2c0befd
+      SESSION_FERNET_KEY: jY0gDbATEOQolx2SGj46YnkkbN6HQBB4YCABzwl1H1A=
       SQLALCHEMY_DATABASE_URI: postgresql://hushline:hushline@postgres:5432/hushline
       REGISTRATION_CODES_REQUIRED: 'false'
       ALIAS_MODE: always

--- a/docs/README.md
+++ b/docs/README.md
@@ -317,6 +317,13 @@ These configs are needed for the web app.
       <td>Set the server/host name in Flask</td>
     </tr>
     <tr>
+      <td><code>SESSION_FERNET_KEY</code></td>
+      <td>true</td>
+      <td>b64 encoded Fernet key</td>
+      <td></td>
+      <td>The key uses for en/decryption of sessions.</td>
+    </tr>
+    <tr>
       <td><code>SMTP_ENCRYPTION</code></td>
       <td>false</td>
       <td>string</td>

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -12,12 +12,14 @@ from .config import AliasMode, load_config
 from .db import db, migrate
 from .md import md_to_html
 from .model import OrganizationSetting, Tier, User
+from .secure_session import EncryptedSessionInterface
 from .storage import public_store
 from .version import __version__
 
 
 def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
     app = Flask(__name__)
+    app.session_interface = EncryptedSessionInterface()
     app.logger.setLevel(logging.DEBUG)
 
     if not config:

--- a/hushline/config.py
+++ b/hushline/config.py
@@ -107,10 +107,12 @@ def _load_smtp(env: Mapping[str, str]) -> Mapping[str, Any]:
 def _load_hushline_misc(env: Mapping[str, str]) -> Mapping[str, Any]:
     data: dict[str, Any] = {}
 
-    # this is required by the Flask app but not by the Stripe worker
-    # so we have to allow for it to be missing
+    # these are required by the Flask app but not by the Stripe worker
+    # so we have to allow for them to be missing
     if key := env.get("ENCRYPTION_KEY"):
         data["ENCRYPTION_KEY"] = key
+    if key := env.get("SESSION_FERNET_KEY"):
+        data["SESSION_FERNET_KEY"] = key
 
     if onion := env.get("ONION_HOSTNAME"):
         data["ONION_HOSTNAME"] = onion

--- a/hushline/secure_session.py
+++ b/hushline/secure_session.py
@@ -1,0 +1,91 @@
+import json
+from json import JSONDecodeError
+
+from cryptography.fernet import Fernet, InvalidToken
+from flask import Flask, Request, Response
+from flask.sessions import SecureCookieSession, SessionInterface, SessionMixin
+
+
+class EncryptedSessionInterface(SessionInterface):
+    """
+    Config:
+    - SESSION_FERNET_KEY: string representing a Fernet key
+    """
+
+    session_class = SecureCookieSession
+
+    def _get_fernet(self, app: Flask) -> Fernet | None:
+        if key := app.config.get("SESSION_FERNET_KEY"):
+            return Fernet(key)
+        return None
+
+    def open_session(self, app: Flask, request: Request) -> SecureCookieSession | None:
+        if not (fernet := self._get_fernet(app)):
+            return None
+
+        if not (val := request.cookies.get(self.get_cookie_name(app))):
+            return self.session_class()
+
+        max_age = int(app.permanent_session_lifetime.total_seconds())
+        try:
+            data = fernet.decrypt(val, ttl=max_age)
+        except InvalidToken:
+            return self.session_class()
+
+        try:
+            decoded = json.loads(data)
+        except JSONDecodeError:
+            return self.session_class()
+
+        return self.session_class(decoded)
+
+    def save_session(self, app: Flask, session: SessionMixin, response: Response) -> None:
+        name = self.get_cookie_name(app)
+        domain = self.get_cookie_domain(app)
+        path = self.get_cookie_path(app)
+        secure = self.get_cookie_secure(app)
+        partitioned = self.get_cookie_partitioned(app)
+        samesite = self.get_cookie_samesite(app)
+        httponly = self.get_cookie_httponly(app)
+
+        # Add a "Vary: Cookie" header if the session was accessed at all.
+        if session.accessed:
+            response.vary.add("Cookie")
+
+        # If the session is modified to be empty, remove the cookie.
+        # If the session is empty, return without setting the cookie.
+        if not session:
+            if session.modified:
+                response.delete_cookie(
+                    name,
+                    domain=domain,
+                    path=path,
+                    secure=secure,
+                    partitioned=partitioned,
+                    samesite=samesite,
+                    httponly=httponly,
+                )
+                response.vary.add("Cookie")
+
+            return
+
+        if not self.should_set_cookie(app, session):
+            return
+
+        expires = self.get_expiration_time(app, session)
+        if not (fernet := self._get_fernet(app)):
+            raise RuntimeError("Fernet key not set")
+
+        val = fernet.encrypt(json.dumps(dict(session)).encode("utf-8")).decode("utf-8")
+        response.set_cookie(
+            name,
+            val,
+            expires=expires,
+            httponly=httponly,
+            domain=domain,
+            path=path,
+            secure=secure,
+            partitioned=partitioned,
+            samesite=samesite,
+        )
+        response.vary.add("Cookie")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -94,7 +94,6 @@ def init_db_via_create_all(db_uri: str) -> None:
     # dumb hack to easily get the create_all() functionality
     os.environ["SQLALCHEMY_DATABASE_URI"] = db_uri
     app = create_app()
-
     with app.app_context():
         db.session.commit()
         db.create_all()
@@ -103,7 +102,7 @@ def init_db_via_create_all(db_uri: str) -> None:
 
 
 def init_db_via_alembic(db_uri: str) -> None:
-    # dumb hack to easily get the create_all() functionality
+    # dumb hack to easily get the Migrate extension correctly configured
     os.environ["SQLALCHEMY_DATABASE_URI"] = db_uri
     app = create_app()
     with app.app_context():

--- a/tests/test_secure_session.py
+++ b/tests/test_secure_session.py
@@ -1,0 +1,77 @@
+from typing import Generator
+
+import pytest
+from cryptography.fernet import Fernet
+from flask import Flask, request, session, url_for
+from flask.testing import FlaskClient
+
+from hushline.secure_session import EncryptedSessionInterface
+
+FERNET_KEY = Fernet.generate_key().decode("utf-8")
+ARG_KEY = "x"
+SESSION_KEY = "y"
+MISSING = "missing"
+
+
+class Fixtures:
+    HAS_SESSION_KEY = True
+
+    @pytest.fixture()
+    def app(self) -> Generator[Flask, None, None]:
+        app_ = Flask(__name__)
+        if self.HAS_SESSION_KEY:
+            app_.config["SESSION_FERNET_KEY"] = FERNET_KEY
+        app_.config["SERVER_NAME"] = "localhost.tld"
+        app_.session_interface = EncryptedSessionInterface()
+
+        @app_.route("/session", methods=["GET", "POST", "DELETE"])
+        def has_session() -> str:
+            if request.method == "POST":
+                session[SESSION_KEY] = request.args[ARG_KEY]
+            elif request.method == "DELETE":
+                del session[SESSION_KEY]
+            return session.get(SESSION_KEY, MISSING)
+
+        @app_.route("/no-session", methods=["GET", "POST"])
+        def no_session() -> str:
+            return ""
+
+        with app_.app_context():
+            yield app_
+
+    @pytest.fixture()
+    def client(self, app: Flask) -> Generator[FlaskClient, None, None]:
+        with app.test_client() as c:
+            yield c
+
+
+class TestSessionEnabled(Fixtures):
+    def test_get_set(self, client: FlaskClient) -> None:
+        resp = client.get(url_for("has_session"))
+        assert resp.status_code == 200
+        assert resp.text == MISSING
+
+        expected = "test data"
+        resp = client.post(url_for("has_session", **{ARG_KEY: expected}))  # type: ignore[arg-type]
+        assert resp.status_code == 200
+        assert resp.text == expected
+
+        resp = client.get(url_for("has_session"))
+        assert resp.status_code == 200
+        assert resp.text == expected
+
+        resp = client.delete(url_for("has_session"))
+        assert resp.status_code == 200
+        assert resp.text == MISSING
+
+        resp = client.get(url_for("has_session"))
+        assert resp.status_code == 200
+        assert resp.text == MISSING
+
+
+class TestNoSessionEnabled(Fixtures):
+    HAS_SESSION_KEY = False
+
+    def test_no_session(self, client: FlaskClient) -> None:
+        resp = client.get(url_for("no_session"))
+        assert resp.status_code == 200


### PR DESCRIPTION
Overrides the default session interface to use on that is encrypted and timed via Fernet. The logic largely copies the internal logic of Flask's default `SecureSessionInterface`, so comparison should be quite easy.

Flask Docs: https://flask.palletsprojects.com/en/3.0.x/api/#flask.sessions.SessionInterface

Fixes #603 