### PR TITLE
Add No‑JS warning banner and layout adjustment

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1384,6 +1384,22 @@ img.empty {
   animation: fadeInDown 0.5s ease forwards;
 }
 
+.noscript-warning {
+  display: none;
+  padding: 1rem;
+  border: 1px solid #f5c2c7;
+  border-radius: 8px;
+  background: #f8d7da;
+  color: #842029;
+  position: fixed;
+  top: calc(7.625rem + env(safe-area-inset-top));
+  z-index: 99;
+}
+
+.no-js .noscript-warning {
+  display: block;
+}
+
 .flash-messages.is-dismissing {
   animation: fadeOutUp 0.5s ease forwards;
 }
@@ -1393,6 +1409,10 @@ img.empty {
   display: flex;
   align-items: center;
   gap: 0.75rem;
+}
+
+.no-js main {
+  margin-top: calc(7rem + env(safe-area-inset-top)) !important;
 }
 
 .flash-message-text {

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="no-js">
   <head>
     <meta charset="UTF-8" />
     <meta name="theme-color" content="{{ brand_primary_color }}" id="theme-color" />
@@ -137,6 +137,9 @@
       rel="stylesheet"
       href="{{ url_for('static', filename='css/style.css') }}"
     />
+    <script>
+      document.documentElement.classList.remove("no-js");
+    </script>
     <!-- prettier-ignore -->
     <style>
       :root {
@@ -147,6 +150,9 @@
 
   <body class="{% block body_class %}{% endblock %}">
     <a class="skip-link" href="#main-content">Skip to main content</a>
+    <div class="noscript-warning" role="status" aria-live="polite" aria-atomic="true">
+      ‼️ Enable JavaScript for full functionality, including end-to-end encrypted messages.
+    </div>
     {% with messages = get_flashed_messages() %}
       {% if messages %}
         <div class="flash-messages" role="status" aria-live="polite" aria-atomic="true">


### PR DESCRIPTION
- Show a banner when JavaScript is disabled using a no-js class toggle
- Style the No‑JS warning and only add extra top margin when JS is disabled
- Ensure the warning works even when NoScript blocks <noscript> rendering

Closes #878