### PR TITLE
Reuse screenshots automation branch without force-push

### DIFF
--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -195,7 +195,11 @@ jobs:
 
           git clone "https://x-access-token:${SCREENSHOTS_PUSH_TOKEN}@github.com/${SCREENSHOTS_REPOSITORY}.git" /tmp/hushline-screenshots
           cd /tmp/hushline-screenshots
-          git checkout -B "${SCREENSHOTS_BRANCH}" "origin/${SCREENSHOTS_DEFAULT_BRANCH}"
+          if git ls-remote --exit-code --heads origin "${SCREENSHOTS_BRANCH}" >/dev/null 2>&1; then
+            git checkout -B "${SCREENSHOTS_BRANCH}" "origin/${SCREENSHOTS_BRANCH}"
+          else
+            git checkout -B "${SCREENSHOTS_BRANCH}" "origin/${SCREENSHOTS_DEFAULT_BRANCH}"
+          fi
 
           mkdir -p "releases/${RELEASE_KEY}" "releases/latest"
           rsync -a --delete "${RELEASE_ROOT}/" "releases/${RELEASE_KEY}/"
@@ -215,7 +219,7 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git commit -m "Update screenshot archive for ${RELEASE_KEY}"
-          git push --force-with-lease origin "HEAD:${SCREENSHOTS_BRANCH}"
+          git push origin "HEAD:${SCREENSHOTS_BRANCH}"
 
           pr_title="Update screenshot archive for ${RELEASE_KEY}"
           pr_body="$(cat <<EOF


### PR DESCRIPTION
## What changed
- when publishing to `scidsg/hushline-screenshots`, reuse the existing `automation/docs-screenshots` branch if it already exists
- push normally instead of using `--force-with-lease`

## Why it changed
- the latest `Docs Screenshots` failure was not a PAT problem anymore
- the publish job successfully pushed once, then later reruns failed because `hushline-screenshots` blocks force-pushes on `automation/docs-screenshots`
- reruns should update the existing automation branch, not try to force-rewrite it

## Validation
- `make workflow-security-checks`
- `make lint`
- `make test`

## Manual testing
- not run end-to-end against GitHub Actions from this branch
- expected behavior after merge: reruns can update the existing screenshots automation branch and continue to PR creation/merge

## Known risks / follow-ups
- if a stale remote branch already exists with unexpected content, the workflow now builds on that branch instead of force-resetting it
- if needed, the next operational cleanup is to inspect or merge the existing `automation/docs-screenshots` branch in `scidsg/hushline-screenshots`