### PR TITLE
fix: restore codex stdin in timeout fallback

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -131,7 +131,8 @@ run_with_timeout() {
   timeout_flag="$(mktemp)"
   rm -f "$timeout_flag" >/dev/null 2>&1 || true
 
-  "$@" &
+  # Preserve stdin for backgrounded commands (needed for codex prompt via "< file").
+  "$@" <&0 &
   cmd_pid=$!
 
   # Use a single-process watchdog so we can reliably terminate it without leaving


### PR DESCRIPTION
## Summary
- restore stdin preservation in `run_with_timeout` fallback by running backgrounded commands as `"$@" <&0 &`
- this ensures `codex exec - < "$PROMPT_FILE"` receives the prompt when launched under `launchd`

## Root Cause
A recent timeout-watchdog refactor dropped stdin forwarding (`"$@" &`), which caused launchd-triggered runs to pass `/dev/null` to backgrounded codex commands. Codex then failed with `No prompt provided via stdin.` immediately after docker build.

## Validation
- `bash -n scripts/agent_daily_issue_runner.sh`
- prior failure signature reproduced in logs and mapped to this exact code path
