### PR TITLE
fix: avoid empty failure-signature runner aborts

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -907,7 +907,7 @@ failure_signature_from_text() {
   local text="$1"
 
   {
-    printf '%s\n' "$text" | grep -E 'FAILED tests/|AssertionError:|sqlalchemy\.exc\.|psycopg\.errors\.|Traceback|Error:'
+    printf '%s\n' "$text" | grep -E 'FAILED tests/|AssertionError:|sqlalchemy\.exc\.|psycopg\.errors\.|Traceback|Error:' || true
   } | head -n 20
 }
 
@@ -1097,6 +1097,7 @@ build_issue_prompt "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY"
 
 issue_attempt=1
 PREVIOUS_FAILURE_SIGNATURE=""
+FAILURE_SIGNATURE=""
 REPEATED_FAILURE_COUNT=0
 while true; do
   echo "==> Codex issue attempt $issue_attempt"


### PR DESCRIPTION
## Summary
- Prevent the daily runner from aborting when a failed check log tail does not contain a matched failure signature.
- Initialize `FAILURE_SIGNATURE` before the self-heal loop so `set -u` never trips on an unset variable.
- Allow `failure_signature_from_text` to return an empty result cleanly when no signature lines are present.

## Why
A manual runner invocation ended with `scripts/agent_daily_issue_runner.sh: line 1146: FAILURE_SIGNATURE: unbound variable`. The self-heal path assumed the extracted signature variable always existed, but some failure tails can produce no grep matches.

## Validation
- `make lint`
- `make test`

## Manual Testing
- Reproduced the no-match shell path locally with `set -euo pipefail` and verified it now yields an empty signature instead of aborting.
- Confirmed the runner script still parses with `bash -n scripts/agent_daily_issue_runner.sh`.

## Risks / Follow-ups
- This changes only the runner self-heal bookkeeping path; it does not alter application runtime behavior.
