### PR TITLE
Fix webpack build by moving to Node 20

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -1,5 +1,5 @@
 # vim: set syntax=dockerfile :
-FROM node:18.20.4-alpine3.20 AS webpack
+FROM node:20.19.5-alpine3.22 AS webpack
 
 WORKDIR /src
 

--- a/docker-compose.personal-server.yaml
+++ b/docker-compose.personal-server.yaml
@@ -56,7 +56,7 @@ services:
       retries: 10
 
   webpack:
-    image: node:18.20.4-alpine3.20
+    image: node:20.19.5-alpine3.22
     volumes:
       - ./:/app/
       - hushline-node-modules:/app/node_modules

--- a/docker-compose.stripe.yaml
+++ b/docker-compose.stripe.yaml
@@ -93,7 +93,7 @@ services:
       retries: 10
 
   webpack:
-    image: node:18.20.4-alpine3.20
+    image: node:20.19.5-alpine3.22
     volumes:
       - ./:/app/
       - hushline-node-modules:/app/node_modules

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -86,7 +86,7 @@ services:
       retries: 10
 
   webpack:
-    image: node:18.20.4-alpine3.20
+    image: node:20.19.5-alpine3.22
     volumes:
       - ./:/app/
       - hushline-node-modules:/app/node_modules

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "webpack-cli": "^5.0.1"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/@discoveryjs/json-ext": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "engines": {
-    "node": ">=18"
+    "node": ">=20"
   },
   "scripts": {
     "build:dev": "webpack --config webpack.config.js --watch",


### PR DESCRIPTION
## Summary
- update the frontend webpack build runtime from Node 18 to Node 20
- align the local webpack compose services and package engine floor with that runtime
- keep the merged `serialize-javascript` security fix buildable on `main`

## Testing
- npm install --package-lock-only
- make lint
- docker run --rm -v /Users/scidsg/hushline:/src -w /src node:20.19.5-alpine3.22 sh -lc 'npm ci --no-audit --no-fund && npm run build:prod'\n\n## Manual testing\n- Confirm the `Build latest container image` workflow succeeds on this branch.\n- Confirm the production webpack stage builds under Node 20 without the `crypto is not defined` error.