### PR TITLE
Potential fix for code scanning alert no. 85: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/w3c-validators.yml
+++ b/.github/workflows/w3c-validators.yml
@@ -1,5 +1,8 @@
 name: W3C Validators
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/scidsg/hushline/security/code-scanning/85](https://github.com/scidsg/hushline/security/code-scanning/85)

In general, fix this by adding an explicit `permissions` block to the workflow (either at the root so it applies to all jobs, or under the specific job) restricting `GITHUB_TOKEN` to the minimal required scopes. For this workflow, all steps only read the repository (via `actions/checkout`) and then run local build, Docker, curl, and Python commands; they don’t write to the repo or use GitHub APIs for issues/PRs. Thus `contents: read` is sufficient.

The best minimal fix without changing functionality is to add a top-level `permissions` block after the `name:` declaration, setting `contents: read`. This will apply to all jobs (currently only `validate`) and satisfies CodeQL’s recommendation. No imports or other code changes are needed; only the YAML header of `.github/workflows/w3c-validators.yml` needs to be updated.

Concretely, in `.github/workflows/w3c-validators.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `name: W3C Validators` line and the `on:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
