### PR TITLE
Fix vulnerable serialize-javascript dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,9 @@
         "sass": "^1.56.2",
         "sass-loader": "^13.2.0",
         "webpack-cli": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@discoveryjs/json-ext": {
@@ -1671,17 +1674,6 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "dev": true,
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/readdirp": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
@@ -1756,28 +1748,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "peer": true
     },
     "node_modules/sass": {
       "version": "1.86.3",
@@ -1869,14 +1839,14 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.0.3.tgz",
+      "integrity": "sha512-h+cZ/XXarqDgCjo+YSyQU/ulDEESGGf8AMK9pPNmhNSl/FzPl6L8pMp1leca5z6NuG6tvV/auC8/43tmovowww==",
       "dev": true,
       "license": "BSD-3-Clause",
       "peer": true,
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/shallow-clone": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "dependencies": {
     "openpgp": "^6.3.0"
   },
+  "overrides": {
+    "serialize-javascript": "^7.0.3"
+  },
   "devDependencies": {
     "css-loader": "^6.7.2",
     "mini-css-extract-plugin": "^2.7.2",


### PR DESCRIPTION
## Summary
- add an npm override to force `serialize-javascript` to `^7.0.3`
- regenerate `package-lock.json` so the transitive dependency no longer resolves to `6.0.2`

## Testing
- npm install --package-lock-only
- make lint

## Manual testing
- Confirm `package-lock.json` resolves `node_modules/serialize-javascript` to `7.0.3`.
- Confirm the Dependabot alert for `serialize-javascript` closes after merge.

## Notes
- This is a transitive dev-tool dependency via `terser-webpack-plugin`.
- The override resolves the security issue, but `serialize-javascript@7.0.3` declares `node >=20`, so the lockfile should continue to be generated in a modern Node environment.