### PR TITLE
Let encrypt_message raise on failure

### DIFF
--- a/hushline/crypto.py
+++ b/hushline/crypto.py
@@ -123,21 +123,17 @@ def can_encrypt_with_pgp_key(key: str) -> bool:
         return False
 
 
-def encrypt_message(message: str, user_pgp_key: str) -> str | None:
+def encrypt_message(message: str, user_pgp_key: str) -> str:
     current_app.logger.info("Encrypting message for user with provided PGP key")
-    try:
-        # Load the user's PGP certificate (public key) from the key data
-        recipient_cert = Cert.from_bytes(user_pgp_key.encode())
+    # Load the user's PGP certificate (public key) from the key data
+    recipient_cert = Cert.from_bytes(user_pgp_key.encode())
 
-        # Encode the message string to bytes
-        message_bytes = message.encode("utf-8")
+    # Encode the message string to bytes
+    message_bytes = message.encode("utf-8")
 
-        # Assuming there is no signer (i.e., unsigned encryption).
-        # Adjust the call to encrypt by passing the encoded message
-        return encrypt([recipient_cert], message_bytes)  # Use message_bytes
-    except Exception as e:
-        current_app.logger.error(f"Error during encryption: {e}")
-        return None
+    # Assuming there is no signer (i.e., unsigned encryption).
+    # Adjust the call to encrypt by passing the encoded message
+    return encrypt([recipient_cert], message_bytes)  # Use message_bytes
 
 
 def encrypt_bytes(data: bytes, user_pgp_key: str) -> bytes | None:

--- a/hushline/model/field_value.py
+++ b/hushline/model/field_value.py
@@ -85,11 +85,7 @@ class FieldValue(Model):
             pgp_key = self.message.username.user.pgp_key
             if not pgp_key:
                 raise ValueError("User does not have a PGP key")
-            encrypted_value = encrypt_message(padded_value, pgp_key)
-            if encrypted_value:
-                val_to_save = encrypted_value
-            else:
-                raise ValueError("Failed to encrypt value")
+            val_to_save = encrypt_message(padded_value, pgp_key)
         else:
             # Do not encrypt with PGP, and instead only encrypt with db key
             val_to_save = value

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -120,7 +120,15 @@ def register_message_routes(app: Flask) -> None:
                     if "-----BEGIN PGP MESSAGE-----" in value:
                         email_body = value
                     else:
-                        email_body = encrypt_message(value, user.pgp_key) if user.pgp_key else None
+                        try:
+                            email_body = (
+                                encrypt_message(value, user.pgp_key) if user.pgp_key else None
+                            )
+                        except Exception as e:
+                            current_app.logger.error(
+                                "Failed to encrypt email body: %s", str(e), exc_info=True
+                            )
+                            email_body = None
                     do_send_email(user, (email_body or generic_body).strip())
                 else:
                     do_send_email(user, value.strip())


### PR DESCRIPTION
- Remove catch‑and‑return‑None behavior from `encrypt_message`
- Simplify field encryption path to rely on exceptions
- Catch encryption errors when resending email content and fall back to generic body

Closes #697 