### PR TITLE
fix: reset runner worktree during cleanup

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -60,6 +60,7 @@ This runner runs directly in the local repo and now executes the full local CI-e
 15. Include runner log path in PR context and use the narrative + structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`).
 16. Refresh run log after PR creation (including opened PR URL and post-check steps), commit/push that log update when changed.
 17. Return to `main` on exit (explicit checkout + cleanup trap fallback).
+    - Exit cleanup force-resets the repo to `origin/main` and removes untracked files so interrupted runs do not leave bot work on `main`.
 
 ## ASCII Workflow (Current)
 

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -64,6 +64,15 @@ cleanup() {
   if [[ -d "$REPO_DIR/.git" ]]; then
     if ! git -C "$REPO_DIR" checkout "$BASE_BRANCH" >/dev/null 2>&1; then
       echo "Warning: failed to switch back to $BASE_BRANCH during cleanup." >&2
+      return
+    fi
+    if ! git -C "$REPO_DIR" reset --hard "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+      if ! git -C "$REPO_DIR" reset --hard "$BASE_BRANCH" >/dev/null 2>&1; then
+        echo "Warning: failed to reset $BASE_BRANCH during cleanup." >&2
+      fi
+    fi
+    if ! git -C "$REPO_DIR" clean -fd >/dev/null 2>&1; then
+      echo "Warning: failed to remove untracked files during cleanup." >&2
     fi
   fi
 }


### PR DESCRIPTION
## Summary
Make runner cleanup force-reset the repo back to `origin/main` so interrupted runs cannot leave bot work on `main`.

## Why
The runner trap only checked out the base branch on exit. If a run was interrupted after Codex edited files, those bot changes could remain in the local `main` worktree and poison the next run.

## What Changed
- keep the existing cleanup checkout to the base branch
- add `git reset --hard origin/main` during cleanup, with a local-branch fallback
- add `git clean -fd` during cleanup
- document the cleanup guarantee in `docs/AGENT_RUNNER.md`

## Validation
- `bash -n scripts/agent_daily_issue_runner.sh`
- `git diff --check`

## Manual Testing
- Not run; PR opened immediately at user request.

## Risks / Follow-ups
- This makes exit cleanup intentionally destructive for uncommitted runner changes, which is the correct behavior for this dedicated automation worktree.