### PR TITLE
fix: keep runner prompts off schema-hanging checks

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -29,6 +29,7 @@ This runner runs directly in the local repo and now executes the full local CI-e
    - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
 10. Create/update issue branch `codex/daily-issue-<issue_number>` from `main`.
 11. Run Codex issue loop until repository changes exist.
+    - The issue/fix prompts tell Codex to avoid local container-backed make validation by default, and to defer validation entirely to the runner when schema-affecting files are touched (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`).
 12. Run required checks in a self-heal loop:
     - Before lint/test validation, if the working tree includes schema-affecting changes (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), rebuild the local runtime and reseed dev data so the live stack matches the current code.
     - `make lint`

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -912,11 +912,13 @@ Requirements:
 2) Add or update tests for behavior changes.
 3) Focus on implementation and tests only; this runner runs the full local CI-equivalent suite before opening a PR (lint, tests, dependency audits, workflow security, W3C, Lighthouse).
 4) Keep security, privacy, and E2EE protections intact.
-5) If you need local validation/fix commands, use repository make targets (for example `make lint`, `make fix`, `make test`) instead of host-only tool invocations.
-6) Do not invoke host `poetry`, `ruff`, or `pytest` directly; assume check tooling lives in the app container unless the repo make target handles it for you.
-7) Do not run scripts/agent_issue_bootstrap.sh, Docker commands, or Dependabot/GitHub connectivity checks; this runner handles infra.
-8) Do not include meta-compliance statements like "per your constraints" in your final summary.
-9) Prefer repository-root searches and avoid scanning hardcoded directories that may not exist.
+5) Avoid local validation unless it is necessary to make progress; the runner will execute the full validation suite after your implementation.
+6) If you need local validation/fix commands, use repository make targets (for example `make lint`, `make fix`, `make test`) instead of host-only tool invocations.
+7) Do not invoke host `poetry`, `ruff`, or `pytest` directly; assume check tooling lives in the app container unless the repo make target handles it for you.
+8) If you touch schema-affecting files (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), do not run container-backed make validation commands in this implementation loop; leave runtime refresh and validation to the runner.
+9) Do not run scripts/agent_issue_bootstrap.sh, Docker commands, or Dependabot/GitHub connectivity checks; this runner handles infra.
+10) Do not include meta-compliance statements like "per your constraints" in your final summary.
+11) Prefer repository-root searches and avoid scanning hardcoded directories that may not exist.
 EOF2
   } > "$PROMPT_FILE"
 }
@@ -951,10 +953,12 @@ Requirements:
 2) Keep diffs minimal and focused.
 3) Focus on code/test fixes only; this runner executes the full local CI-equivalent suite before opening a PR.
 4) Keep security, privacy, and E2EE protections intact.
-5) If you need local validation/fix commands, use repository make targets (for example `make lint`, `make fix`, `make test`) instead of host-only tool invocations.
-6) Do not invoke host `poetry`, `ruff`, or `pytest` directly; assume check tooling lives in the app container unless the repo make target handles it for you.
-7) Do not run scripts/agent_issue_bootstrap.sh, Docker commands, or Dependabot/GitHub connectivity checks; this runner handles infra.
-8) Do not include meta-compliance statements like "per your constraints" in your final summary.
+5) Avoid local validation unless it is necessary to make progress; the runner will rerun the full validation suite after your changes.
+6) If you need local validation/fix commands, use repository make targets (for example `make lint`, `make fix`, `make test`) instead of host-only tool invocations.
+7) Do not invoke host `poetry`, `ruff`, or `pytest` directly; assume check tooling lives in the app container unless the repo make target handles it for you.
+8) If you touch schema-affecting files (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), do not run container-backed make validation commands in this fix loop; leave runtime refresh and validation to the runner.
+9) Do not run scripts/agent_issue_bootstrap.sh, Docker commands, or Dependabot/GitHub connectivity checks; this runner handles infra.
+10) Do not include meta-compliance statements like "per your constraints" in your final summary.
 EOF2
   } > "$PROMPT_FILE"
 }


### PR DESCRIPTION
## Summary
Stop the daily runner's Codex issue/fix prompts from telling the model to run container-backed make validation in the exact schema-change cases that deadlock the local runtime.

## Why
The runner validation phase was already hardened in #1492, but the Codex implementation loop could still run `make test` or similar container-backed commands after editing schema-affecting files. That causes `docker compose run --rm app ...` to hang while `dev_data` crash-loops against the stale local schema.

## What Changed
- tell Codex to avoid local validation by default during the issue/fix loop
- explicitly block container-backed make validation in the issue/fix loop when schema-affecting files changed
- document that behavior in `docs/AGENT_RUNNER.md`

## Validation
- `bash -n scripts/agent_daily_issue_runner.sh`
- `git diff --check`
- `make lint`
- `make test` was still in progress when this PR was opened at the user's request

## Manual Testing
- Not applicable beyond runner behavior validation.

## Risks / Follow-ups
- This is prompt-level hardening; it reduces the chance of Codex self-inflicted hangs but does not change the post-Codex validation pipeline.