### PR TITLE
Use auto-merge for staging bump PRs

### DIFF
--- a/.github/workflows/bump-staging-after-release.yml
+++ b/.github/workflows/bump-staging-after-release.yml
@@ -198,6 +198,7 @@ jobs:
 
           gh pr merge \
             --repo "$INFRA_REPOSITORY" \
+            --auto \
             --squash \
             --delete-branch \
             "${{ steps.create_or_update_pr.outputs.pr_url }}"


### PR DESCRIPTION
## Summary
- switch the staging infra workflow from immediate PR merge to GitHub auto-merge
- let the infra PR wait for branch policy requirements instead of failing immediately

## Testing
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bump-staging-after-release.yml"); puts "yaml ok"'\n\n## Manual testing\n- Publish a release and confirm the staging bump workflow creates the infra PR and enables auto-merge instead of failing at the merge step.