### PR TITLE
First user automatically becomes an admin

### DIFF
--- a/docker-compose.personal-server.yaml
+++ b/docker-compose.personal-server.yaml
@@ -1,0 +1,47 @@
+---
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.prod
+    ports:
+      - 127.0.0.1:8080:8080
+    environment:
+      IS_DOCKER: '1'
+      FLASK_APP: hushline
+      FLASK_ENV: production
+      ENCRYPTION_KEY: bi5FDwhZGKfc4urLJ_ChGtIAaOPgxd3RDOhnvct10mw=
+      SECRET_KEY: cb3f4afde364bfb3956b97ca22ef4d2b593d9d980a4330686267cabcd2c0befd
+      SESSION_FERNET_KEY: jY0gDbATEOQolx2SGj46YnkkbN6HQBB4YCABzwl1H1A=
+      SQLALCHEMY_DATABASE_URI: postgresql://hushline:hushline@postgres:5432/hushline
+      REGISTRATION_CODES_REQUIRED: "false"
+      ALIAS_MODE: always
+      FIELDS_MODE: always
+      SESSION_COOKIE_NAME: session
+      DIRECTORY_VERIFIED_TAB_ENABLED: "false"
+      BLOB_STORAGE_PUBLIC_DRIVER: file-system
+      BLOB_STORAGE_PUBLIC_FS_ROOT: /hushline-public-files
+    depends_on:
+      postgres:
+        condition: service_healthy
+    volumes:
+      - hushline-public-files:/hushline-public-files
+    restart: always
+
+  postgres:
+    image: postgres:16.4-alpine3.20
+    environment:
+      POSTGRES_USER: hushline
+      POSTGRES_PASSWORD: hushline
+      POSTGRES_DB: hushline
+    restart: on-failure
+    ports:
+      - 127.0.0.1:5432:5432
+    healthcheck:
+      test: ["CMD", "pg_isready", "-U", "hushline"]
+      interval: 5s
+      timeout: 1s
+      retries: 10
+
+volumes:
+  hushline-public-files:

--- a/docker-compose.personal-server.yaml
+++ b/docker-compose.personal-server.yaml
@@ -1,15 +1,15 @@
 ---
 services:
-  app:
+  app: &app_env
     build:
       context: .
-      dockerfile: Dockerfile.prod
+      dockerfile: Dockerfile.dev
     ports:
       - 127.0.0.1:8080:8080
     environment:
       IS_DOCKER: '1'
       FLASK_APP: hushline
-      FLASK_ENV: production
+      FLASK_ENV: development
       ENCRYPTION_KEY: bi5FDwhZGKfc4urLJ_ChGtIAaOPgxd3RDOhnvct10mw=
       SECRET_KEY: cb3f4afde364bfb3956b97ca22ef4d2b593d9d980a4330686267cabcd2c0befd
       SESSION_FERNET_KEY: jY0gDbATEOQolx2SGj46YnkkbN6HQBB4YCABzwl1H1A=
@@ -25,8 +25,18 @@ services:
       postgres:
         condition: service_healthy
     volumes:
+      - ./:/app
       - hushline-public-files:/hushline-public-files
     restart: always
+
+  dev_data:
+    <<: *app_env
+    ports: []
+    command: poetry run ./scripts/dev_migrations.py
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: on-failure
 
   postgres:
     image: postgres:16.4-alpine3.20

--- a/hushline/routes/auth.py
+++ b/hushline/routes/auth.py
@@ -109,11 +109,15 @@ def register_auth_routes(app: Flask) -> None:
             flash("Registration successful!", "success")
             return redirect(url_for("login"))
 
+        # Check if this is the first user
+        first_user = db.session.query(User).count() == 0
+
         return render_template(
             "register.html",
             form=form,
             require_invite_code=require_invite_code,
             math_problem=math_problem,
+            first_user=first_user,
         )
 
     @app.route("/login", methods=["GET", "POST"])

--- a/hushline/routes/auth.py
+++ b/hushline/routes/auth.py
@@ -51,6 +51,9 @@ def register_auth_routes(app: Flask) -> None:
             # Use the existing math problem from the session
             math_problem = session.get("math_problem", "Error: CAPTCHA not generated.")
 
+        # Check if this is the first user
+        first_user = db.session.query(User).count() == 0
+
         if form.validate_on_submit():
             captcha_answer = request.form.get("captcha_answer", "")
             app.logger.debug(f"Session math_answer: {session.get('math_answer')}")
@@ -97,10 +100,20 @@ def register_auth_routes(app: Flask) -> None:
                 )
 
             user = User(password=password)
