### PR TITLE
Fix manual docs screenshots workflow permissions

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -25,6 +25,7 @@ on:
         default: ""
 
 permissions:
+  actions: read
   contents: read
 
 jobs:


### PR DESCRIPTION
## What changed
- added `actions: read` to the top-level permissions block in `.github/workflows/docs-screenshots.yml`

## Why it changed
- manual `Docs Screenshots` runs were failing at workflow startup
- GitHub reported: `The workflow is requesting 'actions: read', but is only allowed 'actions: none'`
- the parent workflow calls `publish-docs-screenshots.yml`, and the child workflow needs `actions: read` to fetch artifacts via the Actions API

## Validation
- `make workflow-security-checks`
- `make lint`
- `make test`

## Manual testing
- Not run end-to-end in this branch. The failure mode was diagnosed from the startup error on run `#92` and fixed at workflow permission level.

## Risks / follow-ups
- rerun the manual `Docs Screenshots` workflow after merge to confirm capture and publish both start normally
