### PR TITLE
Keep docs screenshots aligned with releases

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.release_ref != '' && inputs.release_ref || github.sha }}
+          ref: ${{ inputs.release_ref != '' && inputs.release_ref || inputs.release_key != '' && inputs.release_key || github.sha }}
           fetch-depth: 0
           persist-credentials: false
 
@@ -118,15 +118,27 @@ jobs:
           RELEASE_KEY: ${{ steps.vars.outputs.release_key }}
         run: |
           set -euo pipefail
-          SRC_ROOT="docs/screenshots/releases/${RELEASE_KEY}"
-          if [ ! -d "$SRC_ROOT" ]; then
-            echo "Expected screenshot source directory not found: $SRC_ROOT"
+          RELEASE_ROOT="docs/screenshots/releases/${RELEASE_KEY}"
+          LATEST_ROOT="docs/screenshots/releases/latest"
+          ROOT_README="docs/screenshots/README.md"
+          if [ ! -d "$RELEASE_ROOT" ]; then
+            echo "Expected screenshot source directory not found: $RELEASE_ROOT"
+            exit 1
+          fi
+          if [ ! -d "$LATEST_ROOT" ]; then
+            echo "Expected latest screenshot directory not found: $LATEST_ROOT"
+            exit 1
+          fi
+          if [ ! -f "$ROOT_README" ]; then
+            echo "Expected root screenshot README not found: $ROOT_README"
             exit 1
           fi
 
           ARTIFACT_ROOT="$(mktemp -d)"
-          mkdir -p "${ARTIFACT_ROOT}/screenshots"
-          cp -R "$SRC_ROOT" "${ARTIFACT_ROOT}/screenshots/${RELEASE_KEY}"
+          mkdir -p "${ARTIFACT_ROOT}/screenshots/releases"
+          cp -R "$RELEASE_ROOT" "${ARTIFACT_ROOT}/screenshots/releases/${RELEASE_KEY}"
+          cp -R "$LATEST_ROOT" "${ARTIFACT_ROOT}/screenshots/releases/latest"
+          cp "$ROOT_README" "${ARTIFACT_ROOT}/screenshots/README.md"
           printf '%s\n' "$RELEASE_KEY" > "${ARTIFACT_ROOT}/release_key.txt"
           echo "artifact_root=$ARTIFACT_ROOT" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -66,17 +66,30 @@ jobs:
           RELEASE_KEY="$(tr -d '\r\n' < "${ARTIFACT_DIR}/release_key.txt")"
           RELEASE_KEY="$RELEASE_KEY" python -c 'import os, re, sys; release_key = os.environ["RELEASE_KEY"].strip(); re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", release_key) or sys.exit(f"Unexpected docs screenshot release key: {release_key!r}")'
 
-          SRC_ROOT="${ARTIFACT_DIR}/screenshots/${RELEASE_KEY}"
-          if [ ! -d "$SRC_ROOT" ]; then
-            echo "Expected screenshot source directory not found: $SRC_ROOT"
+          RELEASE_ROOT="${ARTIFACT_DIR}/screenshots/releases/${RELEASE_KEY}"
+          LATEST_ROOT="${ARTIFACT_DIR}/screenshots/releases/latest"
+          ROOT_README="${ARTIFACT_DIR}/screenshots/README.md"
+          if [ ! -d "$RELEASE_ROOT" ]; then
+            echo "Expected screenshot source directory not found: $RELEASE_ROOT"
+            exit 1
+          fi
+          if [ ! -d "$LATEST_ROOT" ]; then
+            echo "Expected latest screenshot directory not found: $LATEST_ROOT"
+            exit 1
+          fi
+          if [ ! -f "$ROOT_README" ]; then
+            echo "Expected screenshot README not found: $ROOT_README"
             exit 1
           fi
 
           git clone "https://x-access-token:${WEBSITE_PUSH_TOKEN}@github.com/${WEBSITE_REPOSITORY}.git" /tmp/hushline-website
           cd /tmp/hushline-website
 
