### PR TITLE
Enable basic PWA support

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -299,4 +299,9 @@ document.addEventListener("DOMContentLoaded", () => {
       firstModalContent.style.opacity = "1";
     });
   }
+  if ('serviceWorker' in navigator) {
+    navigator.serviceWorker.register('/static/service-worker.js')
+      .then(() => console.log('Service Worker registered'))
+      .catch((err) => console.error('Service Worker registration failed:', err));
+  }
 });

--- a/assets/js/service-worker.js
+++ b/assets/js/service-worker.js
@@ -1,0 +1,20 @@
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open('hushline-cache').then((cache) => {
+      return cache.addAll([
+        '/',
+        '/static/css/style.css',
+        '/static/favicon/android-chrome-192x192.png',
+        '/static/favicon/android-chrome-512x512.png'
+      ]);
+    })
+  );
+});
+
+self.addEventListener('fetch', (event) => {
+  event.respondWith(
+    caches.match(event.request).then((response) => {
+      return response || fetch(event.request);
+    })
+  );
+});


### PR DESCRIPTION
This PR introduces minimal PWA functionality to improve mobile and desktop installability:
• Added `assets/js/service-worker.js` with basic caching (homepage, CSS, favicon) for faster load and offline support.
• Registered service worker in `global.js` for automatic activation on supported browsers.
• Ensured service worker registration does not interfere with other scripts and runs only when supported.

This completes the initial PWA setup:
• Installable on Android, desktop Chrome, Edge.
• Fullscreen standalone display.
• Slight offline capability (static assets cached).

Future improvements (not in this PR):
• Add offline fallback page.