### PR TITLE
fix: support macOS bash in daily runner

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -77,7 +77,9 @@ run_check_capture() {
 
 kill_all_docker_containers() {
   local ids=()
-  mapfile -t ids < <(docker ps -aq)
+  while IFS= read -r id; do
+    [[ -n "$id" ]] && ids+=("$id")
+  done < <(docker ps -aq)
   if (( ${#ids[@]} == 0 )); then
     return 0
   fi


### PR DESCRIPTION
## Summary
- replace mapfile usage in kill_all_docker_containers with a Bash 3.2-compatible read loop
- keep existing behavior while allowing runner execution on default macOS Bash

## Testing
- bash -n scripts/agent_daily_issue_runner.sh