-          mkdir -p "${WEBSITE_SCREENSHOT_ROOT}"
-          rsync -a --delete "${SRC_ROOT}/" "${WEBSITE_SCREENSHOT_ROOT}/"
+          mkdir -p "${WEBSITE_SCREENSHOT_ROOT}/releases/${RELEASE_KEY}" "${WEBSITE_SCREENSHOT_ROOT}/releases/latest"
+          rsync -a --delete --exclude 'releases/' "${LATEST_ROOT}/" "${WEBSITE_SCREENSHOT_ROOT}/"
+          rsync -a --delete "${RELEASE_ROOT}/" "${WEBSITE_SCREENSHOT_ROOT}/releases/${RELEASE_KEY}/"
+          rsync -a --delete "${LATEST_ROOT}/" "${WEBSITE_SCREENSHOT_ROOT}/releases/latest/"
+          cp "${ROOT_README}" "${WEBSITE_SCREENSHOT_ROOT}/README.md"
 
           cat > badge-docs-screenshots.json <<EOF
           {"schemaVersion":1,"label":"docs screenshots","message":"${RELEASE_KEY}","color":"blue"}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -40,4 +40,4 @@ Automated follow-on release actions:
 
 - `.github/workflows/bump-staging-after-release.yml` opens or updates a PR in `scidsg/hushline-infra` so staging tracks the released image tag.
 - `.github/workflows/bump-personal-server-after-release.yml` opens or updates a PR in `scidsg/hushline-personal-server` so the package version and bundled app image track the released image tag.
-- `build-release.yml` now calls `.github/workflows/docs-screenshots.yml` after the release image push succeeds, then calls `.github/workflows/publish-docs-screenshots.yml` to sync the artifact into `scidsg/hushline-website` with the website PAT.
+- `build-release.yml` now calls `.github/workflows/docs-screenshots.yml` after the release image push succeeds, then calls `.github/workflows/publish-docs-screenshots.yml` to sync the artifact into `scidsg/hushline-website` with the website PAT. The website repo keeps the latest screenshots at `src/assets/img/screenshots/` and archives `src/assets/img/screenshots/releases/latest/` plus `src/assets/img/screenshots/releases/vX.Y.Z/`.

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -27,5 +27,6 @@ make docs-screenshots RELEASE=v0.5.53
 Release automation note:
 
 - `build-release.yml` now calls `.github/workflows/docs-screenshots.yml` after the release image push succeeds for a tag.
-- `.github/workflows/docs-screenshots.yml` captures screenshots and uploads an artifact without using the website PAT.
-- `build-release.yml` then calls `.github/workflows/publish-docs-screenshots.yml`, which is the only workflow that uses `HUSHLINE_WEBSITE_SCREENSHOTS_PAT` and syncs the latest screenshots into `scidsg/hushline-website`.
+- `.github/workflows/docs-screenshots.yml` captures screenshots from the tagged release commit and uploads both `releases/<version>/` and `releases/latest/` in an artifact without using the website PAT.
+- Manual `Docs Screenshots` runs now treat `release_key` as the checkout ref when `release_ref` is omitted, so backfills follow the requested release tag instead of `main`.
+- `build-release.yml` then calls `.github/workflows/publish-docs-screenshots.yml`, which is the only workflow that uses `HUSHLINE_WEBSITE_SCREENSHOTS_PAT` and syncs the latest screenshots plus the `releases/latest/` and `releases/<version>/` archives into `scidsg/hushline-website`.


### PR DESCRIPTION
## What changed
- make manual `Docs Screenshots` runs default to checking out `release_key` when `release_ref` is omitted
- package both `docs/screenshots/releases/<version>/`, `docs/screenshots/releases/latest/`, and the root screenshots README into the publish artifact
- publish the website screenshots in three synchronized views:
  - `src/assets/img/screenshots/` for the current latest set used by the site
  - `src/assets/img/screenshots/releases/latest/` as an explicit latest alias
  - `src/assets/img/screenshots/releases/vX.Y.Z/` as a per-release archive
- update screenshot automation docs and release architecture notes to match the actual publish layout

## Why it changed
Release-triggered screenshot runs were tied to the right tag, but the publish step only flattened one release directory into the website root. That left no persistent `latest` alias in `hushline-website`, and manual backfills could still label a run as `v0.5.101` while capturing `main` if only `release_key` was set. This change makes the checkout and publish paths follow the requested release consistently.

## Validation
- `git diff --check`
- `make workflow-security-checks`
- `make lint`
- `make test`

## Manual testing
- Not run end-to-end against a real release tag in GitHub Actions from this branch.
- Reviewed the reusable workflow inputs and artifact layout locally to confirm that:
  - release-triggered runs still pass `release_key` and `release_ref` from `build-release.yml`
  - manual runs with only `release_key` now check out the matching tag
  - website publish preserves `releases/` while refreshing the root latest screenshots

## Risks / follow-ups
- This does not backfill older missing `releases/latest/` directories in `hushline-website`; the next successful publish run will populate the new layout.
- If you want, I can manually dispatch the fixed workflows against `v0.5.101` after this PR is up to verify the website repo contents directly.
