### PR TITLE
Codex Daily: #1361 Add spinner animation to button when POST or GET is in progress

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -73,6 +73,72 @@ document.addEventListener("DOMContentLoaded", function () {
 
   setupFlashDismiss();
 
+  function setupSubmitSpinners() {
+    const forms = document.querySelectorAll("form[data-submit-spinner='true']");
+    forms.forEach((form) => {
+      const method = (form.getAttribute("method") || "GET").toUpperCase();
+      if (method !== "POST" && method !== "GET") {
+        return;
+      }
+
+      const submitButton = form.querySelector(
+        "button[type='submit'], input[type='submit']",
+      );
+      if (
+        !submitButton ||
+        submitButton.tagName !== "BUTTON" ||
+        submitButton.dataset.submitSpinnerInit === "true"
+      ) {
+        return;
+      }
+
+      const labelText = submitButton.textContent.trim();
+      submitButton.textContent = "";
+
+      const label = document.createElement("span");
+      label.className = "submit-button-label";
+      label.textContent = labelText;
+
+      const spinner = document.createElement("span");
+      spinner.className = "submit-button-spinner";
+      spinner.setAttribute("aria-hidden", "true");
+
+      submitButton.appendChild(label);
+      submitButton.appendChild(spinner);
+      submitButton.dataset.submitSpinnerInit = "true";
+
+      const setLoading = () => {
+        submitButton.classList.add("is-loading");
+        submitButton.setAttribute("aria-busy", "true");
+      };
+
+      const clearLoading = () => {
+        submitButton.classList.remove("is-loading");
+        submitButton.removeAttribute("aria-busy");
+      };
+
+      form.addEventListener("submit", function () {
+        setLoading();
+      });
+
+      const observer = new MutationObserver(function () {
+        if (submitButton.classList.contains("is-loading") && !submitButton.disabled) {
+          clearLoading();
+        }
+      });
+      observer.observe(submitButton, {
+        attributes: true,
+        attributeFilter: ["disabled"],
+      });
+
+      window.addEventListener("pageshow", function () {
+        clearLoading();
+      });
+    });
+  }
+
+  setupSubmitSpinners();
+
   function setupStatusForm() {
     const statusForm = document.getElementById("statusForm");
     if (!statusForm) return;

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1825,6 +1825,41 @@ input[type="file"]::file-selector-button {
   box-shadow: 0px 2px 0px 0px oklch(from var(--color-brand) l c h / 0.25);
 }
 
+button[data-submit-spinner-init="true"] {
+  position: relative;
+}
+
+button[data-submit-spinner-init="true"] .submit-button-label {
+  display: inline-block;
+}
+
+button[data-submit-spinner-init="true"] .submit-button-spinner {
+  display: none;
+  width: 1rem;
+  height: 1rem;
+  border: 0.125rem solid currentColor;
+  border-right-color: transparent;
+  border-radius: 50%;
+}
+
+button[data-submit-spinner-init="true"].is-loading .submit-button-label {
+  opacity: 0;
+}
+
+button[data-submit-spinner-init="true"].is-loading .submit-button-spinner {
+  display: block;
+  position: absolute;
+  top: calc(50% - 0.5rem);
+  left: calc(50% - 0.5rem);
+  animation: submit-button-spinner-rotate 0.75s linear infinite;
+}
+
+@keyframes submit-button-spinner-rotate {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
 textarea {
   height: 320px;
 }

--- a/docs/DEV.md
+++ b/docs/DEV.md
@@ -10,3 +10,7 @@ When your code changes are ready, create a migration by running the command the 
 Migrations are tested as part of the test suite.
 You will need to write your own tests to ensure the upgrade and downgrade behave as expected.
 See [`./tests/test_migrations.py`](./tests/test_migrations.py) and [`./tests/migrations/`](./tests/migrations/) for examples.
+
+## Submit Loading Feedback
+
+The login, registration, and public submit-message forms use a submit-button spinner while POST/GET requests from those submit actions are in progress.

--- a/hushline/templates/login.html
+++ b/hushline/templates/login.html
@@ -3,7 +3,7 @@
 
 {% block content %}
   <h2>Login</h2>
-  <form method="POST" action="{{ url_for('login') }}">
+  <form method="POST" action="{{ url_for('login') }}" data-submit-spinner="true">
     {{ form.hidden_tag() }}
     <div>
       {{ form.username.label(for="username") }}

--- a/hushline/templates/profile.html
+++ b/hushline/templates/profile.html
@@ -95,6 +95,7 @@
     method="POST"
     action="{{ url_for('profile', username=username.username) }}"
     id="messageForm"
+    data-submit-spinner="true"
     onsubmit="return false;"
   >
     {{ form.hidden_tag() }}

--- a/hushline/templates/register.html
+++ b/hushline/templates/register.html
@@ -13,7 +13,7 @@
   </div>
   {% endif %}
 
-  <form method="POST" action="{{ url_for('register') }}">
+  <form method="POST" action="{{ url_for('register') }}" data-submit-spinner="true">
     {{ form.hidden_tag() }}
     <div>
       {{ form.username.label(for="username") }}

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -19,3 +19,15 @@ def test_client_side_encryption_has_platform_guards() -> None:
     assert "window.ReadableStream" in js
     assert 'typeof BigInt === "undefined"' in js
     assert "assertClientCryptoSupport();" in js
+
+
+def test_submit_spinner_hooks_exist_for_scoped_forms() -> None:
+    js = (ROOT / "assets/js/global.js").read_text(encoding="utf-8")
+    scss = (ROOT / "assets/scss/style.scss").read_text(encoding="utf-8")
+
+    assert "form[data-submit-spinner='true']" in js
+    assert "submit-button-label" in js
+    assert "submit-button-spinner" in js
+    assert 'attributeFilter: ["disabled"]' in js
+    assert 'button[data-submit-spinner-init="true"]' in scss
+    assert "@keyframes submit-button-spinner-rotate" in scss

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -167,6 +167,7 @@ def test_profile_pgp_required(client: FlaskClient, app: Flask, user: User) -> No
     assert response.status_code == 200
 
     assert 'id="messageForm"' in response.text
+    assert 'data-submit-spinner="true"' in response.text
     assert "You can't send encrypted messages to this user through Hush Line" not in response.text
 
     user.pgp_key = None

--- a/tests/test_registration_and_login.py
+++ b/tests/test_registration_and_login.py
@@ -137,6 +137,15 @@ def test_register_page_loads(client: FlaskClient) -> None:
     response = client.get(url_for("register"))
     assert response.status_code == 200
     assert "<h2>Register</h2>" in response.text
+    assert 'data-submit-spinner="true"' in response.text
+
+
+def test_login_page_loads(client: FlaskClient) -> None:
+    """Test if the login page loads successfully."""
+    response = client.get(url_for("login"))
+    assert response.status_code == 200
+    assert "<h2>Login</h2>" in response.text
+    assert 'data-submit-spinner="true"' in response.text
 
 
 def test_user_login_after_registration(client: FlaskClient) -> None:


### PR DESCRIPTION
Automated daily issue runner.

Closes #1361

Issue: https://github.com/scidsg/hushline/issues/1361
Branch: codex/daily-issue-1361

Local workflow-equivalent checks executed:
- Run Linter and Tests (lint, test)

Codex summary:
Implemented issue #1361 with a minimal, scoped diff for the three requested submit flows.

- Added spinner hooks only on the target forms:
  - [profile.html](/Users/scidsg/hushline/hushline/templates/profile.html:94)
  - [login.html](/Users/scidsg/hushline/hushline/templates/login.html:6)
  - [register.html](/Users/scidsg/hushline/hushline/templates/register.html:16)
- Added submit-loading behavior in [global.js](/Users/scidsg/hushline/assets/js/global.js:76):
  - Triggers on submit for `POST`/`GET`.
  - Replaces label with a CSS spinner.
  - Keeps existing debounce/disable behavior unchanged.
  - Clears spinner if the in-page submit is canceled/fails (disabled-attribute observer) and on `pageshow`.
- Added spinner styling in [style.scss](/Users/scidsg/hushline/assets/scss/style.scss:1828):
  - Stable button dimensions (no layout shift).
  - Works in light/dark mode via `currentColor`.
- Added/updated tests:
  - [test_frontend_compat.py](/Users/scidsg/hushline/tests/test_frontend_compat.py:24)
  - [test_profile.py](/Users/scidsg/hushline/tests/test_profile.py:169)
  - [test_registration_and_login.py](/Users/scidsg/hushline/tests/test_registration_and_login.py:135)
- Added docs note:
  - [docs/DEV.md](/Users/scidsg/hushline/docs/DEV.md:14)

Per your instruction, I did not run lint/tests/audits/lighthouse/w3c checks.
