### PR TITLE
fix: stabilize local W3C and Lighthouse checks

### DIFF
--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Extract score
         run: |
-          SCORE=$(python -c "import json; from pathlib import Path; data=json.loads(Path('lighthouse-performance.json').read_text()); print(round(data['categories']['performance']['score'] * 100))")
+          SCORE=$(python3 -c "import json; from pathlib import Path; data=json.loads(Path('lighthouse-performance.json').read_text()); print(round(data['categories']['performance']['score'] * 100))")
           if [ "$SCORE" -lt 95 ]; then
             echo "Performance score must be at least 95, got $SCORE"
             exit 1

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: Extract score
         run: |
-          SCORE=$(python -c "import json; from pathlib import Path; data=json.loads(Path('lighthouse.json').read_text()); print(round(data['categories']['accessibility']['score'] * 100))")
+          SCORE=$(python3 -c "import json; from pathlib import Path; data=json.loads(Path('lighthouse.json').read_text()); print(round(data['categories']['accessibility']['score'] * 100))")
           if [ "$SCORE" -lt 95 ]; then
             echo "Accessibility score must be at least 95, got $SCORE"
             exit 1

--- a/.github/workflows/w3c-validators.yml
+++ b/.github/workflows/w3c-validators.yml
@@ -38,8 +38,9 @@ jobs:
         run: |
           docker run --rm \
             -v /tmp/w3c:/work \
+            --entrypoint java \
             ghcr.io/validator/validator:latest \
-            java -jar /vnu.jar --errors-only --no-langdetect /work/index.html /work/directory.html
+            -jar /vnu.jar --errors-only --no-langdetect /work/index.html /work/directory.html
 
       - name: Validate CSS (W3C CSS)
         run: |
@@ -60,4 +61,4 @@ jobs:
             echo "W3C CSS validator unavailable (rate limited or error); skipping CSS validation."
             exit 0
           fi
-          python -c "import json,sys; from pathlib import Path; data=json.loads(Path('/tmp/w3c/css.json').read_text()); errors=data.get('cssvalidation',{}).get('errors',[]); sys.exit(f'W3C CSS validation failed with {len(errors)} error(s).') if errors else print('W3C CSS validation passed.')"
+          python3 -c "import json,sys; from pathlib import Path; data=json.loads(Path('/tmp/w3c/css.json').read_text()); errors=data.get('cssvalidation',{}).get('errors',[]); sys.exit(f'W3C CSS validation failed with {len(errors)} error(s).') if errors else print('W3C CSS validation passed.')"

--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,9 @@ w3c-validators: runner-wait-for-app ## Run W3C HTML and CSS validators (CI-equiv
 	curl -fsS "$(RUNNER_APP_URL)/directory" -o /tmp/w3c/directory.html
 	docker run --rm \
 		-v /tmp/w3c:/work \
+		--entrypoint java \
 		ghcr.io/validator/validator:latest \
-		java -jar /vnu.jar --errors-only --no-langdetect /work/index.html /work/directory.html
+		-jar /vnu.jar --errors-only --no-langdetect /work/index.html /work/directory.html
 	@set +e; \
 	success=0; \
 	for i in 1 2 3 4 5; do \
@@ -199,7 +200,7 @@ lighthouse-accessibility: runner-wait-for-app ## Run Lighthouse accessibility ch
 	  fi; \
 	  sleep $$((i * 5)); \
 	done
-	@SCORE=$$(python -c "import json; from pathlib import Path; data=json.loads(Path('lighthouse.json').read_text()); print(round(data['categories']['accessibility']['score'] * 100))"); \
+	@SCORE=$$(python3 -c "import json; from pathlib import Path; data=json.loads(Path('lighthouse.json').read_text()); print(round(data['categories']['accessibility']['score'] * 100))"); \
 	if [ "$$SCORE" -lt 95 ]; then \
 	  echo "Accessibility score must be at least 95, got $$SCORE"; \
 	  exit 1; \
@@ -225,7 +226,7 @@ lighthouse-performance: runner-wait-for-app ## Run Lighthouse performance check 
 	  fi; \
 	  sleep $$((i * 5)); \
 	done
-	@SCORE=$$(python -c "import json; from pathlib import Path; data=json.loads(Path('lighthouse-performance.json').read_text()); print(round(data['categories']['performance']['score'] * 100))"); \
+	@SCORE=$$(python3 -c "import json; from pathlib import Path; data=json.loads(Path('lighthouse-performance.json').read_text()); print(round(data['categories']['performance']['score'] * 100))"); \
 	if [ "$$SCORE" -lt 95 ]; then \
 	  echo "Performance score must be at least 95, got $$SCORE"; \
 	  exit 1; \


### PR DESCRIPTION
## Summary
- use `python3` for local and CI W3C/Lighthouse score parsing
- bypass the W3C validator image entrypoint and invoke `vnu.jar` via `java` directly
- keep the validation flags and thresholds unchanged

## Testing
- `git diff --check`
- `make -n w3c-validators lighthouse-accessibility lighthouse-performance`
