### PR TITLE
Harden core behavior contracts and add security/privacy requirements for agents

### DIFF
--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -10,8 +10,33 @@ from flask.testing import FlaskClient
 from helpers import get_captcha_from_session, get_captcha_from_session_register
 
 from hushline.db import db
-from hushline.model import Message, MessageStatus, User, Username
+from hushline.model import (
+    InviteCode,
+    Message,
+    MessageStatus,
+    OrganizationSetting,
+    Tier,
+    User,
+    Username,
+)
 from hushline.routes.common import format_full_message_email_body
+from hushline.settings import (
+    ChangePasswordForm,
+    ChangeUsernameForm,
+    DisplayNameForm,
+    NewAliasForm,
+    PGPKeyForm,
+)
+from hushline.settings.branding import ToggleDonateButtonForm
+from hushline.settings.forms import (
+    SetHomepageUsernameForm,
+    UpdateBrandAppNameForm,
+    UpdateBrandPrimaryColorForm,
+    UpdateDirectoryTextForm,
+    UpdateProfileHeaderForm,
+    UserGuidanceForm,
+)
+from tests.helpers import form_to_data
 
 GENERIC_EMAIL_BODY = "You have a new Hush Line message! Please log in to read it."
 PGP_SIG = "-----BEGIN PGP MESSAGE-----"
@@ -43,6 +68,13 @@ def _latest_message_for(user: User) -> Message:
     ).first()
     assert message is not None
     return message
+
+
+def _authenticate_as(client: FlaskClient, user: User) -> None:
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["username"] = user.primary_username.username
+        sess["is_authenticated"] = True
 
 
 def test_contract_register_login_and_2fa_challenge(client: FlaskClient, app: Flask) -> None:
