### PR TITLE
Update config.py

### DIFF
--- a/hushline/config.py
+++ b/hushline/config.py
@@ -68,10 +68,10 @@ def load_config(env: Optional[Mapping[str, str]] = None) -> Mapping[str, Any]:
 
 def _load_flask(env: Mapping[str, str]) -> Mapping[str, Any]:
     data = {
-        "SESSION_COOKIE_NAME": env.get("SESSION_COOKIE_NAME", "__HOST-session"),
+        "SESSION_COOKIE_NAME": "__HOST-session",
         "SESSION_COOKIE_SECURE": True,
         "SESSION_COOKIE_HTTPONLY": True,
-        "SESSION_COOKIE_SAMESITE": "Lax",
+        "SESSION_COOKIE_SAMESITE": "Strict",
         "PERMANENT_SESSION_LIFETIME": timedelta(minutes=30),
     }
 


### PR DESCRIPTION
- `SESSION_COOKIE_NAME` is now hard‑coded to `__HOST-session` (no env override).
- `SESSION_COOKIE_SAMESITE` set to `Strict`.

Closes #929
