### PR TITLE
ci: always run workflow security checks on pull requests

### DIFF
--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -3,8 +3,6 @@ name: Workflow Security Checks
 
 on:
   pull_request:
-    paths:
-      - ".github/workflows/**"
   push:
     branches: [main]
     paths:


### PR DESCRIPTION
## Summary
- remove `pull_request.paths` filter from `Workflow Security Checks`
- ensure workflow security checks run on every PR

## Why
- avoid PRs getting blocked when required security checks are expected but not triggered by path filters

## Validation
- make lint
- make test