### PR TITLE
fix: enforce 100% coverage for test-gap issues

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -28,6 +28,7 @@ This runner is intentionally bare-bones. It runs directly in the local repo and 
 11. Run required checks:
    - `make lint`
    - `make test`
+   - If the issue has label `test-gap`, require the referenced file in the issue title/body to show `0` misses and `100%` coverage in the test output table.
 12. If checks fail, feed failures back to Codex and retry until checks pass.
 13. Commit, push branch (`--force-with-lease`), and open PR.
 14. Return to `main` on exit.


### PR DESCRIPTION
## Runner Context
This change is specifically for `scripts/agent_daily_issue_runner.sh`.

Goal: prevent the daily runner from opening "test-gap" PRs that still leave the referenced file below 100% coverage.

## Current Runner Problem
Before this patch, runner success for all issues was:
- `make lint` passes
- `make test` passes

That allowed `test-gap` issues to open PRs even when the target file still showed misses (for example, 97% coverage).

## Runner Behavior After This PR
When the selected issue has label `test-gap`, the runner now adds a hard gate before PR creation:

1. Run normal checks (`make lint`, `make test`).
2. Resolve target file from issue metadata:
- title form: `[Test Gap] <path>` (preferred)
- fallback: first `hushline/... .py` path in issue body
3. Read that file’s coverage row from `make test` output.
4. Require:
- `Miss = 0`
- `Cover = 100%`
5. If requirement fails, runner stays in self-heal loop and does not open PR.

Fail-closed rule: if issue is labeled `test-gap` but no target file can be resolved, runner treats checks as failed and continues healing (no PR).

## Non-Goals
- No change to issue prioritization: runner still takes top item from `Agent Eligible`.
- No change to non-`test-gap` issues.
- No application runtime behavior changes.

## Files Changed
- `scripts/agent_daily_issue_runner.sh`
- `docs/AGENT_RUNNER.md`

## Validation
- `bash -n scripts/agent_daily_issue_runner.sh`

## Operational Impact
- `test-gap` runs may take more iterations.
- PRs for `test-gap` should now represent actual gap closure for the referenced file.
