### PR TITLE
chore: add dependency audit make targets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,9 +126,10 @@ This file provides operating guidance for coding agents working in the Hush Line
   - Never bypass supply-chain or integrity controls with flags such as `--ignore-signatures`, `--trusted-host`, or equivalent unless there is a formally documented emergency exception approved by maintainers.
   - If a task appears to require any such flag, stop and ask for a security review path instead of proceeding.
 - Run dependency vulnerability checks before PR:
-  - Python: `poetry run pip-audit`
-  - Node runtime deps: `npm audit --omit=dev`
-  - Run full Node audit when frontend/runtime dependencies change: `npm audit`
+  - Python: `make audit-python`
+  - Node runtime deps: `make audit-node-runtime`
+  - Run full Node audit when frontend/runtime dependencies change: `make audit-node-full`
+- If local dependency-audit commands are blocked by environment/network issues, document the failure reason in the PR and require a passing `Dependency Security Audit` workflow before merge.
 - If a CVE is found in reachable runtime code, block merge until fixed or formally risk-accepted.
 - For security-related changes, include in PR:
   - threat or risk summary

--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,18 @@ TESTS ?= ./tests/
 test: ## Run the test suite
 	$(CMD) poetry run pytest --cov hushline --cov-report term --cov-report html -vv $(PYTEST_ADDOPTS) $(TESTS)
 
+.PHONY: audit-python
+audit-python: ## Run Python dependency audit (CI-equivalent)
+	$(CMD) bash -lc 'poetry self add poetry-plugin-export && poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt && python -m pip install --disable-pip-version-check pip-audit==2.10.0 && pip-audit -r /tmp/requirements.txt'
+
+.PHONY: audit-node-runtime
+audit-node-runtime: ## Run Node runtime dependency audit (CI-equivalent)
+	$(CMD) npm audit --omit=dev --package-lock-only
+
+.PHONY: audit-node-full
+audit-node-full: ## Run full Node dependency audit (CI-equivalent)
+	$(CMD) npm audit --package-lock-only
+
 .PHONY: docs-screenshots
 docs-screenshots: ## Capture docs screenshots into docs/screenshots/releases/<release>
 	docker compose run --rm dev_data && \

--- a/README.md
+++ b/README.md
@@ -105,15 +105,17 @@ docker compose run --rm app poetry run pytest --cov hushline --cov-report term-m
 7. Run dependency vulnerability audits:
 
 ```sh
-poetry run pip-audit
-npm audit --omit=dev
+make audit-python
+make audit-node-runtime
 ```
 
 When frontend/runtime dependencies change, also run:
 
 ```sh
-npm audit
+make audit-node-full
 ```
+
+If local audit commands are blocked by network/tooling availability, document that in the PR and wait for a passing `Dependency Security Audit` workflow before merge.
 
 8. Ensure commits are cryptographically signed and verifiable on GitHub.
 


### PR DESCRIPTION
## What changed
- Added `make audit-python`, `make audit-node-runtime`, and `make audit-node-full` targets to `Makefile` using CI-equivalent commands.
- Updated `README.md` pre-PR checklist to use the new Make targets.
- Updated `AGENTS.md` security requirements to reference the same Make targets and document the workflow fallback when local audits are blocked.

## Why
- Standardize local dependency audit commands with a single, documented interface that matches CI behavior.
- Reduce command drift between contributor docs and agent guidance.

## Validation
- `make lint`
- `make test`

## Risks / follow-ups
- `audit-python` currently installs/updates tooling at runtime (`poetry-plugin-export` and `pip-audit`) and depends on network/tool availability.