### PR TITLE
Bound agent runner retry loops

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -28,11 +28,11 @@ This runner runs directly in the local repo and now executes the full local CI-e
    - Use `--issue <n>` when provided (must still be open), otherwise
    - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
 10. Create/update issue branch `codex/daily-issue-<issue_number>` from `main`.
-11. Run Codex issue loop until repository changes exist.
+11. Run a bounded Codex issue loop until repository changes exist (max attempts configurable via `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS`, default `10`).
     - The issue/fix prompts tell Codex to avoid local container-backed make validation by default, and to defer validation entirely to the runner when schema-affecting files are touched (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`).
     - The fix prompt also includes the current branch diff summary, the prior Codex summary, and an extracted failure signature so Codex can repair the current implementation instead of repeating a narrow patch against the same failing symptom.
     - Codex transcript output is captured in a temporary file for the duration of the run and is excluded from the persisted runner log; only the final Codex summary is written into the run log.
-12. Run required checks in a self-heal loop:
+12. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
     - Before lint/test validation, if the working tree includes schema-affecting changes (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), rebuild the local runtime and reseed dev data so the live stack matches the current code.
     - `make lint`
     - `make workflow-security-checks`
@@ -211,6 +211,8 @@ Optional forced issue:
 - `HUSHLINE_DAILY_BRANCH_PREFIX` (default `codex/daily-issue-`)
 - `HUSHLINE_DAILY_KILL_PORTS` (default `4566 4571 5432 8080`)
 - `HUSHLINE_DAILY_RUN_LOG_RETENTION` (default `10`)
+- `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS` (default `10`; positive integer)
+- `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS` (default `8`; positive integer)
 - `HUSHLINE_CODEX_MODEL` (default `gpt-5.4`)
 - `HUSHLINE_CODEX_REASONING_EFFORT` (default `high`)
 - `HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT` (default `0`; set `1` to print full Codex transcript output to the live console only, without writing it into persisted runner logs)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -19,6 +19,8 @@ PROJECT_TITLE="${HUSHLINE_DAILY_PROJECT_TITLE:-Hush Line Roadmap}"
 PROJECT_COLUMN="${HUSHLINE_DAILY_PROJECT_COLUMN:-Agent Eligible}"
 PROJECT_ITEM_LIMIT="${HUSHLINE_DAILY_PROJECT_ITEM_LIMIT:-200}"
 HOST_PORTS_TO_CLEAR="${HUSHLINE_DAILY_KILL_PORTS:-4566 4571 5432 8080}"
+MAX_ISSUE_ATTEMPTS="${HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS:-10}"
+MAX_FIX_ATTEMPTS="${HUSHLINE_DAILY_MAX_FIX_ATTEMPTS:-8}"
 
 CHECK_LOG_FILE=""
 PROMPT_FILE=""
@@ -95,6 +97,16 @@ require_cmd() {
   if ! command -v "$1" >/dev/null 2>&1; then
     echo "Missing required command: $1" >&2
     exit 1
+  fi
+}
+
+require_positive_integer() {
+  local name="$1"
+  local value="$2"
+
+  if ! [[ "$value" =~ ^[0-9]+$ ]] || (( value < 1 )); then
+    echo "${name} must be a positive integer (got '${value}')." >&2
+    return 1
   fi
 }
 
@@ -1046,6 +1058,88 @@ EOF2
   } > "$PROMPT_FILE"
 }
 
+run_fix_attempt_loop() {
+  local issue_number="$1"
+  local issue_title="$2"
+  local issue_body="$3"
+  local issue_labels="$4"
+  local branch_name="$5"
+  local fix_attempt=1
+
+  while (( fix_attempt <= MAX_FIX_ATTEMPTS )); do
+    if run_local_workflow_checks && run_test_gap_gate "$issue_title" "$issue_body" "$issue_labels"; then
+      return 0
+    fi
+
+    if (( fix_attempt == MAX_FIX_ATTEMPTS )); then
+      echo "Blocked: workflow checks failed after $MAX_FIX_ATTEMPTS self-heal attempt(s) for issue #$issue_number." >&2
+      return 1
+    fi
+
+    echo "Workflow checks failed; Codex self-heal attempt $fix_attempt."
+    FAILURE_LOG_TAIL="$(tail -n 400 "$CHECK_LOG_FILE")"
+    FAILURE_SIGNATURE="$(failure_signature_from_text "$FAILURE_LOG_TAIL")"
+    if [[ -n "$FAILURE_SIGNATURE" && "$FAILURE_SIGNATURE" == "$PREVIOUS_FAILURE_SIGNATURE" ]]; then
+      REPEATED_FAILURE_COUNT=$((REPEATED_FAILURE_COUNT + 1))
+    else
+      REPEATED_FAILURE_COUNT=1
+      PREVIOUS_FAILURE_SIGNATURE="$FAILURE_SIGNATURE"
+    fi
+    build_fix_prompt \
+      "$issue_number" \
+      "$issue_title" \
+      "$branch_name" \
+      "$FAILURE_LOG_TAIL" \
+      "$(current_change_summary)" \
+      "$(sed -n '1,80p' "$CODEX_OUTPUT_FILE")" \
+      "$FAILURE_SIGNATURE" \
+      "$REPEATED_FAILURE_COUNT"
+    run_codex_from_prompt
+    fix_attempt=$((fix_attempt + 1))
+  done
+
+  echo "Blocked: workflow checks did not pass for issue #$issue_number." >&2
+  return 1
+}
+
+run_issue_attempt_loop() {
+  local issue_number="$1"
+  local issue_title="$2"
+  local issue_body="$3"
+  local issue_labels="$4"
+  local issue_branch="$5"
+  local issue_attempt=1
+
+  PREVIOUS_FAILURE_SIGNATURE=""
+  FAILURE_SIGNATURE=""
+  REPEATED_FAILURE_COUNT=0
+
+  while (( issue_attempt <= MAX_ISSUE_ATTEMPTS )); do
+    echo "==> Codex issue attempt $issue_attempt"
+    run_codex_from_prompt
+
+    if ! has_changes; then
+      echo "Codex produced no changes for issue #$issue_number; retrying."
+      issue_attempt=$((issue_attempt + 1))
+      continue
+    fi
+
+    if ! run_fix_attempt_loop "$issue_number" "$issue_title" "$issue_body" "$issue_labels" "$issue_branch"; then
+      return 1
+    fi
+
+    if has_changes; then
+      return 0
+    fi
+
+    build_issue_prompt "$issue_number" "$issue_title" "$issue_body"
+    issue_attempt=$((issue_attempt + 1))
+  done
+
+  echo "Blocked: Codex produced no usable changes for issue #$issue_number after $MAX_ISSUE_ATTEMPTS attempt(s)." >&2
+  return 1
+}
+
 main() {
   parse_args "$@"
   initialize_run_state
@@ -1057,6 +1151,9 @@ main() {
   require_cmd docker
   require_cmd make
   require_cmd node
+
+  require_positive_integer "HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS" "$MAX_ISSUE_ATTEMPTS"
+  require_positive_integer "HUSHLINE_DAILY_MAX_FIX_ATTEMPTS" "$MAX_FIX_ATTEMPTS"
 
   if [[ ! -d "$REPO_DIR/.git" ]]; then
     echo "Repository not found: $REPO_DIR" >&2
@@ -1122,55 +1219,7 @@ main() {
   run_step "Create branch $BRANCH_NAME" git checkout -B "$BRANCH_NAME" "$BASE_BRANCH"
 
   build_issue_prompt "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY"
-
-  issue_attempt=1
-  PREVIOUS_FAILURE_SIGNATURE=""
-  FAILURE_SIGNATURE=""
-  REPEATED_FAILURE_COUNT=0
-  while true; do
-    echo "==> Codex issue attempt $issue_attempt"
-    run_codex_from_prompt
-
-    if ! has_changes; then
-      echo "Codex produced no changes for issue #$ISSUE_NUMBER; retrying."
-      issue_attempt=$((issue_attempt + 1))
-      continue
-    fi
-
-    fix_attempt=1
-    while true; do
-      if run_local_workflow_checks && run_test_gap_gate "$ISSUE_TITLE" "$ISSUE_BODY" "$ISSUE_LABELS"; then
-        break
-      fi
-      echo "Workflow checks failed; Codex self-heal attempt $fix_attempt."
-      FAILURE_LOG_TAIL="$(tail -n 400 "$CHECK_LOG_FILE")"
-      FAILURE_SIGNATURE="$(failure_signature_from_text "$FAILURE_LOG_TAIL")"
-      if [[ -n "$FAILURE_SIGNATURE" && "$FAILURE_SIGNATURE" == "$PREVIOUS_FAILURE_SIGNATURE" ]]; then
-        REPEATED_FAILURE_COUNT=$((REPEATED_FAILURE_COUNT + 1))
-      else
-        REPEATED_FAILURE_COUNT=1
-        PREVIOUS_FAILURE_SIGNATURE="$FAILURE_SIGNATURE"
-      fi
-      build_fix_prompt \
-        "$ISSUE_NUMBER" \
-        "$ISSUE_TITLE" \
-        "$BRANCH_NAME" \
-        "$FAILURE_LOG_TAIL" \
-        "$(current_change_summary)" \
-        "$(sed -n '1,80p' "$CODEX_OUTPUT_FILE")" \
-        "$FAILURE_SIGNATURE" \
-        "$REPEATED_FAILURE_COUNT"
-      run_codex_from_prompt
-      fix_attempt=$((fix_attempt + 1))
-    done
-
-    if has_changes; then
-      break
-    fi
-
-    build_issue_prompt "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY"
-    issue_attempt=$((issue_attempt + 1))
-  done
+  run_issue_attempt_loop "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY" "$ISSUE_LABELS" "$BRANCH_NAME"
 
   persist_run_log "$ISSUE_NUMBER"
 

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -143,3 +143,74 @@ fi
 
     assert result.returncode == 0, result.stderr
     assert result.stdout == "non-environmental\n"
+
+
+def test_require_positive_integer_rejects_zero() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+require_positive_integer "HUSHLINE_DAILY_MAX_FIX_ATTEMPTS" "0"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 1
+    assert "HUSHLINE_DAILY_MAX_FIX_ATTEMPTS must be a positive integer" in result.stderr
+
+
+def test_issue_attempt_loop_stops_after_max_attempts() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+MAX_ISSUE_ATTEMPTS=3
+build_issue_prompt() {{ :; }}
+run_codex_from_prompt() {{ :; }}
+has_changes() {{ return 1; }}
+run_fix_attempt_loop() {{ return 0; }}
+set +e
+run_issue_attempt_loop 1558 "Title" "Body" "" "branch"
+rc=$?
+set -e
+printf 'rc=%s\\n' "$rc"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "rc=1" in result.stdout
+    assert "Codex produced no usable changes for issue #1558 after 3 attempt(s)." in result.stderr
+
+
+def test_fix_attempt_loop_stops_after_max_attempts(tmp_path: Path) -> None:
+    check_log_file = tmp_path / "check.log"
+    codex_output_file = tmp_path / "codex-output.txt"
+    check_log_file.write_text("persistent failure\n", encoding="utf-8")
+    codex_output_file.write_text("prior summary\n", encoding="utf-8")
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+MAX_FIX_ATTEMPTS=2
+CHECK_LOG_FILE={shlex.quote(str(check_log_file))}
+CODEX_OUTPUT_FILE={shlex.quote(str(codex_output_file))}
+PREVIOUS_FAILURE_SIGNATURE=""
+FAILURE_SIGNATURE=""
+REPEATED_FAILURE_COUNT=0
+run_local_workflow_checks() {{ return 1; }}
+run_test_gap_gate() {{ return 0; }}
+failure_signature_from_text() {{ printf 'same-failure\\n'; }}
+current_change_summary() {{ printf 'summary\\n'; }}
+build_fix_prompt() {{ :; }}
+run_codex_from_prompt() {{ :; }}
+set +e
+run_fix_attempt_loop 1558 "Title" "Body" "" "branch"
+rc=$?
+set -e
+printf 'rc=%s\\n' "$rc"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "rc=1" in result.stdout
+    assert (
+        "Blocked: workflow checks failed after 2 self-heal attempt(s) for issue #1558."
+        in result.stderr
+    )


### PR DESCRIPTION
## Summary

- bound the daily agent runner issue loop with `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS` (default `10`)
- bound the self-heal loop with `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS` (default `8`)
- validate both environment variables as positive integers and fail closed when retry budgets are exhausted
- document the new retry limits and add shell-level regression tests for invalid config and exhausted retries

## Why

- the runner previously used unbounded `while true` loops for both issue generation and self-heal, so persistent no-change output or persistent check failures could hang the runner indefinitely and hold the automation lock
- bounding both loops restores predictable failure behavior and prevents the runner from wedging the pipeline on one issue

## Risk summary

- affected path: internal automation in `scripts/agent_daily_issue_runner.sh`
- prior risk: persistent failures could consume the runner indefinitely and block later scheduled runs
- mitigation: explicit retry budgets with clear terminal errors, plus tests that lock in the stop conditions

## Validation

- `make lint`
- `make test TESTS="tests/test_agent_daily_issue_runner.py"`

## Manual testing

- Not applicable; runner helper behavior is covered by automated tests

## Known risks / follow-up

- I did not run the full `make test` suite for this runner-focused change

Refs aa2e509667808191ab76749a705a0b92
