### PR TITLE
Directly merge staging bump PRs

### DIFF
--- a/.github/workflows/bump-staging-after-release.yml
+++ b/.github/workflows/bump-staging-after-release.yml
@@ -198,7 +198,6 @@ jobs:
 
           gh pr merge \
             --repo "$INFRA_REPOSITORY" \
-            --auto \
             --squash \
             --delete-branch \
             "${{ steps.create_or_update_pr.outputs.pr_url }}"


### PR DESCRIPTION
## Summary
- switch the staging bump workflow back from `gh pr merge --auto` to direct `gh pr merge`
- keep the existing single-file diff guard in place
- rely on the saved hushline-infra bypass rule instead of GitHub auto-merge support

## Testing
- git diff --check
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/bump-staging-after-release.yml"); puts "yaml ok"'\n\n## Manual testing\n- Publish a release and confirm the staging bump workflow opens and directly merges the hushline-infra PR without requiring manual auto-merge enablement.