### PR TITLE
refactor: simplify daily runner gating and self-heal flow

### DIFF
--- a/scripts/agent_issue_bootstrap.sh
+++ b/scripts/agent_issue_bootstrap.sh
@@ -44,6 +44,7 @@ ensure_docker_running() {
 
 ensure_docker_running
 
+docker compose build
 docker compose down -v --remove-orphans
 docker compose up -d postgres blob-storage
 docker compose run --rm dev_data


### PR DESCRIPTION
## Why
The runner behavior had accumulated extra branching/check layers that made failures noisy and hard to reason about.

This change aligns runner flow to a simpler policy:
- bot PR guard first
- human PR guard second
- one top-priority issue only
- lint+test self-heal loop with no retry cap

## What changed
- daily runner gating order:
  - exits with "I'm still waiting for my open PR's approval..." when bot PRs are open
  - exits with "Humans are working, I'll check back tomorrow..." when human PRs are open
- issue selection now takes only the first candidate from Roadmap/Agent Eligible (top priority)
- removed bounded self-heal cap and loop now continues until checks pass
- simplified pre-PR validation to lint + test checks only
- removed FULL_SUITE/MAX_FIX config knobs from runner
- issue bootstrap now builds docker images before resetting services
- updated docs/AGENT_RUNNER.md to match behavior

## Validation
- bash -n scripts/agent_daily_issue_runner.sh
- bash -n scripts/agent_issue_bootstrap.sh

## Notes
- no dry-run execution was performed