### PR TITLE
fix: prevent duplicate lines in runner global log

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -70,7 +70,7 @@ touch "$GLOBAL_LOG_FILE"
 LOG_PIPE_FILE="$(mktemp "/tmp/hushline-agent-runner-log-pipe.XXXXXX")"
 rm -f "$LOG_PIPE_FILE"
 mkfifo "$LOG_PIPE_FILE"
-tee -a "$RUN_LOG_FILE" "$GLOBAL_LOG_FILE" < "$LOG_PIPE_FILE" &
+tee -a "$RUN_LOG_FILE" "$GLOBAL_LOG_FILE" < "$LOG_PIPE_FILE" >/dev/null &
 LOG_TEE_PID=$!
 exec > "$LOG_PIPE_FILE" 2>&1
 echo "Run log file: $RUN_LOG_FILE"


### PR DESCRIPTION
## Summary
- fix runner log fanout to prevent duplicate lines in `~/.codex/logs/hushline-agent-runner.log`
- keep dual logging enabled (per-run log + global log)

## Notes
- no checks were run in this PR per request
