### PR TITLE
Registration settings

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3428,3 +3428,30 @@ li.tab .badge {
   text-align: center;
   padding: 1rem;
 }
+
+.registration-code-list {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+
+.registration-code-entry {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: center;
+  position: relative;
+  /* needed for stretched-link */
+}
+
+.registration-code-entry .registration-code {
+  font-family: var(--font-sans-bold);
+  font-size: var(--font-size-base);
+}
+
+.registration-code-entry .registration-code-exp {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-small);
+  color: var(--color-gray);
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -309,13 +309,6 @@ These configs are needed for the web app.
       <td>Email address to use for sending message notifications</td>
     </tr>
     <tr>
-      <td><code>REGISTRATION_CODES_REQUIRED</code></td>
-      <td>false</td>
-      <td>boolean</td>
-      <td><code>true</code></td>
-      <td>Whether or not new user registrations require invite codes.</td>
-    </tr>
-    <tr>
       <td><code>SECRET_KEY</code></td>
       <td>true</td>
       <td>string</td>

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -132,6 +132,8 @@ def configure_jinja(app: Flask) -> None:
             OrganizationSetting.GUIDANCE_EXIT_BUTTON_LINK,
             OrganizationSetting.GUIDANCE_PROMPTS,
             OrganizationSetting.HIDE_DONATE_BUTTON,
+            OrganizationSetting.REGISTRATION_ENABLED,
+            OrganizationSetting.REGISTRATION_CODES_REQUIRED,
         )
 
         data.update(
@@ -140,6 +142,10 @@ def configure_jinja(app: Flask) -> None:
             directory_verified_tab_enabled=app.config["DIRECTORY_VERIFIED_TAB_ENABLED"],
             is_onion_service=request.host.lower().endswith(".onion"),
             is_premium_enabled=bool(app.config.get("STRIPE_SECRET_KEY", False)),
+            registration_enabled=data.get(OrganizationSetting.REGISTRATION_ENABLED, True),
+            registration_codes_required=data.get(
+                OrganizationSetting.REGISTRATION_CODES_REQUIRED, False
+            ),
         )
 
         if "user_id" in session:

--- a/hushline/config.py
+++ b/hushline/config.py
@@ -142,7 +142,6 @@ def _load_hushline_misc(env: Mapping[str, str]) -> Mapping[str, Any]:
     bool_configs = [
         ("DIRECTORY_VERIFIED_TAB_ENABLED", True),
         ("FILE_UPLOADS_ENABLED", False),
-        ("REGISTRATION_CODES_REQUIRED", True),
         ("MANAGED_SERVICE", False),
     ]
     for key, default in bool_configs:

--- a/hushline/model/organization_setting.py
+++ b/hushline/model/organization_setting.py
@@ -27,6 +27,8 @@ class OrganizationSetting(Model):
     GUIDANCE_PROMPTS = "guidance_prompts"
     HIDE_DONATE_BUTTON = "hide_donate_button"
     HOMEPAGE_USER_NAME = "homepage_user_name"
+    REGISTRATION_ENABLED = "registration_enabled"
+    REGISTRATION_CODES_REQUIRED = "registration_codes_required"
 
     # non-default values
     BRAND_LOGO_VALUE = "brand/logo.png"
@@ -40,6 +42,8 @@ class OrganizationSetting(Model):
         GUIDANCE_EXIT_BUTTON_LINK: "https://en.wikipedia.org/wiki/Main_Page",
         GUIDANCE_PROMPTS: [{"heading_text": "", "prompt_text": "", "index": 0}],
         HIDE_DONATE_BUTTON: False,
+        REGISTRATION_ENABLED: True,
+        REGISTRATION_CODES_REQUIRED: False,
     }
 
     key: Mapped[str] = mapped_column(primary_key=True)

--- a/hushline/routes/auth.py
+++ b/hushline/routes/auth.py
@@ -18,6 +18,7 @@ from hushline.db import db
 from hushline.model import (
     AuthenticationLog,
     InviteCode,
+    OrganizationSetting,
     User,
     Username,
 )
