### PR TITLE
Tighten audit environmental failure detection

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -205,7 +205,7 @@ lighthouse_performance_files_changed() {
 audit_failure_looks_environmental() {
   local text="$1"
   printf '%s\n' "$text" | grep -Eqi \
-    '(temporary failure in name resolution|name or service not known|could not resolve|network is unreachable|connection timed out|timed out|connection reset|connection refused|no route to host|tls|ssl|certificate|service unavailable|bad gateway|gateway timeout|read timed out|proxyerror|econnreset|enotfound|eai_again)'
+    '(temporary failure in name resolution|name or service not known|could not resolve|network is unreachable|connection timed out|timed out|connection reset|connection refused|no route to host|service unavailable|bad gateway|gateway timeout|read timed out|proxyerror|econnreset|enotfound|eai_again)'
 }
 
 auto_fix_lint_with_containerized_tooling() {

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -110,3 +110,36 @@ run_codex_from_prompt > {shlex.quote(str(run_log_file))} 2>&1
     assert "VERBOSE_TRANSCRIPT_LINE" in console_text
     assert "VERBOSE_TRANSCRIPT_LINE" not in run_log_text
     assert "Safe final summary" in run_log_text
+
+
+def test_audit_failure_environmental_classifier_matches_network_errors() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+if audit_failure_looks_environmental "pip failed: temporary failure in name resolution"; then
+  printf 'environmental\\n'
+else
+  printf 'non-environmental\\n'
+fi
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "environmental\n"
+
+
+def test_audit_failure_environmental_classifier_rejects_tls_vulnerability_text() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+audit_output="CVE-2023-1234: TLS certificate validation bypass in dependency"
+if audit_failure_looks_environmental "$audit_output"; then
+  printf 'environmental\\n'
+else
+  printf 'non-environmental\\n'
+fi
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "non-environmental\n"


### PR DESCRIPTION
## Summary

- tighten `audit_failure_looks_environmental` so dependency audit failures only downgrade on explicit network/environment transport errors
- stop treating generic `tls`, `ssl`, and `certificate` terms as environmental, since those appear in real vulnerability descriptions
- add regression tests covering both a genuine name-resolution failure and a TLS/certificate CVE-style audit message

## Why

- the daily runner could misclassify a real dependency finding as an environmental audit outage and continue with `AUDIT_STATUS="blocked"` instead of failing locally
- this change restores fail-closed behavior for vulnerability text while preserving the intended retry path for actual network problems

## Threat / risk summary

- affected path: local dependency-audit gating in `scripts/agent_daily_issue_runner.sh`
- prior risk: legitimate audit failures containing TLS/SSL/certificate language could be downgraded and missed in local automation
- mitigation: environmental classification now keys only on concrete network/transport failure phrases, with regression tests locking that behavior in

## Validation

- `make lint`
- `make test TESTS="tests/test_agent_daily_issue_runner.py"`

## Manual testing

- Not applicable; behavior is covered by automated tests against the runner shell functions

## Known risks / follow-up

- I did not run the full `make test` suite for this narrowly scoped runner change

Refs #729b8a3e150881919a64e3646a81af68
