### PR TITLE
ci: publish badges directly without automation PRs

### DIFF
--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -85,18 +85,35 @@ jobs:
             exit 1
           fi
 
-      - name: Create badge update PR
+      - name: Publish performance badge
         if: github.ref == 'refs/heads/main'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          sign-commits: true
-          commit-message: "Update Lighthouse performance badge"
-          title: "Update Lighthouse performance badge"
-          body: "Automated update of `badge-performance.json` from Lighthouse workflow."
-          branch: "automation/lighthouse-performance-badge"
-          delete-branch: true
-          add-paths: |
-            badge-performance.json
+        env:
+          REPO_SLUG: ${{ github.repository }}
+          PUSH_TOKEN: ${{ github.token }}
+          BADGE_BRANCH: badges
+          BADGE_FILE: badge-performance.json
+        run: |
+          set -euo pipefail
+          WORKDIR="$(mktemp -d /tmp/hushline-badges.XXXXXX)"
+          if ! git clone --depth 1 --branch "${BADGE_BRANCH}" "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO_SLUG}.git" "${WORKDIR}"; then
+            git clone --depth 1 "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO_SLUG}.git" "${WORKDIR}"
+            cd "${WORKDIR}"
+            git checkout --orphan "${BADGE_BRANCH}"
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          cd "${WORKDIR}"
+          cp "${GITHUB_WORKSPACE}/${BADGE_FILE}" "${BADGE_FILE}"
+          git add "${BADGE_FILE}"
+          if git diff --cached --quiet; then
+            echo "No badge changes to publish."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update performance badge"
+          git push origin "HEAD:${BADGE_BRANCH}"
 
       - name: Upload badge artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -64,18 +64,35 @@ jobs:
             exit 1
           fi
 
-      - name: Create badge update PR
+      - name: Publish accessibility badge
         if: github.ref == 'refs/heads/main'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          sign-commits: true
-          commit-message: "Update Lighthouse accessibility badge"
-          title: "Update Lighthouse accessibility badge"
-          body: "Automated update of `badge.json` from Lighthouse workflow."
-          branch: "automation/lighthouse-badge"
-          delete-branch: true
-          add-paths: |
-            badge.json
+        env:
+          REPO_SLUG: ${{ github.repository }}
+          PUSH_TOKEN: ${{ github.token }}
+          BADGE_BRANCH: badges
+          BADGE_FILE: badge.json
+        run: |
+          set -euo pipefail
+          WORKDIR="$(mktemp -d /tmp/hushline-badges.XXXXXX)"
+          if ! git clone --depth 1 --branch "${BADGE_BRANCH}" "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO_SLUG}.git" "${WORKDIR}"; then
+            git clone --depth 1 "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO_SLUG}.git" "${WORKDIR}"
+            cd "${WORKDIR}"
+            git checkout --orphan "${BADGE_BRANCH}"
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          cd "${WORKDIR}"
+          cp "${GITHUB_WORKSPACE}/${BADGE_FILE}" "${BADGE_FILE}"
+          git add "${BADGE_FILE}"
+          if git diff --cached --quiet; then
+            echo "No badge changes to publish."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update accessibility badge"
+          git push origin "HEAD:${BADGE_BRANCH}"
 
       - name: Upload badge artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,18 +61,35 @@ jobs:
             COLOR="red"
           fi
           echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"$COLOR\"}" > badge-coverage.json
-      - name: Create coverage badge update PR
+      - name: Publish coverage badge
         if: github.ref == 'refs/heads/main'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          sign-commits: true
-          commit-message: "Update test coverage badge"
-          title: "Update test coverage badge"
-          body: "Automated update of `badge-coverage.json` from test workflow."
-          branch: "automation/test-coverage-badge"
-          delete-branch: true
-          add-paths: |
-            badge-coverage.json
+        env:
+          REPO_SLUG: ${{ github.repository }}
+          PUSH_TOKEN: ${{ github.token }}
+          BADGE_BRANCH: badges
+          BADGE_FILE: badge-coverage.json
+        run: |
+          set -euo pipefail
+          WORKDIR="$(mktemp -d /tmp/hushline-badges.XXXXXX)"
+          if ! git clone --depth 1 --branch "${BADGE_BRANCH}" "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO_SLUG}.git" "${WORKDIR}"; then
+            git clone --depth 1 "https://x-access-token:${PUSH_TOKEN}@github.com/${REPO_SLUG}.git" "${WORKDIR}"
+            cd "${WORKDIR}"
+            git checkout --orphan "${BADGE_BRANCH}"
+            git rm -rf . >/dev/null 2>&1 || true
+          fi
+
+          cd "${WORKDIR}"
+          cp "${GITHUB_WORKSPACE}/${BADGE_FILE}" "${BADGE_FILE}"
+          git add "${BADGE_FILE}"
+          if git diff --cached --quiet; then
+            echo "No badge changes to publish."
+            exit 0
+          fi
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update coverage badge"
+          git push origin "HEAD:${BADGE_BRANCH}"
       - name: Upload coverage badge artifact
         if: always()
         uses: actions/upload-artifact@v4

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [Hush Line](https://hushline.app) is a whistleblower platform that provides secure, anonymous tip lines with no self-hosting required. Sign up for a free account at <https://tips.hushline.app/register>
 
-![Accessibility](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/main/badge.json)
-![Performance](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/main/badge-performance.json)
-![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/main/badge-coverage.json)
+![Accessibility](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/badges/badge.json)
+![Performance](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/badges/badge-performance.json)
+![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/badges/badge-coverage.json)
 ![Tests](https://github.com/scidsg/hushline/actions/workflows/tests.yml/badge.svg)
 ![GDPR Compliance](https://github.com/scidsg/hushline/actions/workflows/gdpr-compliance.yml/badge.svg)
 ![CCPA Compliance](https://github.com/scidsg/hushline/actions/workflows/ccpa-compliance.yml/badge.svg)


### PR DESCRIPTION
## Summary
- remove badge population PR creation from tests, lighthouse accessibility, and lighthouse performance workflows
- publish badge JSON files directly to a dedicated `badges` branch in the same `hushline` repo
- point README badge endpoints at `raw.githubusercontent.com/scidsg/hushline/badges/...`

## Why
- no PRs for badge population
- avoid stuck automation PRs waiting on required checks

## Validation
- make lint
- make test