@@ -27,6 +28,14 @@ from hushline.routes.forms import LoginForm, RegistrationForm, TwoFactorForm
 def register_auth_routes(app: Flask) -> None:
     @app.route("/register", methods=["GET", "POST"])
     def register() -> Response | str:
+        # Check if registration is allowed
+        registration_enabled = OrganizationSetting.fetch_one(
+            OrganizationSetting.REGISTRATION_ENABLED
+        )
+        if not registration_enabled:
+            flash("⛔️ Registration is disabled.")
+            return redirect(url_for("index"))
+
         if (
             session.get("is_authenticated", False)
             and (user_id := session.get("user_id", False))

--- a/hushline/settings/__init__.py
+++ b/hushline/settings/__init__.py
@@ -37,6 +37,7 @@ from hushline.settings.guidance import register_guidance_routes
 from hushline.settings.notifications import register_notifications_routes
 from hushline.settings.profile import register_profile_routes
 from hushline.settings.proton import register_proton_routes
+from hushline.settings.registration import register_registration_routes
 from hushline.settings.replies import register_replies_routes
 from hushline.settings.twofa import register_2fa_routes
 
@@ -57,5 +58,6 @@ def create_blueprint() -> Blueprint:
     register_profile_routes(bp)
     register_proton_routes(bp)
     register_replies_routes(bp)
+    register_registration_routes(bp)
 
     return bp

--- a/hushline/settings/registration.py
+++ b/hushline/settings/registration.py
@@ -1,6 +1,6 @@
 from typing import Tuple
 
-from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
+from flask import Blueprint, flash, redirect, render_template, request, url_for
 from flask_wtf import FlaskForm
 from werkzeug.wrappers.response import Response
 from wtforms import BooleanField, SubmitField
@@ -37,9 +37,6 @@ def register_registration_routes(bp: Blueprint) -> None:
                 toggle_registration_form.submit.name in request.form
                 and toggle_registration_form.validate()
             ):
-                current_app.logger.info(
-                    f"Registration enabled: {toggle_registration_form}"
-                )
                 OrganizationSetting.upsert(
                     key=OrganizationSetting.REGISTRATION_ENABLED,
                     value=toggle_registration_form.registration_enabled.data,
@@ -54,9 +51,6 @@ def register_registration_routes(bp: Blueprint) -> None:
                 toggle_registration_codes_form.submit.name in request.form
                 and toggle_registration_codes_form.validate()
             ):
