### PR TITLE
Pin workflow actions to full SHAs

### DIFF
--- a/.github/workflows/build-latest.yml
+++ b/.github/workflows/build-latest.yml
@@ -13,22 +13,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to DockerHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           file: ./Dockerfile.prod

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Make sure the version string matches the tag
         run: |
           HUSHLINE_VERSION=$(cut -d'"' -f2 hushline/version.py)
@@ -24,20 +24,20 @@ jobs:
             exit 1
           fi
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Log in to DockerHub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25
         with:
           context: .
           file: ./Dockerfile.prod

--- a/.github/workflows/bump-personal-server-after-release.yml
+++ b/.github/workflows/bump-personal-server-after-release.yml
@@ -27,10 +27,10 @@ jobs:
       PERSONAL_SERVER_COMPOSE_FILE: hushline-personal-server/var/lib/hushline/docker-compose.yaml
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -55,7 +55,7 @@ jobs:
           exit 1
 
       - name: Check out hushline-personal-server
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: ${{ env.PERSONAL_SERVER_REPOSITORY }}
           ref: ${{ env.PERSONAL_SERVER_BASE_REF }}

--- a/.github/workflows/bump-staging-after-release.yml
+++ b/.github/workflows/bump-staging-after-release.yml
@@ -25,10 +25,10 @@ jobs:
       INFRA_FILE: hushline-env/hushline.tf
     steps:
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -53,7 +53,7 @@ jobs:
           exit 1
 
       - name: Check out hushline-infra
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: ${{ env.INFRA_REPOSITORY }}
           ref: ${{ env.INFRA_BASE_REF }}

--- a/.github/workflows/ccpa-compliance.yml
+++ b/.github/workflows/ccpa-compliance.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run CCPA compliance evidence tests
         run: |
           make test \

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout terraform
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: ${{ env.HUSHLINE_INFRA_REPO }}
           ref: ${{ env.HUSHLINE_INFRA_REF }}
@@ -82,7 +82,7 @@ jobs:
           fi
 
       - name: Plan test infrastrucutre
-        uses: dflook/terraform-plan@v1.43.0
+        uses: dflook/terraform-plan@d9df4f6c2484e709ba7ffaa16c98a6906f4760cd
         with:
           path: ${{ env.DEV_TF_PATH }}
           workspace: ${{ env.WORKSPACE_NAME }}
@@ -92,7 +92,7 @@ jobs:
             name = "${{ env.DO_APP_NAME }}"
 
       - name: Apply test infrastrucutre
-        uses: dflook/terraform-apply@v1.43.0
+        uses: dflook/terraform-apply@dcda97d729f1843ede471d2fac989cb946f5622a
         with:
           path: ${{ env.DEV_TF_PATH }}
           workspace: ${{ env.WORKSPACE_NAME }}
@@ -101,14 +101,14 @@ jobs:
             name = "${{ env.DO_APP_NAME }}"
 
       - name: terraform output
-        uses: dflook/terraform-output@v1.43.0
+        uses: dflook/terraform-output@115959bea4cc9e0ccc7a7fa0a85528cef1ec4350
         id: tf-outputs
         with:
           path: ${{ env.DEV_TF_PATH }}
           workspace: ${{ env.WORKSPACE_NAME }}
 
       - name: comment app url
-        uses: actions/github-script@v7.0.1
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
             github.rest.issues.createComment({
@@ -123,7 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: checkout terraform
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         if: contains(github.event.pull_request.labels.*.name, 'deploy')
         with:
           repository: ${{ env.HUSHLINE_INFRA_REPO }}
@@ -131,7 +131,7 @@ jobs:
           token: ${{ secrets.HUSHLINE_INFRA_TOKEN }}
 
       - name: destroy worspace
-        uses: dflook/terraform-destroy-workspace@v1.43.0
+        uses: dflook/terraform-destroy-workspace@371a74d6159f2dd763b43e9c421707d3d6d5d151
         if: contains(github.event.pull_request.labels.*.name, 'deploy')
         id: first_try
         continue-on-error: true
@@ -143,7 +143,7 @@ jobs:
             name = "${{ env.DO_APP_NAME }}"
 
       - name: retry destroy worspace
-        uses: dflook/terraform-destroy-workspace@v1.43.0
+        uses: dflook/terraform-destroy-workspace@371a74d6159f2dd763b43e9c421707d3d6d5d151
         if: ${{ steps.first_try.outputs.failure-reason == 'destroy-failed' }}
         with:
           path: ${{ env.DEV_TF_PATH }}
@@ -153,7 +153,7 @@ jobs:
             name = "${{ env.DO_APP_NAME }}"
 
       - name: remove deploy label
-        uses: actions-ecosystem/action-remove-labels@v1.3.0
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
         if: contains(github.event.pull_request.labels.*.name, 'deploy')
         with:
           github_token: ${{ github.token }}
@@ -161,7 +161,7 @@ jobs:
             deploy
 
       - name: remove destroy label
-        uses: actions-ecosystem/action-remove-labels@v1.3.0
+        uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0
         if: contains(github.event.pull_request.labels.*.name, 'destroy')
         with:
           github_token: ${{ github.token }}

--- a/.github/workflows/docs-screenshots-after-release.yml
+++ b/.github/workflows/docs-screenshots-after-release.yml
@@ -45,10 +45,10 @@ jobs:
           echo "release_tag=$RELEASE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -31,7 +31,7 @@ jobs:
   capture:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ inputs.release_ref != '' && inputs.release_ref || inputs.release_key != '' && inputs.release_key || github.sha }}
           fetch-depth: 0
