### PR TITLE
fix: refresh runner runtime before validation

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -30,6 +30,7 @@ This runner runs directly in the local repo and now executes the full local CI-e
 10. Create/update issue branch `codex/daily-issue-<issue_number>` from `main`.
 11. Run Codex issue loop until repository changes exist.
 12. Run required checks in a self-heal loop:
+    - Before lint/test validation, if the working tree includes schema-affecting changes (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), rebuild the local runtime and reseed dev data so the live stack matches the current code.
     - `make lint`
     - `make workflow-security-checks`
     - `make test` (full suite)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -108,9 +108,7 @@ run_check_with_self_heal_retry() {
 
 reseed_runtime_for_self_heal() {
   echo "Self-heal: restarting local runtime stack and reseeding dev data." | tee -a "$CHECK_LOG_FILE"
-  docker compose down -v --remove-orphans >/dev/null 2>&1 || true
-  docker compose up -d postgres blob-storage app >/dev/null
-  docker compose run --rm dev_data >/dev/null
+  reset_runtime_stack_and_seed_dev_data
 }
 
 run_runtime_check_with_self_heal() {
@@ -124,14 +122,42 @@ run_runtime_check_with_self_heal() {
   run_check_capture "${description} (self-heal retry after runtime reset)" "$@"
 }
 
-node_runtime_dependency_files_changed() {
-  git diff --name-only "${BASE_BRANCH}...HEAD" \
-    | grep -Eq '(^|/)(package\.json|package-lock\.json|npm-shrinkwrap\.json)$'
+reset_runtime_stack_and_seed_dev_data() {
+  docker compose down -v --remove-orphans >/dev/null 2>&1 || true
+  docker compose up -d postgres blob-storage app >/dev/null
+  docker compose run --rm dev_data >/dev/null
+}
+
+refresh_runtime_after_schema_changes() {
+  echo "==> Refresh local runtime after schema changes" | tee -a "$CHECK_LOG_FILE"
+  if ! runtime_schema_files_changed; then
+    echo "Skipped: no schema-affecting files changed." | tee -a "$CHECK_LOG_FILE"
+    return 0
+  fi
+
+  reset_runtime_stack_and_seed_dev_data
+}
+
+list_changed_files() {
+  {
+    git diff --name-only "${BASE_BRANCH}...HEAD"
+    git diff --name-only
+    git diff --cached --name-only
+    git ls-files --others --exclude-standard
+  } | awk 'NF && !seen[$0]++'
 }
 
 changed_files_match() {
   local pattern="$1"
-  git diff --name-only "${BASE_BRANCH}...HEAD" | grep -Eq "$pattern"
+  list_changed_files | grep -Eq "$pattern"
+}
+
+node_runtime_dependency_files_changed() {
+  changed_files_match '(^|/)(package\.json|package-lock\.json|npm-shrinkwrap\.json)$'
+}
+
+runtime_schema_files_changed() {
+  changed_files_match '^(hushline/model/|migrations/|scripts/dev_data\.py$|scripts/dev_migrations\.py$)'
 }
 
 migration_smoke_files_changed() {
@@ -425,6 +451,7 @@ run_local_workflow_checks() {
   GDPR_COMPLIANCE_REQUIRED=0
   E2EE_PRIVACY_REQUIRED=0
   local lint_failure_tail=""
+  refresh_runtime_after_schema_changes || return 1
   if ! run_check_capture "Run lint" make lint; then
     lint_failure_tail="$(tail -n 240 "$CHECK_LOG_FILE")"
     if ! lint_failure_looks_auto_fixable "$lint_failure_tail"; then


### PR DESCRIPTION
## Summary
Fix the daily agent runner so schema-touching issue work does not deadlock validation at `make lint`.

## Why
The runner was only comparing `BASE...HEAD`, so it missed uncommitted bot edits to models/migrations. When that happened, `make lint` blocked on `docker compose run --rm app ...` because `app` waits for `dev_data`, and `dev_data` was crash-looping against a stale local schema.

## What Changed
- detect changed files from the real working tree, including unstaged, staged, and untracked files
- reset the local runtime and reseed `dev_data` before validation when schema-affecting files changed
- reuse the same runtime reset helper for self-heal retries
- document the runner behavior in `docs/AGENT_RUNNER.md`

## Validation
- `make lint`
- `make test`

## Manual Testing
- Not applicable beyond local runner validation and the reproduced deadlock condition.

## Risks / Follow-ups
- This does not change PR selection or Codex issue logic; it only hardens runtime preparation before validation.
- A manual runner invocation after merge is the clean final confirmation.