### PR TITLE
Fix Codex model arg + auth test gap coverage

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -73,4 +73,5 @@ Optional forced issue:
 - `HUSHLINE_DAILY_PROJECT_ITEM_LIMIT` (default `200`)
 - `HUSHLINE_DAILY_BRANCH_PREFIX` (default `codex/daily-issue-`)
 - `HUSHLINE_DAILY_KILL_PORTS` (default `4566 4571 5432 8080`)
-- `HUSHLINE_CODEX_MODEL` (default `gpt-5.3-codex high`)
+- `HUSHLINE_CODEX_MODEL` (default `gpt-5.3-codex`)
+- `HUSHLINE_CODEX_REASONING_EFFORT` (default `high`)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -29,7 +29,8 @@ BOT_GIT_EMAIL="${HUSHLINE_BOT_GIT_EMAIL:-git-dev@scidsg.org}"
 BOT_GIT_GPG_FORMAT="${HUSHLINE_BOT_GIT_GPG_FORMAT:-ssh}"
 BOT_GIT_SIGNING_KEY="${HUSHLINE_BOT_GIT_SIGNING_KEY:-}"
 BRANCH_PREFIX="${HUSHLINE_DAILY_BRANCH_PREFIX:-codex/daily-issue-}"
-CODEX_MODEL="${HUSHLINE_CODEX_MODEL:-gpt-5.3-codex high}"
+CODEX_MODEL="${HUSHLINE_CODEX_MODEL:-gpt-5.3-codex}"
+CODEX_REASONING_EFFORT="${HUSHLINE_CODEX_REASONING_EFFORT:-high}"
 PROJECT_OWNER="${HUSHLINE_DAILY_PROJECT_OWNER:-${REPO_SLUG%%/*}}"
 PROJECT_TITLE="${HUSHLINE_DAILY_PROJECT_TITLE:-Hush Line Roadmap}"
 PROJECT_COLUMN="${HUSHLINE_DAILY_PROJECT_COLUMN:-Agent Eligible}"
@@ -45,6 +46,7 @@ RUN_LOG_TIMESTAMP="$(date -u +%Y%m%dT%H%M%SZ)"
 RUN_LOG_GIT_PATH=""
 
 exec > >(tee -a "$RUN_LOG_TMP_FILE") 2>&1
+echo "Runner Codex config: model=$CODEX_MODEL reasoning_effort=$CODEX_REASONING_EFFORT"
 
 cleanup() {
   rm -f "$CHECK_LOG_FILE" "$PROMPT_FILE" "$PR_BODY_FILE" "$CODEX_OUTPUT_FILE" "$RUN_LOG_TMP_FILE"
@@ -460,6 +462,7 @@ append_pr_url_to_run_log() {
 run_codex_from_prompt() {
   codex exec \
     --model "$CODEX_MODEL" \
+    -c "model_reasoning_effort=\"$CODEX_REASONING_EFFORT\"" \
     --full-auto \
     --sandbox workspace-write \
     -C "$REPO_DIR" \


### PR DESCRIPTION
## What changed
- Updated the daily issue runner to pass Codex model and reasoning effort separately:
  - `--model gpt-5.3-codex`
  - `-c model_reasoning_effort="high"`
- Added a startup runner log line so saved run logs include resolved Codex model/effort.
- Added a targeted regression test for `hushline/auth.py` session-id mismatch path to close the test-gap branch.
- Updated runner docs to document `HUSHLINE_CODEX_MODEL` and `HUSHLINE_CODEX_REASONING_EFFORT` defaults.

## Why
- Fixes Codex invocation failures caused by passing `gpt-5.3-codex high` as a single model value.
- Improves observability in persisted run logs.
- Covers previously missed auth branch behavior for tampered session IDs.

## Validation
- Did not run lint/test/audit/lighthouse/w3c checks in this session (per task constraints).