### PR TITLE
Directory: remove SecureDrop badge from SecureDrop tab listings

### DIFF
--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -248,7 +248,6 @@
             <article class="user">
               <h3>{{ listing.name }}</h3>
               <div class="badgeContainer">
-                <span class="badge" role="img" aria-label="SecureDrop listing">🛡️ SecureDrop</span>
                 <span class="badge" role="img" aria-label="Automated listing">🤖 Automated</span>
               </div>
               <p class="bio">{{ listing.description }}</p>

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -250,8 +250,10 @@ def test_directory_securedrop_render_only_in_securedrop_and_all(
     assert listing.name in all_panel.text
     assert listing.description in securedrop_panel.text
     assert listing.description in all_panel.text
-    assert "🛡️ SecureDrop" in securedrop_panel.text
-    assert "🤖 Automated" in securedrop_panel.text
+    assert securedrop_panel.select_one('span.badge[aria-label="SecureDrop listing"]') is None
+    assert securedrop_panel.select_one('span.badge[aria-label="Automated listing"]') is not None
+    assert all_panel.select_one('span.badge[aria-label="SecureDrop listing"]') is not None
+    assert all_panel.select_one('span.badge[aria-label="Automated listing"]') is not None
     assert public_records_panel is not None
     assert listing.name not in public_records_panel.text
     assert verified_panel is not None


### PR DESCRIPTION
## What changed
- Removed the `🛡️ SecureDrop` badge from listing cards shown in the **SecureDrop** tab.
- Kept the `🤖 Automated` badge in the SecureDrop tab.
- Kept SecureDrop badges in the **All** tab unchanged.
- Updated `tests/test_directory.py` to assert this tab-specific badge behavior.

## Why
- Addresses #1520: the SecureDrop badge on the SecureDrop tab is redundant, while it should remain visible in the All tab.

## Validation
- `make lint`
- `make test`

## Manual testing
- Not run manually; change is covered by automated tests in `tests/test_directory.py`.

## Risks / follow-ups
- Low risk; scoped template and test assertion update only.

Closes #1520
