### PR TITLE
fix: reduce runner test duplication

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -33,11 +33,10 @@ This runner runs directly in the local repo and now executes the full local CI-e
     - `make lint`
     - `make workflow-security-checks`
     - `make test` (full suite)
-    - `make test-ci-skip-local-only`
     - `make test-ci-alembic`
-    - `make test-ccpa-compliance`
-    - `make test-gdpr-compliance`
-    - `make test-e2ee-privacy-regressions`
+    - `make test-ccpa-compliance` when CCPA workflow trigger paths change
+    - `make test-gdpr-compliance` when GDPR workflow trigger paths change
+    - `make test-e2ee-privacy-regressions` when E2EE/privacy workflow trigger paths change
     - `make test-migration-smoke` when migration workflow trigger paths change
     - `make audit-python`
     - `make audit-node-runtime`


### PR DESCRIPTION
## Summary
- Reduce redundant pytest passes in the daily runner.
- Keep broad regression coverage and alembic coverage.
- Make targeted compliance/privacy suites conditional instead of always-on.
- Preserve W3C, Lighthouse, and dependency audit gates.

## What Changed
- Removed `make test-ci-skip-local-only` from the runner check sequence.
- Kept:
  - `make test` (full suite)
  - `make test-ci-alembic`
- Added path-based gating for:
  - `make test-ccpa-compliance`
  - `make test-gdpr-compliance`
  - `make test-e2ee-privacy-regressions`
- Left migration-smoke, dependency audits, W3C validators, and Lighthouse checks in place.
- Updated runner docs to match the new behavior.

## Validation
- `bash -n scripts/agent_daily_issue_runner.sh`
- `git diff --check`

## Rationale
The prior runner mirrored multiple CI pytest jobs too literally, which caused overlapping full or near-full test passes locally. This change keeps meaningful coverage while reducing wasted runtime before PR creation.
