### PR TITLE
Fix github actions workflow fail

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - fix-gh-actions
   pull_request:
     branches:
       - main

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - fix-gh-actions
   pull_request:
     branches:
       - main

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -25,13 +25,13 @@ RUN pip install poetry
 
 WORKDIR /app
 
-COPY package.json package-lock.json .
+COPY package.json package-lock.json ./
 
 RUN npm install
 
 ENV PYTHONPATH=/app
 
-COPY pyproject.toml poetry.lock .
+COPY pyproject.toml poetry.lock ./
 
 RUN poetry install --no-root
 

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -8,15 +8,15 @@ FROM python:3.12.6-slim-bookworm
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-        curl \
-        build-essential \
-        clang \
-        pkg-config \
-        libffi-dev \
-        libpq-dev \
-        libpcsclite-dev \
-        nettle-dev \
-        npm
+    curl \
+    build-essential \
+    clang \
+    pkg-config \
+    libffi-dev \
+    libpq-dev \
+    libpcsclite-dev \
+    nettle-dev \
+    npm
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"
@@ -33,7 +33,7 @@ ENV PYTHONPATH=/app
 
 COPY pyproject.toml poetry.lock .
 
-RUN poetry install
+RUN poetry install --no-root
 
 ENV FLASK_APP="hushline"
 CMD ["./scripts/dev_start.sh"]


### PR DESCRIPTION
This fixes the github actions workflow fail problems. Something changed with poetry, or with pip, and now running `poetry install` inside the dev container is failing. This fixes it by changing it to `poetry install --no-root`.