### PR TITLE
ci: prioritize daily runner from roadmap Agent Eligible column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,8 @@ This file provides operating guidance for coding agents working in the Hush Line
 - Daily issue runner script: `scripts/agent_daily_issue_runner.sh`
 - Daily issue eligibility:
   - Runner first performs a live coverage pre-pass and prioritizes closing coverage gaps to target before issue work.
-  - When coverage target is satisfied, daily issue automation processes one open issue labeled `agent-eligible` or `low-risk`.
+  - Daily issue automation processes one open issue from the `Hush Line Roadmap` project column `Agent Eligible`, top to bottom.
+  - When coverage target is satisfied, daily issue automation processes one open issue from the `Hush Line Roadmap` project column `Agent Eligible`, top to bottom.
 - One-bot-PR guard:
   - Runner exits early if any open PR exists from bot login (`HUSHLINE_BOT_LOGIN`, default `hushline-dev`).
 - Required runner behavior:

--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -24,7 +24,7 @@ Behavior:
 3. Exit cleanly when any open PR exists authored by `hushline-dev`.
 4. Run a coverage pre-check (`pytest --cov hushline --cov-report term-missing -q --skip-local-only`).
 5. If coverage is below the configured target (default `100%`), run Codex to close coverage gaps first and open a dedicated coverage-gap PR, then exit.
-6. Select one open issue labeled `agent-eligible` or `low-risk` only when coverage meets the target.
+6. Select one open issue from the `Hush Line Roadmap` project column `Agent Eligible`, in top-down order, only when coverage meets the target.
 7. Start each issue attempt with the issue bootstrap sequence:
    - `docker compose down -v --remove-orphans`
    - `docker compose up -d postgres blob-storage`
@@ -117,8 +117,10 @@ Dry run:
 - `HUSHLINE_REPO_SLUG` (default `scidsg/hushline`)
 - `HUSHLINE_BASE_BRANCH` (default `main`)
 - `HUSHLINE_BOT_LOGIN` (default `hushline-dev`)
-- `HUSHLINE_DAILY_PRIMARY_LABEL` (default `agent-eligible`)
-- `HUSHLINE_DAILY_FALLBACK_LABEL` (default `low-risk`)
+- `HUSHLINE_DAILY_PROJECT_OWNER` (default repo owner from `HUSHLINE_REPO_SLUG`, typically `scidsg`)
+- `HUSHLINE_DAILY_PROJECT_TITLE` (default `Hush Line Roadmap`)
+- `HUSHLINE_DAILY_PROJECT_COLUMN` (default `Agent Eligible`)
+- `HUSHLINE_DAILY_PROJECT_ITEM_LIMIT` (default `200`)
 - `HUSHLINE_DAILY_BRANCH_PREFIX` (default `codex/daily-issue-`)
 - `HUSHLINE_DAILY_COVERAGE_GATE_ENABLED` (default `1`; set `0` to skip coverage pre-pass)
 - `HUSHLINE_DAILY_COVERAGE_TARGET_PERCENT` (default `100`)


### PR DESCRIPTION
## Summary
- change the daily runner to select candidate issues from the **Hush Line Roadmap** project column **Agent Eligible** instead of label filtering
- process project issues in returned order so work is picked top-down
- remove `agent-eligible`/`low-risk` label requirements from runner docs and policy text

## Why
- aligns runner prioritization with roadmap ordering in the project board
- removes duplicated priority signaling via labels

## Validation
- `make lint`
- `make test`

## Notes
- forced runs via `--issue` now require only that the issue is open
