### PR TITLE
Update models to match the current state of the db

### DIFF
--- a/hushline/model/authentication_log.py
+++ b/hushline/model/authentication_log.py
@@ -17,7 +17,7 @@ else:
 class AuthenticationLog(Model):
     __tablename__ = "authentication_logs"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     user_id: Mapped[int] = mapped_column(db.ForeignKey("users.id"))
     user: Mapped["User"] = relationship(backref=db.backref("authentication_logs", lazy=True))
     successful: Mapped[bool]

--- a/hushline/model/field_definition.py
+++ b/hushline/model/field_definition.py
@@ -20,16 +20,20 @@ class FieldDefinition(Model):
     __tablename__ = "field_definitions"
     __table_args__ = (UniqueConstraint("username_id", "sort_order"),)
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    username_id: Mapped[int] = mapped_column(db.ForeignKey("usernames.id"), index=True)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False)
+    username_id: Mapped[int] = mapped_column(
+        db.ForeignKey("usernames.id"), nullable=True, index=True
+    )
     username: Mapped["Username"] = relationship(back_populates="message_fields")
-    label: Mapped[str] = mapped_column(db.String(255))
-    field_type: Mapped[FieldType] = mapped_column(SQLAlchemyEnum(FieldType))
-    required: Mapped[bool] = mapped_column()
-    enabled: Mapped[bool] = mapped_column()
-    encrypted: Mapped[bool] = mapped_column()
-    choices: Mapped[list[str]] = mapped_column(type_=JSONB)
-    sort_order: Mapped[int] = mapped_column()
+    label: Mapped[str] = mapped_column(db.String(255), nullable=False)
+    field_type: Mapped[FieldType] = mapped_column(
+        SQLAlchemyEnum(FieldType, name="fieldtype"), nullable=True
+    )
+    required: Mapped[bool] = mapped_column(nullable=True)
+    enabled: Mapped[bool] = mapped_column(nullable=True)
+    encrypted: Mapped[bool] = mapped_column(nullable=True)
+    choices: Mapped[list[str]] = mapped_column(type_=JSONB, nullable=True)
+    sort_order: Mapped[int] = mapped_column(nullable=True)
 
     def __init__(  # noqa: PLR0913
         self,

--- a/hushline/model/field_definition.py
+++ b/hushline/model/field_definition.py
@@ -20,7 +20,7 @@ class FieldDefinition(Model):
     __tablename__ = "field_definitions"
     __table_args__ = (UniqueConstraint("username_id", "sort_order"),)
 
-    id: Mapped[int] = mapped_column(primary_key=True, nullable=False)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     username_id: Mapped[int] = mapped_column(
         db.ForeignKey("usernames.id"), nullable=True, index=True
     )

--- a/hushline/model/field_value.py
+++ b/hushline/model/field_value.py
@@ -36,7 +36,7 @@ def add_padding(value: str, block_size: int = 512) -> str:
 class FieldValue(Model):
     __tablename__ = "field_values"
 
-    id: Mapped[int] = mapped_column(primary_key=True, nullable=False)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     field_definition_id: Mapped[int] = mapped_column(
         db.ForeignKey("field_definitions.id", ondelete="CASCADE"), nullable=True
     )

--- a/hushline/model/field_value.py
+++ b/hushline/model/field_value.py
@@ -36,13 +36,17 @@ def add_padding(value: str, block_size: int = 512) -> str:
 class FieldValue(Model):
     __tablename__ = "field_values"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    field_definition_id: Mapped[int] = mapped_column(db.ForeignKey("field_definitions.id"))
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False)
+    field_definition_id: Mapped[int] = mapped_column(
+        db.ForeignKey("field_definitions.id", ondelete="CASCADE"), nullable=True
+    )
     field_definition: Mapped["FieldDefinition"] = relationship(uselist=False)
-    message_id: Mapped[int] = mapped_column(db.ForeignKey("messages.id"))
+    message_id: Mapped[int] = mapped_column(
+        db.ForeignKey("messages.id", ondelete="CASCADE"), nullable=True
+    )
     message: Mapped["Message"] = relationship("Message", back_populates="field_values")
-    _value: Mapped[str] = mapped_column(db.Text)
-    encrypted: Mapped[bool] = mapped_column()
+    _value: Mapped[str] = mapped_column(db.Text, nullable=False)
+    encrypted: Mapped[bool] = mapped_column(nullable=True)
 
     def __init__(
         self,

--- a/hushline/model/invite_code.py
+++ b/hushline/model/invite_code.py
@@ -15,7 +15,7 @@ else:
 class InviteCode(Model):
     __tablename__ = "invite_codes"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     code: Mapped[str] = mapped_column(db.String(255), unique=True)
     expiration_date: Mapped[datetime]
 

--- a/hushline/model/message.py
+++ b/hushline/model/message.py
@@ -22,7 +22,7 @@ else:
 class Message(Model):
     __tablename__ = "messages"
 
-    id: Mapped[int] = mapped_column(primary_key=True, nullable=False)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     created_at: Mapped[datetime] = mapped_column(
         db.DateTime(timezone=True), server_default=text("NOW()"), nullable=False
     )

--- a/hushline/model/message.py
+++ b/hushline/model/message.py
@@ -22,16 +22,18 @@ else:
 class Message(Model):
     __tablename__ = "messages"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
-    created_at: Mapped[datetime] = mapped_column(server_default=text("NOW()"))
-    username_id: Mapped[int] = mapped_column(db.ForeignKey("usernames.id"))
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        db.DateTime(timezone=True), server_default=text("NOW()"), nullable=False
+    )
+    username_id: Mapped[int] = mapped_column(db.ForeignKey("usernames.id"), nullable=False)
     username: Mapped["Username"] = relationship(uselist=False)
