### PR TITLE
docs: align runner docs with current scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ npm audit
 - Docs index: [`docs/README.md`](./docs/README.md)
 - Developer notes: [`docs/DEV.md`](./docs/DEV.md)
 - Architecture: [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)
-- Runner automation: [`docs/RUNNERS.md`](./docs/RUNNERS.md)
+- Runner automation: [`docs/AGENT_RUNNER.md`](./docs/AGENT_RUNNER.md)
 - Terms: [`docs/TERMS.md`](./docs/TERMS.md)
 
 ## Latest Screenshots


### PR DESCRIPTION
## Summary
- align `AGENTS.md` runner policy text with the current behavior in `scripts/agent_daily_issue_runner.sh`
- update `docs/AGENT_RUNNER.md` execution flow details (including push retry behavior and `HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT`)
- add an `agent_issue_bootstrap.sh` section documenting Docker auto-start and timeout behavior
- fix the stale runner documentation link in root `README.md` (`docs/RUNNERS.md` -> `docs/AGENT_RUNNER.md`)

## Why
Runner scripts were updated, but key policy/docs text still reflected older behavior. This PR removes that drift so operational docs match the scripts in-repo.

## Validation
- `make lint`
- `make test`
- Dependabot triage checks before work:
  - `gh pr list --state open --author app/dependabot --json number,title,headRefName,baseRefName,url`
  - `gh issue list --state open --author app/dependabot --json number,title,url`
  - `gh api 'repos/scidsg/hushline/dependabot/alerts?state=open&per_page=100'`

## Audit Notes
- `poetry run pip-audit` could not run because `pip-audit` is not installed in this environment.
- `npm audit --omit=dev` could not complete because DNS/network access to `registry.npmjs.org` is unavailable in this environment.

## Risk
- low; documentation-only changes
