### PR TITLE
ci: publish badge JSON updates without PR branches

### DIFF
--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -85,18 +85,38 @@ jobs:
             exit 1
           fi
 
-      - name: Create badge update PR
+      - name: Publish performance badge to external repo
         if: github.ref == 'refs/heads/main'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          sign-commits: true
-          commit-message: "Update Lighthouse performance badge"
-          title: "Update Lighthouse performance badge"
-          body: "Automated update of `badge-performance.json` from Lighthouse workflow."
-          branch: "automation/lighthouse-performance-badge"
-          delete-branch: true
-          add-paths: |
-            badge-performance.json
+        env:
+          SCREENSHOTS_REPO: ${{ vars.SCREENSHOTS_REPO }}
+          SCREENSHOTS_PUSH_TOKEN: ${{ secrets.SCREENSHOTS_PUSH_TOKEN }}
+          BADGE_FILE: badge-performance.json
+        run: |
+          set -euo pipefail
+          if [ -z "${SCREENSHOTS_REPO:-}" ] || [ -z "${SCREENSHOTS_PUSH_TOKEN:-}" ]; then
+            echo "Skipping publish: SCREENSHOTS_REPO variable or SCREENSHOTS_PUSH_TOKEN secret is missing."
+            exit 0
+          fi
+          if [ ! -f "${BADGE_FILE}" ]; then
+            echo "Expected badge file not found: ${BADGE_FILE}"
+            exit 1
+          fi
+
+          WORKDIR="$(mktemp -d /tmp/hushline-badges.XXXXXX)"
+          git clone "https://x-access-token:${SCREENSHOTS_PUSH_TOKEN}@github.com/${SCREENSHOTS_REPO}.git" "${WORKDIR}"
+          cd "${WORKDIR}"
+          cp "${GITHUB_WORKSPACE}/${BADGE_FILE}" "${BADGE_FILE}"
+
+          git add "${BADGE_FILE}"
+          if git diff --cached --quiet; then
+            echo "No badge changes to publish."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update performance badge"
+          git push origin HEAD
 
       - name: Upload badge artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -64,18 +64,38 @@ jobs:
             exit 1
           fi
 
-      - name: Create badge update PR
+      - name: Publish accessibility badge to external repo
         if: github.ref == 'refs/heads/main'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          sign-commits: true
-          commit-message: "Update Lighthouse accessibility badge"
-          title: "Update Lighthouse accessibility badge"
-          body: "Automated update of `badge.json` from Lighthouse workflow."
-          branch: "automation/lighthouse-badge"
-          delete-branch: true
-          add-paths: |
-            badge.json
+        env:
+          SCREENSHOTS_REPO: ${{ vars.SCREENSHOTS_REPO }}
+          SCREENSHOTS_PUSH_TOKEN: ${{ secrets.SCREENSHOTS_PUSH_TOKEN }}
+          BADGE_FILE: badge.json
+        run: |
+          set -euo pipefail
+          if [ -z "${SCREENSHOTS_REPO:-}" ] || [ -z "${SCREENSHOTS_PUSH_TOKEN:-}" ]; then
+            echo "Skipping publish: SCREENSHOTS_REPO variable or SCREENSHOTS_PUSH_TOKEN secret is missing."
+            exit 0
+          fi
+          if [ ! -f "${BADGE_FILE}" ]; then
+            echo "Expected badge file not found: ${BADGE_FILE}"
+            exit 1
+          fi
+
+          WORKDIR="$(mktemp -d /tmp/hushline-badges.XXXXXX)"
+          git clone "https://x-access-token:${SCREENSHOTS_PUSH_TOKEN}@github.com/${SCREENSHOTS_REPO}.git" "${WORKDIR}"
+          cd "${WORKDIR}"
+          cp "${GITHUB_WORKSPACE}/${BADGE_FILE}" "${BADGE_FILE}"
+
+          git add "${BADGE_FILE}"
+          if git diff --cached --quiet; then
+            echo "No badge changes to publish."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update accessibility badge"
+          git push origin HEAD
 
       - name: Upload badge artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,18 +61,38 @@ jobs:
             COLOR="red"
           fi
           echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"$COLOR\"}" > badge-coverage.json
-      - name: Create coverage badge update PR
+      - name: Publish coverage badge to external repo
         if: github.ref == 'refs/heads/main'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          sign-commits: true
-          commit-message: "Update test coverage badge"
-          title: "Update test coverage badge"
-          body: "Automated update of `badge-coverage.json` from test workflow."
-          branch: "automation/test-coverage-badge"
-          delete-branch: true
-          add-paths: |
-            badge-coverage.json
+        env:
+          SCREENSHOTS_REPO: ${{ vars.SCREENSHOTS_REPO }}
+          SCREENSHOTS_PUSH_TOKEN: ${{ secrets.SCREENSHOTS_PUSH_TOKEN }}
+          BADGE_FILE: badge-coverage.json
+        run: |
+          set -euo pipefail
+          if [ -z "${SCREENSHOTS_REPO:-}" ] || [ -z "${SCREENSHOTS_PUSH_TOKEN:-}" ]; then
+            echo "Skipping publish: SCREENSHOTS_REPO variable or SCREENSHOTS_PUSH_TOKEN secret is missing."
+            exit 0
+          fi
+          if [ ! -f "${BADGE_FILE}" ]; then
+            echo "Expected badge file not found: ${BADGE_FILE}"
+            exit 1
+          fi
+
+          WORKDIR="$(mktemp -d /tmp/hushline-badges.XXXXXX)"
+          git clone "https://x-access-token:${SCREENSHOTS_PUSH_TOKEN}@github.com/${SCREENSHOTS_REPO}.git" "${WORKDIR}"
+          cd "${WORKDIR}"
+          cp "${GITHUB_WORKSPACE}/${BADGE_FILE}" "${BADGE_FILE}"
+
+          git add "${BADGE_FILE}"
+          if git diff --cached --quiet; then
+            echo "No badge changes to publish."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update coverage badge"
+          git push origin HEAD
       - name: Upload coverage badge artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [Hush Line](https://hushline.app) is a whistleblower platform that provides secure, anonymous tip lines with no self-hosting required. Sign up for a free account at <https://tips.hushline.app/register>
 
-![Accessibility](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/main/badge.json)
-![Performance](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/main/badge-performance.json)
-![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/main/badge-coverage.json)
+![Accessibility](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline-screenshots/main/badge.json)
+![Performance](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline-screenshots/main/badge-performance.json)
+![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline-screenshots/main/badge-coverage.json)
 ![Tests](https://github.com/scidsg/hushline/actions/workflows/tests.yml/badge.svg)
 ![GDPR Compliance](https://github.com/scidsg/hushline/actions/workflows/gdpr-compliance.yml/badge.svg)
 ![CCPA Compliance](https://github.com/scidsg/hushline/actions/workflows/ccpa-compliance.yml/badge.svg)


### PR DESCRIPTION
## Summary
- stop creating automation PRs for coverage/accessibility/performance badge JSON updates
- publish badge JSON files directly to the external screenshots repo (same endpoint pattern as docs badge)
- update README badge endpoints to the external repo

## Why
- PRs created by GITHUB_TOKEN do not trigger downstream pull_request workflows
- required checks then stay in expected/pending state with no status reported

## Validation
- make lint
- make test

## Risk
- badge publish step now depends on SCREENSHOTS_REPO variable and SCREENSHOTS_PUSH_TOKEN secret; step safely no-ops when unset