-    reply_slug: Mapped[str] = mapped_column(index=True)
+    reply_slug: Mapped[str] = mapped_column(index=True, nullable=False)
     status: Mapped[MessageStatus] = mapped_column(
-        SQLAlchemyEnum(MessageStatus), default=MessageStatus.PENDING
+        SQLAlchemyEnum(MessageStatus), default=MessageStatus.PENDING, nullable=False
     )
     status_changed_at: Mapped[datetime] = mapped_column(
-        db.DateTime(timezone=True), server_default=text("NOW()")
+        db.DateTime(timezone=True), server_default=text("NOW()"), nullable=False
     )
     field_values: Mapped[list["FieldValue"]] = relationship(
         "FieldValue", back_populates="message", cascade="all, delete-orphan"

--- a/hushline/model/message_status_text.py
+++ b/hushline/model/message_status_text.py
@@ -23,7 +23,7 @@ class MessageStatusText(Model):
     __tablename__ = "message_status_text"
     __table_args__ = (UniqueConstraint("user_id", "status"),)
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     user_id: Mapped[int] = mapped_column(db.ForeignKey("users.id"))
     status: Mapped[MessageStatus] = mapped_column(SQLAlchemyEnum(MessageStatus))
     markdown: Mapped[str] = mapped_column()

--- a/hushline/model/stripe_event.py
+++ b/hushline/model/stripe_event.py
@@ -17,7 +17,7 @@ else:
 class StripeEvent(Model):
     __tablename__ = "stripe_events"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     event_id: Mapped[str] = mapped_column(db.String(255), unique=True, index=True)
     event_type: Mapped[str] = mapped_column(db.String(255))
     event_created: Mapped[int] = mapped_column(db.Integer)

--- a/hushline/model/stripe_invoice.py
+++ b/hushline/model/stripe_invoice.py
@@ -19,7 +19,7 @@ else:
 class StripeInvoice(Model):
     __tablename__ = "stripe_invoices"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     customer_id: Mapped[str] = mapped_column(db.String(255))
     invoice_id: Mapped[str] = mapped_column(db.String(255), unique=True, index=True)
     hosted_invoice_url: Mapped[str] = mapped_column(db.String(2048))

--- a/hushline/model/tier.py
+++ b/hushline/model/tier.py
@@ -15,7 +15,7 @@ class Tier(Model):
 
     __tablename__ = "tiers"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     name: Mapped[str] = mapped_column(db.String(255), unique=True)
     monthly_amount: Mapped[int] = mapped_column(db.Integer)  # in cents USD
     stripe_product_id: Mapped[Optional[str]] = mapped_column(db.String(255), unique=True)

--- a/hushline/model/user.py
+++ b/hushline/model/user.py
@@ -24,7 +24,7 @@ else:
 class User(Model):
     __tablename__ = "users"
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     is_admin: Mapped[bool] = mapped_column(default=False)
     _password_hash: Mapped[str] = mapped_column("password_hash", db.String(512))
     _totp_secret: Mapped[Optional[str]] = mapped_column("totp_secret", db.String(255))

--- a/hushline/model/username.py
+++ b/hushline/model/username.py
@@ -35,7 +35,7 @@ class Username(Model):
     DISPLAY_NAME_MIN_LENGTH = 1
     DISPLAY_NAME_MAX_LENGTH = 100
 
-    id: Mapped[int] = mapped_column(primary_key=True)
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
     user_id: Mapped[int] = mapped_column(db.ForeignKey("users.id"))
     user: Mapped["User"] = relationship()
     _username: Mapped[str] = mapped_column("username", unique=True)


### PR DESCRIPTION
Fixes #870 

Now when you create an autogenerated alembic migration, it doesn't create a migration at all.

It still has a few warnings though which I'm not sure how to get rid of, but I think we can safely ignore:

```
INFO  [alembic.ddl.postgresql] Detected sequence named 'message_id_seq' as owned by integer column 'messages(id)', assuming SERIAL and omitting
INFO  [alembic.ddl.postgresql] Detected sequence named 'invite_code_id_seq' as owned by integer column 'invite_codes(id)', assuming SERIAL and omitting
INFO  [alembic.ddl.postgresql] Detected sequence named 'authentication_logs_id_seq' as owned by integer column 'authentication_logs(id)', assuming SERIAL and omitting
INFO  [alembic.ddl.postgresql] Detected sequence named 'field_definitions_id_seq' as owned by integer column 'field_definitions(id)', assuming SERIAL and omitting
INFO  [alembic.ddl.postgresql] Detected sequence named 'message_status_text_id_seq' as owned by integer column 'message_status_text(id)', assuming SERIAL and omitting
INFO  [alembic.ddl.postgresql] Detected sequence named 'stripe_events_id_seq' as owned by integer column 'stripe_events(id)', assuming SERIAL and omitting
INFO  [alembic.ddl.postgresql] Detected sequence named 'field_values_id_seq' as owned by integer column 'field_values(id)', assuming SERIAL and omitting
INFO  [alembic.ddl.postgresql] Detected sequence named 'stripe_invoices_id_seq' as owned by integer column 'stripe_invoices(id)', assuming SERIAL and omitting
INFO  [alembic.env] No changes in schema detected.

```