### PR TITLE
Narrow broad exception handling to explicit exception types across app paths

### DIFF
--- a/hushline/admin.py
+++ b/hushline/admin.py
@@ -1,6 +1,7 @@
 from flask import Blueprint, abort, current_app, flash, redirect, request, session, url_for
 from flask_wtf.csrf import validate_csrf
 from werkzeug.wrappers.response import Response
+from wtforms.validators import ValidationError
 
 from hushline.auth import admin_authentication_required
 from hushline.db import db
@@ -28,7 +29,7 @@ def _validate_csrf() -> None:
         abort(400)
     try:
         validate_csrf(token)
-    except Exception:
+    except ValidationError:
         abort(400)
 
 

--- a/hushline/crypto.py
+++ b/hushline/crypto.py
@@ -104,7 +104,7 @@ def is_valid_pgp_key(key: str) -> bool:
         # Attempt to load the PGP key to verify its validity
         Cert.from_bytes(key.encode())
         return True
-    except Exception as e:
+    except (RuntimeError, TypeError, ValueError) as e:
         current_app.logger.error(f"Error validating PGP key: {e}")
         return False
 
@@ -118,7 +118,7 @@ def can_encrypt_with_pgp_key(key: str) -> bool:
         test_message = b"pgp-encryption-test"
         encrypted = encrypt([recipient_cert], test_message)
         return bool(encrypted)
-    except Exception as e:
+    except (RuntimeError, TypeError, ValueError) as e:
         current_app.logger.error(f"Error during encryption test: {e}")
         return False
 
@@ -144,7 +144,7 @@ def encrypt_bytes(data: bytes, user_pgp_key: str) -> bytes | None:
         if isinstance(encrypted, str):
             return encrypted.encode("utf-8")
         return encrypted
-    except Exception as e:
+    except (RuntimeError, TypeError, ValueError) as e:
         current_app.logger.error(f"Error during encryption: {e}")
         return None
 

--- a/hushline/premium.py
+++ b/hushline/premium.py
@@ -367,7 +367,15 @@ async def worker(app: Flask) -> None:
                     elif event.type == "invoice.updated":
                         handle_invoice_updated(invoice)
 
-            except Exception as e:
+            except (
+                json.JSONDecodeError,
+                KeyError,
+                TypeError,
+                ValueError,
+                RuntimeError,
+                sa.exc.SQLAlchemyError,
+                stripe._error.StripeError,
+            ) as e:
                 current_app.logger.error(
                     f"Error processing event {stripe_event.event_type} ({stripe_event.event_id}): {e}\n{stripe_event.event_data}",  # noqa: E501
                     exc_info=True,

--- a/hushline/routes/common.py
+++ b/hushline/routes/common.py
@@ -1,4 +1,5 @@
 import re
+import smtplib
 import socket
 import unicodedata
 from typing import Sequence
@@ -59,7 +60,7 @@ def get_ip_address() -> str:
     try:
         s.connect(("1.1.1.1", 1))
         ip_address = s.getsockname()[0]
-    except Exception:
+    except OSError:
         ip_address = "127.0.0.1"
     finally:
         s.close()
@@ -91,7 +92,7 @@ def do_send_email(user: User, body: str) -> None:
             )
 
         send_email(user.email, "New Hush Line Message Received", body, smtp_config)
-    except Exception as e:
+    except (KeyError, OSError, TypeError, ValueError, smtplib.SMTPException) as e:
         current_app.logger.error(f"Error sending email: {str(e)}", exc_info=True)
 
 

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -124,7 +124,7 @@ def register_message_routes(app: Flask) -> None:
                             email_body = (
                                 encrypt_message(value, user.pgp_key) if user.pgp_key else None
                             )
-                        except Exception as e:
+                        except (RuntimeError, TypeError, ValueError) as e:
                             current_app.logger.error(
                                 "Failed to encrypt email body: %s", str(e), exc_info=True
                             )

--- a/hushline/settings/notifications.py
+++ b/hushline/settings/notifications.py
@@ -1,3 +1,4 @@
+import smtplib
 from typing import Optional, Tuple
 
 from flask import (
@@ -64,7 +65,7 @@ def handle_email_forwarding_form(user: User, form: EmailForwardingForm) -> Optio
             )
             with smtp_config.smtp_login():
                 pass
-        except Exception as e:
+        except (OSError, ValueError, smtplib.SMTPException) as e:
             current_app.logger.debug(e)
             flash("⛔️ Unable to validate SMTP connection settings")
             return None


### PR DESCRIPTION
## Summary

  This PR addresses the “avoid blanket except Exception” issue by replacing broad exception
  catches with explicit exception classes in current code paths.

  ## What Changed

  - hushline/admin.py
      - _validate_csrf() now catches wtforms.validators.ValidationError instead of blanket
        Exception.
  - hushline/settings/notifications.py
      - SMTP validation now catches only:
          - OSError
          - ValueError
          - smtplib.SMTPException
  - hushline/routes/common.py
      - get_ip_address() now catches OSError instead of blanket Exception.
      - do_send_email() now catches only:
          - KeyError
          - OSError
          - TypeError
          - ValueError
          - smtplib.SMTPException
  - hushline/routes/message.py
      - Resend-path encryption fallback now catches:
          - RuntimeError
          - TypeError
          - ValueError
  - hushline/crypto.py
      - PGP validation/encryption helpers now catch:
          - RuntimeError
          - TypeError
          - ValueError
  - hushline/premium.py
      - Stripe worker event processing now catches only:
          - json.JSONDecodeError
          - KeyError
          - TypeError
          - ValueError
          - RuntimeError
          - sqlalchemy.exc.SQLAlchemyError (via sa.exc.SQLAlchemyError)
          - stripe._error.StripeError

  ## Why

  - Avoids hiding programming errors behind blanket catches.
  - Improves testability and failure visibility.
  - Keeps defensive handling only around expected operational/integration failures.

  ## Validation

  - make lint passes.
  - Targeted tests pass:
      - tests/test_admin.py
      - tests/test_notifications.py
      - tests/test_settings.py
      - tests/test_profile.py
      - tests/test_premium.py
      - Result: 93 passed.
  - Verified no except Exception remains under hushline/.

Closes #278