### PR TITLE
chore: harden daily runner start/loop behavior

### DIFF
--- a/docs/agent-run-log/.gitignore
+++ b/docs/agent-run-log/.gitignore
@@ -1,0 +1,2 @@
+*.log
+!.gitignore


### PR DESCRIPTION
## Summary
- save each runner invocation to a unique per-run log file in `docs/agent-run-log/`
- block runner execution when any human-authored PR is open with message: `Humans are at work, I'll check back in tomorrow...`
- prevent infinite self-heal loops by bounding fix attempts (default `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS=3`)
- preserve runner logs during startup clean/reset and document the new behavior in `docs/AGENT_RUNNER.md`

## Notes
- no checks were run in this PR per request
