### PR TITLE
Lock onboarding directory opt-out behavior

### DIFF
--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -96,6 +96,32 @@ def test_onboarding_flow(client: FlaskClient, user: User) -> None:
 
 
 @pytest.mark.usefixtures("_authenticated_user")
+def test_onboarding_directory_opt_out_persists_false(client: FlaskClient, user: User) -> None:
+    user.onboarding_complete = False
+    user.primary_username.display_name = "Test User"
+    user.primary_username.bio = "Short bio"
+    user.primary_username.show_in_directory = False
+    user.pgp_key = _load_test_pgp_key()
+    user.enable_email_notifications = True
+    user.email_include_message_content = True
+    user.email_encrypt_entire_body = True
+    user.email = "test@example.com"
+    db.session.commit()
+
+    response = client.post(
+        url_for("onboarding"),
+        data={"step": "directory"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(url_for("inbox"))
+
+    db.session.refresh(user)
+    assert user.onboarding_complete is True
+    assert user.primary_username.show_in_directory is False
+
+
+@pytest.mark.usefixtures("_authenticated_user")
 def test_onboarding_skip(client: FlaskClient, user: User) -> None:
     user.onboarding_complete = False
     db.session.commit()


### PR DESCRIPTION
## Summary
- add a regression test covering the unchecked onboarding directory form submission
- verify onboarding completion persists `show_in_directory=False` when the checkbox is omitted
- keep the existing checked-path coverage intact

## Why
- addresses issue #1560
- the reported bug is not reproducible in WTForms, but this behavior was not explicitly locked by tests
- this prevents future regressions and gives a concrete basis to close the issue as not reproducible in current code

## Validation
- `make lint`
- `make test TESTS=tests/test_onboarding.py`
- `make test`

## Manual testing
- not applicable; covered by onboarding route tests

## Risks / follow-ups
- low risk; test-only change