### PR TITLE
ci: remove custom badge publishing and use workflow badges

### DIFF
--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -26,8 +26,7 @@ on:
       - ".github/workflows/lighthouse-performance.yml"
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   lighthouse:
@@ -73,57 +72,7 @@ jobs:
       - name: Extract score
         run: |
           SCORE=$(node -e "console.log(Math.round(JSON.parse(require('fs').readFileSync('lighthouse-performance.json','utf8')).categories.performance.score*100))")
-          echo "{\"schemaVersion\":1,\"label\":\"performance\",\"message\":\"$SCORE\",\"color\":\"brightgreen\"}" > badge-performance.json
-          PR_NUMBER="${GITHUB_REF#refs/pull/}"
-          PR_NUMBER="${PR_NUMBER%/merge}"
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            PR_NUMBER=""
-          fi
-          echo "{\"score\":$SCORE,\"runId\":\"${GITHUB_RUN_ID}\",\"runNumber\":\"${GITHUB_RUN_NUMBER}\",\"sha\":\"${GITHUB_SHA}\",\"workflow\":\"${GITHUB_WORKFLOW}\",\"url\":\"http://localhost:8080/directory\",\"generatedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"prNumber\":\"${PR_NUMBER}\"}" > badge-performance-meta.json
           if [ "$SCORE" -lt 95 ]; then
             echo "Performance score must be at least 95, got $SCORE"
             exit 1
           fi
-
-      - name: Publish performance badge to main
-        if: github.ref == 'refs/heads/main'
-        env:
-          REPO_SLUG: ${{ github.repository }}
-          PUSH_TOKEN: ${{ secrets.BADGE_PUSH_TOKEN }}
-          DEFAULT_GITHUB_TOKEN: ${{ github.token }}
-          TARGET_BRANCH: main
-          BADGE_FILE: badge-performance.json
-        run: |
-          set -euo pipefail
-          TOKEN="${PUSH_TOKEN:-${DEFAULT_GITHUB_TOKEN:-}}"
-          if [ -z "${TOKEN}" ]; then
-            echo "No token available for badge publish."
-            exit 1
-          fi
-
-          WORKDIR="$(mktemp -d /tmp/hushline-badges.XXXXXX)"
-          git clone --depth 1 --branch "${TARGET_BRANCH}" "https://x-access-token:${TOKEN}@github.com/${REPO_SLUG}.git" "${WORKDIR}"
-
-          cd "${WORKDIR}"
-          mkdir -p badges
-          cp "${GITHUB_WORKSPACE}/${BADGE_FILE}" "badges/${BADGE_FILE}"
-          git add "badges/${BADGE_FILE}"
-          if git diff --cached --quiet; then
-            echo "No badge changes to publish."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "Update performance badge [skip ci]"
-          if ! git push origin "HEAD:${TARGET_BRANCH}"; then
-            echo "Push to ${TARGET_BRANCH} failed. If branch protection blocks workflow pushes, configure BADGE_PUSH_TOKEN with bypass rights."
-            exit 1
-          fi
-
-      - name: Upload badge artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: performance-badge
-          path: |
-            badge-performance.json

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -3,13 +3,10 @@ name: Lighthouse Accessibility
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "badges/**"
   pull_request:
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   lighthouse:
@@ -54,57 +51,7 @@ jobs:
       - name: Extract score
         run: |
           SCORE=$(node -e "console.log(Math.round(JSON.parse(require('fs').readFileSync('lighthouse.json','utf8')).categories.accessibility.score*100))")
-          echo "{\"schemaVersion\":1,\"label\":\"accessibility\",\"message\":\"$SCORE\",\"color\":\"brightgreen\"}" > badge.json
-          PR_NUMBER="${GITHUB_REF#refs/pull/}"
-          PR_NUMBER="${PR_NUMBER%/merge}"
-          if [ "$GITHUB_EVENT_NAME" != "pull_request" ]; then
-            PR_NUMBER=""
-          fi
-          echo "{\"score\":$SCORE,\"runId\":\"${GITHUB_RUN_ID}\",\"runNumber\":\"${GITHUB_RUN_NUMBER}\",\"sha\":\"${GITHUB_SHA}\",\"workflow\":\"${GITHUB_WORKFLOW}\",\"url\":\"http://localhost:8080\",\"generatedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"prNumber\":\"${PR_NUMBER}\"}" > badge-meta.json
           if [ "$SCORE" -ne 100 ]; then
             echo "Accessibility score must be 100, got $SCORE"
             exit 1
           fi
-
-      - name: Publish accessibility badge to main
-        if: github.ref == 'refs/heads/main'
-        env:
-          REPO_SLUG: ${{ github.repository }}
-          PUSH_TOKEN: ${{ secrets.BADGE_PUSH_TOKEN }}
-          DEFAULT_GITHUB_TOKEN: ${{ github.token }}
-          TARGET_BRANCH: main
-          BADGE_FILE: badge.json
-        run: |
-          set -euo pipefail
-          TOKEN="${PUSH_TOKEN:-${DEFAULT_GITHUB_TOKEN:-}}"
-          if [ -z "${TOKEN}" ]; then
-            echo "No token available for badge publish."
-            exit 1
-          fi
-
-          WORKDIR="$(mktemp -d /tmp/hushline-badges.XXXXXX)"
-          git clone --depth 1 --branch "${TARGET_BRANCH}" "https://x-access-token:${TOKEN}@github.com/${REPO_SLUG}.git" "${WORKDIR}"
-
-          cd "${WORKDIR}"
-          mkdir -p badges
-          cp "${GITHUB_WORKSPACE}/${BADGE_FILE}" "badges/${BADGE_FILE}"
-          git add "badges/${BADGE_FILE}"
-          if git diff --cached --quiet; then
-            echo "No badge changes to publish."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "Update accessibility badge [skip ci]"
-          if ! git push origin "HEAD:${TARGET_BRANCH}"; then
-            echo "Push to ${TARGET_BRANCH} failed. If branch protection blocks workflow pushes, configure BADGE_PUSH_TOKEN with bypass rights."
-            exit 1
-          fi
-
-      - name: Upload badge artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: accessibility-badge
-          path: |
-            badge.json

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,15 +1,12 @@
 ---
 name: Run Linter and Tests
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 on:
   push:
     branches:
       - main
