### PR TITLE
ci: simplify Codex coverage runner to single test pass

### DIFF
--- a/scripts/codex_coverage_gap_runner.sh
+++ b/scripts/codex_coverage_gap_runner.sh
@@ -141,11 +141,8 @@ Follow AGENTS.md and any deeper AGENTS.md files exactly. This repository is secu
 Required output:
 1) Raise coverage to at least ${TARGET_COVERAGE}%.
 2) Prefer adding/updating tests. Avoid production behavior changes unless required for testability.
-3) Run and pass:
-   - make lint
-   - make test PYTEST_ADDOPTS="--skip-local-only"
-   - docker compose run --rm app poetry run pytest --cov hushline --cov-report term-missing -q --skip-local-only --cov-fail-under=${TARGET_COVERAGE}
-4) Summarize what changed, checks run, and residual risks.
+3) Do not run lint/test/coverage commands; the runner executes required checks after your code changes are complete.
+4) Summarize what changed and any residual risks.
 
 Important:
 - Do not weaken E2EE, auth, anonymity, or privacy protections.
@@ -177,7 +174,6 @@ run_check() {
 
 if [[ "$RUN_LOCAL_CHECKS" == "1" ]]; then
   run_check "lint" make lint
-  run_check "tests" make test PYTEST_ADDOPTS="--skip-local-only"
   run_check "coverage threshold >= ${TARGET_COVERAGE}%" \
     docker compose run --rm app poetry run pytest --cov hushline --cov-report term-missing -q --skip-local-only --cov-fail-under="$TARGET_COVERAGE"
 fi


### PR DESCRIPTION
## What changed
- Added local Codex runner scripts from the runner branch baseline:
  - scripts/codex_coverage_gap_runner.sh
  - scripts/codex_daily_issue_runner.sh
- Simplified scripts/codex_coverage_gap_runner.sh so validation runs once after Codex changes.
- Updated the Codex prompt in the coverage runner to explicitly skip running lint/test/coverage commands inside codex exec (runner now owns validation).

## Why
- The previous flow repeated the full suite multiple times (inside codex exec and again in runner invariants), causing unnecessary runtime and higher failure risk under local Docker constraints.
- This keeps safety checks while removing duplicate full-suite execution.

## Validation
- make lint
- make test

Both commands passed locally on this branch.