### PR TITLE
security: resolve node audit blockers for Dependabot PRs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "hushline",
       "version": "0.0.0",
       "dependencies": {
-        "openpgp": "^5.11.3"
+        "openpgp": "^6.3.0"
       },
       "devDependencies": {
         "css-loader": "^6.7.2",
@@ -674,10 +674,11 @@
       }
     },
     "node_modules/ajv": {
-      "version": "8.17.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
-      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -718,17 +719,6 @@
         "ajv": "^8.8.2"
       }
     },
-    "node_modules/asn1.js": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-5.4.1.tgz",
-      "integrity": "sha512-+I//4cYPccV8LdmBLiX8CYvf9Sp3vQsrqu2QNXRcrbiWvcx/UdlFiqUJJzxRQxgsZmvhXhn4cSKeSmoFjVdupA==",
-      "dependencies": {
-        "bn.js": "^4.0.0",
-        "inherits": "^2.0.1",
-        "minimalistic-assert": "^1.0.0",
-        "safer-buffer": "^2.1.0"
-      }
-    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.9.19",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
@@ -739,11 +729,6 @@
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
       }
-    },
-    "node_modules/bn.js": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.12.1.tgz",
-      "integrity": "sha512-k8TVBiPkPJT9uHLdOKfFpqcfprwBFOAAXXozRubr7R7PfIuKvQlzcI4M0pALeqXN09vdaMbUdUj+pass+uULAg=="
     },
     "node_modules/braces": {
       "version": "3.0.3",
@@ -1212,11 +1197,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/inherits": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-    },
     "node_modules/interpret": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/interpret/-/interpret-3.1.1.tgz",
@@ -1431,11 +1411,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/minimalistic-assert": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
-      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
-    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -1476,15 +1451,12 @@
       "peer": true
     },
     "node_modules/openpgp": {
-      "version": "5.11.3",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.11.3.tgz",
-      "integrity": "sha512-jXOPfIteBUQ2zSmRG4+Y6PNntIIDEAvoM/lOYCnvpXAByJEruzrHQZWE/0CGOKHbubwUuty2HoPHsqBzyKHOpA==",
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-6.3.0.tgz",
+      "integrity": "sha512-pLzCU8IgyKXPSO11eeharQkQ4GzOKNWhXq79pQarIRZEMt1/ssyr+MIuWBv1mNoenJLg04gvPx+fi4gcKZ4bag==",
       "license": "LGPL-3.0+",
-      "dependencies": {
-        "asn1.js": "^5.0.0"
-      },
       "engines": {
-        "node": ">= 8.0.0"
+        "node": ">= 18.0.0"
       }
     },
     "node_modules/p-limit": {
@@ -1806,11 +1778,6 @@
       ],
       "license": "MIT",
       "peer": true
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/sass": {
       "version": "1.86.3",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build:prod": "webpack --config webpack.config.js"
   },
   "dependencies": {
-    "openpgp": "^5.11.3"
+    "openpgp": "^6.3.0"
   },
   "devDependencies": {
     "css-loader": "^6.7.2",


### PR DESCRIPTION
## What changed
- Updated runtime OpenPGP dependency from `^5.11.3` to `^6.3.0`.
- Regenerated lockfile via `npm install` + `npm audit fix`.

## Why
- Dependabot PRs were blocked by failing dependency audit checks:
  - `Dependency Security Audit / node-runtime-audit`
  - `Dependency Security Audit / node-full-audit`
- Failing advisories included vulnerable `bn.js` (via old OpenPGP chain) and `ajv` in lockfile dependency graph.

## Validation
- `npm audit --omit=dev --package-lock-only` -> `found 0 vulnerabilities`
- `npm audit --package-lock-only` -> `found 0 vulnerabilities`