-    paths-ignore:
-      - "badges/**"
   pull_request:
     branches:
       - main
@@ -41,70 +38,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Test
-        run: |
-          make test PYTEST_ADDOPTS="--skip-local-only" | tee test-output.txt
-      - name: Generate coverage badge JSON
-        if: always()
-        run: |
-          COVERAGE=$(grep -E '^TOTAL' test-output.txt | awk '{print $4}' | tr -d '%' | tail -n 1)
-          if [ -z "$COVERAGE" ]; then
-            echo "Could not parse TOTAL coverage from test output"
-            exit 1
-          fi
-          if [ "$COVERAGE" -ge 95 ]; then
-            COLOR="brightgreen"
-          elif [ "$COVERAGE" -ge 90 ]; then
-            COLOR="green"
-          elif [ "$COVERAGE" -ge 80 ]; then
-            COLOR="yellowgreen"
-          elif [ "$COVERAGE" -ge 70 ]; then
-            COLOR="yellow"
-          else
-            COLOR="red"
-          fi
-          echo "{\"schemaVersion\":1,\"label\":\"coverage\",\"message\":\"${COVERAGE}%\",\"color\":\"$COLOR\"}" > badge-coverage.json
-      - name: Publish coverage badge to main
-        if: github.ref == 'refs/heads/main'
-        env:
-          REPO_SLUG: ${{ github.repository }}
-          PUSH_TOKEN: ${{ secrets.BADGE_PUSH_TOKEN }}
-          DEFAULT_GITHUB_TOKEN: ${{ github.token }}
-          TARGET_BRANCH: main
-          BADGE_FILE: badge-coverage.json
-        run: |
-          set -euo pipefail
-          TOKEN="${PUSH_TOKEN:-${DEFAULT_GITHUB_TOKEN:-}}"
-          if [ -z "${TOKEN}" ]; then
-            echo "No token available for badge publish."
-            exit 1
-          fi
-
-          WORKDIR="$(mktemp -d /tmp/hushline-badges.XXXXXX)"
-          git clone --depth 1 --branch "${TARGET_BRANCH}" "https://x-access-token:${TOKEN}@github.com/${REPO_SLUG}.git" "${WORKDIR}"
-
-          cd "${WORKDIR}"
-          mkdir -p badges
-          cp "${GITHUB_WORKSPACE}/${BADGE_FILE}" "badges/${BADGE_FILE}"
-          git add "badges/${BADGE_FILE}"
-          if git diff --cached --quiet; then
-            echo "No badge changes to publish."
-            exit 0
-          fi
-
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "Update coverage badge [skip ci]"
-          if ! git push origin "HEAD:${TARGET_BRANCH}"; then
-            echo "Push to ${TARGET_BRANCH} failed. If branch protection blocks workflow pushes, configure BADGE_PUSH_TOKEN with bypass rights."
-            exit 1
-          fi
-      - name: Upload coverage badge artifact
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-badge
-          path: |
-            badge-coverage.json
+        run: make test PYTEST_ADDOPTS="--skip-local-only"
 
   test-with-alembic:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 [Hush Line](https://hushline.app) is a whistleblower platform that provides secure, anonymous tip lines with no self-hosting required. Sign up for a free account at <https://tips.hushline.app/register>
 
-![Accessibility](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/refs/heads/main/badges/badge.json)
-![Performance](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/refs/heads/main/badges/badge-performance.json)
-![Coverage](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline/refs/heads/main/badges/badge-coverage.json)
-![Tests](https://github.com/scidsg/hushline/actions/workflows/tests.yml/badge.svg)
+![Accessibility](https://github.com/scidsg/hushline/actions/workflows/lighthouse.yml/badge.svg)
+![Performance](https://github.com/scidsg/hushline/actions/workflows/lighthouse-performance.yml/badge.svg)
+![Run Linter and Tests](https://github.com/scidsg/hushline/actions/workflows/tests.yml/badge.svg)
 ![GDPR Compliance](https://github.com/scidsg/hushline/actions/workflows/gdpr-compliance.yml/badge.svg)
 ![CCPA Compliance](https://github.com/scidsg/hushline/actions/workflows/ccpa-compliance.yml/badge.svg)
 ![Database Migration Compatibility Tests](https://github.com/scidsg/hushline/actions/workflows/migration-smoke.yml/badge.svg)


### PR DESCRIPTION
## Summary
- remove custom badge JSON generation, publish-to-main, and artifact upload steps
- keep accessibility/performance/test checks themselves unchanged
- switch README top badges to built-in workflow badges (`badge.svg`)

## Why
- no custom badge population workflow
- rely on native GitHub workflow status badges only

## Validation
- make lint
- make test