@@ -244,6 +276,39 @@ def test_contract_onboarding_notifications_and_directory_persist_expected_state(
     assert user.primary_username.show_in_directory is True
 
 
+def test_contract_directory_users_surface_verified_and_unverified_accounts(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    user.primary_username.show_in_directory = True
+    user.primary_username.is_verified = True
+    user.primary_username._display_name = "Verified Sender"
+    user.primary_username.bio = "verified bio"
+
+    user2.primary_username.show_in_directory = True
+    user2.primary_username.is_verified = False
+    user2.primary_username._display_name = None
+    user2.primary_username.bio = "unverified bio"
+    db.session.commit()
+
+    response = client.get(url_for("directory_users"))
+    assert response.status_code == 200
+    rows = response.json or []
+
+    verified_row = next(
+        row for row in rows if row["primary_username"] == user.primary_username.username
+    )
+    unverified_row = next(
+        row for row in rows if row["primary_username"] == user2.primary_username.username
+    )
+
+    assert verified_row["is_verified"] is True
+    assert verified_row["display_name"] == "Verified Sender"
+    assert verified_row["bio"] == "verified bio"
+    assert unverified_row["is_verified"] is False
+    assert unverified_row["display_name"] == user2.primary_username.username
+    assert unverified_row["bio"] == "unverified bio"
+
+
 @pytest.mark.usefixtures("_authenticated_user", "_pgp_user")
 def test_contract_whistleblower_message_flow_defaults_and_actions(
     client: FlaskClient, user: User
@@ -298,3 +363,322 @@ def test_contract_whistleblower_message_flow_defaults_and_actions(
     assert (
         db.session.scalars(db.select(Message).where(Message.id == message.id)).one_or_none() is None
     )
+
+
+@pytest.mark.usefixtures("_authenticated_user", "_pgp_user")
+def test_contract_message_actions_do_not_cross_user_boundaries(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    _submit_message(client, user)
+    message = _latest_message_for(user)
+
+    _authenticate_as(client, user2)
+
+    message_response = client.get(
+        url_for("message", public_id=message.public_id), follow_redirects=True
+    )
+    assert message_response.status_code == 404
+    assert "404: Not Found" in message_response.text
+
+    status_response = client.post(
+        url_for("set_message_status", public_id=message.public_id),
+        data={"status": MessageStatus.ACCEPTED.value},
+        follow_redirects=True,
+    )
+    assert status_response.status_code == 404
+    db.session.refresh(message)
+    assert message.status != MessageStatus.ACCEPTED
+
+    with patch("hushline.routes.message.do_send_email", new=MagicMock()) as send_email_mock:
+        resend_response = client.post(
+            url_for("resend_message", public_id=message.public_id),
+            data={"submit": ""},
+            follow_redirects=True,
+        )
+        assert resend_response.status_code == 200
+        assert "Message not found." in resend_response.text
+        send_email_mock.assert_not_called()
+
+    delete_response = client.post(
+        url_for("delete_message", public_id=message.public_id),
+        data={"submit": ""},
+        follow_redirects=True,
+    )
+    assert delete_response.status_code == 200
+    assert "Message not found." in delete_response.text
+    assert db.session.get(Message, message.id) is not None
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_contract_authenticated_settings_profile_and_auth_round_trip(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    display_name = "Contract Display"
+    profile_bio = "Contract Bio"
+    username_suffix = "-ct"
+    new_username = f"{user.primary_username.username}{username_suffix}"
+    new_password = "ContractPassword123!"
+
+    response = client.post(
+        url_for("settings.profile"),
+        data=form_to_data(DisplayNameForm(data={"display_name": display_name})),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "Display name updated successfully" in response.text
+
+    response = client.post(
+        url_for("settings.profile"),
+        data={
+            "bio": profile_bio,
+            "extra_field_label1": "Signal",
+            "extra_field_value1": "@contract-user",
+            "update_bio": "",
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "Bio and fields updated successfully" in response.text
+
+    response = client.post(
+        url_for("settings.profile"),
+        data={"show_in_directory": "y", "update_directory_visibility": ""},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "Directory visibility updated successfully" in response.text
+
+    response = client.post(
+        url_for("settings.auth"),
+        data=form_to_data(ChangeUsernameForm(data={"new_username": new_username})),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "Username changed successfully" in response.text
+
+    response = client.post(
+        url_for("settings.auth"),
+        data=form_to_data(
+            ChangePasswordForm(data={"old_password": user_password, "new_password": new_password})
+        ),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "Password successfully changed. Please log in again." in response.text
+
+    login_response = client.post(
+        url_for("login"),
+        data={"username": new_username, "password": new_password},
+        follow_redirects=True,
+    )
+    assert login_response.status_code == 200
+    assert "Inbox" in login_response.text
+
+    updated_username = db.session.scalars(
+        db.select(Username).where(Username._username == new_username)
+    ).one()
+    assert updated_username.display_name == display_name
+    assert updated_username.bio == profile_bio
+    assert updated_username.show_in_directory is True
+    assert updated_username.extra_field_label1 == "Signal"
+    assert updated_username.extra_field_value1 == "@contract-user"
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_contract_authenticated_encryption_and_data_export_flow(
+    client: FlaskClient, user: User
+) -> None:
+    with open("tests/test_pgp_key.txt", encoding="utf-8") as f:
+        pgp_key = f.read().strip()
+
+    response = client.post(
+        url_for("settings.encryption"),
+        data=form_to_data(PGPKeyForm(data={"pgp_key": pgp_key})),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "PGP key updated successfully" in response.text
+
+    with (
+        patch(
+            "hushline.settings.proton.requests.get",
+            return_value=MagicMock(status_code=200, text=pgp_key),
+        ),
+        patch("hushline.settings.proton.is_valid_pgp_key", return_value=True),
+        patch("hushline.settings.proton.can_encrypt_with_pgp_key", return_value=True),
+    ):
+        proton_response = client.post(
+            url_for("settings.update_pgp_key_proton"),
+            data={"email": "contract@proton.me"},
+            follow_redirects=True,
+        )
+    assert proton_response.status_code == 200
+    assert "PGP key updated successfully." in proton_response.text
+
+    export_response = client.post(url_for("settings.data_export"), data={"encrypt_export": "false"})
+    assert export_response.status_code == 200
+    assert export_response.mimetype == "application/zip"
+    assert export_response.headers["Content-Disposition"].startswith("attachment;")
+
+    encrypted_export_response = client.post(
+        url_for("settings.data_export"), data={"encrypt_export": "y"}
+    )
+    assert encrypted_export_response.status_code == 200
+    assert encrypted_export_response.mimetype == "application/pgp-encrypted"
+    assert encrypted_export_response.data.startswith(b"-----BEGIN PGP MESSAGE-----")
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_contract_paid_user_alias_vision_and_subscription_controls(
+    client: FlaskClient, user: User
+) -> None:
+    business_tier = db.session.scalars(
+        db.select(Tier).where(Tier.name.in_(["Business", "Super User"]))
+    ).first()
+    assert business_tier is not None
+    user.tier_id = business_tier.id
+    user.stripe_subscription_id = "sub_contract_123"
+    db.session.commit()
+
+    add_alias_response = client.post(
+        url_for("settings.aliases"),
+        data=form_to_data(NewAliasForm(data={"username": "contractalias"})),
+        follow_redirects=True,
+    )
+    assert add_alias_response.status_code == 200
+    added_alias = db.session.scalars(
+        db.select(Username).where(
+            Username.user_id == user.id,
+            Username.is_primary.is_(False),
+            Username._username == "contractalias",
+        )
+    ).one_or_none()
+    assert added_alias is not None
+
+    delete_alias_response = client.post(
+        url_for("settings.delete_alias", username_id=added_alias.id),
+        data={"delete_alias": ""},
+        follow_redirects=True,
+    )
+    assert delete_alias_response.status_code == 200
+    assert db.session.get(Username, added_alias.id) is None
+
+    vision_response = client.get(url_for("vision"), follow_redirects=True)
+    assert vision_response.status_code == 200
+    assert "Vision Assistant" in vision_response.text
+
+    with patch("hushline.premium.stripe.Subscription.modify", return_value=MagicMock()):
+        disable_response = client.post(url_for("premium.disable_autorenew"), follow_redirects=False)
+    assert disable_response.status_code == 302
+    assert disable_response.headers["Location"].endswith(url_for("premium.index"))
+    db.session.refresh(user)
+    assert user.stripe_subscription_cancel_at_period_end is True
+
+    with patch("hushline.premium.stripe.Subscription.modify", return_value=MagicMock()):
+        enable_response = client.post(url_for("premium.enable_autorenew"), follow_redirects=False)
+    assert enable_response.status_code == 302
+    assert enable_response.headers["Location"].endswith(url_for("premium.index"))
+    db.session.refresh(user)
+    assert user.stripe_subscription_cancel_at_period_end is False
+
+    with patch("hushline.premium.stripe.Subscription.delete", return_value=MagicMock()):
+        cancel_response = client.post(url_for("premium.cancel"), follow_redirects=False)
+    assert cancel_response.status_code == 302
+    assert cancel_response.headers["Location"].endswith(url_for("premium.index"))
+    db.session.refresh(user)
+    assert user.is_free_tier
+
+
+@pytest.mark.usefixtures("_authenticated_admin")
+def test_contract_admin_branding_guidance_and_registration_controls(
+    client: FlaskClient, app: Flask, admin: User, user: User
+) -> None:
+    app.config["USER_VERIFICATION_ENABLED"] = True
+
+    directory_text = "Contract directory intro"
+    branding_response = client.post(
+        url_for("settings.branding"),
+        data={"markdown": directory_text, UpdateDirectoryTextForm.submit.name: ""},
+        follow_redirects=True,
+    )
+    assert branding_response.status_code == 200
+    assert "Directory intro text updated" in branding_response.text
+    assert OrganizationSetting.fetch_one(OrganizationSetting.DIRECTORY_INTRO_TEXT) == directory_text
+
+    color_response = client.post(
+        url_for("settings.branding"),
+        data=form_to_data(UpdateBrandPrimaryColorForm(data={"brand_primary_hex_color": "#1144aa"})),
+        follow_redirects=True,
+    )
+    assert color_response.status_code == 200
+    assert "Brand primary color updated successfully" in color_response.text
+
+    name_response = client.post(
+        url_for("settings.branding"),
+        data=form_to_data(UpdateBrandAppNameForm(data={"brand_app_name": "Hush Contract"})),
+        follow_redirects=True,
+    )
+    assert name_response.status_code == 200
+    assert "Brand app name updated successfully" in name_response.text
+
+    homepage_response = client.post(
+        url_for("settings.branding"),
+        data={
+            "username": user.primary_username.username,
+            SetHomepageUsernameForm.submit.name: "",
+        },
+        follow_redirects=True,
+    )
+    assert homepage_response.status_code == 200
+    assert "Homepage set to user" in homepage_response.text
+
+    profile_header_response = client.post(
+        url_for("settings.branding"),
+        data=form_to_data(UpdateProfileHeaderForm(data={"template": "<p>{{username}}</p>"})),
+        follow_redirects=True,
+    )
+    assert profile_header_response.status_code == 200
+    assert "Profile header template updated successfully" in profile_header_response.text
+
+    donate_toggle_response = client.post(
+        url_for("settings.branding"),
+        data=form_to_data(ToggleDonateButtonForm(data={"hide_button": True})),
+        follow_redirects=True,
+    )
+    assert donate_toggle_response.status_code == 200
+    assert "Donate button set to hidden" in donate_toggle_response.text
+
+    guidance_toggle_response = client.post(
+        url_for("settings.guidance"),
+        data={"show_user_guidance": True, UserGuidanceForm.submit.name: ""},
+        content_type="multipart/form-data",
+        follow_redirects=True,
+    )
+    assert guidance_toggle_response.status_code == 200
+    assert "User guidance enabled." in guidance_toggle_response.text
+
+    registration_toggle_response = client.post(
+        url_for("settings.registration"),
+        data={"registration_enabled": "y"},
+        follow_redirects=True,
+    )
+    assert registration_toggle_response.status_code == 200
+    assert "Registration enabled." in registration_toggle_response.text
+
+    create_invite_response = client.post(
+        url_for("settings.registration"),
+        data={"create_invite_code": ""},
+        follow_redirects=True,
+    )
+    assert create_invite_response.status_code == 200
+    invite = db.session.scalars(db.select(InviteCode).order_by(InviteCode.id.desc())).first()
+    assert invite is not None
+
+    verify_response = client.post(
+        url_for("admin.toggle_verified", user_id=user.id),
+        data={"is_verified": "true"},
+        follow_redirects=True,
+    )
+    assert verify_response.status_code == 200
+    db.session.refresh(user)
+    assert user.primary_username.is_verified is True


### PR DESCRIPTION
## Summary

  This PR strengthens behavior lock-in for Hush Line’s core flows and updates agent guidance with explicit security/privacy expectations.

  ## Changes

  ### 1. Expanded behavior contract coverage

  Updated tests/test_behavior_contracts.py with additional contract tests covering:

  - Directory behavior:
      - verified + unverified directory surface
      - display-name fallback and bio propagation
  - Cross-user authorization boundaries:
      - cannot view/update/resend/delete another user’s message
  - Authenticated user core settings flow:
      - display name, bio/fields, directory visibility
      - username change
      - password change + login with new credentials
  - Encryption + export flow:
      - manual PGP key update
      - Proton key lookup update path
      - data export (zip + encrypted export)
  - Paid-user flow:
      - alias add/remove
      - Vision access for paid users
      - disable/enable autorenew and cancel subscription behavior
  - Admin flow:
      - directory intro text
      - brand color/app name
      - homepage override
      - profile header template
      - donate-button visibility
      - guidance enablement
      - registration enablement + invite creation
      - account verification toggle

  ### 2. Agent governance update

  Updated AGENTS.md to add a new Security and Privacy Requirements section, including:

  - treating whistleblower paths as security-critical
  - preserving E2EE/anonymization guarantees
  - dependency vulnerability checks (pip-audit, npm audit)
  - merge-blocking expectations for reachable runtime CVEs unless risk-accepted
  - security PR documentation requirements
  - prohibition on logging secrets/plaintext disclosures

  ## Validation

  - docker compose run --rm app poetry run pytest tests/test_behavior_contracts.py -q
      - 14 passed
  - make lint
      - passed
  - make test
      - 520 passed, 1 xfailed
      - coverage: TOTAL 4091 0 100%

  ## Notes

  - AGENTS.md was also normalized by formatter as part of lint compliance (formatting only).