### PR TITLE
Update frontend compat test for Node 20

### DIFF
--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -4,10 +4,10 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 
 
-def test_package_json_declares_node_18_plus() -> None:
+def test_package_json_declares_node_20_plus() -> None:
     package_json = json.loads((ROOT / "package.json").read_text(encoding="utf-8"))
     engines = package_json.get("engines", {})
-    assert engines.get("node") == ">=18"
+    assert engines.get("node") == ">=20"
 
 
 def test_client_side_encryption_has_platform_guards() -> None:


### PR DESCRIPTION
## Summary
- update the frontend compatibility test to match the current Node 20 engine floor
- rename the test so the expectation is explicit

## Testing
- git diff --check
- docker compose run --rm app poetry run pytest tests/test_frontend_compat.py -vv

## Manual testing
- Run `make test` and confirm the frontend compatibility check no longer fails on the stale `>=18` expectation.