### PR TITLE
Sign automation-created PR commits

### DIFF
--- a/.github/workflows/codex-issue-trigger.yml
+++ b/.github/workflows/codex-issue-trigger.yml
@@ -374,6 +374,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ github.token }}
+          sign-commits: true
           commit-message: ${{ steps.issue_meta.outputs.commit_message }}
           branch: "codex/issue-${{ github.event.issue.number }}"
           delete-branch: true
@@ -396,6 +397,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ github.token }}
+          sign-commits: true
           commit-message: ${{ steps.issue_meta.outputs.commit_message }}
           branch: "codex/issue-${{ github.event.issue.number }}"
           delete-branch: true

--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -87,8 +87,9 @@ jobs:
 
       - name: Create badge update PR
         if: github.ref == 'refs/heads/main'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
+          sign-commits: true
           commit-message: "Update Lighthouse performance badge"
           title: "Update Lighthouse performance badge"
           body: "Automated update of `badge-performance.json` from Lighthouse workflow."

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -66,8 +66,9 @@ jobs:
 
       - name: Create badge update PR
         if: github.ref == 'refs/heads/main'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
+          sign-commits: true
           commit-message: "Update Lighthouse accessibility badge"
           title: "Update Lighthouse accessibility badge"
           body: "Automated update of `badge.json` from Lighthouse workflow."

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -63,8 +63,9 @@ jobs:
           echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"$COLOR\"}" > badge-coverage.json
       - name: Create coverage badge update PR
         if: github.ref == 'refs/heads/main'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@v7
         with:
+          sign-commits: true
           commit-message: "Update test coverage badge"
           title: "Update test coverage badge"
           body: "Automated update of `badge-coverage.json` from test workflow."


### PR DESCRIPTION
## What changed
- Upgraded `peter-evans/create-pull-request` from `v6` to `v7` in badge workflows.
- Enabled `sign-commits: true` for automation PR creation in:
  - `.github/workflows/tests.yml`
  - `.github/workflows/lighthouse.yml`
  - `.github/workflows/lighthouse-performance.yml`
  - `.github/workflows/codex-issue-trigger.yml`

## Why
Main now requires verified commit signatures. This ensures automation-created PR commits are signed and can be merged without bypassing signature protections.

## Validation
- `make lint`
- `make test`
