### PR TITLE
Fix docs screenshot publishing and release tagging

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -76,11 +76,15 @@ jobs:
         run: |
           RELEASE_KEY="${{ github.event.inputs.release_key }}"
           if [ -z "$RELEASE_KEY" ] && [ "${{ github.event_name }}" = "workflow_run" ]; then
-            RELEASE_KEY="${{ github.event.workflow_run.head_branch }}"
+            RELEASE_KEY="$(python3 -c 'import json, os; print(json.load(open(os.environ["GITHUB_EVENT_PATH"], encoding="utf-8"))["workflow_run"]["head_branch"])')"
           fi
           if [ -z "$RELEASE_KEY" ]; then
             VERSION=$(cut -d'"' -f2 hushline/version.py)
             RELEASE_KEY="v$VERSION"
+          fi
+          if [[ ! "$RELEASE_KEY" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "::error title=Invalid release key::Expected release key to match vX.Y.Z, got $RELEASE_KEY"
+            exit 1
           fi
           echo "release_key=$RELEASE_KEY" >> "$GITHUB_OUTPUT"
 


### PR DESCRIPTION
## What changed
- publish docs screenshots to `scidsg/hushline-website` instead of the old standalone screenshots repo
- sync captured screenshots into `src/assets/img/screenshots/`
- use `HUSHLINE_WEBSITE_SCREENSHOTS_PAT` for website publishing
- fix release-triggered screenshot runs to use the triggering release run tag/SHA instead of reading `main`'s current `hushline/version.py`
- update README screenshot badge and example links to point at `hushline-website`

## Why
- the workflow was still publishing to `scidsg/hushline-screenshots`, while the website expects assets in `scidsg/hushline-website`
- release-triggered screenshot runs were labeling captures from `main` (for example `v0.5.102`) instead of the actual release container tag (for example `v0.5.101`)

## Validation
- `make workflow-security-checks`
- `make lint`
- manual docs-screenshots workflow dispatch started for website publish verification: https://github.com/scidsg/hushline/actions/runs/22784143079

## Manual testing
- workflow-dispatch verification is in progress separately for the updated publish path

## Known risks or follow-ups
- the workflow now assumes screenshots publish directly to `scidsg/hushline-website` on `main`
- if the website screenshot asset path changes, `WEBSITE_SCREENSHOT_ROOT` must change with it