### PR TITLE
Add workflow guard for qualified PR heads

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,6 +150,7 @@ test-migration-smoke: ## Run migration compatibility tests (CI-equivalent)
 .PHONY: workflow-security-checks
 workflow-security-checks: ## Run workflow security checks (CI-equivalent)
 	docker run --rm -v "$(PWD):/work" -w /work rhysd/actionlint:1.7.7 -color
+	python3 scripts/check_workflow_pr_head_qualification.py
 	@set -euo pipefail; \
 	PATTERN='github\.event\.(issue|pull_request|comment|review|review_comment)(\.[A-Za-z_]+)*\.(title|body)'; \
 	if rg -n --glob ".github/workflows/*.yml" --glob ".github/workflows/*.yaml" "$$PATTERN" .github/workflows; then \

--- a/scripts/check_workflow_pr_head_qualification.py
+++ b/scripts/check_workflow_pr_head_qualification.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Fail if workflow gh pr list/create commands use an unqualified --head."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+WORKFLOW_DIR = Path(".github/workflows")
+COMMAND_RE = re.compile(r"\bgh pr (list|create)\b")
+HEAD_RE = re.compile(r"--head\s+(?P<token>\"[^\"]+\"|'[^']+'|\S+)")
+
+
+def iter_command_blocks(text: str) -> list[tuple[int, str]]:
+    blocks: list[tuple[int, str]] = []
+    lines = text.splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        if not COMMAND_RE.search(line):
+            index += 1
+            continue
+
+        start = index
+        block = [line]
+        index += 1
+        while index < len(lines):
+            previous = block[-1].rstrip()
+            current = lines[index]
+            stripped = current.lstrip()
+            if previous.endswith("\\") or stripped.startswith("--"):
+                block.append(current)
+                index += 1
+                continue
+            break
+
+        blocks.append((start + 1, "\n".join(block)))
+    return blocks
+
+
+def is_unqualified_head(command: str) -> bool:
+    if "--repo" not in command or "--head" not in command:
+        return False
+
+    match = HEAD_RE.search(command)
+    if match is None:
+        return False
+
+    token = match.group("token").strip("\"'")
+    return ":" not in token
+
+
+def main() -> int:
+    violations: list[str] = []
+    for workflow_path in sorted(WORKFLOW_DIR.glob("*.y*ml")):
+        text = workflow_path.read_text(encoding="utf-8")
+        for line_number, command in iter_command_blocks(text):
+            if is_unqualified_head(command):
+                violations.append(
+                    f"{workflow_path}:{line_number}: gh pr command with --repo "
+                    "must use owner-qualified --head",
+                )
+
+    if violations:
+        print("\n".join(violations), file=sys.stderr)
+        return 1
+
+    print("All workflow gh pr commands use owner-qualified --head values.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a workflow-security check that fails when a GitHub Actions workflow uses `gh pr list` or `gh pr create` with `--repo` but an unqualified `--head`
- keep the existing owner-qualified cross-repo PR automation fix from `main` from regressing silently

## Why

- `origin/main` already contains the direct workflow fix for issue #1557, but there was no guard preventing a future workflow from reintroducing the same ambiguous head-selection pattern

## Validation

- `python3 scripts/check_workflow_pr_head_qualification.py`
- `make workflow-security-checks`
- `make lint` in the primary worktree on the same code path before isolating this branch
- `make test TESTS="tests/test_security_headers.py"` in the primary worktree on the same code path before isolating this branch

## Manual testing

- Not applicable; this change only adds a static workflow policy check

## Known risks / follow-up

- Full `make lint` and full `make test` in this temporary worktree were blocked by local Docker port collisions with an already-running stack on `127.0.0.1:4566`; I did not tear down the existing stack to avoid disrupting local state.

Refs #1557
