### PR TITLE
chore: simplify daily runner issue handling

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -28,7 +28,6 @@ This runner is intentionally bare-bones. It runs directly in the local repo and 
 11. Run required checks:
    - `make lint`
    - `make test`
-   - For issues with `[Test Gap] <path>` in the title or a `test-gap` label, require target file coverage to report `0` missed and `100%` in the test output table.
 12. If checks fail, feed failures back to Codex and retry until checks pass.
 13. Commit, push branch (`--force-with-lease`), and open PR.
 14. Return to `main` on exit.

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -285,76 +285,6 @@ run_local_workflow_checks() {
   run_check_capture "Run test" make test || return 1
 }
 
-extract_test_gap_target_path() {
-  local issue_title="$1"
-  local issue_body="${2:-}"
-  if [[ "$issue_title" =~ ^\[Test[[:space:]]+Gap\][[:space:]]+(.+)$ ]]; then
-    printf '%s\n' "${BASH_REMATCH[1]}"
-    return 0
-  fi
-
-  local body_path
-  body_path="$(printf '%s\n' "$issue_body" | awk '
-    {
-      for (i = 1; i <= NF; i++) {
-        if ($i ~ /^hushline\/[A-Za-z0-9_./-]+\.py$/) {
-          print $i;
-          exit;
-        }
-      }
-    }
-  ')"
-  if [[ -n "$body_path" ]]; then
-    printf '%s\n' "$body_path"
-  fi
-}
-
-run_issue_specific_checks() {
-  local issue_title="$1"
-  local issue_body="$2"
-  local issue_labels="$3"
-
-  if [[ "$issue_title" != *"[Test Gap]"* ]] && ! printf '%s\n' "$issue_labels" | grep -qi '^test-gap$'; then
-    return 0
-  fi
-
-  local test_gap_target
-  test_gap_target="$(extract_test_gap_target_path "$issue_title" "$issue_body")"
-  if [[ -z "$test_gap_target" ]]; then
-    echo "Test-gap gate is active, but no target path was found in issue title/body." | tee -a "$CHECK_LOG_FILE"
-    return 1
-  fi
-
-  echo "==> Validate test gap coverage target: ${test_gap_target}" | tee -a "$CHECK_LOG_FILE"
-
-  local coverage_row missed cover
-  coverage_row="$(
-    awk -v target="$test_gap_target" '
-      $1 == target { row = $0; missed = $3; cover = $4 }
-      END {
-        if (row != "") {
-          print row;
-        }
-      }
-    ' "$CHECK_LOG_FILE"
-  )"
-  if [[ -z "$coverage_row" ]]; then
-    echo "Coverage row for ${test_gap_target} not found in test output." | tee -a "$CHECK_LOG_FILE"
-    return 1
-  fi
-
-  missed="$(printf '%s\n' "$coverage_row" | awk '{print $3}')"
-  cover="$(printf '%s\n' "$coverage_row" | awk '{print $4}')"
-  cover="${cover%\%}"
-
-  if [[ "$missed" != "0" || "$cover" != "100" ]]; then
-    echo "Coverage gap remains for ${test_gap_target}: missed=${missed}, cover=${cover}%." | tee -a "$CHECK_LOG_FILE"
-    return 1
-  fi
-
-  echo "Coverage gap resolved for ${test_gap_target}." | tee -a "$CHECK_LOG_FILE"
-}
-
 run_codex_from_prompt() {
   codex exec \
     --model "$CODEX_MODEL" \
@@ -482,7 +412,6 @@ fi
 ISSUE_TITLE="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO_SLUG" --json title --jq .title)"
 ISSUE_BODY="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO_SLUG" --json body --jq .body)"
 ISSUE_URL="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO_SLUG" --json url --jq .url)"
-ISSUE_LABELS="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO_SLUG" --json labels --jq '.labels[].name // empty')"
 BRANCH_NAME="${BRANCH_PREFIX}${ISSUE_NUMBER}"
 
 run_step "Create branch $BRANCH_NAME" git checkout -B "$BRANCH_NAME" "$BASE_BRANCH"
@@ -502,7 +431,7 @@ while true; do
 
   fix_attempt=1
   while true; do
-    if run_local_workflow_checks && run_issue_specific_checks "$ISSUE_TITLE" "$ISSUE_BODY" "$ISSUE_LABELS"; then
+    if run_local_workflow_checks; then
       break
     fi
     echo "Workflow checks failed; Codex self-heal attempt $fix_attempt."


### PR DESCRIPTION
## Summary
- remove issue-specific test-gap parsing/gating from the daily runner
- keep runner focused on selecting the highest-priority eligible project issue and running standard checks
- align AGENT_RUNNER docs with simplified behavior

## Validation
- bash -n scripts/agent_daily_issue_runner.sh