-                current_app.logger.info(
-                    f"Registration codes required: {toggle_registration_codes_form}"
-                )
                 OrganizationSetting.upsert(
                     key=OrganizationSetting.REGISTRATION_CODES_REQUIRED,
                     value=toggle_registration_codes_form.registration_codes_required.data,

--- a/hushline/settings/registration.py
+++ b/hushline/settings/registration.py
@@ -1,0 +1,39 @@
+import json
+from typing import Tuple
+
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
+from werkzeug.wrappers.response import Response
+
+from hushline.auth import admin_authentication_required
+from hushline.db import db
+from hushline.model import (
+    OrganizationSetting,
+    User,
+)
+from hushline.settings.common import (
+    form_error,
+)
+from hushline.settings.forms import (
+    UserGuidanceAddPromptForm,
+    UserGuidanceEmergencyExitForm,
+    UserGuidanceForm,
+    UserGuidancePromptContentForm,
+)
+
+
+def register_registration_routes(bp: Blueprint) -> None:
+    @bp.route("/registration", methods=["GET", "POST"])
+    @admin_authentication_required
+    def registration() -> Tuple[str, int] | Response:
+        return render_template(
+            "settings/registration.html",
+        ), 200

--- a/hushline/settings/registration.py
+++ b/hushline/settings/registration.py
@@ -1,39 +1,87 @@
-import json
 from typing import Tuple
 
-from flask import (
-    Blueprint,
-    current_app,
-    flash,
-    redirect,
-    render_template,
-    request,
-    session,
-    url_for,
-)
+from flask import Blueprint, current_app, flash, redirect, render_template, request, url_for
+from flask_wtf import FlaskForm
 from werkzeug.wrappers.response import Response
+from wtforms import BooleanField, SubmitField
+from wtforms.validators import Optional as OptionalField
 
 from hushline.auth import admin_authentication_required
 from hushline.db import db
-from hushline.model import (
-    OrganizationSetting,
-    User,
-)
-from hushline.settings.common import (
-    form_error,
-)
-from hushline.settings.forms import (
-    UserGuidanceAddPromptForm,
-    UserGuidanceEmergencyExitForm,
-    UserGuidanceForm,
-    UserGuidancePromptContentForm,
-)
+from hushline.forms import DisplayNoneButton
+from hushline.model import OrganizationSetting
+
+
+class ToggleRegistrationForm(FlaskForm):
+    registration_enabled = BooleanField("Enable Registrations", validators=[OptionalField()])
+    submit = SubmitField("Submit", name="registration_enabled", widget=DisplayNoneButton())
+
+
+class ToggleRegistrationCodesForm(FlaskForm):
+    registration_codes_required = BooleanField(
+        "Require Registration Codes", validators=[OptionalField()]
+    )
+    submit = SubmitField("Submit", name="registration_codes_required", widget=DisplayNoneButton())
 
 
 def register_registration_routes(bp: Blueprint) -> None:
     @bp.route("/registration", methods=["GET", "POST"])
     @admin_authentication_required
     def registration() -> Tuple[str, int] | Response:
+        toggle_registration_form = ToggleRegistrationForm()
+        toggle_registration_codes_form = ToggleRegistrationCodesForm()
+
+        status_code = 200
+        if request.method == "POST":
+            if (
+                toggle_registration_form.submit.name in request.form
+                and toggle_registration_form.validate()
+            ):
+                current_app.logger.info(
+                    f"Registration enabled: {toggle_registration_form}"
+                )
+                OrganizationSetting.upsert(
+                    key=OrganizationSetting.REGISTRATION_ENABLED,
+                    value=toggle_registration_form.registration_enabled.data,
+                )
+                db.session.commit()
+                if toggle_registration_form.registration_enabled.data:
+                    flash("👍 Registration enabled.")
+                else:
+                    flash("👍 Registration disabled.")
+                return redirect(url_for(".registration"))
+            elif (
+                toggle_registration_codes_form.submit.name in request.form
+                and toggle_registration_codes_form.validate()
+            ):
+                current_app.logger.info(
+                    f"Registration codes required: {toggle_registration_codes_form}"
+                )
+                OrganizationSetting.upsert(
+                    key=OrganizationSetting.REGISTRATION_CODES_REQUIRED,
+                    value=toggle_registration_codes_form.registration_codes_required.data,
+                )
+                db.session.commit()
+                if toggle_registration_codes_form.registration_codes_required.data:
+                    flash("👍 Registration codes required.")
+                else:
+                    flash("👍 Registration codes not required.")
+                return redirect(url_for(".registration"))
+
+        registration_enabled = OrganizationSetting.fetch_one(
+            OrganizationSetting.REGISTRATION_ENABLED
+        )
+        registration_codes_required = OrganizationSetting.fetch_one(
+            OrganizationSetting.REGISTRATION_CODES_REQUIRED
+        )
+
+        toggle_registration_form.registration_enabled.data = registration_enabled
+        toggle_registration_codes_form.registration_codes_required.data = (
+            registration_codes_required
+        )
+
         return render_template(
             "settings/registration.html",
-        ), 200
+            toggle_registration_form=toggle_registration_form,
+            toggle_registration_codes_form=toggle_registration_codes_form,
+        ), status_code

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -158,7 +158,9 @@
               </li>
             {% else %}
               <li><a href="{{ url_for('login') }}">Login</a></li>
