### PR TITLE
Match attorney detail badges to directory

### DIFF
--- a/hushline/templates/directory_public_record.html
+++ b/hushline/templates/directory_public_record.html
@@ -6,7 +6,7 @@
   <h2 class="submit">{{ listing.name }}</h2>
 
   <div class="badgeContainer">
-    <span class="badge" role="img" aria-label="Public record listing">🏛️ Public Record</span>
+    <span class="badge" role="img" aria-label="Attorney listing">⚖️ Attorney</span>
     <span class="badge" role="img" aria-label="Automated listing">🤖 Automated</span>
   </div>
 

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -464,8 +464,9 @@ def test_public_record_listing_page_is_read_only(client: FlaskClient) -> None:
     assert response.status_code == 200
     soup = BeautifulSoup(response.text, "html.parser")
     page_text = soup.get_text(" ", strip=True)
-    assert "🏛️ Public Record" in page_text
-    assert "🤖 Automated" in page_text
+    assert soup.select_one('span.badge[aria-label="Attorney listing"]') is not None
+    assert soup.select_one('span.badge[aria-label="Automated listing"]') is not None
+    assert "🏛️ Public Record" not in page_text
     assert listing.description in page_text
     assert listing.website in response.text
     assert "Source" in page_text


### PR DESCRIPTION
## What changed
- replace the attorney profile page `Public Record` badge with `Attorney`
- keep the `Automated` badge on attorney profile pages so detail pages match the directory `All` tab
- update the profile-page test coverage to lock in the new badge copy

## Why
- the merged directory listing change updated attorney cards, but the attorney detail drill-down still used the old `Public Record` badge
- this follow-up keeps the profile page consistent with the rest of the directory

## Validation
- `git diff --check`
- `make lint`
- `make test`

## Manual testing
- not applicable; template/test-only copy alignment

## Risks / follow-ups
- none beyond standard CI confirmation