### PR TITLE
ci: run full checks on automated badge update PRs

### DIFF
--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -89,7 +89,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "Update Lighthouse performance badge [skip ci]"
+          commit-message: "Update Lighthouse performance badge"
           title: "Update Lighthouse performance badge"
           body: "Automated update of `badge-performance.json` from Lighthouse workflow."
           branch: "automation/lighthouse-performance-badge"

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -68,7 +68,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "Update Lighthouse accessibility badge [skip ci]"
+          commit-message: "Update Lighthouse accessibility badge"
           title: "Update Lighthouse accessibility badge"
           body: "Automated update of `badge.json` from Lighthouse workflow."
           branch: "automation/lighthouse-badge"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -65,7 +65,7 @@ jobs:
         if: github.ref == 'refs/heads/main'
         uses: peter-evans/create-pull-request@v6
         with:
-          commit-message: "Update test coverage badge [skip ci]"
+          commit-message: "Update test coverage badge"
           title: "Update test coverage badge"
           body: "Automated update of `badge-coverage.json` from test workflow."
           branch: "automation/test-coverage-badge"


### PR DESCRIPTION
## What changed
- Removed `[skip ci]` from automated badge-update commit messages in:
  - `.github/workflows/tests.yml`
  - `.github/workflows/lighthouse.yml`
  - `.github/workflows/lighthouse-performance.yml`

## Why
- Badge update PRs were skipping CI workflows, which caused incomplete/expected checks and inconsistent PR gating.

## Impact
- Badge update PRs will now run normal PR workflows and required checks.
