### PR TITLE
Fix runner prompt expansion and lint self-heal gating

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -45,7 +45,7 @@ This runner runs directly in the local repo and now executes the full local CI-e
     - `make lighthouse-accessibility`
     - `make lighthouse-performance` when lighthouse-performance workflow trigger paths change
     - Every executed check gets a local self-heal retry before handing failures to Codex.
-    - Lint failures get a deterministic `make fix` self-heal pass before the runner hands the failure back to Codex.
+    - Lint failures only run deterministic `make fix` self-heal when the failure looks auto-fixable (for example Ruff formatting/check or Prettier); non-auto-fixable lint failures go straight back to Codex.
     - Runtime-dependent checks (tests, W3C, Lighthouse) self-heal by restarting the local stack and reseeding dev data, then retrying once.
     - If the issue has label `test-gap`, require the referenced file in the issue title/body to show `0` misses and `100%` coverage in the test output table.
     - If local dependency audits are blocked by environment/network issues, continue with explicit PR note and require a passing `Dependency Security Audit` workflow before merge.


### PR DESCRIPTION
## Summary
- stop runner prompt generation from executing backticked examples while building prompt files
- only run deterministic `make fix` lint self-heal for auto-fixable lint failures
- send non-auto-fixable lint failures, such as mypy-only issues, straight back to Codex

## Validation
- bash -n scripts/agent_daily_issue_runner.sh
- git diff --check
