### PR TITLE
Reserve verified users for the managed service

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -288,6 +288,13 @@ These configs are needed for the web app.
       </td>
     </tr>
     <tr>
+      <td><code>MANAGED_SERVICE</code></td>
+      <td>false</td>
+      <td>boolean</td>
+      <td><code>false</code></td>
+      <td>When this instance is the main managed service at tips.hushline.app.</td>
+    </tr>
+    <tr>
       <td><code>ONION_HOSTNAME</code></td>
       <td>false</td>
       <td>string</td>

--- a/hushline/admin.py
+++ b/hushline/admin.py
@@ -1,4 +1,4 @@
-from flask import Blueprint, abort, flash, redirect, request, url_for
+from flask import Blueprint, abort, current_app, flash, redirect, request, url_for
 from werkzeug.wrappers.response import Response
 
 from hushline.auth import admin_authentication_required
@@ -13,6 +13,9 @@ def create_blueprint() -> Blueprint:
     @bp.route("/toggle_verified/<int:user_id>", methods=["POST"])
     @admin_authentication_required
     def toggle_verified(user_id: int) -> Response:
+        if not current_app.config.get("MANAGED_SERVICE"):
+            abort(401)
+
         user = db.session.get(User, user_id)
         if user is None:
             abort(404)

--- a/hushline/config.py
+++ b/hushline/config.py
@@ -143,6 +143,7 @@ def _load_hushline_misc(env: Mapping[str, str]) -> Mapping[str, Any]:
         ("DIRECTORY_VERIFIED_TAB_ENABLED", True),
         ("FILE_UPLOADS_ENABLED", False),
         ("REGISTRATION_CODES_REQUIRED", True),
+        ("MANAGED_SERVICE", False),
     ]
     for key, default in bool_configs:
         if value := env.get(key):

--- a/hushline/settings/admin.py
+++ b/hushline/settings/admin.py
@@ -32,5 +32,5 @@ def register_admin_routes(bp: Blueprint) -> None:
             pgp_key_count=pgp_key_count,
             two_fa_percentage=(two_fa_count / user_count * 100) if user_count else 0,
             pgp_key_percentage=(pgp_key_count / user_count * 100) if user_count else 0,
-            is_managed_service=current_app.config.get("MANAGED_SERVICE")
+            is_managed_service=current_app.config.get("MANAGED_SERVICE"),
         )

--- a/hushline/settings/admin.py
+++ b/hushline/settings/admin.py
@@ -1,5 +1,6 @@
 from flask import (
     Blueprint,
+    current_app,
     render_template,
     session,
 )
@@ -31,4 +32,5 @@ def register_admin_routes(bp: Blueprint) -> None:
             pgp_key_count=pgp_key_count,
             two_fa_percentage=(two_fa_count / user_count * 100) if user_count else 0,
             pgp_key_percentage=(pgp_key_count / user_count * 100) if user_count else 0,
+            is_managed_service=current_app.config.get("MANAGED_SERVICE")
         )

--- a/hushline/templates/settings/admin.html
+++ b/hushline/templates/settings/admin.html
@@ -34,13 +34,15 @@
           Admin: {{ "✅ Yes" if user.is_admin else "👎 No" }}
         </p>
         <div class="tableActions">
-          <form
-            action="{{ url_for('admin.toggle_verified', user_id=user.id) }}"
-            method="POST"
-            class="formBody"
-          >
-            <button type="submit">Toggle Verified</button>
-          </form>
+          {% if is_managed_service %}
+            <form
+              action="{{ url_for('admin.toggle_verified', user_id=user.id) }}"
+              method="POST"
+              class="formBody"
+            >
+              <button type="submit">Toggle Verified</button>
+            </form>
+          {% endif %}
           <form
             action="{{ url_for('admin.toggle_admin', user_id=user.id) }}"
             method="POST"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -252,10 +252,26 @@ def user2(app: Flask, user_password: str, database: str) -> User:
 
 
 @pytest.fixture()
+def admin_user(app: Flask, user_password: str, database: str) -> User:
+    user = make_user(user_password)
+    user.is_admin = True
+    db.session.add(user)
+    db.session.commit()
+    return user
+
+
+@pytest.fixture()
 def _authenticated_user(client: FlaskClient, user: User) -> None:
     with client.session_transaction() as session:
         session["user_id"] = user.id
         session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
+
+@pytest.fixture()
+def _authenticated_admin_user(client: FlaskClient, admin_user: User) -> None:
+    with client.session_transaction() as session:
+        session["user_id"] = admin_user.id
+        session["username"] = admin_user.primary_username.username
         session["is_authenticated"] = True
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,6 +267,7 @@ def _authenticated_user(client: FlaskClient, user: User) -> None:
         session["username"] = user.primary_username.username
         session["is_authenticated"] = True
 
+
 @pytest.fixture()
 def _authenticated_admin_user(client: FlaskClient, admin_user: User) -> None:
     with client.session_transaction() as session:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -27,3 +27,25 @@ def test_admin_settings_hides_verified_on_nonmanaged_service(
     response = client.get(url_for("settings.admin"), follow_redirects=True)
     assert response.status_code == 200
     assert "Toggle Verified" not in response.text
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_toggle_verified_on_managed_service(app: Flask, client: FlaskClient, user: User) -> None:
+    app.config["MANAGED_SERVICE"] = True
+
+    response = client.post(
+        url_for("admin.toggle_verified", user_id=user.id),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_toggle_verified_on_nonmanaged_service(app: Flask, client: FlaskClient, user: User) -> None:
+    app.config["MANAGED_SERVICE"] = False
+
+    response = client.post(
+        url_for("admin.toggle_verified", user_id=user.id),
+        follow_redirects=True,
+    )
+    assert response.status_code == 401

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,0 +1,29 @@
+import pytest
+from flask import Flask, url_for
+from flask.testing import FlaskClient
+
+from hushline.model import (
+    User,
+)
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_admin_settings_shows_verified_on_managed_service(
+    app: Flask, client: FlaskClient, user: User
+) -> None:
+    app.config["MANAGED_SERVICE"] = True
+
+    response = client.get(url_for("settings.admin"), follow_redirects=True)
+    assert response.status_code == 200
+    assert "Toggle Verified" in response.text
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_admin_settings_hides_verified_on_nonmanaged_service(
+    app: Flask, client: FlaskClient, user: User
+) -> None:
+    app.config["MANAGED_SERVICE"] = False
+
+    response = client.get(url_for("settings.admin"), follow_redirects=True)
+    assert response.status_code == 200
+    assert "Toggle Verified" not in response.text


### PR DESCRIPTION
Fixes #980.

This create a new environment variable `MANAGED_SERVICE` which defaults to false. If `MANAGED_SERVICE` is false, it hides the toggle verified button in settings, and it returns 401 if you try accessing the route.

Because this adds a new environment variable, we need to make sure to set it when we deploy the update to the managed service. This doesn't require any changes for updating the personal server because `MANAGED_SERVICE` defaults to false.