### PR TITLE
Potential fix for code scanning alert no. 86: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/owasp-zap.yml
+++ b/.github/workflows/owasp-zap.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   zap:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/scidsg/hushline/security/code-scanning/86](https://github.com/scidsg/hushline/security/code-scanning/86)

To fix the problem, explicitly define a least-privilege `permissions:` block so the `GITHUB_TOKEN` used by this workflow is limited to what the steps require. Since this workflow only checks out code and uploads artifacts, it only needs read access to repository contents.

The best fix without changing existing functionality is to add a root-level `permissions:` block (applies to all jobs) with `contents: read`. No steps write to the repo, manage issues, or interact with other privileged resources through the `GITHUB_TOKEN`, so this is sufficient. Concretely, in `.github/workflows/owasp-zap.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (e.g., after line 5 and a blank line). No imports, methods, or other definitions are needed; this is pure workflow configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