-              <li><a href="{{ url_for('register') }}">Register</a></li>
+              {% if registration_enabled %}
+                <li><a href="{{ url_for('register') }}">Register</a></li>
+              {% endif %}
             {% endif %}
           </ul>
           {% if not hide_donate_button %}

--- a/hushline/templates/register.html
+++ b/hushline/templates/register.html
@@ -31,7 +31,7 @@
         {% endfor %}
       {% endif %}
     </div>
-    {% if require_invite_code %}
+    {% if registration_codes_required %}
       <div>
         {{ form.invite_code.label }}
         {{ form.invite_code(size=32) }}

--- a/hushline/templates/settings/nav.html
+++ b/hushline/templates/settings/nav.html
@@ -11,6 +11,7 @@
       ('settings.replies', 'Message Statuses', user.pgp_key is not none),
       ('settings.notifications', 'Notifications', True),
       ('settings.guidance', 'User Guidance', user.is_admin),
+      ('settings.registration', 'Registration', user.is_admin),
       ('settings.admin', 'Admin', user.is_admin),
       ('settings.advanced', 'Advanced', True)
     ] %}

--- a/hushline/templates/settings/registration.html
+++ b/hushline/templates/settings/registration.html
@@ -38,6 +38,35 @@
         </div>
         {{ toggle_registration_codes_form.submit }}
     </form>
+
+    {% if toggle_registration_codes_form.registration_codes_required.data %}
+        <h4>Registration Codes</h4>
+
+        <form method="POST" class="formBody">
+          {{ create_invite_code_form.hidden_tag() }}
+          {{ create_invite_code_form.submit }}
+        </form>
+
+        {% if invite_codes %}
+            <div class="registration-code-list">
+            {% for invite_code in invite_codes %}
+                <div class="registration-code-entry">
+                  <div>
+                      <div class="registration-code">{{ invite_code.code }}</div>
+                      <div class="registration-code-exp">expires {{ invite_code.expiration_date.strftime('%Y-%m-%d') }}</div>
+                  </div>
+                  <form method="POST" class="formBody">
+                    {{ delete_invite_code_form.hidden_tag() }}
+                    <input type="hidden" name="{{ delete_invite_code_form.invite_code_id.name }}" value="{{ invite_code.id }}">
+                    {{ delete_invite_code_form.submit }}
+                  </form>
+                </div>
+            {% endfor %}
+            </div>
+        {% else %}
+            <p>🙊 No registration codes.</p>
+        {% endif %}
+    {% endif %}
   {% endif %}
 
 {% endblock %}

--- a/hushline/templates/settings/registration.html
+++ b/hushline/templates/settings/registration.html
@@ -1,0 +1,14 @@
+{% extends "settings/base.html" %}
+
+{% block settings_content %}
+  <h3>Registration</h3>
+  <p>
+    Registration allows you to control how users can create accounts on your Hush Line
+    instance. You can disable registration, choose to allow anyone to register, or
+    require an invite code.
+  </p>
+{% endblock %}
+
+{% block scripts %}
+  <script src="{{ url_for('static', filename='js/settings.js') }}"></script>
+{% endblock %}

--- a/hushline/templates/settings/registration.html
+++ b/hushline/templates/settings/registration.html
@@ -12,6 +12,7 @@
     {{ toggle_registration_form.hidden_tag() }}
     <div class="checkbox-group toggle-ui">
       {{ toggle_registration_form.registration_enabled }}
+      <input type="hidden" name="{{ toggle_registration_form.registration_enabled.name }}" value="false">
       <label for="{{ toggle_registration_form.registration_enabled.name }}" class="toggle-label">
         {{ toggle_registration_form.registration_enabled.label }}
         <div class="toggle">
@@ -22,19 +23,22 @@
     {{ toggle_registration_form.submit }}
   </form>
 