@@ -47,7 +47,7 @@ jobs:
             echo "Skipping docs screenshots: docs/screenshots/scenes.json not found."
           fi
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         if: steps.manifest.outputs.enabled == 'true'
         with:
           node-version: 20
@@ -144,7 +144,7 @@ jobs:
 
       - name: Upload screenshot artifacts
         if: steps.manifest.outputs.enabled == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: docs-screenshots-${{ steps.vars.outputs.release_key }}
           path: ${{ steps.artifact.outputs.artifact_root }}

--- a/.github/workflows/gdpr-compliance.yml
+++ b/.github/workflows/gdpr-compliance.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
       - name: Run GDPR compliance evidence tests
         run: |
           make test \

--- a/.github/workflows/lighthouse-performance.yml
+++ b/.github/workflows/lighthouse-performance.yml
@@ -32,7 +32,7 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Start app
         run: |

--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -12,7 +12,7 @@ jobs:
   lighthouse:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Start app
         run: |

--- a/.github/workflows/public-directory-weekly-report.yml
+++ b/.github/workflows/public-directory-weekly-report.yml
@@ -24,7 +24,7 @@ jobs:
     env:
       DIRECTORY_URL: ${{ inputs.directory_url != '' && inputs.directory_url || 'https://tips.hushline.app/directory/users.json' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           persist-credentials: false
 
@@ -34,7 +34,7 @@ jobs:
           curl -fsSL "$DIRECTORY_URL" --output /tmp/public-directory-current.json
 
       - name: Check out hushline-stats
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           repository: scidsg/hushline-stats
           token: ${{ secrets.HUSHLINE_WEEKLY_REPORT }}

--- a/.github/workflows/public-record-link-check.yml
+++ b/.github/workflows/public-record-link-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Validate live public record links
         run: make test-public-record-links

--- a/.github/workflows/public-record-weekly-refresh.yml
+++ b/.github/workflows/public-record-weekly-refresh.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Refresh public-record listings
         run: |
@@ -49,7 +49,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create or update refresh PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
         with:
           branch: bot/public-record-weekly-refresh
           delete-branch: true

--- a/.github/workflows/securedrop-directory-refresh.yml
+++ b/.github/workflows/securedrop-directory-refresh.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Refresh SecureDrop directory listings
         run: |
@@ -48,7 +48,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create or update refresh PR
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
         with:
           branch: bot/securedrop-directory-refresh
           delete-branch: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,12 +15,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Install Poetry
         run: pipx install poetry
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: "3.12"
           cache: "poetry"
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Test
         run: make test PYTEST_ADDOPTS="--skip-local-only"
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Test with alembic
         run: make test

--- a/.github/workflows/w3c-validators.yml
+++ b/.github/workflows/w3c-validators.yml
@@ -12,7 +12,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Start app
         run: |


### PR DESCRIPTION
## What changed
- pinned every third-party GitHub Action in `.github/workflows/` to a full commit SHA
- covered the currently active `actions/*`, `docker/*`, `dflook/*`, `peter-evans/*`, and `actions-ecosystem/*` references
- left already-pinned workflow actions unchanged

## Why it changed
- this is the prerequisite for enabling GitHub's SHA pinning requirement safely
- it reduces supply-chain risk from mutable action tags like `@v4` or `@v7`
- it aligns the workflow set with the stricter repo-level Actions posture now on `main`

## Validation
- `make workflow-security-checks`
- `make lint`
- `make test`

## Manual testing
- Not applicable; this change only pins workflow action references and does not alter product behavior.

## Risks / follow-ups
- follow-up repo setting: enable GitHub Actions SHA pinning requirement after this lands
- follow-up review: consider narrowing `allowed_actions` after the pinned set is stable
