### PR TITLE
Run release screenshots from build-release instead of workflow_run

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,5 +1,6 @@
 name: Build release container image
 permissions:
+  actions: read
   contents: read
   packages: write
 
@@ -54,3 +55,17 @@ jobs:
           cache-to: |
             type=gha,mode=max
             type=registry,ref=ghcr.io/${{ github.repository }}/hushline:buildcache,mode=max
+
+  capture-docs-screenshots:
+    needs: build-and-push
+    uses: ./.github/workflows/docs-screenshots.yml
+    with:
+      release_key: ${{ github.ref_name }}
+      release_ref: ${{ github.sha }}
+
+  publish-docs-screenshots:
+    needs: capture-docs-screenshots
+    uses: ./.github/workflows/publish-docs-screenshots.yml
+    with:
+      source_run_id: ${{ github.run_id }}
+    secrets: inherit

--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -1,13 +1,26 @@
 name: Docs Screenshots
 
 on:
-  workflow_run:
-    workflows: ["Build release container image"]
-    types: [completed]
+  workflow_call:
+    inputs:
+      release_key:
+        description: "Release key (optional, e.g. v0.5.53). Leave blank to auto-detect from tags or version.py."
+        required: false
+        default: ""
+        type: string
+      release_ref:
+        description: "Git ref or SHA to capture (optional). Leave blank to use the current workflow ref."
+        required: false
+        default: ""
+        type: string
   workflow_dispatch:
     inputs:
       release_key:
-        description: "Release key (optional, e.g. v0.5.53). Leave blank to auto-use version."
+        description: "Release key (optional, e.g. v0.5.53). Leave blank to auto-detect from tags or version.py."
+        required: false
+        default: ""
+      release_ref:
+        description: "Git ref or SHA to capture (optional). Leave blank to use the current workflow ref."
         required: false
         default: ""
 
@@ -16,19 +29,11 @@ permissions:
 
 jobs:
   capture:
-    if: >-
-      ${{
-        github.event_name != 'workflow_run' ||
-        (
-          github.event.workflow_run.conclusion == 'success' &&
-          github.event.workflow_run.event == 'push'
-        )
-      }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_sha || github.sha }}
+          ref: ${{ inputs.release_ref != '' && inputs.release_ref || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -83,13 +88,9 @@ jobs:
         if: steps.manifest.outputs.enabled == 'true'
         run: |
           set -euo pipefail
-          RELEASE_KEY="${{ github.event.inputs.release_key }}"
-          if [ -z "$RELEASE_KEY" ] && [ "${GITHUB_EVENT_NAME}" = "workflow_run" ]; then
+          RELEASE_KEY="${{ inputs.release_key }}"
+          if [ -z "$RELEASE_KEY" ]; then
             RELEASE_KEY="$(git tag --points-at HEAD | rg '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"
-            if [ -z "$RELEASE_KEY" ]; then
-              echo "::error title=Missing release tag::No release tag matching vX.Y.Z points at ${GITHUB_SHA}."
-              exit 1
-            fi
           fi
           if [ -z "$RELEASE_KEY" ]; then
             VERSION=$(cut -d'"' -f2 hushline/version.py)

--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -1,9 +1,21 @@
 name: Publish docs screenshots
 
 on:
-  workflow_run:
-    workflows: ["Docs Screenshots"]
-    types: [completed]
+  workflow_call:
+    inputs:
+      source_run_id:
+        description: "GitHub Actions run ID that owns the docs screenshot artifact."
+        required: true
+        type: string
+    secrets:
+      HUSHLINE_WEBSITE_SCREENSHOTS_PAT:
+        required: false
+  workflow_dispatch:
+    inputs:
+      source_run_id:
+        description: "GitHub Actions run ID that owns the docs screenshot artifact."
+        required: true
+        default: ""
 
 permissions:
   actions: read
@@ -11,21 +23,13 @@ permissions:
 
 jobs:
   publish:
-    if: >-
-      ${{
-        github.event.workflow_run.conclusion == 'success' &&
-        (
-          github.event.workflow_run.event == 'workflow_run' ||
-          github.event.workflow_run.event == 'workflow_dispatch'
-        )
-      }}
     runs-on: ubuntu-latest
     steps:
       - name: Download screenshot artifact
         id: artifact
         env:
           GH_TOKEN: ${{ github.token }}
-          RUN_ID: ${{ github.event.workflow_run.id }}
+          RUN_ID: ${{ inputs.source_run_id }}
         run: |
           set -euo pipefail
           ARTIFACT_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/artifacts")"

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,4 +40,4 @@ Automated follow-on release actions:
 
 - `.github/workflows/bump-staging-after-release.yml` opens or updates a PR in `scidsg/hushline-infra` so staging tracks the released image tag.
 - `.github/workflows/bump-personal-server-after-release.yml` opens or updates a PR in `scidsg/hushline-personal-server` so the package version and bundled app image track the released image tag.
-- `.github/workflows/docs-screenshots.yml` captures release screenshots after `build-release.yml` succeeds, and `.github/workflows/publish-docs-screenshots.yml` separately syncs the artifact into `scidsg/hushline-website` with the website PAT.
+- `build-release.yml` now calls `.github/workflows/docs-screenshots.yml` after the release image push succeeds, then calls `.github/workflows/publish-docs-screenshots.yml` to sync the artifact into `scidsg/hushline-website` with the website PAT.

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -26,7 +26,6 @@ make docs-screenshots RELEASE=v0.5.53
 
 Release automation note:
 
-- `.github/workflows/docs-screenshots.yml` captures screenshots after `Build release container image` succeeds for a release tag and uploads an artifact.
-- `.github/workflows/publish-docs-screenshots.yml` is the only workflow that uses
-  `HUSHLINE_WEBSITE_SCREENSHOTS_PAT`; it downloads that artifact and syncs the latest screenshots
-  into `scidsg/hushline-website`.
+- `build-release.yml` now calls `.github/workflows/docs-screenshots.yml` after the release image push succeeds for a tag.
+- `.github/workflows/docs-screenshots.yml` captures screenshots and uploads an artifact without using the website PAT.
+- `build-release.yml` then calls `.github/workflows/publish-docs-screenshots.yml`, which is the only workflow that uses `HUSHLINE_WEBSITE_SCREENSHOTS_PAT` and syncs the latest screenshots into `scidsg/hushline-website`.


### PR DESCRIPTION
Replacement for #1532 with the same code on a fresh branch from current `main`.

## What changed
- moved release screenshot automation off `workflow_run`
- updated `build-release.yml` to call `.github/workflows/docs-screenshots.yml` after the release image push succeeds
- updated `build-release.yml` to call `.github/workflows/publish-docs-screenshots.yml` after screenshot capture succeeds
- converted both screenshot workflows to reusable/manual workflows driven by explicit inputs instead of `workflow_run`
- updated architecture and screenshot docs to describe the new release path

## Why it changed
- the previous fix closed code scanning alerts `#98-#100`, but CodeQL then opened new cache-poisoning alerts `#101-#103`
- those new alerts are caused by running screenshot capture in a `workflow_run` context on the default branch
- moving capture/publish under the trusted tag-push `build-release.yml` path preserves the original intent: screenshots only run after the release container build succeeds

## Validation
- `make workflow-security-checks`
- `make lint`
- `make test`

## Notes
- same code as #1532, reapplied onto a fresh branch because GitHub reported #1532 as conflicting despite the branch graph being clean locally