### PR TITLE
fix: avoid apt npm dependency failures in dev image

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -2,11 +2,10 @@
 FROM python:3.12.6-slim-bookworm
 
 # libffi-dev for Python C extensions
-# libpq-dev for `psycopg` Python packge
+# libpq-dev for `psycopg` Python package
 # curl for installing `cargo`
-# clang, pkg-config, libpscsclite-dev, nettle-dev for `pysequoia`
+# clang, pkg-config, libpcsclite-dev, nettle-dev for `pysequoia`
 RUN apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update && \
-    apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 upgrade -y && \
     apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y --fix-missing --no-install-recommends \
     curl \
     build-essential \
@@ -15,8 +14,8 @@ RUN apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=30 -o Acquire::http
     libffi-dev \
     libpq-dev \
     libpcsclite-dev \
-    nettle-dev \
-    npm
+    nettle-dev && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 ENV PATH="/root/.cargo/bin:${PATH}"


### PR DESCRIPTION
## Summary
- remove apt-get upgrade from Dockerfile.dev to reduce package churn during build
- stop installing Debian npm in the Python dev image (frontend uses dedicated Node service)
- keep only required native dependencies and clean apt lists after install

## Validation
- docker compose build dev_data