### PR TITLE
ci: require agent-eligible label for daily issue runner

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,8 @@ This file provides operating guidance for coding agents working in the Hush Line
 - Run order and schedule:
   - Coverage first at `00:00`
   - Daily issue second at `02:00`, and it only proceeds when no bot PR is open from the coverage run.
+- Daily issue eligibility:
+  - Daily issue automation must only process issues explicitly labeled `agent-eligible`.
 - One-bot-PR guard:
   - Both runners must exit early if any open PR exists from bot login (`HUSHLINE_BOT_LOGIN`, default `hushline-dev`).
   - This enforces one bot PR at a time and avoids duplicate compute.

--- a/docs/RUNNERS.md
+++ b/docs/RUNNERS.md
@@ -70,7 +70,7 @@ Script: `scripts/codex_daily_issue_runner.sh`
 
 ### Purpose
 
-Pick one safe open issue, implement it with Codex, run required checks, and open a PR.
+Pick one open issue labeled for automation, implement it with Codex, run required checks, and open a PR.
 
 ### CLI flags
 
@@ -81,9 +81,14 @@ Pick one safe open issue, implement it with Codex, run required checks, and open
 
 If `--issue` is not provided:
 
-- Dependabot-authored issues are prioritized first.
-- Non-Dependabot issues use conservative safety filters.
-- If no sufficiently safe issue is found, the run exits without changes.
+- Only issues with label `agent-eligible` are considered (default behavior).
+- Dependabot-authored issues are prioritized first within eligible issues.
+- If no eligible issue is found, the run exits without changes.
+
+If `--issue <number>` is provided:
+
+- The issue must still include the required eligibility label when enforcement is enabled.
+- If the required label is missing, the run is blocked.
 
 ### Main checks (when `HUSHLINE_DAILY_RUN_CHECKS=1`)
 
@@ -105,6 +110,8 @@ If `--issue` is not provided:
 - `HUSHLINE_DAILY_MIN_COVERAGE` (default `100`)
 - `HUSHLINE_CODEX_MODEL` (default `gpt-5.3-codex`)
 - `HUSHLINE_BOT_LOGIN` (default `hushline-dev`)
+- `HUSHLINE_DAILY_ELIGIBLE_LABEL` (default `agent-eligible`)
+- `HUSHLINE_DAILY_REQUIRE_ELIGIBLE_LABEL` (default `1`)
 
 ## Coverage Gap Runner
 


### PR DESCRIPTION
## Summary
- enforce explicit issue eligibility for daily automation by requiring the `agent-eligible` label by default
- keep Dependabot prioritization within eligible issues
- block forced `--issue` runs when the required label is missing (unless label enforcement is explicitly disabled)
- harden prompt construction by marking issue body as untrusted and explicitly disallowing policy overrides from issue text
- document the policy in `AGENTS.md` and `docs/RUNNERS.md`

## Validation
- `make lint`
- `make test`

## Notes
- default label gate is configured by `HUSHLINE_DAILY_ELIGIBLE_LABEL=agent-eligible`
- label enforcement can be toggled via `HUSHLINE_DAILY_REQUIRE_ELIGIBLE_LABEL` (default `1`)
