### PR TITLE
 Enforce least-privilege `GITHUB_TOKEN` in all workflows

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -1,5 +1,8 @@
 name: Build latest container image
-
+permissions:
+  contents: read
+  packages: write
+  
 on:
   push:
     branches:

--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -2,7 +2,7 @@ name: Build latest container image
 permissions:
   contents: read
   packages: write
-  
+
 on:
   push:
     branches:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,4 +1,7 @@
 name: Build release container image
+permissions:
+  contents: read
+  packages: write
 
 on:
   push:

--- a/.github/workflows/bypass-review.yaml
+++ b/.github/workflows/bypass-review.yaml
@@ -1,4 +1,6 @@
 name: Bypass Review by Admin for Specific Files
+permissions:
+  contents: read
 
 on:
   pull_request:

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -4,7 +4,7 @@ permissions:
   contents: read
   pull-requests: write
   issues: write
-  
+
 on:
   pull_request:
     types: [labeled, closed]

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -1,6 +1,10 @@
 ---
 name: Deploy/Destroy Branch Dev Environment
-
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+  
 on:
   pull_request:
     types: [labeled, closed]

--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -1,7 +1,7 @@
 name: Post to Mastodon on PR Merge
 permissions:
   contents: none
-  
+
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/post-to-mastodon.yml
+++ b/.github/workflows/post-to-mastodon.yml
@@ -1,5 +1,7 @@
 name: Post to Mastodon on PR Merge
-
+permissions:
+  contents: none
+  
 on:
   pull_request:
     types: [closed]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,8 @@
 ---
 name: Run Linter and Tests
-
+permissions:
+  contents: read
+  
 on:
   push:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@
 name: Run Linter and Tests
 permissions:
   contents: read
-  
+
 on:
   push:
     branches:


### PR DESCRIPTION
Add a top-level permissions: block to every workflow to scope GITHUB_TOKEN to only the APIs each job needs. Clears CodeQL “missing-workflow-permissions” alerts and aligns with the principle of least privilege.

### Changed workflows:
• .github/workflows/dev_deploy.yml
• .github/workflows/tests.yml
• .github/workflows/post-to-mastodon.yml
• .github/workflows/build-release.yml
• .github/workflows/build-latest.yml
• .github/workflows/bypass-review.yaml

### Key changes per file:
• contents: read for all workflows using actions/checkout
• pull-requests: write & issues: write where we add/remove labels or post comments
• packages: write for container builds/pushes
• contents: none in Mastodon post (no GitHub API calls)