### PR TITLE
Run public record link checks asynchronously

### DIFF
--- a/.github/workflows/public-record-link-check.yml
+++ b/.github/workflows/public-record-link-check.yml
@@ -5,17 +5,8 @@ permissions:
 
 on:
   workflow_dispatch:
-  pull_request:
-    branches:
-      - main
-    paths:
-      - "hushline/data/public_record_law_firms.json"
-      - "hushline/public_record_refresh.py"
-      - "scripts/refresh_public_record_law_firms.py"
-      - "tests/test_directory.py"
-      - "Makefile"
-      - ".github/workflows/public-record-link-check.yml"
-      - ".github/workflows/public-record-weekly-refresh.yml"
+  schedule:
+    - cron: "0 15 * * 1"
 
 jobs:
   public-record-links:


### PR DESCRIPTION
## What changed
- removed the `pull_request` trigger from `.github/workflows/public-record-link-check.yml`
- kept `workflow_dispatch`
- added a weekly scheduled run so the live external link check still runs automatically

## Why it changed
Live external link validation is asynchronous operational hygiene, not a per-PR signal. Running it on PRs turns third-party link volatility into merge noise without improving review quality.

## Validation
- `git diff --check`
- `make workflow-security-checks`
- `make lint`
- `make test`

## Manual testing
- Not run manually in GitHub Actions.
- Verified the workflow now only supports manual dispatch plus a weekly schedule.

## Risks / follow-ups
- The link-check badge will now update on the weekly schedule instead of on PR activity.
