### PR TITLE
Separate public record link checks from default tests

### DIFF
--- a/.github/workflows/public-record-link-check.yml
+++ b/.github/workflows/public-record-link-check.yml
@@ -1,0 +1,27 @@
+name: Public Record Link Check
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 14 * * 1"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "hushline/data/public_record_law_firms.json"
+      - "tests/test_directory.py"
+      - "Makefile"
+      - ".github/workflows/public-record-link-check.yml"
+
+jobs:
+  public-record-links:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate live public record links
+        run: make test-public-record-links

--- a/Makefile
+++ b/Makefile
@@ -88,9 +88,14 @@ endif
 		'make migrate-prod && poetry run flask db revision -m "$(MESSAGE)" --autogenerate'
 
 TESTS ?= ./tests/
+PYTEST_DEFAULT_MARK_EXPR ?= not external_network
 .PHONY: test
 test: ## Run the test suite
-	$(CMD) poetry run pytest --cov hushline --cov-report term --cov-report html -vv $(PYTEST_ADDOPTS) $(TESTS)
+	$(CMD) poetry run pytest --cov hushline --cov-report term --cov-report html -vv -m "$(PYTEST_DEFAULT_MARK_EXPR)" $(PYTEST_ADDOPTS) $(TESTS)
+
+.PHONY: test-public-record-links
+test-public-record-links: ## Validate live public-record external links
+	$(CMD) poetry run pytest -vv tests/test_directory.py -k public_record_external_links_resolve
 
 .PHONY: audit-python
 audit-python: ## Run Python dependency audit (CI-equivalent)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ filterwarnings = [
 ]
 markers = [
     "local_only",
+    "external_network",
 ]
 
 [tool.coverage.report]

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -234,6 +234,7 @@ def test_public_record_listing_slug_cannot_be_messaged(client: FlaskClient) -> N
 
 
 @pytest.mark.local_only()
+@pytest.mark.external_network()
 def test_public_record_external_links_resolve() -> None:
     session = requests.Session()
     session.headers.update(


### PR DESCRIPTION
## Summary
- mark the public record external-link sweep as an external-network test
- exclude that marker from the default `make test` path
- add a dedicated `make test-public-record-links` target and workflow for scheduled/manual runs

## Testing
- git diff --check
- make test TESTS="tests/test_directory.py"
- make -n test-public-record-links
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/public-record-link-check.yml"); puts "yaml ok"'\n\n## Manual testing\n- Run `make test` and confirm it no longer hangs on public-record external link verification.\n- Run `make test-public-record-links` when you want the live external-link sweep explicitly.