-  <form method="POST" class="formBody auto-submit">
-    {{ toggle_registration_codes_form.hidden_tag() }}
-    <div class="checkbox-group toggle-ui">
-      {{ toggle_registration_codes_form.registration_codes_required }}
-      <label for="{{ toggle_registration_codes_form.registration_codes_required.name }}" class="toggle-label">
-        {{ toggle_registration_codes_form.registration_codes_required.label }}
-        <div class="toggle">
-          <div class="toggle__ball"></div>
+  {% if toggle_registration_form.registration_enabled.data %}
+    <form method="POST" class="formBody auto-submit">
+        {{ toggle_registration_codes_form.hidden_tag() }}
+        <div class="checkbox-group toggle-ui">
+        {{ toggle_registration_codes_form.registration_codes_required }}
+        <input type="hidden" name="{{ toggle_registration_codes_form.registration_codes_required.name }}" value="false">
+        <label for="{{ toggle_registration_codes_form.registration_codes_required.name }}" class="toggle-label">
+            {{ toggle_registration_codes_form.registration_codes_required.label }}
+            <div class="toggle">
+            <div class="toggle__ball"></div>
+            </div>
+        </label>
         </div>
-      </label>
-    </div>
-    {{ toggle_registration_codes_form.submit }}
-  </form>
+        {{ toggle_registration_codes_form.submit }}
+    </form>
+  {% endif %}
 
 {% endblock %}
 

--- a/hushline/templates/settings/registration.html
+++ b/hushline/templates/settings/registration.html
@@ -7,6 +7,35 @@
     instance. You can disable registration, choose to allow anyone to register, or
     require an invite code.
   </p>
+
+  <form method="POST" class="formBody auto-submit">
+    {{ toggle_registration_form.hidden_tag() }}
+    <div class="checkbox-group toggle-ui">
+      {{ toggle_registration_form.registration_enabled }}
+      <label for="{{ toggle_registration_form.registration_enabled.name }}" class="toggle-label">
+        {{ toggle_registration_form.registration_enabled.label }}
+        <div class="toggle">
+          <div class="toggle__ball"></div>
+        </div>
+      </label>
+    </div>
+    {{ toggle_registration_form.submit }}
+  </form>
+
+  <form method="POST" class="formBody auto-submit">
+    {{ toggle_registration_codes_form.hidden_tag() }}
+    <div class="checkbox-group toggle-ui">
+      {{ toggle_registration_codes_form.registration_codes_required }}
+      <label for="{{ toggle_registration_codes_form.registration_codes_required.name }}" class="toggle-label">
+        {{ toggle_registration_codes_form.registration_codes_required.label }}
+        <div class="toggle">
+          <div class="toggle__ball"></div>
+        </div>
+      </label>
+    </div>
+    {{ toggle_registration_codes_form.submit }}
+  </form>
+
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
Fixes #973.

There's now a registration settings page, only accessible to admins:

![image](https://github.com/user-attachments/assets/32492272-84e9-4f3a-a668-c5b4ca033fc0)

You can turn on registration, required registration codes, and also create and delete codes:

![image](https://github.com/user-attachments/assets/9898f9b2-c709-4128-b6f4-7127625d1038)

![image](https://github.com/user-attachments/assets/a66c3ba7-a0fb-4162-9ba6-bd810b5b62a7)

![image](https://github.com/user-attachments/assets/4fb3e4be-3306-4360-9efd-ea49159fa2e4)

If registrations are disabled, the `/register` route redirects to index, and the Register link doesn't get displayed in the nav bar.

This also fixes two small bugs:

- The `register.html` template needs a variable `first_user` and it was only being passed in on GET requests, not POST requests, so this fixes that
- Invite codes are deleted after use

This also completely deletes the REGISTRATION_CODES_REQUIRED environment variable. By default this setting was disabled, and I doubt it's actively used in the wild (since there's no interface for generating invite codes). So this just means that if there is an instance that has this env var set to true, this PR will make it so they're no longer required, and the user will need to login as an admin and change the setting there. (The alternative would to write a little migration, which doesn't seem worth it since I don't think it's being used.)