### PR TITLE
Fix AttributeError for SERVER_NAME when unset in add_security_header

### DIFF
--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -71,7 +71,7 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
         response.headers["X-XSS-Protection"] = "1; mode=block"
 
         # If SERVER_NAME does not end in .onion, add Strict-Transport-Security
-        if not app.config.get("SERVER_NAME", "").endswith(".onion"):
+        if not (app.config.get("SERVER_NAME") or "").endswith(".onion"):
             response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubdomains"
 
         return response


### PR DESCRIPTION
Fix AttributeError when `SERVER_NAME` is `None` in `add_security_header`.
- Updated `if not app.config.get("SERVER_NAME", "").endswith(".onion")` to safely handle `None` values using or `""`.
- Ensures compatibility when `SERVER_NAME` is not set in app.config.

Changes:
- 1 addition, 1 deletion in hushline/__init__.py.
- Prevents errors caused by calling `.endswith()` on `None`.