### PR TITLE
Codex Coverage: raise coverage to 100%

### DIFF
--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -190,6 +190,23 @@ def test_fs_driver_rejects_windows_reserved_device_names(tmpdir: LocalPath) -> N
         driver.serve("docs/PRN.txt")
 
 
+def test_fs_driver_allows_empty_and_dot_only_path_segments(tmpdir: LocalPath) -> None:
+    app = Flask(__name__)
+    app.config["BLOB_STORAGE_FS_ROOT"] = str(tmpdir)
+    driver = FsDriver(app)
+
+    path = "nested//./data.bin"
+    payload = b"x"
+
+    driver.put(path, BytesIO(payload))
+
+    stored_path = Path(str(tmpdir)) / "nested" / "data.bin"
+    assert stored_path.read_bytes() == payload
+
+    driver.delete(path)
+    assert not stored_path.exists()
+
+
 def test_s3_driver_private_serve_uses_presigned_url(mocker: MockFixture) -> None:
     app = MagicMock()
     app.config = {


### PR DESCRIPTION
Automated local Codex coverage run.

Coverage before run: 99%
Coverage target: 100%
Branch: codex/coverage-gap-20260222-200635

Codex summary:
Implemented a focused test-only change to cover the two uncovered branches in `hushline/storage.py` (lines 100 and 104).

**What changed**
- Added `test_fs_driver_allows_empty_and_dot_only_path_segments` in `tests/test_storage.py:193`.
- The test uses `nested//./data.bin` so `FsDriver.__reject_windows_device_path_segments` hits:
  - empty segment branch (`continue` at line 100)
  - dot-only normalized-empty branch (`continue` at line 104)
- It verifies behavior by writing and then deleting the file path.
- No production code was changed.

**Residual risks**
- I did not run lint/tests/coverage per your instruction.
- Coverage should now include those previously uncovered lines; the runner will confirm 100%.