+
+            # If this is the first user, set them as admin
+            if first_user:
+                user.is_admin = True
+
             db.session.add(user)
             db.session.flush()
 
             username = Username(_username=username, user_id=user.id, is_primary=True)
+
+            # If this is the first user, show them in the directory
+            if first_user:
+                username.show_in_directory = True
+
             db.session.add(username)
             db.session.commit()
 
@@ -108,9 +121,6 @@ def register_auth_routes(app: Flask) -> None:
 
             flash("Registration successful!", "success")
             return redirect(url_for("login"))
-
-        # Check if this is the first user
-        first_user = db.session.query(User).count() == 0
 
         return render_template(
             "register.html",

--- a/hushline/routes/index.py
+++ b/hushline/routes/index.py
@@ -18,6 +18,7 @@ from hushline.model import (
 def register_index_routes(app: Flask) -> None:
     @app.route("/")
     def index() -> Response:
+        # If logged in, redirect to inbox
         if "user_id" in session:
             user = db.session.get(User, session.get("user_id"))
             if user:
@@ -27,6 +28,12 @@ def register_index_routes(app: Flask) -> None:
             session.pop("user_id", None)  # Clear the invalid user_id from session
             return redirect(url_for("login"))
 
+        # If there are no users, redirect to registration
+        user_count = db.session.query(User).count()
+        if user_count == 0:
+            return redirect(url_for("register"))
+
+        # If there is a homepage username set, redirect to that user's profile
         if homepage_username := OrganizationSetting.fetch_one(
             OrganizationSetting.HOMEPAGE_USER_NAME
         ):
@@ -37,4 +44,5 @@ def register_index_routes(app: Flask) -> None:
             else:
                 app.logger.warning(f"Homepage for username {homepage_username!r} not found")
 
+        # If there is no homepage username set, redirect to the directory
         return redirect(url_for("directory"))

--- a/hushline/static/css/style.css
+++ b/hushline/static/css/style.css
@@ -411,7 +411,7 @@
     color: white;
   }
 
-  .upgrade {
+  .alert {
     background-color: var(--color-brand);
     color: white;
   }
@@ -845,12 +845,12 @@
     color: #333;
   }
 
-  .upgrade .btn {
+  .alert .btn {
     border: 1px solid #333;
     color: #333;
   }
 
-  .upgrade {
+  .alert {
     background-color: var(--color-brand-dark-min-saturation);
     color: #333;
   }
@@ -988,7 +988,7 @@ h4 {
   margin-top: 1.325rem;
 }
 
-.upgrade h4 {
+.alert h4 {
   margin-top: 0;
   margin-bottom: 0.25rem;
 }
@@ -1588,7 +1588,7 @@ li a.small {
   margin: 0;
 }
 
-img.upgrade {
+img.alert {
   max-width: 164px;
 }
 
@@ -2490,7 +2490,7 @@ p.bio + .extra-fields {
   border: 1px solid #666;
 }
 
-.upgrade {
+.alert {
   padding: 1rem;
   margin-top: 0.75rem;
   margin-bottom: 2rem;
@@ -2501,14 +2501,14 @@ p.bio + .extra-fields {
   gap: 1rem;
 }
 
-.upgrade .btn {
+.alert .btn {
   width: fit-content;
   box-sizing: border-box;
   text-align: center;
   margin: 0;
 }
 
-.upgrade h3 {
+.alert h3 {
   font-size: var(--font-size-4);
   margin-bottom: 0.25rem;
 }
@@ -2517,7 +2517,7 @@ p.bio + .extra-fields {
   margin-bottom: 0.75rem;
 }
 
-.upgrade p {
+.alert p {
   font-size: var(--font-size-small);
   margin: 0;
 }
@@ -2979,7 +2979,7 @@ strong {
 }
 
 @media (max-width: 640px) {
-  .upgrade {
+  .alert {
     flex-direction: column;
     align-items: start;
     gap: 0.75rem;
@@ -3413,4 +3413,9 @@ li.tab:not(.active) .badge {
 
 li.tab .badge {
   padding: 0.25rem 0.325rem;
+}
+
+.first-user {
+  text-align: center;
+  padding: 1rem;
 }

--- a/hushline/templates/register.html
+++ b/hushline/templates/register.html
@@ -3,6 +3,16 @@
 
 {% block content %}
   <h2>Register</h2>
+
+  {% if first_user %}
+  <div class="alert">
+    <div>
+      <h4>Create the Admin User</h4>
+      <p class="info">The first user you create on your Hush Line server will be the admin.</p>
+    </div>
+  </div>
+  {% endif %}
+
   <form method="POST" action="{{ url_for('register') }}">
     {{ form.hidden_tag() }}
     <div>

--- a/hushline/templates/settings/profile.html
+++ b/hushline/templates/settings/profile.html
@@ -3,7 +3,7 @@
 {% block settings_content %}
   <h3>Profile</h3>
   {% if is_premium_enabled and user.is_free_tier %}
-    <div class="upgrade">
+    <div class="alert">
       <div>
         <h4>Business User?</h4>
         <p class="info">

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -61,6 +61,18 @@ assert (Missing() == Missing()) ^ bool("x")
 assert Missing() != Missing()
 
 
+def get_captcha_from_session_register(client: FlaskClient) -> str:
+    """Retrieve the CAPTCHA answer from the session."""
+    # Simulate loading the registration page to generate the CAPTCHA
+    response = client.get(url_for("register"))
+    assert response.status_code == 200
+
+    with client.session_transaction() as session:
+        captcha_answer = session.get("math_answer")
+        assert captcha_answer, "CAPTCHA answer not found in session"
+        return captcha_answer
+
+
 def get_captcha_from_session(client: FlaskClient, username: str) -> str:
     # Simulate loading the profile page to generate and retrieve the CAPTCHA from the session
     response = client.get(url_for("profile", username=username))

--- a/tests/test_first_user.py
+++ b/tests/test_first_user.py
@@ -22,3 +22,19 @@ def test_no_users_register_should_show_alert(client: FlaskClient) -> None:
     assert response.status_code == 200
 
     assert "Create the Admin User" in response.text
+
+
+def test_some_users_register_should_hide_alert(client: FlaskClient, user_password: str) -> None:
+    user_count = db.session.query(User).count()
+    assert user_count == 0
+
+    user = User(password=user_password)
+    user.tier_id = 1
+    db.session.add(user)
+    db.session.commit()
+    assert db.session.query(User).count() == 1
+
+    response = client.get(url_for("register"))
+    assert response.status_code == 200
+
+    assert "Create the Admin User" not in response.text

--- a/tests/test_first_user.py
+++ b/tests/test_first_user.py
@@ -42,6 +42,7 @@ def test_some_users_register_should_hide_alert(client: FlaskClient, user_passwor
 
     assert "Create the Admin User" not in response.text
 
+
 def test_first_user_is_admin(client: FlaskClient) -> None:
     user_count = db.session.query(User).count()
     assert user_count == 0
@@ -67,6 +68,7 @@ def test_first_user_is_admin(client: FlaskClient) -> None:
     user = db.session.scalars(db.select(User)).one()
     assert user.is_admin
     assert user.primary_username.show_in_directory
+
 
 def test_second_user_is_not_admin(client: FlaskClient, user_password: str) -> None:
     user_count = db.session.query(User).count()

--- a/tests/test_first_user.py
+++ b/tests/test_first_user.py
@@ -1,0 +1,24 @@
+from flask import url_for
+from flask.testing import FlaskClient
+
+from hushline.db import db
+from hushline.model import User
+
+
+def test_no_users_redirect_to_register(client: FlaskClient) -> None:
+    user_count = db.session.query(User).count()
+    assert user_count == 0
+
+    response = client.get(url_for("index"))
+    assert response.status_code == 302
+    assert response.location == url_for("register")
+
+
+def test_no_users_register_should_show_alert(client: FlaskClient) -> None:
+    user_count = db.session.query(User).count()
+    assert user_count == 0
+
+    response = client.get(url_for("register"))
+    assert response.status_code == 200
+
+    assert "Create the Admin User" in response.text

--- a/tests/test_first_user.py
+++ b/tests/test_first_user.py
@@ -1,8 +1,11 @@
+import os
+
 from flask import url_for
 from flask.testing import FlaskClient
+from helpers import get_captcha_from_session_register
 
 from hushline.db import db
-from hushline.model import User
+from hushline.model import User, Username
 
 
 def test_no_users_redirect_to_register(client: FlaskClient) -> None:
@@ -38,3 +41,62 @@ def test_some_users_register_should_hide_alert(client: FlaskClient, user_passwor
     assert response.status_code == 200
 
     assert "Create the Admin User" not in response.text
+
+def test_first_user_is_admin(client: FlaskClient) -> None:
+    user_count = db.session.query(User).count()
+    assert user_count == 0
+
+    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+    username = "test_user"
+
+    captcha_answer = get_captcha_from_session_register(client)
+
+    response = client.post(
+        url_for("register"),
+        data={
+            "username": username,
+            "password": "SecurePassword123!",
+            "captcha_answer": captcha_answer,
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "Registration successful!" in response.text
+
+    # The user should be an admin
+    user = db.session.scalars(db.select(User)).one()
+    assert user.is_admin
+    assert user.primary_username.show_in_directory
+
+def test_second_user_is_not_admin(client: FlaskClient, user_password: str) -> None:
+    user_count = db.session.query(User).count()
+    assert user_count == 0
+
+    user = User(password=user_password)
+    user.tier_id = 1
+    user.is_admin = True
+    db.session.add(user)
+    db.session.commit()
+    assert db.session.query(User).count() == 1
+
+    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+    username = "test_user"
+
+    captcha_answer = get_captcha_from_session_register(client)
+
+    response = client.post(
+        url_for("register"),
+        data={
+            "username": username,
+            "password": "SecurePassword123!",
+            "captcha_answer": captcha_answer,
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "Registration successful!" in response.text
+
+    # The user should not be an admin
+    uname = db.session.scalars(db.select(Username).filter_by(_username=username)).one()
+    assert not uname.user.is_admin
+    assert not uname.show_in_directory

--- a/tests/test_registration_and_login.py
+++ b/tests/test_registration_and_login.py
@@ -2,21 +2,10 @@ import os
 
 from flask import url_for
 from flask.testing import FlaskClient
+from helpers import get_captcha_from_session_register
 
 from hushline.db import db
 from hushline.model import InviteCode, Username
-
-
-def get_captcha_from_session(client: FlaskClient) -> str:
-    """Retrieve the CAPTCHA answer from the session."""
-    # Simulate loading the registration page to generate the CAPTCHA
-    response = client.get(url_for("register"))
-    assert response.status_code == 200
-
-    with client.session_transaction() as session:
-        captcha_answer = session.get("math_answer")
-        assert captcha_answer, "CAPTCHA answer not found in session"
-        return captcha_answer
 
 
 def test_user_registration_with_invite_code_disabled(client: FlaskClient) -> None:
@@ -24,7 +13,7 @@ def test_user_registration_with_invite_code_disabled(client: FlaskClient) -> Non
     os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
     username = "test_user"
 
-    captcha_answer = get_captcha_from_session(client)
+    captcha_answer = get_captcha_from_session_register(client)
 
     response = client.post(
         url_for("register"),
@@ -52,7 +41,7 @@ def test_user_registration_with_invite_code_enabled(client: FlaskClient) -> None
     db.session.add(code)
     db.session.commit()
 
-    captcha_answer = get_captcha_from_session(client)
+    captcha_answer = get_captcha_from_session_register(client)
 
     response = client.post(
         url_for("register"),
@@ -84,7 +73,7 @@ def test_user_login_after_registration(client: FlaskClient) -> None:
     username = "newuser"
     password = "SecurePassword123!"
 
-    captcha_answer = get_captcha_from_session(client)
+    captcha_answer = get_captcha_from_session_register(client)
 
     # Register the user
     response = client.post(
@@ -109,7 +98,7 @@ def test_user_login_with_incorrect_password(client: FlaskClient) -> None:
     username = "newuser"
     password = "SecurePassword123!"
 
-    captcha_answer = get_captcha_from_session(client)
+    captcha_answer = get_captcha_from_session_register(client)
 
     # Register the user
     response = client.post(


### PR DESCRIPTION
Fixes #972 and #975

I've added a new docker compose file, `docker-compose.personal-server.yaml`, to simulate the personal server. Specifically, I needed to be able to test this in dev mode but without dev data. You can test with:

```sh
docker compose -f docker-compose.personal-server.yaml up --build
```

This does a few things:

When loading the index, if there are no users, it redirects to the register page.

If there are no users, the register page shows a special alert to create the first admin user:

![Screenshot from 2025-04-03 13-48-05](https://github.com/user-attachments/assets/2abbac57-f4ed-4cbb-9bf2-a1d3e1730799)

For the styles, I decided to make the alert look just like the upgrade buttons in settings. To do this, I renamed the `upgrade` class to `alert` so we can re-use this style in other places.

When creating the first user, it make the user an admin, and it also by default adds the user's primary username to the directory.

I have tests for all of this.

---

Now that Personal Server users can be admins, I discovered problems we should fix in a separate issue:

- Settings > Admin: You can toggle verified users. But I think it makes sense to remove verified functionality altogether except from the hosted service.
- Settings > Admin: You can make yourself no longer an admin. If you click this, it happens immediately, and now the personal server has no admins and the user is locked out forever. At the very least, we need a check that if the user is the only admin, they can't remove admin from themselves.
- Settings > Advanced: you can delete the only admin account. That should also be disallowed.