### PR TITLE
Publish docs screenshots to hushline-website

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -93,16 +93,17 @@ jobs:
             --release "${{ steps.vars.outputs.release_key }}" \
             --manifest docs/screenshots/scenes.json
 
-      - name: Publish screenshots to external repo
+      - name: Publish screenshots to hushline-website
         if: steps.manifest.outputs.enabled == 'true'
         env:
-          SCREENSHOTS_REPO: ${{ vars.SCREENSHOTS_REPO }}
-          SCREENSHOTS_PUSH_TOKEN: ${{ secrets.SCREENSHOTS_PUSH_TOKEN }}
+          WEBSITE_REPOSITORY: scidsg/hushline-website
+          WEBSITE_PUSH_TOKEN: ${{ secrets.HUSHLINE_WEBSITE_SCREENSHOTS_PAT }}
+          WEBSITE_SCREENSHOT_ROOT: src/assets/img/screenshots
           RELEASE_KEY: ${{ steps.vars.outputs.release_key }}
         run: |
           set -euo pipefail
-          if [ -z "${SCREENSHOTS_REPO:-}" ] || [ -z "${SCREENSHOTS_PUSH_TOKEN:-}" ]; then
-            echo "Skipping publish: SCREENSHOTS_REPO variable or SCREENSHOTS_PUSH_TOKEN secret is missing."
+          if [ -z "${WEBSITE_PUSH_TOKEN:-}" ]; then
+            echo "Skipping publish: HUSHLINE_WEBSITE_SCREENSHOTS_PAT secret is missing."
             exit 0
           fi
 
@@ -112,27 +113,17 @@ jobs:
             exit 1
           fi
 
-          git clone "https://x-access-token:${SCREENSHOTS_PUSH_TOKEN}@github.com/${SCREENSHOTS_REPO}.git" /tmp/hushline-screenshots
-          cd /tmp/hushline-screenshots
+          git clone "https://x-access-token:${WEBSITE_PUSH_TOKEN}@github.com/${WEBSITE_REPOSITORY}.git" /tmp/hushline-website
+          cd /tmp/hushline-website
 
-          mkdir -p "releases/${RELEASE_KEY}" "releases/latest"
-          rsync -a --delete "${GITHUB_WORKSPACE}/${SRC_ROOT}/" "releases/${RELEASE_KEY}/"
-          rsync -a --delete "${GITHUB_WORKSPACE}/${SRC_ROOT}/" "releases/latest/"
-
-          cat > README.md <<'EOF'
-          # Hush Line Screenshots
-
-          Automated screenshots published by the Hush Line app repo workflow.
-
-          - Latest: `releases/latest/`
-          - Versioned sets: `releases/<version>/`
-          EOF
+          mkdir -p "${WEBSITE_SCREENSHOT_ROOT}"
+          rsync -a --delete "${GITHUB_WORKSPACE}/${SRC_ROOT}/" "${WEBSITE_SCREENSHOT_ROOT}/"
 
           cat > badge-docs-screenshots.json <<EOF
           {"schemaVersion":1,"label":"docs screenshots","message":"${RELEASE_KEY}","color":"blue"}
           EOF
 
-          git add README.md releases badge-docs-screenshots.json
+          git add "${WEBSITE_SCREENSHOT_ROOT}" badge-docs-screenshots.json
           if git diff --cached --quiet; then
             echo "No screenshot changes to publish."
             exit 0
@@ -140,7 +131,7 @@ jobs:
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git commit -m "Update screenshots for ${RELEASE_KEY}"
+          git commit -m "Update website screenshots for ${RELEASE_KEY}"
           git push origin HEAD
 
       - name: Upload screenshot artifacts

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Start here: <https://hushline.app/library/docs/getting-started/start-here/>
 [![Python Dependency Audit](https://github.com/scidsg/hushline/actions/workflows/dependency-security-audit.yml/badge.svg)](https://github.com/scidsg/hushline/actions/workflows/dependency-security-audit.yml)
 [![W3C Validators](https://github.com/scidsg/hushline/actions/workflows/w3c-validators.yml/badge.svg)](https://github.com/scidsg/hushline/actions/workflows/w3c-validators.yml)
 [![Public Record Link Check](https://github.com/scidsg/hushline/actions/workflows/public-record-link-check.yml/badge.svg)](https://github.com/scidsg/hushline/actions/workflows/public-record-link-check.yml)
-[![Docs Screenshots](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline-screenshots/main/badge-docs-screenshots.json)](https://github.com/scidsg/hushline-screenshots/tree/main/releases/latest)
+[![Docs Screenshots](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/scidsg/hushline-website/main/badge-docs-screenshots.json)](https://github.com/scidsg/hushline-website/tree/main/src/assets/img/screenshots)
 
 ## Why Hush Line
 
@@ -134,14 +134,14 @@ If local audit commands are blocked by network/tooling availability, document th
   <tr>
     <td valign="bottom" width="73%">
       <img
-        src="https://github.com/scidsg/hushline-screenshots/blob/main/releases/latest/guest/guest-directory-verified-desktop-light-fold.png?raw=true"
+        src="https://raw.githubusercontent.com/scidsg/hushline-website/main/src/assets/img/screenshots/guest/guest-directory-verified-desktop-light-fold.png"
         width="100%"
         alt="Guest directory screenshot"
       />
     </td>
     <td valign="bottom" width="27%">
       <img
-        src="https://github.com/scidsg/hushline-screenshots/blob/main/releases/latest/newman/auth-newman-onboarding-profile-mobile-light-fold.png?raw=true"
+        src="https://raw.githubusercontent.com/scidsg/hushline-website/main/src/assets/img/screenshots/newman/auth-newman-onboarding-profile-mobile-light-fold.png"
         width="100%"
         alt="Onboarding screenshot"
       />
@@ -149,7 +149,7 @@ If local audit commands are blocked by network/tooling availability, document th
   </tr>
 </table>
 
-More screenshots: <https://github.com/scidsg/hushline-screenshots/tree/main/releases/latest>
+More screenshots: <https://github.com/scidsg/hushline-website/tree/main/src/assets/img/screenshots>
 
 ## In the Media
 


### PR DESCRIPTION
## What changed
- changed the docs screenshots publish step to push into `scidsg/hushline-website` instead of `scidsg/hushline-screenshots`
- syncs the captured release directory directly into `src/assets/img/screenshots/`
- switched the publish secret to `HUSHLINE_WEBSITE_SCREENSHOTS_PAT`
- updated README badge and screenshot links to point at `hushline-website`

## Why
- the workflow was still successfully publishing to the old standalone screenshots repo, while the website now reads screenshots from `hushline-website/src/assets/img/screenshots/`

## Validation
- `make workflow-security-checks`
- `make lint`
- manual workflow dispatch started on the earlier branch: https://github.com/scidsg/hushline/actions/runs/22784143079

## Manual testing
- workflow-dispatch verification is in progress separately; this PR contains the same workflow and README changes on a clean base branch

## Known risks or follow-ups
- the workflow now assumes screenshots should be synced into `scidsg/hushline-website` on `main`
- if the website repo layout changes, `WEBSITE_SCREENSHOT_ROOT` will need to be updated with it