### PR TITLE
fix: keep runner progressing after coverage gate miss

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -810,10 +810,11 @@ run_coverage_gap_first() {
   run_issue_bootstrap
 
   local coverage_rc=0
-  set +e
-  run_coverage_target_check
-  coverage_rc=$?
-  set -e
+  if run_coverage_target_check; then
+    coverage_rc=0
+  else
+    coverage_rc=$?
+  fi
 
   if [[ "$coverage_rc" == "0" ]]; then
     echo "Coverage pre-check passed at ${LAST_COVERAGE_PERCENT}%."
@@ -844,10 +845,11 @@ run_coverage_gap_first() {
   local attempt=1
   while true; do
     if run_full_workflow_checks; then
-      set +e
-      run_coverage_target_check
-      coverage_rc=$?
-      set -e
+      if run_coverage_target_check; then
+        coverage_rc=0
+      else
+        coverage_rc=$?
+      fi
       if [[ "$coverage_rc" == "0" ]]; then
         break
       fi


### PR DESCRIPTION
## Summary
- fix a control-flow bug in `run_coverage_gap_first` where a non-zero coverage gate result (`99%`, return code `2`) could terminate the runner before entering coverage-gap remediation
- capture coverage gate status through `if/else` command context so the runner continues into coverage-fix mode when coverage is below target

## Root Cause
`run_coverage_target_check` can return `2` (coverage below target). The previous `set +e` capture pattern was fragile because downstream helper functions restore `set -e`, causing the script to exit at the coverage gate line instead of progressing to branch creation + Codex remediation.

## Behavior After This Change
When coverage is below target:
- runner does **not** terminate at `Coverage gate: 99% is below target 100%`
- runner proceeds to checkout a coverage branch, invoke Codex for coverage fixes, run checks, and open a coverage-gap PR

## Validation
- `make lint`
- `make test`
