### PR TITLE
fix: enforce test-gap coverage before PR creation

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -28,7 +28,7 @@ This runner is intentionally bare-bones. It runs directly in the local repo and 
 11. Run required checks:
    - `make lint`
    - `make test`
-   - For issue titles matching `[Test Gap] <path>`, require `<path>` to report `0` missed and `100%` coverage in the test output table.
+   - For issues with `[Test Gap] <path>` in the title or a `test-gap` label, require target file coverage to report `0` missed and `100%` in the test output table.
 12. If checks fail, feed failures back to Codex and retry until checks pass.
 13. Commit, push branch (`--force-with-lease`), and open PR.
 14. Return to `main` on exit.


### PR DESCRIPTION
## Summary
- add issue-specific runner validation for titles matching [Test Gap] <path>
- require the target path to show missed=0 and coverage=100% in make test output before PR creation
- document this runner-specific gate in AGENT_RUNNER docs

## Validation
- bash -n scripts/agent_daily_issue_runner.sh