### PR TITLE
Align settings tabs with inbox sticky behavior

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -2,9 +2,36 @@ document.addEventListener("DOMContentLoaded", function () {
   const tabs = document.querySelectorAll(".tab");
   const tabList = document.querySelectorAll(".tab-list .tab");
   const mainElement = document.querySelector("main");
+  const settingsTabsNav = document.querySelector(".settings-tabs");
 
   if (tabList.length >= 5) {
     mainElement.classList.add("settings-main");
+  }
+
+  if (settingsTabsNav) {
+    const updateStickyOffset = () => {
+      const header = document.querySelector("header");
+      const banner = document.querySelector(".banner");
+      const desktopOffset = window.matchMedia("(min-width: 641px)").matches
+        ? Number.parseFloat(
+            window.getComputedStyle(document.documentElement).fontSize,
+          ) || 16
+        : 0;
+      const headerHeight = header ? header.getBoundingClientRect().height : 0;
+      const bannerHeight = banner ? banner.getBoundingClientRect().height : 0;
+      const stickyTop = headerHeight + bannerHeight + desktopOffset;
+
+      settingsTabsNav.style.setProperty(
+        "--settings-tabs-top",
+        `${stickyTop}px`,
+      );
+    };
+
+    updateStickyOffset();
+    window.addEventListener("resize", updateStickyOffset);
+    window.addEventListener("hashchange", () => {
+      requestAnimationFrame(updateStickyOffset);
+    });
   }
 });
 

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3179,19 +3179,30 @@ p.bio+.extra-fields {
   overflow: visible;
 }
 
-.settings-main .settings-content .settings-tabs,
+.settings-tabs,
 .inbox-tabs {
   width: 200px;
 }
 
+.settings-tabs,
 .inbox-tabs-nav {
   position: sticky;
+  align-self: flex-start;
+  box-sizing: border-box;
+  z-index: 8;
+}
+
+.settings-tabs {
+  top: var(--settings-tabs-top, calc(1rem + 65px + env(safe-area-inset-top)));
+  flex: 0 0 200px;
+  width: 200px;
+}
+
+.inbox-tabs-nav {
   top: var(--inbox-tabs-top, calc(1rem + 65px + env(safe-area-inset-top)));
   align-self: flex-start;
   flex: 0 0 200px;
   width: 200px;
-  box-sizing: border-box;
-  z-index: 8;
 }
 
 .inbox-tabs {
@@ -3436,6 +3447,20 @@ p.bio+.extra-fields {
   .inbox-main .inbox-content .tab-list {
     max-width: 100%;
     width: 100%;
+  }
+
+  .settings-main .settings-content .settings-tabs,
+  .inbox-main .inbox-content .inbox-tabs-nav {
+    top: var(--settings-tabs-top, calc(65px + env(safe-area-inset-top)));
+    align-self: stretch;
+    flex-basis: auto;
+    width: auto;
+    max-width: none;
+    margin-left: calc(-1 * var(--container-padding, 1.25rem));
+    margin-right: calc(-1 * var(--container-padding, 1.25rem));
+    padding-left: var(--container-padding, 1.25rem);
+    padding-right: var(--container-padding, 1.25rem);
+    box-sizing: border-box;
   }
 
   .inbox-main .inbox-content .inbox-tabs-nav {

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -79,3 +79,17 @@ def test_inbox_sticky_nav_hooks_exist() -> None:
     assert "--inbox-tabs-top" in inbox_js
     assert ".inbox-tabs-nav {" in scss
     assert "position: sticky;" in scss
+
+
+def test_settings_sticky_nav_hooks_exist() -> None:
+    settings_template = (ROOT / "hushline/templates/settings/nav.html").read_text(
+        encoding="utf-8",
+    )
+    settings_js = (ROOT / "assets/js/settings.js").read_text(encoding="utf-8")
+    scss = (ROOT / "assets/scss/style.scss").read_text(encoding="utf-8")
+
+    assert 'class="settings-tabs"' in settings_template
+    assert 'const settingsTabsNav = document.querySelector(".settings-tabs");' in settings_js
+    assert "--settings-tabs-top" in settings_js
+    assert ".settings-tabs {" in scss
+    assert "position: sticky;" in scss


### PR DESCRIPTION
## Summary
- align the settings tab rail with the inbox sticky behavior on desktop and mobile
- use the same computed sticky offset model for settings that inbox already uses
- make the mobile settings rail bleed to the full container width like inbox

## Testing
- docker compose run --rm app poetry run pytest tests/test_frontend_compat.py tests/test_accessibility.py --skip-local-only
- make test

## Test result notes
- `make test` had 1 unrelated failure in `tests/test_directory.py::test_public_record_external_links_resolve`
- failure was a timeout reaching `https://www.tsmp.com.sg/` during the live external-link check
- the deterministic frontend/accessibility tests for this change passed

## Manual testing
- [ ] Desktop: confirm settings tabs use the same sticky offset spacing as inbox
- [ ] Mobile: confirm settings tabs stick flush to the container edges without card-shadow bleed-through