### PR TITLE
docs: fix markdown formatting to pass lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,4 +124,3 @@ _Around the Bend_<br>
 ## Contribution Guidelines
 
 ❤️ We're excited that you're interested in contributing to Hush Line. To maintain the quality of our codebase and ensure the best experience for everyone, we ask that you agree to and follow our [Code of Conduct](https://github.com/scidsg/business-resources/blob/main/Policies%20%26%20Procedures/Code%20of%20Conduct.md).
-


### PR DESCRIPTION
## What changed
- Ran Prettier formatting fixes for markdown files flagged by lint.
- Updated  and  formatting only.

## Validation
- docker compose run --rm app poetry run ruff format --check && \
	docker compose run --rm app poetry run ruff check --output-format full && \
	docker compose run --rm app poetry run mypy . && \
	docker compose run --rm app npx prettier --check ./*.md ./docs ./.github/workflows/* ./hushline
144 files already formatted
All checks passed!
Success: no issues found in 143 source files
Checking formatting...
All matched files use Prettier code style! passed locally.
