### PR TITLE
Sanitize persisted agent run logs

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -55,6 +55,7 @@ This runner runs directly in the local repo and now executes the full local CI-e
     - If local dependency audits are blocked by environment/network issues, continue with explicit PR note and require a passing `Dependency Security Audit` workflow before merge.
 13. Persist run log to `docs/agent-logs/run-<timestamp>-issue-<n>.txt`.
     - After each persist, prune older runner logs and keep only the newest `10` by default.
+    - Persisted logs are sanitized before commit to remove developer filesystem paths, emails, and Codex session metadata.
 14. Commit, push branch, and open PR:
     - first push uses a normal push when remote branch is absent
     - existing remote branch uses `--force-with-lease` with one stale-info recovery retry.

--- a/docs/agent-logs/run-20260227T231205Z-issue-1444.txt
+++ b/docs/agent-logs/run-20260227T231205Z-issue-1444.txt
@@ -3,7 +3,7 @@ Timestamp (UTC): 20260227T231205Z
 Issue: #1444
 Repository: scidsg/hushline
 
-Runner Codex config: model=gpt-5.3-codex reasoning_effort=high verbose_codex_output=0
+Runner Codex config: [redacted]
 ==> Fetch latest from origin
 ==> Checkout main
 Already on 'main'
@@ -1412,23 +1412,128 @@ Total reclaimed space: 4.203GB
 #7 8.115 Get:460 http://deb.debian.org/debian bookworm/main arm64 pkg-config arm64 1.8.1-1 [13.7 kB]
 #7 8.240 debconf: delaying package configuration, since apt-utils is not installed
 #7 8.256 Fetched 162 MB in 3s (55.8 MB/s)
-#7 8.266 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6689 files and directories currently installed.)
+#7 8.266 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6689 files and directories currently installed.)
 #7 8.271 Preparing to unpack .../perl-base_5.36.0-7+deb12u3_arm64.deb ...
 #7 8.279 Unpacking perl-base (5.36.0-7+deb12u3) over (5.36.0-7+deb12u1) ...
 #7 8.915 Setting up perl-base (5.36.0-7+deb12u3) ...
-#7 8.928 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 8.928 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 8.931 Preparing to unpack .../gcc-12-base_12.2.0-14+deb12u1_arm64.deb ...
 #7 8.935 Unpacking gcc-12-base:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 8.952 Setting up gcc-12-base:arm64 (12.2.0-14+deb12u1) ...
-#7 8.966 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 8.966 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 8.969 Preparing to unpack .../libgcc-s1_12.2.0-14+deb12u1_arm64.deb ...
 #7 8.973 Unpacking libgcc-s1:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 8.987 Setting up libgcc-s1:arm64 (12.2.0-14+deb12u1) ...
-#7 9.001 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.001 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.004 Preparing to unpack .../libstdc++6_12.2.0-14+deb12u1_arm64.deb ...
 #7 9.012 Unpacking libstdc++6:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 9.072 Setting up libstdc++6:arm64 (12.2.0-14+deb12u1) ...
-#7 9.095 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.095 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.099 Preparing to unpack .../libc6_2.36-9+deb12u13_arm64.deb ...
 #7 9.136 debconf: unable to initialize frontend: Dialog
 #7 9.136 debconf: (TERM is not set, so the dialog frontend is not usable.)
@@ -1444,12 +1549,54 @@ Total reclaimed space: 4.203GB
 #7 9.546 debconf: unable to initialize frontend: Readline
 #7 9.546 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
 #7 9.546 debconf: falling back to frontend: Teletype
-#7 10.60 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.60 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.60 Preparing to unpack .../libc-bin_2.36-9+deb12u13_arm64.deb ...
 #7 10.61 Unpacking libc-bin (2.36-9+deb12u13) over (2.36-9+deb12u8) ...
 #7 10.68 Setting up libc-bin (2.36-9+deb12u13) ...
 #7 10.70 Selecting previously unselected package perl-modules-5.36.
-#7 10.70 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.70 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.70 Preparing to unpack .../0-perl-modules-5.36_5.36.0-7+deb12u3_all.deb ...
 #7 10.71 Unpacking perl-modules-5.36 (5.36.0-7+deb12u3) ...
 #7 10.90 Selecting previously unselected package libgdbm-compat4:arm64.
@@ -1473,7 +1620,28 @@ Total reclaimed space: 4.203GB
 #7 11.47 Setting up libpython3.11-minimal:arm64 (3.11.2-6+deb12u6) ...
 #7 11.48 Setting up python3.11-minimal (3.11.2-6+deb12u6) ...
 #7 11.83 Selecting previously unselected package python3-minimal.
-#7 11.83 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9002 files and directories currently installed.)
+#7 11.83 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9002 files and directories currently installed.)
 #7 11.83 Preparing to unpack .../python3-minimal_3.11.2-1+b1_arm64.deb ...
 #7 11.83 Unpacking python3-minimal (3.11.2-1+b1) ...
 #7 11.84 Selecting previously unselected package media-types.
@@ -1483,7 +1651,28 @@ Total reclaimed space: 4.203GB
 #7 11.86 Unpacking liblzma5:arm64 (5.4.1-1) over (5.4.1-0.2) ...
 #7 11.89 Setting up liblzma5:arm64 (5.4.1-1) ...
 #7 11.90 Selecting previously unselected package libpython3.11-stdlib:arm64.
-#7 11.90 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9030 files and directories currently installed.)
+#7 11.90 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9030 files and directories currently installed.)
 #7 11.90 Preparing to unpack .../libpython3.11-stdlib_3.11.2-6+deb12u6_arm64.deb ...
 #7 11.90 Unpacking libpython3.11-stdlib:arm64 (3.11.2-6+deb12u6) ...
 #7 12.01 Selecting previously unselected package python3.11.
@@ -1494,7 +1683,28 @@ Total reclaimed space: 4.203GB
 #7 12.03 Unpacking libpython3-stdlib:arm64 (3.11.2-1+b1) ...
 #7 12.04 Setting up python3-minimal (3.11.2-1+b1) ...
 #7 12.12 Selecting previously unselected package python3.
-#7 12.12 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9412 files and directories currently installed.)
+#7 12.12 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9412 files and directories currently installed.)
 #7 12.12 Preparing to unpack .../000-python3_3.11.2-1+b1_arm64.deb ...
 #7 12.12 Unpacking python3 (3.11.2-1+b1) ...
 #7 12.14 Selecting previously unselected package bzip2.
@@ -3717,14 +3927,14 @@ Switched to a new branch 'codex/daily-issue-1444'
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.105.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.3-codex
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR]
-reasoning effort: high
-reasoning summaries: auto
-session id: 019ca161-fd78-71b2-9f91-677eebea1687
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are implementing GitHub issue #1444 in scidsg/hushline.
@@ -3774,9 +3984,9 @@ thinking
 codex
 I’m reviewing the repository guidance and the current UI structure first, then I’ll identify the smallest accessibility fix set that matches issue #1444 and wire in tests for any behavior change.
 exec
-/bin/zsh -lc "rg --files -g '"'!node_modules'"' -g '"'!vendor'"' | sed -n '1,240p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "pwd && rg --files -g 'AGENTS.md' -g '"'!node_modules'"' -g '"'!vendor'"'" in /Users/scidsg/hushline succeeded in 52ms:
-/Users/scidsg/hushline
+/bin/zsh -lc "rg --files -g '"'!node_modules'"' -g '"'!vendor'"' | sed -n '1,240p'" in [redacted-path]
+/bin/zsh -lc "pwd && rg --files -g 'AGENTS.md' -g '"'!node_modules'"' -g '"'!vendor'"'" in [redacted-path] succeeded in 52ms:
+[redacted-path]
 AGENTS.md
  succeeded in 52ms:
 SECURITY.md
@@ -3805,9 +4015,9 @@ thinking
 codex
 I’ve confirmed there isn’t a deeper `AGENTS.md` under the repository tree. Next I’m checking the existing accessibility coverage and the shared templates/scripts, because the minimal fix here is likely a small cross-cutting template/JS adjustment rather than a broad redesign.
 exec
-/bin/zsh -lc "sed -n '1,260p' tests/test_accessibility.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' hushline/templates/base.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"skip to|aria-|role=|focus|alt=|label\" hushline/templates assets/js tests -g '"'!node_modules'"'" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,260p' tests/test_accessibility.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' hushline/templates/base.html" in [redacted-path]
+/bin/zsh -lc "rg -n \"skip to|aria-|role=|focus|alt=|label\" hushline/templates assets/js tests -g '"'!node_modules'"'" in [redacted-path] succeeded in 51ms:
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
@@ -3871,7 +4081,7 @@ hushline/templates/onboarding.html:32:          {{ profile_form.bio.label }}
 hushline/templates/onboarding.html:51:        <label for="searchInput">Proton Email Search</label>
 hushline/templates/onboarding.html:56:          <span id="searchIcon" aria-hidden="true">
 exec
-/bin/zsh -lc "sed -n '261,520p' hushline/templates/base.html" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '261,520p' hushline/templates/base.html" in [redacted-path] succeeded in 51ms:
                   <span class="dropbtn-label">@{{ session['username'] }}</span>
                   <img
                     class="dropdown-icon"
@@ -3898,9 +4108,9 @@ thinking
 codex
 I’ve found a few likely a11y gaps in shared UI already: unlabeled navigation landmarks, a dialog without an accessible name, and interactive menu/modal controls that need tighter semantics. I’m reading the shared JS next so I can keep the change confined to the base layout and one test file if that’s enough.
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/templates/directory.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' assets/js/global.js" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' hushline/templates/inbox.html" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/templates/directory.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' assets/js/global.js" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' hushline/templates/inbox.html" in [redacted-path] succeeded in 52ms:
 function navController() {
   function setupDropdown() {
     const dropdownToggle = document.querySelector(".dropdown .dropbtn");
@@ -3967,9 +4177,9 @@ function navController() {
 thinking
 **Identifying unlabeled nav landmarks**
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/nav.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/tools/nav.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "<nav" hushline/templates' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/nav.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/tools/nav.html" in [redacted-path]
+/bin/zsh -lc 'rg -n "<nav" hushline/templates' in [redacted-path] succeeded in 51ms:
 {% set aliases_enabled = alias_mode == AliasMode.ALWAYS or (alias_mode == AliasMode.PREMIUM and not user.is_free_tier) %}
 
 <nav class="settings-tabs" aria-label="Settings navigation">
@@ -4014,7 +4224,7 @@ hushline/templates/settings/nav.html:3:<nav class="settings-tabs" aria-label="Se
 thinking
 **Identifying accessibility issues**
 exec
-/bin/zsh -lc "sed -n '261,520p' assets/js/global.js" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '261,520p' assets/js/global.js" in [redacted-path] succeeded in 52ms:
         }
         guidanceDiv.setAttribute(
           "aria-labelledby",
@@ -4041,9 +4251,9 @@ thinking
 codex
 The shared modal script already does some focus work, so I’m narrowing this to defects that are both real and low-risk to fix globally. I’m checking the auth/forms templates now for repeated labeling or error-state gaps that would justify a broader template helper change; otherwise I’ll keep this in the base layout plus targeted tests.
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/login.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,280p' hushline/templates/profile.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,240p' hushline/templates/register.html" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/login.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,280p' hushline/templates/profile.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,240p' hushline/templates/register.html" in [redacted-path] succeeded in 51ms:
 {% extends "base.html" %}
 {% block title %}Login{% endblock %}
 
@@ -4110,8 +4320,8 @@ exec
 thinking
 **Planning audit approach**
 exec
-/bin/zsh -lc "rg -n \"lighthouse|axe|w3c|accessibility\" tests docs scripts hushline -g '"'!node_modules'"'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' tests/test_frontend_compat.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "rg -n \"lighthouse|axe|w3c|accessibility\" tests docs scripts hushline -g '"'!node_modules'"'" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' tests/test_frontend_compat.py" in [redacted-path] succeeded in 52ms:
 docs/AGENT_RUNNER.md:44:    - `make w3c-validators`
 docs/AGENT_RUNNER.md:45:    - `make lighthouse-accessibility`
 docs/AGENT_RUNNER.md:46:    - `make lighthouse-performance` when lighthouse-performance workflow trigger paths change
@@ -4157,9 +4367,9 @@ def test_client_side_encryption_has_platform_guards() -> None:
 thinking
 **Assessing minimal accessibility fixes**
 exec
-/bin/zsh -lc 'rg -n ":focus|focus-visible|outline" assets/scss/style.scss assets/scss/settings-registration.scss' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/tools/base.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' hushline/templates/settings/base.html" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'rg -n ":focus|focus-visible|outline" assets/scss/style.scss assets/scss/settings-registration.scss' in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/tools/base.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' hushline/templates/settings/base.html" in [redacted-path] succeeded in 52ms:
 assets/scss/style.scss:107:.skip-link:focus,
 assets/scss/style.scss:108:.skip-link:focus-visible {
 assets/scss/style.scss:239:  .tab:focus-within {
@@ -4219,7 +4429,7 @@ assets/scss/style.scss:325:  input[type="file"]::file-selector-button:focus,
 thinking
 **Considering ARIA improvements**
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/templates/message.html" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/templates/message.html" in [redacted-path] succeeded in 52ms:
 {% extends "base.html" %}
 
 {% block title %}Message{% endblock %}
@@ -4244,7 +4454,7 @@ exec
 thinking
 **Assessing header tag semantics**
 exec
-/bin/zsh -lc "rg -n \"header h1|brand-wrapper|h1\" assets/scss/style.scss hushline/templates/base.html hushline/templates -g '"'!node_modules'"'" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "rg -n \"header h1|brand-wrapper|h1\" assets/scss/style.scss hushline/templates/base.html hushline/templates -g '"'!node_modules'"'" in [redacted-path] succeeded in 51ms:
 hushline/templates/base.html:205:      <div class="brand-wrapper">
 hushline/templates/base.html:213:        <h1>{{ brand_name }}</h1>
 assets/scss/style.scss:1188:h1,
@@ -4266,7 +4476,7 @@ thinking
 thinking
 **Evaluating accessibility attributes**
 exec
-/bin/zsh -lc "sed -n '1,280p' assets/js/directory_verified.js" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,280p' assets/js/directory_verified.js" in [redacted-path] succeeded in 51ms:
 document.addEventListener("DOMContentLoaded", function () {
   const userSearch = window.HushlineUserSearch;
   const pathPrefix = window.location.pathname.split("/").slice(0, -1).join("/");
@@ -4288,7 +4498,7 @@ document.addEventListener("DOMContentLoaded", function () {
       ? activeTabElement.getAttribute("data-tab")
       : "verified";
 exec
-/bin/zsh -lc "sed -n '281,420p' assets/js/directory_verified.js" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '281,420p' assets/js/directory_verified.js" in [redacted-path] succeeded in 52ms:
       requestAnimationFrame(updateStickyState);
     });
     window.addEventListener("resize", () => {
@@ -4303,7 +4513,7 @@ exec
 thinking
 **Assessing accessibility issues**
 exec
-/bin/zsh -lc "rg -n \"\\.modal|dropdown-content|flash-messages|noscript-warning\" assets/scss/style.scss" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "rg -n \"\\.modal|dropdown-content|flash-messages|noscript-warning\" assets/scss/style.scss" in [redacted-path] succeeded in 51ms:
 366:  .modal {
 370:  .modal-content {
 375:  .modal-buttons-container {
@@ -4325,7 +4535,7 @@ exec
 994:  .dropdown-content a {
 998:  .dropdown-content a:hover {
 exec
-/bin/zsh -lc "sed -n '3728,3770p' assets/scss/style.scss" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '3728,3770p' assets/scss/style.scss" in [redacted-path] succeeded in 52ms:
     transform: translateY(1.5rem);
   }
 
@@ -4350,7 +4560,7 @@ exec
 thinking
 **Assessing potential accessibility issues**
 exec
-/bin/zsh -lc "rg -n \"1444|Accessibility Compliance|Usability Review|a11y audit\" -g '"'!node_modules'"'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "rg -n \"1444|Accessibility Compliance|Usability Review|a11y audit\" -g '"'!node_modules'"'" in [redacted-path] succeeded in 52ms:
 poetry.lock:96:    {file = "aiohttp-3.13.3-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:82611aeec80eb144416956ec85b6ca45a64d76429c1ed46ae1b5f86c6e0c9a26"},
 poetry.lock:1037:    {file = "gunicorn-23.0.0.tar.gz", hash = "sha256:f014447a0101dc57e294f6c18ca6b40227a4c90e9bdb586042628030cba004ec"},
 
@@ -4362,9 +4572,9 @@ thinking
 codex
 I have a cleaner minimal scope now: fix shared landmark labeling, make the inbox filter tabs expose current state, and add a live announcement for dynamic directory search results. That covers actual user-facing accessibility gaps without touching core flows or widening the diff into form rewrites.
 exec
-/bin/zsh -lc 'rg -n "sr-only|visually-hidden|screen-reader|hidden-text" assets/scss/style.scss hushline/templates assets/js' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' assets/js/user_search.js" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' assets/js/directory.js" in /Users/scidsg/hushline exited 1 in 51ms:
+/bin/zsh -lc 'rg -n "sr-only|visually-hidden|screen-reader|hidden-text" assets/scss/style.scss hushline/templates assets/js' in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' assets/js/user_search.js" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' assets/js/directory.js" in [redacted-path] exited 1 in 51ms:
 
  succeeded in 51ms:
 document.addEventListener("DOMContentLoaded", function () {
@@ -4419,9 +4629,9 @@ I’ve settled on a minimal edit set in shared templates and directory search JS
 codex
 The template patches are straightforward; the SCSS patch missed because the selector block is in a different spot than expected. I’m locating the existing skip-link utility styles and then I’ll reapply the changes cleanly.
 exec
-/bin/zsh -lc "sed -n '80,130p' assets/scss/style.scss" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "skip-link|visually-hidden" assets/scss/style.scss' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,120p' hushline/templates/base.html && printf '\\n---\\n' && sed -n '1,90p' hushline/templates/directory.html && printf '\\n---\\n' && sed -n '1,70p' hushline/templates/inbox.html" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '80,130p' assets/scss/style.scss" in [redacted-path]
+/bin/zsh -lc 'rg -n "skip-link|visually-hidden" assets/scss/style.scss' in [redacted-path]
+/bin/zsh -lc "sed -n '1,120p' hushline/templates/base.html && printf '\\n---\\n' && sed -n '1,90p' hushline/templates/directory.html && printf '\\n---\\n' && sed -n '1,70p' hushline/templates/inbox.html" in [redacted-path] succeeded in 51ms:
 95:.skip-link {
 107:.skip-link:focus,
 108:.skip-link:focus-visible {
@@ -4473,10 +4683,10 @@ exec
 thinking
 **Checking base patch application**
 exec
-/bin/zsh -lc "rg -n \"Primary navigation|guidance-heading-0|directory-search-status|Inbox filters|aria-current=\\\"page\\\"\" hushline/templates/base.html hushline/templates/directory.html hushline/templates/inbox.html" in /Users/scidsg/hushline exited 1 in 50ms:
+/bin/zsh -lc "rg -n \"Primary navigation|guidance-heading-0|directory-search-status|Inbox filters|aria-current=\\\"page\\\"\" hushline/templates/base.html hushline/templates/directory.html hushline/templates/inbox.html" in [redacted-path] exited 1 in 50ms:
 
 file update
-M /Users/scidsg/hushline/hushline/templates/directory.html
+M [redacted-path]
 @@ -77,2 +77,9 @@
      </div>
 +    <p
@@ -4487,7 +4697,7 @@ M /Users/scidsg/hushline/hushline/templates/directory.html
 +      aria-atomic="true"
 +    ></p>
    </div>
-M /Users/scidsg/hushline/hushline/templates/base.html
+M [redacted-path]
 @@ -214,3 +214,3 @@
        </div>
 -      <nav>
@@ -4497,7 +4707,7 @@ M /Users/scidsg/hushline/hushline/templates/base.html
          aria-modal="true"
 +        aria-labelledby="guidance-heading-0"
          aria-hidden="true"
-M /Users/scidsg/hushline/hushline/templates/inbox.html
+M [redacted-path]
 @@ -8,19 +8,22 @@
    <div class="inbox-content">
 -    <ul class="tab-list inbox-tabs">
@@ -4538,7 +4748,7 @@ M /Users/scidsg/hushline/hushline/templates/inbox.html
 +      </ul>
 +    </nav>
      <div class="message-list">
-M /Users/scidsg/hushline/assets/scss/style.scss
+M [redacted-path]
 @@ -111,2 +111,14 @@
  
 +.visually-hidden {
@@ -4556,10 +4766,10 @@ M /Users/scidsg/hushline/assets/scss/style.scss
  /* Light Mode */
 apply_patch(auto_approved=true) exited 0 in 57ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/templates/base.html
-M /Users/scidsg/hushline/hushline/templates/directory.html
-M /Users/scidsg/hushline/hushline/templates/inbox.html
-M /Users/scidsg/hushline/assets/scss/style.scss
+M [redacted-path]
+M [redacted-path]
+M [redacted-path]
+M [redacted-path]
 file update:
 diff --git a/assets/scss/style.scss b/assets/scss/style.scss
 index 0826ce0eda61e605c60677462b3b364c74a334a2..38568ce175263475a8c27fea720bf024e69fd5cd
@@ -4790,7 +5000,7 @@ thinking
 codex
 I’m adding the live region plumbing in both directory search scripts now. The change is intentionally small: one hidden status element in the template, one announcer helper in each script, and no changes to search filtering logic or backend routes.
 file update
-M /Users/scidsg/hushline/assets/js/directory.js
+M [redacted-path]
 @@ -5,2 +5,3 @@
    const clearIcon = document.getElementById("clearIcon");
 +  const searchStatus = document.getElementById("directory-search-status");
@@ -4818,7 +5028,7 @@ M /Users/scidsg/hushline/assets/js/directory.js
 +        : `Found ${filteredUsers.length} users matching "${query}".`,
 +    );
      hasRenderedSearch = true;
-M /Users/scidsg/hushline/assets/js/directory_verified.js
+M [redacted-path]
 @@ -7,2 +7,3 @@
    const clearIcon = document.getElementById("clearIcon");
 +  const searchStatus = document.getElementById("directory-search-status");
@@ -4856,8 +5066,8 @@ M /Users/scidsg/hushline/assets/js/directory_verified.js
      hasRenderedSearch = true;
 apply_patch(auto_approved=true) exited 0 in 85ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/assets/js/directory.js
-M /Users/scidsg/hushline/assets/js/directory_verified.js
+M [redacted-path]
+M [redacted-path]
 file update:
 diff --git a/assets/js/directory.js b/assets/js/directory.js
 index 98e678e4c961231a814de8210f028763b4369ff5..634e1110b59ffa99b7f32aedf45537d564ec6915
@@ -5290,7 +5500,7 @@ thinking
 codex
 The remaining work is tests. I’m extending the existing accessibility regression file rather than introducing a new suite, and I’ll add one lightweight frontend-compat check for the directory search announcer so the JS hook doesn’t get dropped later.
 file update
-M /Users/scidsg/hushline/tests/test_frontend_compat.py
+M [redacted-path]
 @@ -47 +47,20 @@
      assert "@keyframes submit-button-spinner-rotate" in scss
 +
@@ -5312,7 +5522,7 @@ M /Users/scidsg/hushline/tests/test_frontend_compat.py
 +    assert "Showing all users." in directory_js
 +    assert "Showing all" in directory_verified_js
 +    assert ".visually-hidden" in scss
-M /Users/scidsg/hushline/tests/test_accessibility.py
+M [redacted-path]
 @@ -14,2 +14,3 @@
      soup = BeautifulSoup(response.text, "html.parser")
 +    primary_nav = soup.find("nav", {"aria-label": "Primary navigation"})
@@ -5332,7 +5542,7 @@ M /Users/scidsg/hushline/tests/test_accessibility.py
  
 @@ -47,2 +54,18 @@
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -5355,8 +5565,8 @@ M /Users/scidsg/hushline/tests/test_accessibility.py
      assert modal.get("aria-hidden") == "true"
 apply_patch(auto_approved=true) exited 0 in 96ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_accessibility.py
-M /Users/scidsg/hushline/tests/test_frontend_compat.py
+M [redacted-path]
+M [redacted-path]
 file update:
 diff --git a/assets/js/directory.js b/assets/js/directory.js
 index 98e678e4c961231a814de8210f028763b4369ff5..634e1110b59ffa99b7f32aedf45537d564ec6915
@@ -5604,7 +5814,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -5906,7 +6116,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -5965,9 +6175,9 @@ index 05ba5ab4dea11f7bf763ed9dc4c3eefa7aa78795..d248321f7af9c4fa8ecd93ede4d0e4bf
 thinking
 **Considering test execution options**
 exec
-/bin/zsh -lc 'ls -1' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "''^test:|''^lint:|''^fix:" Makefile makefile GNUmakefile' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff -- hushline/templates/base.html hushline/templates/directory.html hushline/templates/inbox.html assets/scss/style.scss assets/js/directory.js assets/js/directory_verified.js tests/test_accessibility.py tests/test_frontend_compat.py' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'ls -1' in [redacted-path]
+/bin/zsh -lc 'rg -n "''^test:|''^lint:|''^fix:" Makefile makefile GNUmakefile' in [redacted-path]
+/bin/zsh -lc 'git diff -- hushline/templates/base.html hushline/templates/directory.html hushline/templates/inbox.html assets/scss/style.scss assets/js/directory.js assets/js/directory_verified.js tests/test_accessibility.py tests/test_frontend_compat.py' in [redacted-path] succeeded in 52ms:
 AGENTS.md
 Dockerfile.dev
 Dockerfile.prod
@@ -6264,7 +6474,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -6323,7 +6533,7 @@ index 05ba5ab4dea11f7bf763ed9dc4c3eefa7aa78795..d248321f7af9c4fa8ecd93ede4d0e4bf
 thinking
 **Inspecting Makefile test target**
 exec
-/bin/zsh -lc "sed -n '60,110p' Makefile" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '60,110p' Makefile" in [redacted-path] succeeded in 51ms:
 
 .PHONY: issue-bootstrap
 issue-bootstrap: ## Reset Docker state and reseed dev_data before issue work
@@ -6591,7 +6801,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -6650,7 +6860,7 @@ index 05ba5ab4dea11f7bf763ed9dc4c3eefa7aa78795..d248321f7af9c4fa8ecd93ede4d0e4bf
 thinking
 **Reviewing test command setup**
 exec
-/bin/zsh -lc "sed -n '1,60p' Makefile" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,60p' Makefile" in [redacted-path] succeeded in 52ms:
 .DEFAULT_GOAL := help
 
 ifndef IS_DOCKER
@@ -6918,7 +7128,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -6979,9 +7189,9 @@ thinking
 codex
 I’m not invoking `make test` here because this repo’s test target shells out through `docker compose`, and this issue runner explicitly owns infra/CI validation. I’m doing a quick diff sanity pass instead and checking for formatting/whitespace issues before I stop.
 exec
-/bin/zsh -lc "nl -ba tests/test_frontend_compat.py | sed -n '1,120p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff --check' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba tests/test_accessibility.py | sed -n '1,140p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "nl -ba tests/test_frontend_compat.py | sed -n '1,120p'" in [redacted-path]
+/bin/zsh -lc 'git diff --check' in [redacted-path]
+/bin/zsh -lc "nl -ba tests/test_accessibility.py | sed -n '1,140p'" in [redacted-path] succeeded in 52ms:
      1	import json
      2	from pathlib import Path
      3	
@@ -7272,7 +7482,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -7333,8 +7543,8 @@ thinking
 codex
 The diff is clean and `git diff --check` passed. I’m doing one last pass on line lengths/readability in the new tests so they don’t create avoidable lint churn when the runner formats/checks them.
 file update
-M /Users/scidsg/hushline/tests/test_accessibility.py
-M /Users/scidsg/hushline/tests/test_frontend_compat.py
+M [redacted-path]
+M [redacted-path]
 @@ -50,3 +50,5 @@
  def test_directory_search_accessibility_hooks_exist() -> None:
 -    directory_template = (ROOT / "hushline/templates/directory.html").read_text(encoding="utf-8")
@@ -7357,8 +7567,8 @@ M /Users/scidsg/hushline/tests/test_frontend_compat.py
      assert "Showing all users." in directory_js
 apply_patch(auto_approved=true) exited 0 in 124ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_frontend_compat.py
-M /Users/scidsg/hushline/tests/test_accessibility.py
+M [redacted-path]
+M [redacted-path]
 file update:
 diff --git a/assets/js/directory.js b/assets/js/directory.js
 index 98e678e4c961231a814de8210f028763b4369ff5..634e1110b59ffa99b7f32aedf45537d564ec6915
@@ -7606,7 +7816,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -7916,7 +8126,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -7983,15 +8193,15 @@ index 05ba5ab4dea11f7bf763ed9dc4c3eefa7aa78795..e71c400c700cea856ea4acbcf846a4c2
 thinking
 **Considering prompt dict wrapping**
 exec
-/bin/zsh -lc "nl -ba tests/test_accessibility.py | sed -n '68,100p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba tests/test_frontend_compat.py | sed -n '45,90p'" in /Users/scidsg/hushlineexec
+/bin/zsh -lc "nl -ba tests/test_accessibility.py | sed -n '68,100p'" in [redacted-path]
+/bin/zsh -lc "nl -ba tests/test_frontend_compat.py | sed -n '45,90p'" in [redacted-path]
 /bin/zsh -lc "python3 - <<'PY'
 from pathlib import Path
 for path in [Path('tests/test_accessibility.py'), Path('tests/test_frontend_compat.py')]:
     for i,line in enumerate(path.read_text().splitlines(),1):
         if len(line)>100:
             print(path, i, len(line), line)
-PY" in /Users/scidsg/hushline succeeded in 52ms:
+PY" in [redacted-path] succeeded in 52ms:
     45	    assert "transform: translate(-50%, -50%);" in scss
     46	    assert "translate(-50%, -50%) rotate(360deg)" in scss
     47	    assert "@keyframes submit-button-spinner-rotate" in scss
@@ -8282,7 +8492,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -8349,10 +8559,10 @@ index 05ba5ab4dea11f7bf763ed9dc4c3eefa7aa78795..e71c400c700cea856ea4acbcf846a4c2
 thinking
 **Considering line inspection approach**
 exec
-/bin/zsh -lc "nl -ba hushline/templates/directory.html | sed -n '40,95p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba hushline/templates/base.html | sed -n '208,340p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba hushline/templates/inbox.html | sed -n '1,40p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "nl -ba hushline/templates/directory.html | sed -n '40,95p'" in [redacted-path]
+/bin/zsh -lc "nl -ba hushline/templates/base.html | sed -n '208,340p'" in [redacted-path]
+/bin/zsh -lc "nl -ba hushline/templates/inbox.html | sed -n '1,40p'" in [redacted-path]
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 52ms:
     40	            All
     41	          </button>
     42	        </li>
@@ -8671,7 +8881,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -8738,9 +8948,9 @@ index 05ba5ab4dea11f7bf763ed9dc4c3eefa7aa78795..e71c400c700cea856ea4acbcf846a4c2
 thinking
 **Gathering line references for JS and tests**
 exec
-/bin/zsh -lc "nl -ba assets/js/directory.js | sed -n '1,170p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba assets/scss/style.scss | sed -n '92,126p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba assets/js/directory_verified.js | sed -n '1,210p'" in /Users/scidsg/hushline succeeded in 50ms:
+/bin/zsh -lc "nl -ba assets/js/directory.js | sed -n '1,170p'" in [redacted-path]
+/bin/zsh -lc "nl -ba assets/scss/style.scss | sed -n '92,126p'" in [redacted-path]
+/bin/zsh -lc "nl -ba assets/js/directory_verified.js | sed -n '1,210p'" in [redacted-path] succeeded in 50ms:
     92	    url("../fonts/mono/IBMPlexMono-Medium.woff2") format("woff2");
     93	}
     94	
@@ -9050,7 +9260,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -9119,9 +9329,9 @@ thinking
 codex
 Implemented a minimal accessibility pass focused on shared navigation semantics, inbox filter state, and dynamic directory search announcements.
 
-The markup changes are in [base.html](/Users/scidsg/hushline/hushline/templates/base.html#L215), [base.html](/Users/scidsg/hushline/hushline/templates/base.html#L327), [directory.html](/Users/scidsg/hushline/hushline/templates/directory.html#L52), and [inbox.html](/Users/scidsg/hushline/hushline/templates/inbox.html#L8). The primary nav now has an explicit label, the guidance dialog has an initial accessible name, the directory search has a polite live region, and inbox filters now expose the current selection with `aria-current="page"` inside a labeled nav. The live-region behavior is wired in [directory.js](/Users/scidsg/hushline/assets/js/directory.js#L6), [directory_verified.js](/Users/scidsg/hushline/assets/js/directory_verified.js#L8), and the shared hidden utility class is in [style.scss](/Users/scidsg/hushline/assets/scss/style.scss#L112).
+The markup changes are in [base.html]([redacted-path] [base.html]([redacted-path] [directory.html]([redacted-path] and [inbox.html]([redacted-path] The primary nav now has an explicit label, the guidance dialog has an initial accessible name, the directory search has a polite live region, and inbox filters now expose the current selection with `aria-current="page"` inside a labeled nav. The live-region behavior is wired in [directory.js]([redacted-path] [directory_verified.js]([redacted-path] and the shared hidden utility class is in [style.scss]([redacted-path]
 
-I added regression coverage in [test_accessibility.py](/Users/scidsg/hushline/tests/test_accessibility.py#L10) and [test_frontend_compat.py](/Users/scidsg/hushline/tests/test_frontend_compat.py#L50). I did not run `make test` because this repo’s make targets invoke `docker compose`, and infra validation is handled by the runner for this issue. I did run `git diff --check`, which passed.
+I added regression coverage in [test_accessibility.py]([redacted-path] and [test_frontend_compat.py]([redacted-path] I did not run `make test` because this repo’s make targets invoke `docker compose`, and infra validation is handled by the runner for this issue. I did run `git diff --check`, which passed.
 
 1. Let the runner execute the full validation suite and surface anything Lighthouse/W3C still flags.
 file update:
@@ -9371,7 +9581,7 @@ index 08112490696188f9b01746af7616d0609148fba9..6fb2d40a739f7ab07c4537c943b04cb7
      assert current.text.strip() == "Profile"
  
  
-+@pytest.mark.usefixtures("_authenticated_user")
+[redacted-email]("_authenticated_user")
 +def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
 +    response = client.get(url_for("inbox"), follow_redirects=True)
 +    assert response.status_code == 200
@@ -9438,18 +9648,18 @@ tokens used
 109,209
 Implemented a minimal accessibility pass focused on shared navigation semantics, inbox filter state, and dynamic directory search announcements.
 
-The markup changes are in [base.html](/Users/scidsg/hushline/hushline/templates/base.html#L215), [base.html](/Users/scidsg/hushline/hushline/templates/base.html#L327), [directory.html](/Users/scidsg/hushline/hushline/templates/directory.html#L52), and [inbox.html](/Users/scidsg/hushline/hushline/templates/inbox.html#L8). The primary nav now has an explicit label, the guidance dialog has an initial accessible name, the directory search has a polite live region, and inbox filters now expose the current selection with `aria-current="page"` inside a labeled nav. The live-region behavior is wired in [directory.js](/Users/scidsg/hushline/assets/js/directory.js#L6), [directory_verified.js](/Users/scidsg/hushline/assets/js/directory_verified.js#L8), and the shared hidden utility class is in [style.scss](/Users/scidsg/hushline/assets/scss/style.scss#L112).
+The markup changes are in [base.html]([redacted-path] [base.html]([redacted-path] [directory.html]([redacted-path] and [inbox.html]([redacted-path] The primary nav now has an explicit label, the guidance dialog has an initial accessible name, the directory search has a polite live region, and inbox filters now expose the current selection with `aria-current="page"` inside a labeled nav. The live-region behavior is wired in [directory.js]([redacted-path] [directory_verified.js]([redacted-path] and the shared hidden utility class is in [style.scss]([redacted-path]
 
-I added regression coverage in [test_accessibility.py](/Users/scidsg/hushline/tests/test_accessibility.py#L10) and [test_frontend_compat.py](/Users/scidsg/hushline/tests/test_frontend_compat.py#L50). I did not run `make test` because this repo’s make targets invoke `docker compose`, and infra validation is handled by the runner for this issue. I did run `git diff --check`, which passed.
+I added regression coverage in [test_accessibility.py]([redacted-path] and [test_frontend_compat.py]([redacted-path] I did not run `make test` because this repo’s make targets invoke `docker compose`, and infra validation is handled by the runner for this issue. I did run `git diff --check`, which passed.
 
 1. Let the runner execute the full validation suite and surface anything Lighthouse/W3C still flags.
 Codex execution completed.
 Codex final message:
 Implemented a minimal accessibility pass focused on shared navigation semantics, inbox filter state, and dynamic directory search announcements.
 
-The markup changes are in [base.html](/Users/scidsg/hushline/hushline/templates/base.html#L215), [base.html](/Users/scidsg/hushline/hushline/templates/base.html#L327), [directory.html](/Users/scidsg/hushline/hushline/templates/directory.html#L52), and [inbox.html](/Users/scidsg/hushline/hushline/templates/inbox.html#L8). The primary nav now has an explicit label, the guidance dialog has an initial accessible name, the directory search has a polite live region, and inbox filters now expose the current selection with `aria-current="page"` inside a labeled nav. The live-region behavior is wired in [directory.js](/Users/scidsg/hushline/assets/js/directory.js#L6), [directory_verified.js](/Users/scidsg/hushline/assets/js/directory_verified.js#L8), and the shared hidden utility class is in [style.scss](/Users/scidsg/hushline/assets/scss/style.scss#L112).
+The markup changes are in [base.html]([redacted-path] [base.html]([redacted-path] [directory.html]([redacted-path] and [inbox.html]([redacted-path] The primary nav now has an explicit label, the guidance dialog has an initial accessible name, the directory search has a polite live region, and inbox filters now expose the current selection with `aria-current="page"` inside a labeled nav. The live-region behavior is wired in [directory.js]([redacted-path] [directory_verified.js]([redacted-path] and the shared hidden utility class is in [style.scss]([redacted-path]
 
-I added regression coverage in [test_accessibility.py](/Users/scidsg/hushline/tests/test_accessibility.py#L10) and [test_frontend_compat.py](/Users/scidsg/hushline/tests/test_frontend_compat.py#L50). I did not run `make test` because this repo’s make targets invoke `docker compose`, and infra validation is handled by the runner for this issue. I did run `git diff --check`, which passed.
+I added regression coverage in [test_accessibility.py]([redacted-path] and [test_frontend_compat.py]([redacted-path] I did not run `make test` because this repo’s make targets invoke `docker compose`, and infra validation is handled by the runner for this issue. I did run `git diff --check`, which passed.
 
 1. Let the runner execute the full validation suite and surface anything Lighthouse/W3C still flags.
 ==> Run lint
@@ -9625,7 +9835,7 @@ Success: no issues found in 147 source files
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run workflow security checks
-docker run --rm -v "/Users/scidsg/hushline:/work" -w /work rhysd/actionlint:1.7.7 -color
+docker run --rm -v "[redacted-path]" -w /work rhysd/actionlint:1.7.7 -color
 Unable to find image 'rhysd/actionlint:1.7.7' locally
 1.7.7: Pulling from rhysd/actionlint
 25d2e00cf929: Pulling fs layer

--- a/docs/agent-logs/run-20260228T160005Z-issue-1378.txt
+++ b/docs/agent-logs/run-20260228T160005Z-issue-1378.txt
@@ -3,7 +3,7 @@ Timestamp (UTC): 20260228T160005Z
 Issue: #1378
 Repository: scidsg/hushline
 
-Runner Codex config: model=gpt-5.3-codex reasoning_effort=high verbose_codex_output=0
+Runner Codex config: [redacted]
 ==> Fetch latest from origin
 ==> Checkout main
 Already on 'main'
@@ -1453,23 +1453,128 @@ Total reclaimed space: 5.022GB
 #7 9.606 Get:460 http://deb.debian.org/debian bookworm/main arm64 pkg-config arm64 1.8.1-1 [13.7 kB]
 #7 9.747 debconf: delaying package configuration, since apt-utils is not installed
 #7 9.764 Fetched 162 MB in 4s (37.7 MB/s)
-#7 9.776 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6689 files and directories currently installed.)
+#7 9.776 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6689 files and directories currently installed.)
 #7 9.780 Preparing to unpack .../perl-base_5.36.0-7+deb12u3_arm64.deb ...
 #7 9.788 Unpacking perl-base (5.36.0-7+deb12u3) over (5.36.0-7+deb12u1) ...
 #7 10.42 Setting up perl-base (5.36.0-7+deb12u3) ...
-#7 10.44 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.44 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.44 Preparing to unpack .../gcc-12-base_12.2.0-14+deb12u1_arm64.deb ...
 #7 10.44 Unpacking gcc-12-base:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 10.46 Setting up gcc-12-base:arm64 (12.2.0-14+deb12u1) ...
-#7 10.47 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.47 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.47 Preparing to unpack .../libgcc-s1_12.2.0-14+deb12u1_arm64.deb ...
 #7 10.48 Unpacking libgcc-s1:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 10.49 Setting up libgcc-s1:arm64 (12.2.0-14+deb12u1) ...
-#7 10.51 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.51 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.51 Preparing to unpack .../libstdc++6_12.2.0-14+deb12u1_arm64.deb ...
 #7 10.52 Unpacking libstdc++6:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 10.58 Setting up libstdc++6:arm64 (12.2.0-14+deb12u1) ...
-#7 10.60 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.60 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.60 Preparing to unpack .../libc6_2.36-9+deb12u13_arm64.deb ...
 #7 10.64 debconf: unable to initialize frontend: Dialog
 #7 10.64 debconf: (TERM is not set, so the dialog frontend is not usable.)
@@ -1485,12 +1590,54 @@ Total reclaimed space: 5.022GB
 #7 11.07 debconf: unable to initialize frontend: Readline
 #7 11.07 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
 #7 11.07 debconf: falling back to frontend: Teletype
-#7 12.13 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 12.13 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 12.14 Preparing to unpack .../libc-bin_2.36-9+deb12u13_arm64.deb ...
 #7 12.14 Unpacking libc-bin (2.36-9+deb12u13) over (2.36-9+deb12u8) ...
 #7 12.21 Setting up libc-bin (2.36-9+deb12u13) ...
 #7 12.24 Selecting previously unselected package perl-modules-5.36.
-#7 12.24 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 12.24 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 12.24 Preparing to unpack .../0-perl-modules-5.36_5.36.0-7+deb12u3_all.deb ...
 #7 12.24 Unpacking perl-modules-5.36 (5.36.0-7+deb12u3) ...
 #7 12.43 Selecting previously unselected package libgdbm-compat4:arm64.
@@ -1514,7 +1661,28 @@ Total reclaimed space: 5.022GB
 #7 13.00 Setting up libpython3.11-minimal:arm64 (3.11.2-6+deb12u6) ...
 #7 13.00 Setting up python3.11-minimal (3.11.2-6+deb12u6) ...
 #7 13.43 Selecting previously unselected package python3-minimal.
-#7 13.43 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9002 files and directories currently installed.)
+#7 13.43 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9002 files and directories currently installed.)
 #7 13.44 Preparing to unpack .../python3-minimal_3.11.2-1+b1_arm64.deb ...
 #7 13.44 Unpacking python3-minimal (3.11.2-1+b1) ...
 #7 13.45 Selecting previously unselected package media-types.
@@ -1524,7 +1692,28 @@ Total reclaimed space: 5.022GB
 #7 13.47 Unpacking liblzma5:arm64 (5.4.1-1) over (5.4.1-0.2) ...
 #7 13.49 Setting up liblzma5:arm64 (5.4.1-1) ...
 #7 13.50 Selecting previously unselected package libpython3.11-stdlib:arm64.
-#7 13.50 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9030 files and directories currently installed.)
+#7 13.50 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9030 files and directories currently installed.)
 #7 13.51 Preparing to unpack .../libpython3.11-stdlib_3.11.2-6+deb12u6_arm64.deb ...
 #7 13.51 Unpacking libpython3.11-stdlib:arm64 (3.11.2-6+deb12u6) ...
 #7 13.61 Selecting previously unselected package python3.11.
@@ -1535,7 +1724,28 @@ Total reclaimed space: 5.022GB
 #7 13.64 Unpacking libpython3-stdlib:arm64 (3.11.2-1+b1) ...
 #7 13.65 Setting up python3-minimal (3.11.2-1+b1) ...
 #7 13.73 Selecting previously unselected package python3.
-#7 13.73 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9412 files and directories currently installed.)
+#7 13.73 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9412 files and directories currently installed.)
 #7 13.73 Preparing to unpack .../000-python3_3.11.2-1+b1_arm64.deb ...
 #7 13.73 Unpacking python3 (3.11.2-1+b1) ...
 #7 13.75 Selecting previously unselected package bzip2.
@@ -3758,14 +3968,14 @@ Switched to a new branch 'codex/daily-issue-1378'
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.105.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.3-codex
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR]
-reasoning effort: high
-reasoning summaries: auto
-session id: 019ca4fc-f583-72d0-8f74-bfbac5f26fc5
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are implementing GitHub issue #1378 in scidsg/hushline.
@@ -3858,10 +4068,10 @@ thinking
 codex
 I’m inspecting the repo layout and any nested `AGENTS.md` guidance first, then I’ll map the existing `/docs` structure against the issue’s required article set before editing.
 exec
-/bin/zsh -lc pwd in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg --files -g 'AGENTS.md' -g 'docs/**' -g 'README*'" in /Users/scidsg/hushline succeeded in 52ms:
-/Users/scidsg/hushline
+/bin/zsh -lc pwd in [redacted-path]
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc "rg --files -g 'AGENTS.md' -g 'docs/**' -g 'README*'" in [redacted-path] succeeded in 52ms:
+[redacted-path]
  succeeded in 53ms:
 
  succeeded in 52ms:
@@ -3891,9 +4101,9 @@ thinking
 codex
 I found only the repo-root `AGENTS.md`; there doesn’t appear to be a deeper docs-specific override. Next I’m reading the existing docs index and checking whether any of the requested mirrored articles already exist.
 exec
-/bin/zsh -lc "sed -n '1,220p' AGENTS.md" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' docs/README.md" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "Start Here|New User Onboarding|Prep Your Account|Secure Your Account|Share Your Tip Line|Your Inbox|Reading Messages|Email Validation|Vision Assistant|Message Statuses|Account Verification|Download Your Data|Dark Mode|Personal Server|Welcome to Hush Line" docs' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,220p' AGENTS.md" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' docs/README.md" in [redacted-path]
+/bin/zsh -lc 'rg -n "Start Here|New User Onboarding|Prep Your Account|Secure Your Account|Share Your Tip Line|Your Inbox|Reading Messages|Email Validation|Vision Assistant|Message Statuses|Account Verification|Download Your Data|Dark Mode|Personal Server|Welcome to Hush Line" docs' in [redacted-path] succeeded in 53ms:
 # Hush Line Documentation
 
 For the most up-to-date end-user documentation visit https://hushline.app/start-here.html.
@@ -4007,9 +4217,9 @@ thinking
 codex
 The public docs nav exposes a few pages that search indexing missed: `New User Onboarding`, `Tools`, `Download Your Data`, and `Dark Mode`. I’m pulling context from the app itself now so the mirrored Markdown stays faithful where the public excerpts are sparse.
 exec
-/bin/zsh -lc 'find docs -maxdepth 2 -type f | sort' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg --files hushline/templates hushline/static tests | rg "settings|tool|vision|email|server|profile|download|dark|onboarding|intro|inbox|message"' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "New User Onboarding|Download Your Data|Dark Mode|Email Validation|Vision Assistant|Message Statuses|Account Verification|two-factor|2FA|Mailvelope|Proton|Public User Directory|download.*data|dark mode" hushline templates tests docs' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'find docs -maxdepth 2 -type f | sort' in [redacted-path]
+/bin/zsh -lc 'rg --files hushline/templates hushline/static tests | rg "settings|tool|vision|email|server|profile|download|dark|onboarding|intro|inbox|message"' in [redacted-path]
+/bin/zsh -lc 'rg -n "New User Onboarding|Download Your Data|Dark Mode|Email Validation|Vision Assistant|Message Statuses|Account Verification|two-factor|2FA|Mailvelope|Proton|Public User Directory|download.*data|dark mode" hushline templates tests docs' in [redacted-path] succeeded in 52ms:
 docs/AGENTIC-CODE-POLICY.md
 docs/AGENT_RUNNER.md
 docs/ARCHITECTURE.md
@@ -4229,12 +4439,12 @@ thinking
 codex
 I have enough of the public docs IA now to build the structure. I’m filling the remaining sparse pages from the app’s own templates and UI copy so the mirrored docs stay aligned with current behavior instead of inventing new flows.
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/inbox.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/onboarding.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/tools/nav.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/message.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/email_headers.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/vision.html" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/inbox.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/onboarding.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/tools/nav.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/message.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/email_headers.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/vision.html" in [redacted-path] succeeded in 52ms:
 {% extends "base.html" %}
 
 {% block title %}Guide Me{% endblock %}
@@ -4375,12 +4585,12 @@ Plan update
 thinking
 **Searching settings templates**
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/auth.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/enable_2fa.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/profile-forms.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/advanced.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/server_info.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/notifications.html" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/auth.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/enable_2fa.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/profile-forms.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/advanced.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/server_info.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/notifications.html" in [redacted-path] succeeded in 52ms:
 {% extends "settings/base.html" %}
 
 {% block settings_content %}
@@ -4507,9 +4717,9 @@ exec
     {{ toggle_notifications_form.submit }}
   </form>
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/base.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/nav.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "Personal Server|Raspberry Pi|CPU|RAM|storage|Tor Browser|onion|specs|self-host|self host|ARM|x86|vision assistant|dark mode" README.md docs hushline tests' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/base.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/settings/nav.html" in [redacted-path]
+/bin/zsh -lc 'rg -n "Personal Server|Raspberry Pi|CPU|RAM|storage|Tor Browser|onion|specs|self-host|self host|ARM|x86|vision assistant|dark mode" README.md docs hushline tests' in [redacted-path] succeeded in 53ms:
 {% extends "base.html" %}
 
 {% block title %}Settings{% endblock %}
@@ -4578,8 +4788,8 @@ I’ve confirmed there isn’t an existing docs-specific test harness in the tre
 thinking
 **Reviewing documentation links**
 exec
-/bin/zsh -lc "sed -n '1,180p' README.md" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "markdown|README|docs/README|link check|broken link|markdownlint|remark|lychee|md" tests Makefile package.json pyproject.toml .github docs' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,180p' README.md" in [redacted-path]
+/bin/zsh -lc 'rg -n "markdown|README|docs/README|link check|broken link|markdownlint|remark|lychee|md" tests Makefile package.json pyproject.toml .github docs' in [redacted-path] succeeded in 52ms:
 # Hush Line
 
 [Hush Line](https://hushline.app) is an open source whistleblower platform for secure, anonymous, one-way disclosures to journalists, lawyers, and other trusted recipients.
@@ -4625,7 +4835,7 @@ tests/test_settings_common.py:108:                formdata=MultiDict({"new_usern
 thinking
 **Planning docs index and tests**
 exec
-/bin/zsh -lc "sed -n '1,220p' docs/DEV.md" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,220p' docs/DEV.md" in [redacted-path] succeeded in 53ms:
 # Developer Docs
 
 ## Creating Database Migrations
@@ -4720,7 +4930,7 @@ thinking
 thinking
 **Analyzing message status customization**
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/model/enums.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/model/enums.py" in [redacted-path] succeeded in 51ms:
 import enum
 from typing import Self
 
@@ -4745,8 +4955,8 @@ class MessageStatus(enum.Enum):
 thinking
 **Checking verified badge usage**
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/templates/profile.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "verified|verification|Verified Address|verify|badge" hushline/templates hushline/settings tests | head -n 200' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/templates/profile.html" in [redacted-path]
+/bin/zsh -lc 'rg -n "verified|verification|Verified Address|verify|badge" hushline/templates hushline/settings tests | head -n 200' in [redacted-path] succeeded in 52ms:
 {% extends "base.html" %}
 
 {% block title %}
@@ -4792,7 +5002,7 @@ hushline/settings/common.py:135:            f"URL verification rejected due to h
 thinking
 **Considering data export details**
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/settings/data_export.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/settings/data_export.py" in [redacted-path] succeeded in 52ms:
 import csv
 import io
 import zipfile
@@ -4817,8 +5027,8 @@ from hushline.model import (
 thinking
 **Inspecting dark mode references**
 exec
-/bin/zsh -lc "sed -n '520,700p' hushline/static/css/style.css" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "dark mode|theme|prefers-color-scheme|darkMode|dark-mode|color scheme" hushline hushline/templates hushline/static tests | head -n 200' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '520,700p' hushline/static/css/style.css" in [redacted-path]
+/bin/zsh -lc 'rg -n "dark mode|theme|prefers-color-scheme|darkMode|dark-mode|color scheme" hushline hushline/templates hushline/static tests | head -n 200' in [redacted-path] succeeded in 53ms:
     background-image: url(/static/img/icon-verified-lm.png);
   }
   .plan {
@@ -4864,7 +5074,7 @@ hushline/static/css/style.css:147:@media (prefers-color-scheme: light) {
 thinking
 **Confirming dark mode behavior**
 exec
-/bin/zsh -lc 'rg -n "first user you create on your Hush Line Personal Server|Personal Server|onion URL|Tor Browser|local network|Specs" docs/agent-logs hushline tests | head -n 120' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'rg -n "first user you create on your Hush Line Personal Server|Personal Server|onion URL|Tor Browser|local network|Specs" docs/agent-logs hushline tests | head -n 120' in [redacted-path] succeeded in 53ms:
 Total output lines: 11
 
 docs/agent-logs/run-20260227T195401Z-issue-1371.txt:4733:    11	      <p class="info">⚙️ The first user you create on your Hush Line Personal Server will be the admin.</p>
@@ -4882,7 +5092,7 @@ hushline/static/js/client-side-encryption.js:29:eval("{__webpack_require__.r(__w
 thinking
 **Targeting register template**
 exec
-/bin/zsh -lc "sed -n '1,80p' hushline/templates/register.html" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,80p' hushline/templates/register.html" in [redacted-path] succeeded in 53ms:
 {% extends "base.html" %}
 {% block title %}Register{% endblock %}
 
@@ -4912,7 +5122,7 @@ thinking
 codex
 I’ve finished the source pass. Next I’m writing the docs tree and a small regression test that enforces the required files plus relative-link integrity for the mirrored docs, so future edits don’t break GitHub navigation.
 file update
-A /Users/scidsg/hushline/docs/README.md
+A [redacted-path]
 # Hush Line Documentation
 
 This directory now includes a GitHub-first mirror of the public Hush Line Library docs alongside the existing repository documentation.
@@ -4936,7 +5146,7 @@ This directory now includes a GitHub-first mirror of the public Hush Line Librar
 - [Agentic code policy](./AGENTIC-CODE-POLICY.md)
 - [Security audit hitlist](./SECURITY-AUDIT-HITLIST.md)
 - [Screenshots](./screenshots/README.md)
-A /Users/scidsg/hushline/docs/library/using-your-tip-line/dark-mode.md
+A [redacted-path]
 # Dark Mode
 
 Source: <https://hushline.app/library/docs/using-your-tip-line/dark-mode/>
@@ -4963,7 +5173,7 @@ The web app responds to your system or browser `prefers-color-scheme` setting. T
 
 - [Your Inbox](./your-inbox.md)
 - [Reading Messages](./reading-messages.md)
-A /Users/scidsg/hushline/docs/library/getting-started/prep-your-account.md
+A [redacted-path]
 # Prep Your Account
 
 Source: <https://hushline.app/library/docs/getting-started/account-setup/>
@@ -5016,7 +5226,7 @@ Turning on directory visibility makes your tip line easier to find. If you want 
 
 - [Secure Your Account](./secure-your-account.md)
 - [Share Your Tip Line](./share-your-tip-line.md)
-A /Users/scidsg/hushline/docs/library/using-your-tip-line/reading-messages.md
+A [redacted-path]
 # Reading Messages
 
 Source: <https://hushline.app/library/docs/using-your-tip-line/reading-messages/>
@@ -5052,7 +5262,7 @@ Encrypted values are shown in their encrypted form until you decrypt them with y
 - [Your Inbox](./your-inbox.md)
 - [Message Statuses](./message-statuses.md)
 - [Download Your Data](./download-your-data.md)
-A /Users/scidsg/hushline/docs/library/using-your-tip-line/email-validation.md
+A [redacted-path]
 # Email Validation
 
 Source: <https://hushline.app/library/docs/using-your-tip-line/email-validation/>
@@ -5090,7 +5300,7 @@ Older emails can look suspicious even when they were legitimate at the time, esp
 
 - [Tools](./tools.md)
 - [Vision Assistant](./vision-assistant.md)
-A /Users/scidsg/hushline/docs/library/welcome/welcome-to-hush-line.md
+A [redacted-path]
 # Welcome to Hush Line
 
 Source basis: the public Hush Line Library welcome section and the project overview in [README.md](../../README.md).
@@ -5116,7 +5326,7 @@ Hush Line is an open source whistleblower platform for secure, anonymous, one-wa
 - New hosted-service users should start with [Start Here](../getting-started/start-here.md).
 - If you want the guided setup flow, open [New User Onboarding](../getting-started/new-user-onboarding.md).
 - If you already have an account, jump to [Prep Your Account](../getting-started/prep-your-account.md) and [Secure Your Account](../getting-started/secure-your-account.md).
-A /Users/scidsg/hushline/docs/library/using-your-tip-line/your-inbox.md
+A [redacted-path]
 # Your Inbox
 
 Source: <https://hushline.app/library/docs/using-your-tip-line/your-inbox/>
@@ -5152,7 +5362,7 @@ Those filters are useful once your tip line is active and you need a simple tria
 3. Open a message to review its fields and change its status.
 
 Continue with [Reading Messages](./reading-messages.md) for the per-message workflow.
-A /Users/scidsg/hushline/docs/library/getting-started/share-your-tip-line.md
+A [redacted-path]
 # Share Your Tip Line
 
 Source: <https://hushline.app/library/docs/getting-started/share-your-tip-line/>
@@ -5182,7 +5392,7 @@ Directory visibility can help people discover you, but it should not be your onl
 
 - Watch [Your Inbox](../using-your-tip-line/your-inbox.md) for new tips.
 - Learn the review flow in [Reading Messages](../using-your-tip-line/reading-messages.md).
-A /Users/scidsg/hushline/docs/library/personal-server/README.md
+A [redacted-path]
 # Personal Server
 
 Source category: <https://hushline.app/library/docs/personal-server/the-hush-line-personal-server/>
@@ -5191,7 +5401,7 @@ Source category: <https://hushline.app/library/docs/personal-server/the-hush-lin
 
 - [The Hush Line Personal Server](./the-hush-line-personal-server.md)
 - [Specs](./specs.md)
-A /Users/scidsg/hushline/docs/library/using-your-tip-line/README.md
+A [redacted-path]
 # Using Your Tip Line
 
 Source category: <https://hushline.app/library/docs/using-your-tip-line/your-inbox/>
@@ -5207,7 +5417,7 @@ Source category: <https://hushline.app/library/docs/using-your-tip-line/your-inb
 - [Account Verification](./account-verification.md)
 - [Download Your Data](./download-your-data.md)
 - [Dark Mode](./dark-mode.md)
-A /Users/scidsg/hushline/docs/library/using-your-tip-line/tools.md
+A [redacted-path]
 # Tools
 
 Source: <https://hushline.app/library/docs/using-your-tip-line/tools/>
@@ -5232,7 +5442,7 @@ These tools support tip-handling work that often happens next to message review:
 - turning image-heavy evidence into searchable text
 
 Continue with the specific tool pages for workflow details.
-A /Users/scidsg/hushline/docs/library/welcome/README.md
+A [redacted-path]
 # Welcome
 
 ## Articles
@@ -5243,7 +5453,7 @@ A /Users/scidsg/hushline/docs/library/welcome/README.md
 
 - Continue to [Start Here](../getting-started/start-here.md) if you are setting up a hosted Hush Line account.
 - Continue to [The Hush Line Personal Server](../personal-server/the-hush-line-personal-server.md) if you are using the self-hosted appliance.
-A /Users/scidsg/hushline/docs/library/getting-started/README.md
+A [redacted-path]
 # Getting Started
 
 Source category: <https://hushline.app/library/docs/getting-started/start-here/>
@@ -5255,7 +5465,7 @@ Source category: <https://hushline.app/library/docs/getting-started/start-here/>
 - [Prep Your Account](./prep-your-account.md)
 - [Secure Your Account](./secure-your-account.md)
 - [Share Your Tip Line](./share-your-tip-line.md)
-A /Users/scidsg/hushline/docs/library/getting-started/start-here.md
+A [redacted-path]
 # Start Here
 
 Source: <https://hushline.app/library/docs/getting-started/start-here/>
@@ -5286,7 +5496,7 @@ This is the shortest path to a usable Hush Line account. In practice, most peopl
 - [Your Inbox](../using-your-tip-line/your-inbox.md)
 - [Reading Messages](../using-your-tip-line/reading-messages.md)
 - [Account Verification](../using-your-tip-line/account-verification.md)
-A /Users/scidsg/hushline/docs/library/getting-started/secure-your-account.md
+A [redacted-path]
 # Secure Your Account
 
 Source: <https://hushline.app/library/docs/getting-started/secure-your-account/>
@@ -5324,7 +5534,7 @@ Changing a verified username or display name can affect trust signals shown to s
 
 - [Prep Your Account](./prep-your-account.md)
 - [Account Verification](../using-your-tip-line/account-verification.md)
-A /Users/scidsg/hushline/docs/library/personal-server/specs.md
+A [redacted-path]
 # Specs
 
 Source basis: the public Personal Server docs category and the in-app Personal Server experience described in [server_info.html](../../hushline/templates/server_info.html).
@@ -5355,7 +5565,7 @@ The Personal Server is still Hush Line. After initial access, the same core rece
 ## Publishing guidance
 
 If your goal is anonymous inbound reporting, publish the onion URL rather than only the local-network address. The local address is helpful for setup, but the onion address is the privacy-preserving endpoint intended for public sharing.
-A /Users/scidsg/hushline/docs/library/using-your-tip-line/account-verification.md
+A [redacted-path]
 # Account Verification
 
 Source: <https://hushline.app/library/docs/using-your-tip-line/account-verification/>
@@ -5383,7 +5593,7 @@ Verification works best when paired with:
 
 - Finish [Prep Your Account](../getting-started/prep-your-account.md)
 - Review [Share Your Tip Line](../getting-started/share-your-tip-line.md)
-A /Users/scidsg/hushline/docs/library/using-your-tip-line/vision-assistant.md
+A [redacted-path]
 # Vision Assistant
 
 Source: <https://hushline.app/library/docs/using-your-tip-line/vision-assistant/>
@@ -5418,7 +5628,7 @@ The OCR flow runs in the browser. The app copy describes this tool as not sendin
 
 - [Tools](./tools.md)
 - [Email Validation](./email-validation.md)
-A /Users/scidsg/hushline/docs/library/using-your-tip-line/message-statuses.md
+A [redacted-path]
 # Message Statuses
 
 Source: <https://hushline.app/library/docs/using-your-tip-line/message-statuses/>
@@ -5460,7 +5670,7 @@ This is useful when you want to explain:
 
 - [Your Inbox](./your-inbox.md)
 - [Reading Messages](./reading-messages.md)
-A /Users/scidsg/hushline/tests/test_docs_library_mirror.py
+A [redacted-path]
 from __future__ import annotations
 
 import re
@@ -5532,7 +5742,7 @@ def test_library_docs_relative_links_resolve() -> None:
                 missing_targets.append(f"{source} -> {target.relative_to(REPO_ROOT)}")
 
     assert not missing_targets, f"Broken docs links: {missing_targets}"
-A /Users/scidsg/hushline/docs/library/personal-server/the-hush-line-personal-server.md
+A [redacted-path]
 # The Hush Line Personal Server
 
 Source: <https://hushline.app/library/docs/personal-server/the-hush-line-personal-server/>
@@ -5565,7 +5775,7 @@ The product copy describes the Personal Server as a good fit for lawyers, journa
 - [Specs](./specs.md)
 - [Secure Your Account](../getting-started/secure-your-account.md)
 - [Share Your Tip Line](../getting-started/share-your-tip-line.md)
-A /Users/scidsg/hushline/docs/library/getting-started/new-user-onboarding.md
+A [redacted-path]
 # New User Onboarding
 
 Source: <https://hushline.app/library/docs/getting-started/new-user-onboarding/>
@@ -5607,7 +5817,7 @@ Choose whether to appear in the public user directory. Directory listings help w
 
 - Continue with [Prep Your Account](./prep-your-account.md) for the settings you may still want to tune.
 - Continue with [Secure Your Account](./secure-your-account.md) before broad distribution.
-A /Users/scidsg/hushline/docs/library/using-your-tip-line/download-your-data.md
+A [redacted-path]
 # Download Your Data
 
 Source: <https://hushline.app/library/docs/using-your-tip-line/download-your-data/>
@@ -5643,7 +5853,7 @@ If your account already has a PGP key, you can encrypt the full export with that
 
 - [Reading Messages](./reading-messages.md)
 - [Message Statuses](./message-statuses.md)
-A /Users/scidsg/hushline/docs/library/README.md
+A [redacted-path]
 # Hush Line Library Docs
 
 This section mirrors the public Hush Line Library in plain GitHub Markdown. The content is rewritten for in-repo reading, but it follows the same information architecture and guidance as the public docs.
@@ -8323,13 +8533,13 @@ thinking
 codex
 The docs tree is in place. I’m doing a tight cleanup pass on relative paths now; a few links that jump from `/docs/library/...` back into the repo root need one extra `..` segment to resolve correctly on GitHub.
 exec
-/bin/zsh -lc "rg -n \"\\.\\./\\.\\./README\\.md|\\.\\./\\.\\./hushline\" docs/library docs/README.md tests/test_docs_library_mirror.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "rg -n \"\\.\\./\\.\\./README\\.md|\\.\\./\\.\\./hushline\" docs/library docs/README.md tests/test_docs_library_mirror.py" in [redacted-path] succeeded in 52ms:
 docs/library/getting-started/new-user-onboarding.md:7:![Hush Line onboarding screen](../../hushline/static/img/onboarding.png)
 docs/library/welcome/welcome-to-hush-line.md:3:Source basis: the public Hush Line Library welcome section and the project overview in [README.md](../../README.md).
 docs/library/personal-server/specs.md:3:Source basis: the public Personal Server docs category and the in-app Personal Server experience described in [server_info.html](../../hushline/templates/server_info.html).
 exec
-/bin/zsh -lc "sed -n '1,220p' tests/test_docs_library_mirror.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff -- docs/README.md docs/library tests/test_docs_library_mirror.py' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' tests/test_docs_library_mirror.py" in [redacted-path]
+/bin/zsh -lc 'git diff -- docs/README.md docs/library tests/test_docs_library_mirror.py' in [redacted-path] succeeded in 52ms:
 from __future__ import annotations
 
 import re
@@ -9695,25 +9905,25 @@ thinking
 codex
 I caught two issues in the first pass: a few upward relative paths were off by one directory, and the new docs test regex was over-escaped. I’m fixing those now before running the test target.
 file update
-M /Users/scidsg/hushline/docs/library/welcome/welcome-to-hush-line.md
+M [redacted-path]
 @@ -2,3 +2,3 @@
  
 -Source basis: the public Hush Line Library welcome section and the project overview in [README.md](../../README.md).
 +Source basis: the public Hush Line Library welcome section and the project overview in [README.md](../../../README.md).
  
-M /Users/scidsg/hushline/docs/library/personal-server/specs.md
+M [redacted-path]
 @@ -2,3 +2,3 @@
  
 -Source basis: the public Personal Server docs category and the in-app Personal Server experience described in [server_info.html](../../hushline/templates/server_info.html).
 +Source basis: the public Personal Server docs category and the in-app Personal Server experience described in [server_info.html](../../../hushline/templates/server_info.html).
  
-M /Users/scidsg/hushline/docs/library/getting-started/new-user-onboarding.md
+M [redacted-path]
 @@ -6,3 +6,3 @@
  
 -![Hush Line onboarding screen](../../hushline/static/img/onboarding.png)
 +![Hush Line onboarding screen](../../../hushline/static/img/onboarding.png)
  
-M /Users/scidsg/hushline/tests/test_docs_library_mirror.py
+M [redacted-path]
 @@ -9,3 +9,3 @@
  LIBRARY_ROOT = DOCS_ROOT / "library"
 -LINK_PATTERN = re.compile(r"!?\\[[^\\]]*\\]\\(([^)]+)\\)")
@@ -12365,8 +12575,8 @@ index 0000000000000000000000000000000000000000..354c30b5b5b67824039e90bef6c4ca60
 thinking
 **Considering preserving old README**
 exec
-/bin/zsh -lc 'rg -n "''^test:|pytest|TESTS|PYTEST|lint:" Makefile' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff --stat' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'rg -n "''^test:|pytest|TESTS|PYTEST|lint:" Makefile' in [redacted-path]
+/bin/zsh -lc 'git diff --stat' in [redacted-path] succeeded in 52ms:
  docs/README.md | 480 +++------------------------------------------------------
  1 file changed, 21 insertions(+), 459 deletions(-)
  succeeded in 53ms:
@@ -13706,9 +13916,9 @@ thinking
 codex
 The main remaining risk is `docs/README.md`: the new index is correct, but replacing that file also dropped a large chunk of older development/config reference text. I’m checking whether that content already exists elsewhere before deciding whether to preserve it in a follow-up file.
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "git show HEAD:docs/README.md | sed -n '1,220p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "git show HEAD:docs/README.md | sed -n '221,520p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc "git show HEAD:docs/README.md | sed -n '1,220p'" in [redacted-path]
+/bin/zsh -lc "git show HEAD:docs/README.md | sed -n '221,520p'" in [redacted-path] succeeded in 53ms:
  M docs/README.md
 ?? docs/library/
 ?? tests/test_docs_library_mirror.py
@@ -15078,8 +15288,8 @@ thinking
 codex
 The content pass is complete. I’m running repo-native validation now: first the focused docs test, then `make lint` so the new Markdown and test file go through the same checks CI uses.
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'make test TESTS="tests/test_docs_library_mirror.py"' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path]
+/bin/zsh -lc 'make test TESTS="tests/test_docs_library_mirror.py"' in [redacted-path] update:
 diff --git a/docs/README.md b/docs/README.md
 index a189f0b58ce1de535b1e47d158ab449c5db8b9a2..502408fa2e4bb3f480a7a1532657fdceadeedc21
 --- a/docs/README.md
@@ -19086,7 +19296,7 @@ thinking
 codex
 Lint failed on one new file only: Ruff wants the imports in `tests/test_docs_library_mirror.py` reordered. I’m fixing that and rerunning `make lint`.
 file update
-M /Users/scidsg/hushline/tests/test_docs_library_mirror.py
+M [redacted-path]
 apply_patch(auto_approved=true) exited 0 in 225ms:
 Success. Updated the following files:
 M tests/test_docs_library_mirror.py
@@ -21730,7 +21940,7 @@ index 0000000000000000000000000000000000000000..354c30b5b5b67824039e90bef6c4ca60
 thinking
 **Checking import order**
 exec
-/bin/zsh -lc "sed -n '1,16p' tests/test_docs_library_mirror.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,16p' tests/test_docs_library_mirror.py" in [redacted-path] succeeded in 53ms:
 from __future__ import annotations
 
 import re
@@ -23069,7 +23279,7 @@ index 0000000000000000000000000000000000000000..354c30b5b5b67824039e90bef6c4ca60
 thinking
 **Adjusting switch order**
 file update
-M /Users/scidsg/hushline/tests/test_docs_library_mirror.py
+M [redacted-path]
 @@ -2,4 +2,4 @@
  
 +from pathlib import Path
@@ -25719,7 +25929,7 @@ index 0000000000000000000000000000000000000000..a7b469cc3cdd260fd0a9650632aa6df9
 thinking
 **Rerunning full lint checks**
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/docs/README.md b/docs/README.md
 index a189f0b58ce1de535b1e47d158ab449c5db8b9a2..502408fa2e4bb3f480a7a1532657fdceadeedc21
 --- a/docs/README.md
@@ -29700,7 +29910,7 @@ index 0000000000000000000000000000000000000000..a7b469cc3cdd260fd0a9650632aa6df9
 thinking
 **Assessing import sorting strategy**
 exec
-/bin/zsh -lc "sed -n '60,88p' Makefile" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '60,88p' Makefile" in [redacted-path] succeeded in 52ms:
 
 .PHONY: issue-bootstrap
 issue-bootstrap: ## Reset Docker state and reseed dev_data before issue work
@@ -32366,7 +32576,7 @@ index 0000000000000000000000000000000000000000..a7b469cc3cdd260fd0a9650632aa6df9
 thinking
 **Investigating import order rules**
 exec
-/bin/zsh -lc 'rg -n "isort|known_first_party|force_sort_within_sections|from_first|lines_after_imports|section-order" pyproject.toml' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'rg -n "isort|known_first_party|force_sort_within_sections|from_first|lines_after_imports|section-order" pyproject.toml' in [redacted-path] succeeded in 52ms:
 80:    "I",      # isort
 file update:
 diff --git a/docs/README.md b/docs/README.md
@@ -33692,7 +33902,7 @@ thinking
 codex
 `make fix` itself got blocked by Docker socket permissions in this sandbox, so I’m handling the Ruff complaint manually. The simplest stable fix is to drop the unnecessary future import and keep the file on plain Python 3.12 syntax.
 file update
-M /Users/scidsg/hushline/tests/test_docs_library_mirror.py
+M [redacted-path]
 @@ -1,5 +1,3 @@
 -from __future__ import annotations
 -
@@ -36339,7 +36549,7 @@ index 0000000000000000000000000000000000000000..36be3c7eae24f156bcc2f4b52d49dcb2
 thinking
 **Rerunning lint check**
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/docs/README.md b/docs/README.md
 index a189f0b58ce1de535b1e47d158ab449c5db8b9a2..502408fa2e4bb3f480a7a1532657fdceadeedc21
 --- a/docs/README.md
@@ -40314,7 +40524,7 @@ thinking
 codex
 Ruff is consistent now: it wants the `from ... import ...` line before the plain `import` line in this file. I’m applying that exact order and rerunning lint once more.
 file update
-M /Users/scidsg/hushline/tests/test_docs_library_mirror.py
+M [redacted-path]
 @@ -1,3 +1,3 @@
 +from pathlib import Path
  import re
@@ -42959,7 +43169,7 @@ index 0000000000000000000000000000000000000000..606993bdd01e9b2d4259cb88e1ee1c3d
 thinking
 **Rerunning lint checks**
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/docs/README.md b/docs/README.md
 index a189f0b58ce1de535b1e47d158ab449c5db8b9a2..502408fa2e4bb3f480a7a1532657fdceadeedc21
 --- a/docs/README.md
@@ -46937,7 +47147,7 @@ thinking
 codex
 I’m sidestepping Ruff’s import-sort edge case entirely by removing the regex dependency from the new test. A tiny manual Markdown-link scanner is enough for these docs and leaves the file with a single import line.
 file update
-M /Users/scidsg/hushline/tests/test_docs_library_mirror.py
+M [redacted-path]
 @@ -1,3 +1,2 @@
  from pathlib import Path
 -import re
@@ -49626,8 +49836,8 @@ index 0000000000000000000000000000000000000000..43989f22a977aff7512138ebf35b6c03
 +    assert not missing_targets, f"Broken docs links: {missing_targets}"
 
 exec
-/bin/zsh -lc 'make test TESTS="tests/test_docs_library_mirror.py"' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make test TESTS="tests/test_docs_library_mirror.py"' in [redacted-path]
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/docs/README.md b/docs/README.md
 index a189f0b58ce1de535b1e47d158ab449c5db8b9a2..502408fa2e4bb3f480a7a1532657fdceadeedc21
 --- a/docs/README.md
@@ -52334,7 +52544,7 @@ thinking
 codex
 Ruff’s complaint is down to import-block spacing now, not ordering. There are two blank lines after the lone import; I’m collapsing that to one and rerunning lint.
 file update
-M /Users/scidsg/hushline/tests/test_docs_library_mirror.py
+M [redacted-path]
 @@ -2,3 +2,2 @@
  
 -
@@ -54995,7 +55205,7 @@ index 0000000000000000000000000000000000000000..13aa94dd899c5f4d36f4cd5059cfb08d
 +    assert not missing_targets, f"Broken docs links: {missing_targets}"
 
 exec
-/bin/zsh -lc "sed -n '1,12p' tests/test_docs_library_mirror.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,12p' tests/test_docs_library_mirror.py" in [redacted-path] succeeded in 51ms:
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -57667,7 +57877,7 @@ index 0000000000000000000000000000000000000000..13aa94dd899c5f4d36f4cd5059cfb08d
 thinking
 **Rerunning lint checks**
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/docs/README.md b/docs/README.md
 index a189f0b58ce1de535b1e47d158ab449c5db8b9a2..502408fa2e4bb3f480a7a1532657fdceadeedc21
 --- a/docs/README.md
@@ -65659,8 +65869,8 @@ index 0000000000000000000000000000000000000000..13aa94dd899c5f4d36f4cd5059cfb08d
 thinking
 **Checking task status**
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff --stat -- docs/README.md docs/library tests/test_docs_library_mirror.py' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc 'git diff --stat -- docs/README.md docs/library tests/test_docs_library_mirror.py' in [redacted-path] succeeded in 53ms:
  M docs/README.md
 ?? docs/library/
 ?? tests/test_docs_library_mirror.py
@@ -67000,9 +67210,9 @@ thinking
 thinking
 **Summarizing documentation restructuring**
 codex
-Implemented the docs mirror under [docs/library/README.md](/Users/scidsg/hushline/docs/library/README.md) with category index pages and one Markdown file per requested article across `Welcome`, `Getting Started`, `Using Your Tip Line`, and `Personal Server`. The top-level docs entrypoint at [docs/README.md](/Users/scidsg/hushline/docs/README.md) now links both to the mirrored library docs and the existing repo docs.
+Implemented the docs mirror under [docs/library/README.md]([redacted-path] with category index pages and one Markdown file per requested article across `Welcome`, `Getting Started`, `Using Your Tip Line`, and `Personal Server`. The top-level docs entrypoint at [docs/README.md]([redacted-path] now links both to the mirrored library docs and the existing repo docs.
 
-I also added a regression test at [tests/test_docs_library_mirror.py](/Users/scidsg/hushline/tests/test_docs_library_mirror.py) that verifies the required mirrored files exist and that relative links in the new docs resolve correctly in-repo.
+I also added a regression test at [tests/test_docs_library_mirror.py]([redacted-path] that verifies the required mirrored files exist and that relative links in the new docs resolve correctly in-repo.
 
 Validation:
 - `make test TESTS="tests/test_docs_library_mirror.py"` passed
@@ -68337,9 +68547,9 @@ index 0000000000000000000000000000000000000000..13aa94dd899c5f4d36f4cd5059cfb08d
 
 tokens used
 223,784
-Implemented the docs mirror under [docs/library/README.md](/Users/scidsg/hushline/docs/library/README.md) with category index pages and one Markdown file per requested article across `Welcome`, `Getting Started`, `Using Your Tip Line`, and `Personal Server`. The top-level docs entrypoint at [docs/README.md](/Users/scidsg/hushline/docs/README.md) now links both to the mirrored library docs and the existing repo docs.
+Implemented the docs mirror under [docs/library/README.md]([redacted-path] with category index pages and one Markdown file per requested article across `Welcome`, `Getting Started`, `Using Your Tip Line`, and `Personal Server`. The top-level docs entrypoint at [docs/README.md]([redacted-path] now links both to the mirrored library docs and the existing repo docs.
 
-I also added a regression test at [tests/test_docs_library_mirror.py](/Users/scidsg/hushline/tests/test_docs_library_mirror.py) that verifies the required mirrored files exist and that relative links in the new docs resolve correctly in-repo.
+I also added a regression test at [tests/test_docs_library_mirror.py]([redacted-path] that verifies the required mirrored files exist and that relative links in the new docs resolve correctly in-repo.
 
 Validation:
 - `make test TESTS="tests/test_docs_library_mirror.py"` passed
@@ -68348,9 +68558,9 @@ Validation:
 I did not run the full `make test` suite.
 Codex execution completed.
 Codex final message:
-Implemented the docs mirror under [docs/library/README.md](/Users/scidsg/hushline/docs/library/README.md) with category index pages and one Markdown file per requested article across `Welcome`, `Getting Started`, `Using Your Tip Line`, and `Personal Server`. The top-level docs entrypoint at [docs/README.md](/Users/scidsg/hushline/docs/README.md) now links both to the mirrored library docs and the existing repo docs.
+Implemented the docs mirror under [docs/library/README.md]([redacted-path] with category index pages and one Markdown file per requested article across `Welcome`, `Getting Started`, `Using Your Tip Line`, and `Personal Server`. The top-level docs entrypoint at [docs/README.md]([redacted-path] now links both to the mirrored library docs and the existing repo docs.
 
-I also added a regression test at [tests/test_docs_library_mirror.py](/Users/scidsg/hushline/tests/test_docs_library_mirror.py) that verifies the required mirrored files exist and that relative links in the new docs resolve correctly in-repo.
+I also added a regression test at [tests/test_docs_library_mirror.py]([redacted-path] that verifies the required mirrored files exist and that relative links in the new docs resolve correctly in-repo.
 
 Validation:
 - `make test TESTS="tests/test_docs_library_mirror.py"` passed
@@ -68424,7 +68634,7 @@ Success: no issues found in 148 source files
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run workflow security checks
-docker run --rm -v "/Users/scidsg/hushline:/work" -w /work rhysd/actionlint:1.7.7 -color
+docker run --rm -v "[redacted-path]" -w /work rhysd/actionlint:1.7.7 -color
 Unable to find image 'rhysd/actionlint:1.7.7' locally
 1.7.7: Pulling from rhysd/actionlint
 25d2e00cf929: Pulling fs layer

--- a/docs/agent-logs/run-20260228T193005Z-issue-1458.txt
+++ b/docs/agent-logs/run-20260228T193005Z-issue-1458.txt
@@ -3,7 +3,7 @@ Timestamp (UTC): 20260228T193005Z
 Issue: #1458
 Repository: scidsg/hushline
 
-Runner Codex config: model=gpt-5.3-codex reasoning_effort=high verbose_codex_output=0
+Runner Codex config: [redacted]
 ==> Fetch latest from origin
 ==> Checkout main
 Already on 'main'
@@ -1394,23 +1394,128 @@ Total reclaimed space: 5.022GB
 #7 8.992 Get:460 http://deb.debian.org/debian bookworm/main arm64 pkg-config arm64 1.8.1-1 [13.7 kB]
 #7 9.139 debconf: delaying package configuration, since apt-utils is not installed
 #7 9.160 Fetched 162 MB in 4s (46.1 MB/s)
-#7 9.183 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6689 files and directories currently installed.)
+#7 9.183 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6689 files and directories currently installed.)
 #7 9.188 Preparing to unpack .../perl-base_5.36.0-7+deb12u3_arm64.deb ...
 #7 9.203 Unpacking perl-base (5.36.0-7+deb12u3) over (5.36.0-7+deb12u1) ...
 #7 10.38 Setting up perl-base (5.36.0-7+deb12u3) ...
-#7 10.41 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.41 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.41 Preparing to unpack .../gcc-12-base_12.2.0-14+deb12u1_arm64.deb ...
 #7 10.42 Unpacking gcc-12-base:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 10.44 Setting up gcc-12-base:arm64 (12.2.0-14+deb12u1) ...
-#7 10.47 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.47 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.47 Preparing to unpack .../libgcc-s1_12.2.0-14+deb12u1_arm64.deb ...
 #7 10.48 Unpacking libgcc-s1:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 10.51 Setting up libgcc-s1:arm64 (12.2.0-14+deb12u1) ...
-#7 10.54 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.54 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.54 Preparing to unpack .../libstdc++6_12.2.0-14+deb12u1_arm64.deb ...
 #7 10.55 Unpacking libstdc++6:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 10.63 Setting up libstdc++6:arm64 (12.2.0-14+deb12u1) ...
-#7 10.67 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.67 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.67 Preparing to unpack .../libc6_2.36-9+deb12u13_arm64.deb ...
 #7 10.72 debconf: unable to initialize frontend: Dialog
 #7 10.72 debconf: (TERM is not set, so the dialog frontend is not usable.)
@@ -1426,12 +1531,54 @@ Total reclaimed space: 5.022GB
 #7 11.54 debconf: unable to initialize frontend: Readline
 #7 11.54 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
 #7 11.54 debconf: falling back to frontend: Teletype
-#7 12.58 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 12.58 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 12.59 Preparing to unpack .../libc-bin_2.36-9+deb12u13_arm64.deb ...
 #7 12.59 Unpacking libc-bin (2.36-9+deb12u13) over (2.36-9+deb12u8) ...
 #7 12.69 Setting up libc-bin (2.36-9+deb12u13) ...
 #7 12.73 Selecting previously unselected package perl-modules-5.36.
-#7 12.73 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 12.73 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 12.74 Preparing to unpack .../0-perl-modules-5.36_5.36.0-7+deb12u3_all.deb ...
 #7 12.74 Unpacking perl-modules-5.36 (5.36.0-7+deb12u3) ...
 #7 12.94 Selecting previously unselected package libgdbm-compat4:arm64.
@@ -1455,7 +1602,28 @@ Total reclaimed space: 5.022GB
 #7 13.66 Setting up libpython3.11-minimal:arm64 (3.11.2-6+deb12u6) ...
 #7 13.67 Setting up python3.11-minimal (3.11.2-6+deb12u6) ...
 #7 14.06 Selecting previously unselected package python3-minimal.
-#7 14.06 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9002 files and directories currently installed.)
+#7 14.06 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9002 files and directories currently installed.)
 #7 14.06 Preparing to unpack .../python3-minimal_3.11.2-1+b1_arm64.deb ...
 #7 14.07 Unpacking python3-minimal (3.11.2-1+b1) ...
 #7 14.08 Selecting previously unselected package media-types.
@@ -1465,7 +1633,28 @@ Total reclaimed space: 5.022GB
 #7 14.12 Unpacking liblzma5:arm64 (5.4.1-1) over (5.4.1-0.2) ...
 #7 14.15 Setting up liblzma5:arm64 (5.4.1-1) ...
 #7 14.17 Selecting previously unselected package libpython3.11-stdlib:arm64.
-#7 14.17 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9030 files and directories currently installed.)
+#7 14.17 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9030 files and directories currently installed.)
 #7 14.18 Preparing to unpack .../libpython3.11-stdlib_3.11.2-6+deb12u6_arm64.deb ...
 #7 14.18 Unpacking libpython3.11-stdlib:arm64 (3.11.2-6+deb12u6) ...
 #7 14.30 Selecting previously unselected package python3.11.
@@ -1476,7 +1665,28 @@ Total reclaimed space: 5.022GB
 #7 14.33 Unpacking libpython3-stdlib:arm64 (3.11.2-1+b1) ...
 #7 14.35 Setting up python3-minimal (3.11.2-1+b1) ...
 #7 14.45 Selecting previously unselected package python3.
-#7 14.45 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9412 files and directories currently installed.)
+#7 14.45 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9412 files and directories currently installed.)
 #7 14.45 Preparing to unpack .../000-python3_3.11.2-1+b1_arm64.deb ...
 #7 14.45 Unpacking python3 (3.11.2-1+b1) ...
 #7 14.47 Selecting previously unselected package bzip2.
@@ -3699,14 +3909,14 @@ Switched to a new branch 'codex/daily-issue-1458'
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.105.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.3-codex
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR]
-reasoning effort: high
-reasoning summaries: auto
-session id: 019ca5bd-34fa-7d43-8486-da9a33130c7d
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are implementing GitHub issue #1458 in scidsg/hushline.
@@ -3918,9 +4128,9 @@ mcp startup: no servers
 codex
 I’m inspecting the directory implementation, relevant models/routes/tests, and checking for any deeper `AGENTS.md` files that narrow the rules before I edit anything.
 exec
-/bin/zsh -lc "rg --files -g 'AGENTS.md'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'ls -la' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "directory|Verified|All|Send Message|message-capable|public record|badge" .' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "rg --files -g 'AGENTS.md'" in [redacted-path]
+/bin/zsh -lc 'ls -la' in [redacted-path]
+/bin/zsh -lc 'rg -n "directory|Verified|All|Send Message|message-capable|public record|badge" .' in [redacted-path] succeeded in 52ms:
 AGENTS.md
  succeeded in 51ms:
 total 1056
@@ -3970,7 +4180,7 @@ thinking
 codex
 I’ve confirmed there’s no deeper `AGENTS.md` under the directory code. Next I’m reading the directory route/template and the recipient-resolution path so I can add a separate listing type without letting it leak into message delivery.
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/routes/directory.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/routes/directory.py" in [redacted-path] succeeded in 52ms:
 from flask import (
     Flask,
     render_template,
@@ -3992,10 +4202,10 @@ def register_directory_routes(app: Flask) -> None:
         verified_pgp_usernames = [username for username in pgp_usernames if username.is_verified]
         verified_info_usernames = [username for username in info_usernames if username.is_verified]
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/routes/common.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' hushline/templates/directory.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' assets/js/directory.js" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,320p' assets/js/directory_verified.js" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/routes/common.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' hushline/templates/directory.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' assets/js/directory.js" in [redacted-path]
+/bin/zsh -lc "sed -n '1,320p' assets/js/directory_verified.js" in [redacted-path] succeeded in 51ms:
 document.addEventListener("DOMContentLoaded", function () {
   const userSearch = window.HushlineUserSearch;
   const pathPrefix = window.location.pathname.split("/").slice(0, -1).join("/");
@@ -4085,9 +4295,9 @@ thinking
 codex
 The current directory is still hard-wired to usernames and the search JS only knows two buckets: verified and all. I’m tracing the profile and submission routes now, because the issue explicitly requires policy-level blocking for non-messageable public-record entries.
 exec
-/bin/zsh -lc 'rg --files hushline/templates tests | rg "profile|submit|directory|message|public"' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"class User\\b|class Username\\b|pgp_key|show_in_directory|is_verified\" hushline/model* hushline" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"@app.route\\(|def profile\\(|url_for\\('profile'|/to/<|reply_slug|Username\\)|filter_by\\(username|primary_username\" hushline tests" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'rg --files hushline/templates tests | rg "profile|submit|directory|message|public"' in [redacted-path]
+/bin/zsh -lc "rg -n \"class User\\b|class Username\\b|pgp_key|show_in_directory|is_verified\" hushline/model* hushline" in [redacted-path]
+/bin/zsh -lc "rg -n \"@app.route\\(|def profile\\(|url_for\\('profile'|/to/<|reply_slug|Username\\)|filter_by\\(username|primary_username\" hushline tests" in [redacted-path] succeeded in 52ms:
 tests/test_resend_message.py
 tests/test_directory.py
 tests/test_profile.py
@@ -4145,7 +4355,7 @@ thinking
 codex
 I’ve got the likely minimal shape now: keep real recipients on `Username`, add a separate seeded public-record listing type and read-only route, then teach the directory UI/search to render both without ever routing those records into `/to/<username>` or message submission. I’m reading the profile route/template to line that up cleanly.
 exec
-/bin/zsh -lc "sed -n '1,340p' hushline/routes/profile.py" in /Users/scidsg/hushline succeeded in 50ms:
+/bin/zsh -lc "sed -n '1,340p' hushline/routes/profile.py" in [redacted-path] succeeded in 50ms:
 import secrets
 
 from flask import (
@@ -4167,10 +4377,10 @@ from hushline.db import db
 from hushline.model import (
     FieldDefinition,
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/templates/profile.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' hushline/model/username.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' tests/test_directory.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,420p' tests/test_profile.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/templates/profile.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' hushline/model/username.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' tests/test_directory.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,420p' tests/test_profile.py" in [redacted-path] succeeded in 51ms:
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, Generator, Optional, Sequence
 
@@ -4258,10 +4468,10 @@ def test_profile_header(client: FlaskClient, user: User) -> None:
 thinking
 **Searching config for feature flag**
 exec
-/bin/zsh -lc "sed -n '1,120p' tests/test_frontend_compat.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '200,280p' hushline/__init__.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,180p' tests/test_accessibility.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "directory_verified_tab_enabled|DIRECTORY_VERIFIED|verified tab" hushline tests' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,120p' tests/test_frontend_compat.py" in [redacted-path]
+/bin/zsh -lc "sed -n '200,280p' hushline/__init__.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,180p' tests/test_accessibility.py" in [redacted-path]
+/bin/zsh -lc 'rg -n "directory_verified_tab_enabled|DIRECTORY_VERIFIED|verified tab" hushline tests' in [redacted-path] succeeded in 52ms:
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
@@ -4336,9 +4546,9 @@ hushline/config.py:157:        ("DIRECTORY_VERIFIED_TAB_ENABLED", True),
 thinking
 **Identifying static data file location**
 exec
-/bin/zsh -lc "sed -n '1,120p' Makefile" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "users_directory.json|static/data" hushline tests assets scripts' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'find hushline -maxdepth 3 -type f | rg "static/data|templates/.+public|routes/.+public|model/.+public"' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,120p' Makefile" in [redacted-path]
+/bin/zsh -lc 'rg -n "users_directory.json|static/data" hushline tests assets scripts' in [redacted-path]
+/bin/zsh -lc 'find hushline -maxdepth 3 -type f | rg "static/data|templates/.+public|routes/.+public|model/.+public"' in [redacted-path] succeeded in 52ms:
 .DEFAULT_GOAL := help
 
 ifndef IS_DOCKER
@@ -4367,9 +4577,9 @@ install:
 thinking
 **Scoping model and UI for public records**
 exec
-/bin/zsh -lc "sed -n '1,220p' tests/conftest.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '130,190p' hushline/config.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"DIRECTORY_VERIFIED_TAB_ENABLED|directory_verified_tab_enabled\" tests hushline | sed -n '1,120p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' tests/conftest.py" in [redacted-path]
+/bin/zsh -lc "sed -n '130,190p' hushline/config.py" in [redacted-path]
+/bin/zsh -lc "rg -n \"DIRECTORY_VERIFIED_TAB_ENABLED|directory_verified_tab_enabled\" tests hushline | sed -n '1,120p'" in [redacted-path] succeeded in 52ms:
 import os
 import random
 import string
@@ -4431,8 +4641,8 @@ thinking
 thinking
 **Evaluating seed data sourcing options**
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/model/__init__.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "law firm|law-firm|attorney|lawyer|public record|public records|practice tag|source label" .' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/model/__init__.py" in [redacted-path]
+/bin/zsh -lc 'rg -n "law firm|law-firm|attorney|lawyer|public record|public records|practice tag|source label" .' in [redacted-path] succeeded in 52ms:
 # ruff: noqa: F401
 
 from hushline.model.authentication_log import AuthenticationLog
@@ -4494,9 +4704,9 @@ I’ve got enough context to start changing code. The edit plan is:
 3. Extend the directory page and search JSON to render `Verified`, `Public Records`, and `All`, with explicit `Public Record` and `Automated` badges.
 4. Update tests for tab structure, badges, visibility, and route-level non-messageability, then run targeted `make test` slices.
 exec
-/bin/zsh -lc 'cat package.json' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,120p' webpack.config.js" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'ls -la hushline/static/js' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc 'cat package.json' in [redacted-path]
+/bin/zsh -lc "sed -n '1,120p' webpack.config.js" in [redacted-path]
+/bin/zsh -lc 'ls -la hushline/static/js' in [redacted-path] succeeded in 51ms:
 const path = require('path');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
@@ -4586,8 +4796,8 @@ thinking
 codex
 I’ve settled on a separate read-only listing route plus a small seeded dataset of whistleblower-focused law firms. I’m patching the loader, directory route/template, and profile-side guardrails now, then I’ll tighten the tests around the new JSON shape and the no-message path.
 exec
-/bin/zsh -lc "sed -n '270,330p' tests/test_behavior_contracts.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,120p' tests/test_routes_common.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '270,330p' tests/test_behavior_contracts.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,120p' tests/test_routes_common.py" in [redacted-path] succeeded in 51ms:
         url_for("onboarding"),
         data={"step": "directory", "show_in_directory": "y"},
         follow_redirects=False,
@@ -4633,8 +4843,8 @@ def test_valid_username_validator() -> None:
 thinking
 **Assessing route registration approach**
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/routes/__init__.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,120p' hushline/routes/directory.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/routes/__init__.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,120p' hushline/routes/directory.py" in [redacted-path] succeeded in 52ms:
 import logging
 
 from flask import (
@@ -4688,7 +4898,7 @@ thinking
 codex
 I’m starting the file edits now: new public-record model/seed data, then the directory route/template and a read-only detail view. After that I’ll update the client search rendering and the tests in one pass.
 file update
-A /Users/scidsg/hushline/hushline/model/public_record_listing.py
+A [redacted-path]
 from __future__ import annotations
 
 import json
@@ -4758,7 +4968,7 @@ def _build_listing(row: dict[str, Any]) -> PublicRecordListing:
         source_label=row["source_label"],
         source_url=row.get("source_url"),
     )
-A /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
+A [redacted-path]
 [
   {
     "id": "seed-katz-banks-kumin",
@@ -4796,8 +5006,8 @@ A /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
 ]
 apply_patch(auto_approved=true) exited 0 in 76ms:
 Success. Updated the following files:
-A /Users/scidsg/hushline/hushline/model/public_record_listing.py
-A /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
+A [redacted-path]
+A [redacted-path]
 file update:
 diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
 new file mode 100644
@@ -5038,7 +5248,7 @@ index 0000000000000000000000000000000000000000..63f67071ef46285d9cd7095a1c81e249
 thinking
 **Updating model initialization export**
 file update
-M /Users/scidsg/hushline/hushline/model/__init__.py
+M [redacted-path]
 @@ -17,2 +17,7 @@
  from hushline.model.organization_setting import OrganizationSetting
 +from hushline.model.public_record_listing import (
@@ -5049,7 +5259,7 @@ M /Users/scidsg/hushline/hushline/model/__init__.py
  from hushline.model.stripe_event import StripeEvent
 apply_patch(auto_approved=true) exited 0 in 64ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/model/__init__.py
+M [redacted-path]
 file update:
 diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
 new file mode 100644
@@ -5322,7 +5532,7 @@ index 0000000000000000000000000000000000000000..63f67071ef46285d9cd7095a1c81e249
 thinking
 **Designing directory routes**
 file update
-M /Users/scidsg/hushline/hushline/routes/directory.py
+M [redacted-path]
 @@ -2,4 +2,6 @@
      Flask,
 +    abort,
@@ -5422,7 +5632,7 @@ M /Users/scidsg/hushline/hushline/routes/directory.py
          ]
 apply_patch(auto_approved=true) exited 0 in 68ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/routes/directory.py
+M [redacted-path]
 file update:
 diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
 new file mode 100644
@@ -5920,7 +6130,7 @@ thinking
 thinking
 **Planning accessibility and UI refinements**
 file update
-A /Users/scidsg/hushline/hushline/templates/directory.html
+A [redacted-path]
 {% extends "base.html" %}
 
 {% block title %}Directory{% endblock %}
@@ -6254,8 +6464,8 @@ A /Users/scidsg/hushline/hushline/templates/directory.html
 {% endblock %}
 apply_patch(auto_approved=true) exited 0 in 90ms:
 Success. Updated the following files:
-A /Users/scidsg/hushline/hushline/templates/directory.html
-D /Users/scidsg/hushline/hushline/templates/directory.html
+A [redacted-path]
+D [redacted-path]
 file update:
 diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
 new file mode 100644
@@ -7486,7 +7696,7 @@ index 7747d0a2efb39ff7d8d0250e8c6e709c36f9ad72..01837c7247be81c7facef17436b73877
 thinking
 **Adding detail template file**
 file update
-A /Users/scidsg/hushline/hushline/templates/directory_public_record.html
+A [redacted-path]
 {% extends "base.html" %}
 
 {% block title %}Public Record: {{ listing.name }}{% endblock %}
@@ -7539,7 +7749,7 @@ A /Users/scidsg/hushline/hushline/templates/directory_public_record.html
 {% endblock %}
 apply_patch(auto_approved=true) exited 0 in 109ms:
 Success. Updated the following files:
-A /Users/scidsg/hushline/hushline/templates/directory_public_record.html
+A [redacted-path]
 file update:
 diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
 new file mode 100644
@@ -8882,8 +9092,8 @@ index 0000000000000000000000000000000000000000..c334e6f18f9adb7b38a4dd05eb0cc0fe
 thinking
 **Updating verified.js for tabbed search**
 exec
-/bin/zsh -lc "sed -n '1,220p' assets/js/user_search.js" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,120p' hushline/static/js/user_search.js" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' assets/js/user_search.js" in [redacted-path]
+/bin/zsh -lc "sed -n '1,120p' hushline/static/js/user_search.js" in [redacted-path] succeeded in 52ms:
 (function () {
   function normalizeSearchText(parts) {
     return parts
@@ -9603,7 +9813,7 @@ thinking
 codex
 I hit one template detail while wiring the tabs: the no-verified configuration needs a single default active tab, not two. I’m fixing that while I finish the tab/search JS so the three-way filtering stays deterministic.
 file update
-M /Users/scidsg/hushline/hushline/templates/directory.html
+M [redacted-path]
 @@ -33,6 +33,6 @@
            type="button"
 -          class="tab {% if not directory_verified_tab_enabled %}active{% endif %}"
@@ -9620,7 +9830,7 @@ M /Users/scidsg/hushline/hushline/templates/directory.html
      role="tabpanel"
 apply_patch(auto_approved=true) exited 0 in 104ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/templates/directory.html
+M [redacted-path]
 file update:
 diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
 new file mode 100644
@@ -10963,7 +11173,7 @@ index 0000000000000000000000000000000000000000..c334e6f18f9adb7b38a4dd05eb0cc0fe
 thinking
 **Patching JavaScript file**
 file update
-A /Users/scidsg/hushline/assets/js/directory_verified.js
+A [redacted-path]
 document.addEventListener("DOMContentLoaded", function () {
   const userSearch = window.HushlineUserSearch;
   const pathPrefix = window.location.pathname.split("/").slice(0, -1).join("/");
@@ -11379,8 +11589,8 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 apply_patch(auto_approved=true) exited 0 in 99ms:
 Success. Updated the following files:
-A /Users/scidsg/hushline/assets/js/directory_verified.js
-D /Users/scidsg/hushline/assets/js/directory_verified.js
+A [redacted-path]
+D [redacted-path]
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
 index ad057cce0d909ed0d94174ee352b5f467556af40..3d8071cc8e39e80441e6a27bf4176e6ac00ac710
@@ -13478,7 +13688,7 @@ thinking
 codex
 I’m on the test pass now. I’m adding coverage for the new tab, JSON row shape, the read-only listing page, and the redirect path that must end in `404` for a public-record slug.
 file update
-M /Users/scidsg/hushline/tests/test_directory.py
+M [redacted-path]
 @@ -1,2 +1,3 @@
  import pytest
 +from bs4 import BeautifulSoup
@@ -13561,7 +13771,7 @@ M /Users/scidsg/hushline/tests/test_directory.py
 +    assert response.status_code == 404
 apply_patch(auto_approved=true) exited 0 in 103ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_directory.py
+M [redacted-path]
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
 index ad057cce0d909ed0d94174ee352b5f467556af40..3d8071cc8e39e80441e6a27bf4176e6ac00ac710
@@ -15838,7 +16048,7 @@ index 302f7fcdaea09c3cc28ecbf19349aef857ee10ac..3e85b9bb31aa248702d2c063439eeb5b
 thinking
 **Updating accessibility test**
 file update
-M /Users/scidsg/hushline/tests/test_accessibility.py
+M [redacted-path]
 @@ -16,4 +16,6 @@
      verified_tab = soup.find("button", {"id": "verified-tab"})
 +    public_records_tab = soup.find("button", {"id": "public-records-tab"})
@@ -15860,7 +16070,7 @@ M /Users/scidsg/hushline/tests/test_accessibility.py
      assert all_panel is not None
 apply_patch(auto_approved=true) exited 0 in 102ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_accessibility.py
+M [redacted-path]
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
 index ad057cce0d909ed0d94174ee352b5f467556af40..3d8071cc8e39e80441e6a27bf4176e6ac00ac710
@@ -18208,7 +18418,7 @@ thinking
 thinking
 **Adjusting record labeling logic**
 file update
-M /Users/scidsg/hushline/assets/js/directory_verified.js
+M [redacted-path]
 @@ -230,3 +230,3 @@
      appendSection(panel, "", withPgp, query);
 -    appendSection(panel, withPgp.length ? "📇 Info-Only Accounts" : "", infoOnly, query);
@@ -18216,7 +18426,7 @@ M /Users/scidsg/hushline/assets/js/directory_verified.js
  
 apply_patch(auto_approved=true) exited 0 in 135ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/assets/js/directory_verified.js
+M [redacted-path]
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
 index ad057cce0d909ed0d94174ee352b5f467556af40..3b3ae2fb8e64e05ae758f303e9f42a4605e5e131
@@ -20561,7 +20771,7 @@ index 302f7fcdaea09c3cc28ecbf19349aef857ee10ac..3e85b9bb31aa248702d2c063439eeb5b
 thinking
 **Adjusting messaging capability flag**
 file update
-M /Users/scidsg/hushline/hushline/routes/directory.py
+M [redacted-path]
 @@ -30,3 +30,3 @@
          "is_automated": False,
 -        "message_capable": True,
@@ -20569,7 +20779,7 @@ M /Users/scidsg/hushline/hushline/routes/directory.py
          "meta": f"@{username.username}",
 apply_patch(auto_approved=true) exited 0 in 144ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/routes/directory.py
+M [redacted-path]
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
 index ad057cce0d909ed0d94174ee352b5f467556af40..3b3ae2fb8e64e05ae758f303e9f42a4605e5e131
@@ -22916,7 +23126,7 @@ thinking
 codex
 The code paths are in place. I’m running repo formatting/build steps next so the committed assets and templates match the source edits before I execute targeted tests.
 exec
-/bin/zsh -lc 'npm run build:prod' in /Users/scidsg/hushline exited 127 in 197ms:
+/bin/zsh -lc 'npm run build:prod' in [redacted-path] exited 127 in 197ms:
 
 > hushline@0.0.0 build:prod
 > webpack --config webpack.config.js
@@ -24098,8 +24308,8 @@ thinking
 codex
 The repo `make fix` path is blocked here because it shells through Docker, and this sandbox can’t reach the Docker socket. The frontend bundle command also failed because `webpack` isn’t available on the host PATH in this workspace, so I’m checking whether the local `node_modules` install is usable before I fall back to code-only validation.
 exec
-/bin/zsh -lc 'ls -la node_modules/.bin' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff -- hushline/routes/directory.py hushline/templates/directory.html hushline/templates/directory_public_record.html hushline/model/public_record_listing.py hushline/model/__init__.py assets/js/directory_verified.js tests/test_directory.py tests/test_accessibility.py' in /Users/scidsg/hushline exited 1 in 52ms:
+/bin/zsh -lc 'ls -la node_modules/.bin' in [redacted-path]
+/bin/zsh -lc 'git diff -- hushline/routes/directory.py hushline/templates/directory.html hushline/templates/directory_public_record.html hushline/model/public_record_listing.py hushline/model/__init__.py assets/js/directory_verified.js tests/test_directory.py tests/test_accessibility.py' in [redacted-path] exited 1 in 52ms:
 ls: node_modules/.bin: No such file or directory
  succeeded in 52ms:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
@@ -25298,7 +25508,7 @@ thinking
 codex
 I can’t run the Docker-backed `make test`/`make lint` targets in this sandbox, so I’m doing a manual syntax and diff review now to catch obvious issues before handing this back.
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/model/public_record_listing.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/model/public_record_listing.py" in [redacted-path] succeeded in 52ms:
 from __future__ import annotations
 
 import json
@@ -25320,8 +25530,8 @@ class PublicRecordListing:
     city: str
     state: str
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/routes/directory.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,240p' tests/test_directory.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/routes/directory.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,240p' tests/test_directory.py" in [redacted-path] succeeded in 52ms:
 import pytest
 from bs4 import BeautifulSoup
 from flask import url_for
@@ -25364,7 +25574,7 @@ from hushline.routes.common import get_directory_usernames
 
 def _directory_user_row(username: Username) -> dict[str, object | None]:
 exec
-/bin/zsh -lc 'python3 -m py_compile hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py' in /Users/scidsg/hushline succeeded in 110ms:
+/bin/zsh -lc 'python3 -m py_compile hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py' in [redacted-path] succeeded in 110ms:
 
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
@@ -26540,9 +26750,9 @@ index 302f7fcdaea09c3cc28ecbf19349aef857ee10ac..3e85b9bb31aa248702d2c063439eeb5b
 thinking
 **Verifying template details**
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/templates/directory.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' assets/js/directory_verified.js" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' hushline/templates/directory_public_record.html" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/templates/directory.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' assets/js/directory_verified.js" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' hushline/templates/directory_public_record.html" in [redacted-path] succeeded in 52ms:
 {% extends "base.html" %}
 
 {% block title %}Public Record: {{ listing.name }}{% endblock %}
@@ -27779,8 +27989,8 @@ index 302f7fcdaea09c3cc28ecbf19349aef857ee10ac..3e85b9bb31aa248702d2c063439eeb5b
 thinking
 **Checking line lengths on changed files**
 exec
-/bin/zsh -lc "awk 'length("'$0) > 100 { print FNR ":" length($0) " " $0 }'"' assets/js/directory_verified.js" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "awk 'length("'$0) > 100 { print FNR ":" length($0) " " $0 }'"' hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "awk 'length("'$0) > 100 { print FNR ":" length($0) " " $0 }'"' assets/js/directory_verified.js" in [redacted-path]
+/bin/zsh -lc "awk 'length("'$0) > 100 { print FNR ":" length($0) " " $0 }'"' hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py" in [redacted-path] succeeded in 51ms:
 53:106         (listing for listing in get_public_record_listings() if listing.slug.casefold() == slug_casefold),
 65:101 def test_directory_public_records_render_only_in_public_records_and_all(client: FlaskClient) -> None:
  succeeded in 51ms:
@@ -28964,7 +29174,7 @@ index 302f7fcdaea09c3cc28ecbf19349aef857ee10ac..3e85b9bb31aa248702d2c063439eeb5b
 thinking
 **Identifying missing JS formatting and line-length issues**
 file update
-M /Users/scidsg/hushline/hushline/model/public_record_listing.py
+M [redacted-path]
 @@ -52,3 +52,7 @@
      return next(
 -        (listing for listing in get_public_record_listings() if listing.slug.casefold() == slug_casefold),
@@ -28974,7 +29184,7 @@ M /Users/scidsg/hushline/hushline/model/public_record_listing.py
 +            if listing.slug.casefold() == slug_casefold
 +        ),
          None,
-M /Users/scidsg/hushline/tests/test_directory.py
+M [redacted-path]
 @@ -64,3 +64,5 @@
  
 -def test_directory_public_records_render_only_in_public_records_and_all(client: FlaskClient) -> None:
@@ -28984,8 +29194,8 @@ M /Users/scidsg/hushline/tests/test_directory.py
      listing = get_public_record_listings()[0]
 apply_patch(auto_approved=true) exited 0 in 132ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/model/public_record_listing.py
-M /Users/scidsg/hushline/tests/test_directory.py
+M [redacted-path]
+M [redacted-path]
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
 index ad057cce0d909ed0d94174ee352b5f467556af40..3b3ae2fb8e64e05ae758f303e9f42a4605e5e131
@@ -31342,7 +31552,7 @@ index 302f7fcdaea09c3cc28ecbf19349aef857ee10ac..bae1a18a88ec8706384191fe2ad593c9
 thinking
 **Considering rerunning line routing**
 exec
-/bin/zsh -lc "awk 'length("'$0) > 100 { print FNR ":" length($0) " " $0 }'"' hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "awk 'length("'$0) > 100 { print FNR ":" length($0) " " $0 }'"' hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py" in [redacted-path] succeeded in 51ms:
 
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
@@ -32526,7 +32736,7 @@ thinking
 codex
 The remaining functional gap is the checked-in static bundle: the app serves `hushline/static/js/directory_verified.js`, and I can’t regenerate it with webpack here. I’m replacing that one file directly with the updated source so the browser path matches the template changes.
 file update
-A /Users/scidsg/hushline/hushline/static/js/directory_verified.js
+A [redacted-path]
 document.addEventListener("DOMContentLoaded", function () {
   const userSearch = window.HushlineUserSearch;
   const pathPrefix = window.location.pathname.split("/").slice(0, -1).join("/");
@@ -32942,8 +33152,8 @@ document.addEventListener("DOMContentLoaded", function () {
 });
 apply_patch(auto_approved=true) exited 0 in 119ms:
 Success. Updated the following files:
-A /Users/scidsg/hushline/hushline/static/js/directory_verified.js
-D /Users/scidsg/hushline/hushline/static/js/directory_verified.js
+A [redacted-path]
+D [redacted-path]
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
 index ad057cce0d909ed0d94174ee352b5f467556af40..3b3ae2fb8e64e05ae758f303e9f42a4605e5e131
@@ -36191,9 +36401,9 @@ index 302f7fcdaea09c3cc28ecbf19349aef857ee10ac..bae1a18a88ec8706384191fe2ad593c9
 +    assert response.status_code == 404
 
 exec
-/bin/zsh -lc "awk 'length("'$0) > 120 { print FNR ":" length($0) " " $0 }'"' hushline/static/js/directory_verified.js assets/js/directory_verified.js hushline/templates/directory.html hushline/templates/directory_public_record.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'python3 -m py_compile hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "awk 'length("'$0) > 120 { print FNR ":" length($0) " " $0 }'"' hushline/static/js/directory_verified.js assets/js/directory_verified.js hushline/templates/directory.html hushline/templates/directory_public_record.html" in [redacted-path]
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc 'python3 -m py_compile hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py' in [redacted-path] succeeded in 53ms:
 143:148       <article class="user" aria-label="Public record listing, Display name:${user.display_name}, Location: ${user.location || "Unknown location"}">
 175:179       <article class="user" aria-label="${userType}, Display name:${user.display_name || user.primary_username}, Username: ${user.primary_username}, Bio: ${user.bio || "No bio"}">
 181:125           <a href="${user.profile_url}" aria-label="${user.display_name || user.primary_username}'s profile">View Profile</a>
@@ -37839,7 +38049,7 @@ index 302f7fcdaea09c3cc28ecbf19349aef857ee10ac..bae1a18a88ec8706384191fe2ad593c9
 thinking
 **Analyzing missing file status**
 exec
-/bin/zsh -lc 'git status --short hushline/static/js/directory_verified.js && git ls-files hushline/static/js/directory_verified.js' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git status --short hushline/static/js/directory_verified.js && git ls-files hushline/static/js/directory_verified.js' in [redacted-path] succeeded in 53ms:
 
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
@@ -39479,7 +39689,7 @@ thinking
 codex
 I’m tightening one edge case before I close this out: the public-record route slug should never be a valid Hush Line username. I’m switching those slugs to a format usernames can’t take, so the listing identifiers can’t collide with secure-recipient routes.
 file update
-M /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
+M [redacted-path]
 @@ -3,3 +3,3 @@
      "id": "seed-katz-banks-kumin",
 -    "slug": "katz-banks-kumin",
@@ -39497,7 +39707,7 @@ M /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
      "name": "Constantine Cannon LLP",
 apply_patch(auto_approved=true) exited 0 in 137ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
+M [redacted-path]
 file update:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
 index ad057cce0d909ed0d94174ee352b5f467556af40..3b3ae2fb8e64e05ae758f303e9f42a4605e5e131
@@ -42752,10 +42962,10 @@ exec
 from hushline.model import get_public_record_listings
 rows = get_public_record_listings()
 print(len(rows), rows[0].slug, rows[0].location)
-PY" in /Users/scidsg/hushline exited 1 in 52ms:
+PY" in [redacted-path] exited 1 in 52ms:
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
-  File "/Users/scidsg/hushline/hushline/__init__.py", line 5, in <module>
+  File "[redacted-path]", line 5, in <module>
     from flask import Flask, render_template, request, session, url_for
 ModuleNotFoundError: No module named 'flask'
 file update:
@@ -44385,7 +44595,7 @@ index 302f7fcdaea09c3cc28ecbf19349aef857ee10ac..bae1a18a88ec8706384191fe2ad593c9
 thinking
 **Reviewing route naming and UI visibility**
 exec
-/bin/zsh -lc 'git diff --stat' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc 'git diff --stat' in [redacted-path] succeeded in 51ms:
  assets/js/directory_verified.js   | 255 ++++++++++++++++++++++----------
  hushline/model/__init__.py        |   5 +
  hushline/routes/directory.py      |  73 ++++++++--
@@ -46022,9 +46232,9 @@ thinking
 codex
 Implemented the MVP shape for public-record law-firm listings.
 
-The main changes are in [directory.py](/Users/scidsg/hushline/hushline/routes/directory.py), [public_record_listing.py](/Users/scidsg/hushline/hushline/model/public_record_listing.py), and [directory.html](/Users/scidsg/hushline/hushline/templates/directory.html). The directory now has a `Public Records` tab, seeded law-firm listings also appear in `All`, they never appear in `Verified`, and each listing is modeled separately with `message_capable = false`. I added a dedicated read-only detail route and template at [directory_public_record.html](/Users/scidsg/hushline/hushline/templates/directory_public_record.html), so these listings never route through the secure recipient/message flow.
+The main changes are in [directory.py]([redacted-path] [public_record_listing.py]([redacted-path] and [directory.html]([redacted-path] The directory now has a `Public Records` tab, seeded law-firm listings also appear in `All`, they never appear in `Verified`, and each listing is modeled separately with `message_capable = false`. I added a dedicated read-only detail route and template at [directory_public_record.html]([redacted-path] so these listings never route through the secure recipient/message flow.
 
-I also updated the tabbed directory search/rendering in [directory_verified.js](/Users/scidsg/hushline/assets/js/directory_verified.js) and added test coverage in [test_directory.py](/Users/scidsg/hushline/tests/test_directory.py) and [test_accessibility.py](/Users/scidsg/hushline/tests/test_accessibility.py) for tab visibility, badge rendering, JSON shape, and route-level non-messageability.
+I also updated the tabbed directory search/rendering in [directory_verified.js]([redacted-path] and added test coverage in [test_directory.py]([redacted-path] and [test_accessibility.py]([redacted-path] for tab visibility, badge rendering, JSON shape, and route-level non-messageability.
 
 Validation was limited here. `python3 -m py_compile hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py` passed. I could not run `make lint` or `make test` because this sandbox cannot access Docker, and `npm run build:prod` was unavailable because `webpack` is not installed in the host workspace.
 
@@ -47657,9 +47867,9 @@ tokens used
 186,159
 Implemented the MVP shape for public-record law-firm listings.
 
-The main changes are in [directory.py](/Users/scidsg/hushline/hushline/routes/directory.py), [public_record_listing.py](/Users/scidsg/hushline/hushline/model/public_record_listing.py), and [directory.html](/Users/scidsg/hushline/hushline/templates/directory.html). The directory now has a `Public Records` tab, seeded law-firm listings also appear in `All`, they never appear in `Verified`, and each listing is modeled separately with `message_capable = false`. I added a dedicated read-only detail route and template at [directory_public_record.html](/Users/scidsg/hushline/hushline/templates/directory_public_record.html), so these listings never route through the secure recipient/message flow.
+The main changes are in [directory.py]([redacted-path] [public_record_listing.py]([redacted-path] and [directory.html]([redacted-path] The directory now has a `Public Records` tab, seeded law-firm listings also appear in `All`, they never appear in `Verified`, and each listing is modeled separately with `message_capable = false`. I added a dedicated read-only detail route and template at [directory_public_record.html]([redacted-path] so these listings never route through the secure recipient/message flow.
 
-I also updated the tabbed directory search/rendering in [directory_verified.js](/Users/scidsg/hushline/assets/js/directory_verified.js) and added test coverage in [test_directory.py](/Users/scidsg/hushline/tests/test_directory.py) and [test_accessibility.py](/Users/scidsg/hushline/tests/test_accessibility.py) for tab visibility, badge rendering, JSON shape, and route-level non-messageability.
+I also updated the tabbed directory search/rendering in [directory_verified.js]([redacted-path] and added test coverage in [test_directory.py]([redacted-path] and [test_accessibility.py]([redacted-path] for tab visibility, badge rendering, JSON shape, and route-level non-messageability.
 
 Validation was limited here. `python3 -m py_compile hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py` passed. I could not run `make lint` or `make test` because this sandbox cannot access Docker, and `npm run build:prod` was unavailable because `webpack` is not installed in the host workspace.
 
@@ -47669,9 +47879,9 @@ Codex execution completed.
 Codex final message:
 Implemented the MVP shape for public-record law-firm listings.
 
-The main changes are in [directory.py](/Users/scidsg/hushline/hushline/routes/directory.py), [public_record_listing.py](/Users/scidsg/hushline/hushline/model/public_record_listing.py), and [directory.html](/Users/scidsg/hushline/hushline/templates/directory.html). The directory now has a `Public Records` tab, seeded law-firm listings also appear in `All`, they never appear in `Verified`, and each listing is modeled separately with `message_capable = false`. I added a dedicated read-only detail route and template at [directory_public_record.html](/Users/scidsg/hushline/hushline/templates/directory_public_record.html), so these listings never route through the secure recipient/message flow.
+The main changes are in [directory.py]([redacted-path] [public_record_listing.py]([redacted-path] and [directory.html]([redacted-path] The directory now has a `Public Records` tab, seeded law-firm listings also appear in `All`, they never appear in `Verified`, and each listing is modeled separately with `message_capable = false`. I added a dedicated read-only detail route and template at [directory_public_record.html]([redacted-path] so these listings never route through the secure recipient/message flow.
 
-I also updated the tabbed directory search/rendering in [directory_verified.js](/Users/scidsg/hushline/assets/js/directory_verified.js) and added test coverage in [test_directory.py](/Users/scidsg/hushline/tests/test_directory.py) and [test_accessibility.py](/Users/scidsg/hushline/tests/test_accessibility.py) for tab visibility, badge rendering, JSON shape, and route-level non-messageability.
+I also updated the tabbed directory search/rendering in [directory_verified.js]([redacted-path] and added test coverage in [test_directory.py]([redacted-path] and [test_accessibility.py]([redacted-path] for tab visibility, badge rendering, JSON shape, and route-level non-messageability.
 
 Validation was limited here. `python3 -m py_compile hushline/model/public_record_listing.py hushline/routes/directory.py tests/test_directory.py tests/test_accessibility.py` passed. I could not run `make lint` or `make test` because this sandbox cannot access Docker, and `npm run build:prod` was unavailable because `webpack` is not installed in the host workspace.
 
@@ -47744,7 +47954,7 @@ Success: no issues found in 149 source files
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run workflow security checks
-docker run --rm -v "/Users/scidsg/hushline:/work" -w /work rhysd/actionlint:1.7.7 -color
+docker run --rm -v "[redacted-path]" -w /work rhysd/actionlint:1.7.7 -color
 Unable to find image 'rhysd/actionlint:1.7.7' locally
 1.7.7: Pulling from rhysd/actionlint
 25d2e00cf929: Pulling fs layer

--- a/docs/agent-logs/run-20260302T225717Z-issue-1488.txt
+++ b/docs/agent-logs/run-20260302T225717Z-issue-1488.txt
@@ -3,7 +3,7 @@ Timestamp (UTC): 20260302T225717Z
 Issue: #1488
 Repository: scidsg/hushline
 
-Runner Codex config: model=gpt-5.3-codex reasoning_effort=high verbose_codex_output=0
+Runner Codex config: [redacted]
 ==> Fetch latest from origin
 ==> Checkout main
 Already on 'main'
@@ -1387,23 +1387,128 @@ Total reclaimed space: 4.21GB
 #7 7.667 Get:460 http://deb.debian.org/debian bookworm/main arm64 pkg-config arm64 1.8.1-1 [13.7 kB]
 #7 7.780 debconf: delaying package configuration, since apt-utils is not installed
 #7 7.795 Fetched 162 MB in 3s (60.9 MB/s)
-#7 7.808 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6689 files and directories currently installed.)
+#7 7.808 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6689 files and directories currently installed.)
 #7 7.810 Preparing to unpack .../perl-base_5.36.0-7+deb12u3_arm64.deb ...
 #7 7.819 Unpacking perl-base (5.36.0-7+deb12u3) over (5.36.0-7+deb12u1) ...
 #7 8.427 Setting up perl-base (5.36.0-7+deb12u3) ...
-#7 8.441 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 8.441 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 8.445 Preparing to unpack .../gcc-12-base_12.2.0-14+deb12u1_arm64.deb ...
 #7 8.449 Unpacking gcc-12-base:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 8.465 Setting up gcc-12-base:arm64 (12.2.0-14+deb12u1) ...
-#7 8.482 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 8.482 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 8.485 Preparing to unpack .../libgcc-s1_12.2.0-14+deb12u1_arm64.deb ...
 #7 8.490 Unpacking libgcc-s1:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 8.504 Setting up libgcc-s1:arm64 (12.2.0-14+deb12u1) ...
-#7 8.518 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 8.518 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 8.521 Preparing to unpack .../libstdc++6_12.2.0-14+deb12u1_arm64.deb ...
 #7 8.529 Unpacking libstdc++6:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 8.589 Setting up libstdc++6:arm64 (12.2.0-14+deb12u1) ...
-#7 8.607 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 8.607 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 8.610 Preparing to unpack .../libc6_2.36-9+deb12u13_arm64.deb ...
 #7 8.648 debconf: unable to initialize frontend: Dialog
 #7 8.648 debconf: (TERM is not set, so the dialog frontend is not usable.)
@@ -1419,12 +1524,54 @@ Total reclaimed space: 4.21GB
 #7 9.077 debconf: unable to initialize frontend: Readline
 #7 9.077 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
 #7 9.077 debconf: falling back to frontend: Teletype
-#7 10.13 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.13 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.14 Preparing to unpack .../libc-bin_2.36-9+deb12u13_arm64.deb ...
 #7 10.14 Unpacking libc-bin (2.36-9+deb12u13) over (2.36-9+deb12u8) ...
 #7 10.22 Setting up libc-bin (2.36-9+deb12u13) ...
 #7 10.24 Selecting previously unselected package perl-modules-5.36.
-#7 10.24 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.24 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.24 Preparing to unpack .../0-perl-modules-5.36_5.36.0-7+deb12u3_all.deb ...
 #7 10.24 Unpacking perl-modules-5.36 (5.36.0-7+deb12u3) ...
 #7 10.43 Selecting previously unselected package libgdbm-compat4:arm64.
@@ -1448,7 +1595,28 @@ Total reclaimed space: 4.21GB
 #7 10.99 Setting up libpython3.11-minimal:arm64 (3.11.2-6+deb12u6) ...
 #7 11.00 Setting up python3.11-minimal (3.11.2-6+deb12u6) ...
 #7 11.34 Selecting previously unselected package python3-minimal.
-#7 11.34 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9002 files and directories currently installed.)
+#7 11.34 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9002 files and directories currently installed.)
 #7 11.35 Preparing to unpack .../python3-minimal_3.11.2-1+b1_arm64.deb ...
 #7 11.35 Unpacking python3-minimal (3.11.2-1+b1) ...
 #7 11.36 Selecting previously unselected package media-types.
@@ -1458,7 +1626,28 @@ Total reclaimed space: 4.21GB
 #7 11.38 Unpacking liblzma5:arm64 (5.4.1-1) over (5.4.1-0.2) ...
 #7 11.40 Setting up liblzma5:arm64 (5.4.1-1) ...
 #7 11.42 Selecting previously unselected package libpython3.11-stdlib:arm64.
-#7 11.42 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9030 files and directories currently installed.)
+#7 11.42 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9030 files and directories currently installed.)
 #7 11.42 Preparing to unpack .../libpython3.11-stdlib_3.11.2-6+deb12u6_arm64.deb ...
 #7 11.42 Unpacking libpython3.11-stdlib:arm64 (3.11.2-6+deb12u6) ...
 #7 11.53 Selecting previously unselected package python3.11.
@@ -1469,7 +1658,28 @@ Total reclaimed space: 4.21GB
 #7 11.73 Unpacking libpython3-stdlib:arm64 (3.11.2-1+b1) ...
 #7 11.77 Setting up python3-minimal (3.11.2-1+b1) ...
 #7 11.85 Selecting previously unselected package python3.
-#7 11.85 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9412 files and directories currently installed.)
+#7 11.85 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9412 files and directories currently installed.)
 #7 11.86 Preparing to unpack .../000-python3_3.11.2-1+b1_arm64.deb ...
 #7 11.86 Unpacking python3 (3.11.2-1+b1) ...
 #7 11.87 Selecting previously unselected package bzip2.
@@ -3692,14 +3902,14 @@ Switched to and reset branch 'codex/daily-issue-1488'
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.107.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.3-codex
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR]
-reasoning effort: high
-reasoning summaries: none
-session id: 019cb0c7-7485-7900-b7e4-8950aa330f27
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are implementing GitHub issue #1488 in scidsg/hushline.
@@ -3738,7 +3948,7 @@ I’m going to locate the directory tab UI code and its tests first, then make t
 thinking
 **Searching for agent references**
 exec
-/bin/zsh -lc "rg --files -g 'AGENTS.md'" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "rg --files -g 'AGENTS.md'" in [redacted-path] succeeded in 51ms:
 AGENTS.md
 
 thinking
@@ -3749,16 +3959,16 @@ I found the relevant test files and routes; next I’m narrowing to the director
 thinking
 **Checking git status for changes**
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 52ms:
 
 
 thinking
 **Locating relevant files**
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/templates/directory.html" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' assets/js/directory.js" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' assets/js/directory_verified.js" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg --files | rg 'directory(\\.html|\\.js|_verified\\.js)"'$|directory'"\\.scss|tabs'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/templates/directory.html" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' assets/js/directory.js" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' assets/js/directory_verified.js" in [redacted-path]
+/bin/zsh -lc "rg --files | rg 'directory(\\.html|\\.js|_verified\\.js)"'$|directory'"\\.scss|tabs'" in [redacted-path] succeeded in 52ms:
 document.addEventListener("DOMContentLoaded", function () {
   const userSearch = window.HushlineUserSearch;
   const pathPrefix = window.location.pathname.split("/").slice(0, -1).join("/");
@@ -3829,7 +4039,7 @@ hushline/templates/directory.html
 thinking
 **Continuing code exploration**
 exec
-/bin/zsh -lc "sed -n '261,520p' assets/js/directory_verified.js" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '261,520p' assets/js/directory_verified.js" in [redacted-path] succeeded in 52ms:
     searchInput.addEventListener("input", handleSearchInput);
   }
 
@@ -3856,8 +4066,8 @@ thinking
 codex
 I’ve identified the tab logic in `assets/js/directory_verified.js`; next I’ll add a small click-path for “active + sticky => smooth scroll top” and then extend frontend compatibility tests with a focused assertion that locks this behavior in.
 exec
-/bin/zsh -lc "sed -n '1,220p' tests/test_frontend_compat.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '220,440p' tests/test_frontend_compat.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,220p' tests/test_frontend_compat.py" in [redacted-path]
+/bin/zsh -lc "sed -n '220,440p' tests/test_frontend_compat.py" in [redacted-path] succeeded in 51ms:
 
  succeeded in 51ms:
 import json
@@ -3884,7 +4094,7 @@ def test_client_side_encryption_has_platform_guards() -> None:
 thinking
 **Investigating static JS handling**
 exec
-/bin/zsh -lc "sed -n '260,520p' hushline/templates/directory.html" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '260,520p' hushline/templates/directory.html" in [redacted-path] succeeded in 52ms:
                 {% if username.user.is_admin %}
                   <span class="badge" role="img" aria-label="Administrator account">⚙️ Admin</span>
                 {% endif %}
@@ -3909,7 +4119,7 @@ exec
 thinking
 **Assessing directory script usage**
 exec
-/bin/zsh -lc 'rg -n "directory-tabs|is-sticky|directory-search-top" assets/scss/style.scss assets/js/directory_verified.js' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'rg -n "directory-tabs|is-sticky|directory-search-top" assets/scss/style.scss assets/js/directory_verified.js' in [redacted-path] succeeded in 52ms:
 assets/js/directory_verified.js:334:  const directoryTabs = document.querySelector(".directory-tabs");
 assets/js/directory_verified.js:345:      directoryTabs.classList.toggle("is-sticky", isSticky);
 assets/js/directory_verified.js:351:          "--directory-search-top",
@@ -3941,7 +4151,7 @@ I’m confirming whether this repo expects direct edits in `assets/js` only or a
 thinking
 **Avoiding incorrect tool usage**
 exec
-/bin/zsh -lc "sed -n '1,220p' package.json" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,220p' package.json" in [redacted-path] succeeded in 52ms:
 {
   "name": "hushline",
   "version": "0.0.0",
@@ -3966,7 +4176,7 @@ exec
 thinking
 **Assessing webpack entry and output**
 exec
-/bin/zsh -lc "sed -n '1,260p' webpack.config.js" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,260p' webpack.config.js" in [redacted-path] succeeded in 51ms:
 const path = require('path');
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 
@@ -3991,7 +4201,7 @@ modules = [
 thinking
 **Investigating compiled static asset usage**
 exec
-/bin/zsh -lc 'rg -n "static/js/directory_verified|assets/js/directory_verified|directory_verified.js" tests hushline | head -n 50' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'rg -n "static/js/directory_verified|assets/js/directory_verified|directory_verified.js" tests hushline | head -n 50' in [redacted-path] succeeded in 52ms:
 tests/test_frontend_compat.py:53:    directory_verified_js = (ROOT / "assets/js/directory_verified.js").read_text(encoding="utf-8")
 tests/test_frontend_compat.py:65:        in directory_verified_js
 tests/test_frontend_compat.py:68:    assert "Showing all" in directory_verified_js
@@ -4000,13 +4210,13 @@ hushline/templates/directory.html:310:  <script defer src="{{ url_for('static', 
 thinking
 **Inspecting Dockerfile for build step**
 exec
-/bin/zsh -lc "sed -n '1,260p' Dockerfile" in /Users/scidsg/hushline exited 1 in 52ms:
+/bin/zsh -lc "sed -n '1,260p' Dockerfile" in [redacted-path] exited 1 in 52ms:
 sed: Dockerfile: No such file or directory
 
 thinking
 **Searching for Dockerfiles**
 exec
-/bin/zsh -lc "rg --files | rg -i 'dockerfile|compose|container' | head -n 50" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "rg --files | rg -i 'dockerfile|compose|container' | head -n 50" in [redacted-path] succeeded in 52ms:
 docker-compose.staging.yaml
 Dockerfile.dev
 docker-compose.personal-server.yaml
@@ -4014,7 +4224,7 @@ Dockerfile.prod
 docker-compose.yaml
 docker-compose.stripe.yaml
 exec
-/bin/zsh -lc "sed -n '1,260p' Dockerfile.prod" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' Dockerfile.prod" in [redacted-path] succeeded in 52ms:
 # vim: set syntax=dockerfile :
 FROM node:20.19.5-alpine3.22 AS webpack
 
@@ -4044,7 +4254,7 @@ I’m now editing `assets/js/directory_verified.js` to add a narrow click-path: 
 thinking
 **Preparing to patch tab click handling**
 file update
-M /Users/scidsg/hushline/assets/js/directory_verified.js
+M [redacted-path]
 @@ -308,3 +308,17 @@
      tab.addEventListener("click", function (e) {
 -      window.activateTab(e.currentTarget);
@@ -4129,7 +4339,7 @@ index bba7099f2f9acec1d94b3281b8e675ea11a86502..89a4e011f906c91a50166b42ec91c110
 thinking
 **Assessing line length style**
 exec
-/bin/zsh -lc "sed -n '296,360p' assets/js/directory_verified.js" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '296,360p' assets/js/directory_verified.js" in [redacted-path] succeeded in 51ms:
 
     selectedTab.setAttribute("aria-selected", "true");
     selectedTab.classList.add("active");
@@ -4183,7 +4393,7 @@ index bba7099f2f9acec1d94b3281b8e675ea11a86502..89a4e011f906c91a50166b42ec91c110
 thinking
 **Planning test coverage expansion**
 file update
-M /Users/scidsg/hushline/tests/test_frontend_compat.py
+M [redacted-path]
 @@ -71,2 +71,13 @@
  
 +def test_directory_sticky_active_tab_scroll_to_top_hook_exists() -> None:
@@ -4309,7 +4519,7 @@ thinking
 codex
 I’ve applied the JS behavior change and added a targeted frontend compatibility test assertion set. I’ll quickly review the diff for scope and consistency, then share exactly what changed.
 exec
-/bin/zsh -lc 'git diff -- assets/js/directory_verified.js tests/test_frontend_compat.py' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git diff -- assets/js/directory_verified.js tests/test_frontend_compat.py' in [redacted-path] succeeded in 52ms:
 diff --git a/assets/js/directory_verified.js b/assets/js/directory_verified.js
 index bba7099f..89a4e011 100644
 --- a/assets/js/directory_verified.js
@@ -4385,8 +4595,8 @@ index 3e1cc32b27ea3a609aa8cb5b3d1a5f01575c4f0a..afcb033e344ebdb79cea54c14734d59f
 thinking
 **Evaluating event handler logic and motion preferences**
 exec
-/bin/zsh -lc "nl -ba assets/js/directory_verified.js | sed -n '300,350p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba tests/test_frontend_compat.py | sed -n '60,105p'" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "nl -ba assets/js/directory_verified.js | sed -n '300,350p'" in [redacted-path]
+/bin/zsh -lc "nl -ba tests/test_frontend_compat.py | sed -n '60,105p'" in [redacted-path] succeeded in 51ms:
    300	    targetPanel.style.display = "block";
    301	    targetPanel.classList.add("active");
    302	
@@ -4483,7 +4693,7 @@ index 3e1cc32b27ea3a609aa8cb5b3d1a5f01575c4f0a..afcb033e344ebdb79cea54c14734d59f
 thinking
 **Planning file change check**
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 52ms:
  M assets/js/directory_verified.js
  M tests/test_frontend_compat.py
 file update:
@@ -4544,11 +4754,11 @@ codex
 Implemented issue #1488 with a minimal diff.
 
 **Changes**
-- Added active-tab click handling in [assets/js/directory_verified.js](/Users/scidsg/hushline/assets/js/directory_verified.js#L307):
+- Added active-tab click handling in [assets/js/directory_verified.js]([redacted-path]
   - When the clicked tab is already active **and** `.directory-tabs` is in sticky state (`.is-sticky`), it now calls `window.scrollTo({ top: 0, behavior: "smooth" })`.
   - Honors reduced-motion preference by switching to `"auto"` behavior.
   - Keeps existing tab-switch behavior unchanged for all other clicks.
-- Added a compatibility test in [tests/test_frontend_compat.py](/Users/scidsg/hushline/tests/test_frontend_compat.py#L72) to lock in the new sticky-active-tab scroll-to-top hooks.
+- Added a compatibility test in [tests/test_frontend_compat.py]([redacted-path] to lock in the new sticky-active-tab scroll-to-top hooks.
 
 **Validation**
 - Did not run local validation commands in this implementation pass.
@@ -4608,11 +4818,11 @@ tokens used
 Implemented issue #1488 with a minimal diff.
 
 **Changes**
-- Added active-tab click handling in [assets/js/directory_verified.js](/Users/scidsg/hushline/assets/js/directory_verified.js#L307):
+- Added active-tab click handling in [assets/js/directory_verified.js]([redacted-path]
   - When the clicked tab is already active **and** `.directory-tabs` is in sticky state (`.is-sticky`), it now calls `window.scrollTo({ top: 0, behavior: "smooth" })`.
   - Honors reduced-motion preference by switching to `"auto"` behavior.
   - Keeps existing tab-switch behavior unchanged for all other clicks.
-- Added a compatibility test in [tests/test_frontend_compat.py](/Users/scidsg/hushline/tests/test_frontend_compat.py#L72) to lock in the new sticky-active-tab scroll-to-top hooks.
+- Added a compatibility test in [tests/test_frontend_compat.py]([redacted-path] to lock in the new sticky-active-tab scroll-to-top hooks.
 
 **Validation**
 - Did not run local validation commands in this implementation pass.
@@ -4621,11 +4831,11 @@ Codex final message:
 Implemented issue #1488 with a minimal diff.
 
 **Changes**
-- Added active-tab click handling in [assets/js/directory_verified.js](/Users/scidsg/hushline/assets/js/directory_verified.js#L307):
+- Added active-tab click handling in [assets/js/directory_verified.js]([redacted-path]
   - When the clicked tab is already active **and** `.directory-tabs` is in sticky state (`.is-sticky`), it now calls `window.scrollTo({ top: 0, behavior: "smooth" })`.
   - Honors reduced-motion preference by switching to `"auto"` behavior.
   - Keeps existing tab-switch behavior unchanged for all other clicks.
-- Added a compatibility test in [tests/test_frontend_compat.py](/Users/scidsg/hushline/tests/test_frontend_compat.py#L72) to lock in the new sticky-active-tab scroll-to-top hooks.
+- Added a compatibility test in [tests/test_frontend_compat.py]([redacted-path] to lock in the new sticky-active-tab scroll-to-top hooks.
 
 **Validation**
 - Did not run local validation commands in this implementation pass.
@@ -4698,7 +4908,7 @@ Success: no issues found in 149 source files
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run workflow security checks
-docker run --rm -v "/Users/scidsg/hushline:/work" -w /work rhysd/actionlint:1.7.7 -color
+docker run --rm -v "[redacted-path]" -w /work rhysd/actionlint:1.7.7 -color
 Unable to find image 'rhysd/actionlint:1.7.7' locally
 1.7.7: Pulling from rhysd/actionlint
 25d2e00cf929: Pulling fs layer

--- a/docs/agent-logs/run-20260304T160004Z-issue-1484.txt
+++ b/docs/agent-logs/run-20260304T160004Z-issue-1484.txt
@@ -3,7 +3,7 @@ Timestamp (UTC): 20260304T160004Z
 Issue: #1484
 Repository: scidsg/hushline
 
-Runner Codex config: model=gpt-5.3-codex reasoning_effort=high verbose_codex_output=0
+Runner Codex config: [redacted]
 ==> Fetch latest from origin
 ==> Checkout main
 Already on 'main'
@@ -1199,23 +1199,128 @@ Total reclaimed space: 5.028GB
 #7 26.94 Get:460 http://deb.debian.org/debian bookworm/main arm64 pkg-config arm64 1.8.1-1 [13.7 kB]
 #7 27.08 debconf: delaying package configuration, since apt-utils is not installed
 #7 27.09 Fetched 162 MB in 22s (7463 kB/s)
-#7 27.10 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6689 files and directories currently installed.)
+#7 27.10 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6689 files and directories currently installed.)
 #7 27.11 Preparing to unpack .../perl-base_5.36.0-7+deb12u3_arm64.deb ...
 #7 27.12 Unpacking perl-base (5.36.0-7+deb12u3) over (5.36.0-7+deb12u1) ...
 #7 27.72 Setting up perl-base (5.36.0-7+deb12u3) ...
-#7 27.74 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 27.74 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 27.74 Preparing to unpack .../gcc-12-base_12.2.0-14+deb12u1_arm64.deb ...
 #7 27.75 Unpacking gcc-12-base:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 27.76 Setting up gcc-12-base:arm64 (12.2.0-14+deb12u1) ...
-#7 27.77 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 27.77 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 27.78 Preparing to unpack .../libgcc-s1_12.2.0-14+deb12u1_arm64.deb ...
 #7 27.78 Unpacking libgcc-s1:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 27.80 Setting up libgcc-s1:arm64 (12.2.0-14+deb12u1) ...
-#7 27.81 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 27.81 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 27.81 Preparing to unpack .../libstdc++6_12.2.0-14+deb12u1_arm64.deb ...
 #7 27.82 Unpacking libstdc++6:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 27.88 Setting up libstdc++6:arm64 (12.2.0-14+deb12u1) ...
-#7 27.90 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 27.90 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 27.90 Preparing to unpack .../libc6_2.36-9+deb12u13_arm64.deb ...
 #7 27.94 debconf: unable to initialize frontend: Dialog
 #7 27.94 debconf: (TERM is not set, so the dialog frontend is not usable.)
@@ -1231,12 +1336,54 @@ Total reclaimed space: 5.028GB
 #7 28.38 debconf: unable to initialize frontend: Readline
 #7 28.38 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
 #7 28.38 debconf: falling back to frontend: Teletype
-#7 29.44 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 29.44 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 29.44 Preparing to unpack .../libc-bin_2.36-9+deb12u13_arm64.deb ...
 #7 29.45 Unpacking libc-bin (2.36-9+deb12u13) over (2.36-9+deb12u8) ...
 #7 29.52 Setting up libc-bin (2.36-9+deb12u13) ...
 #7 29.54 Selecting previously unselected package perl-modules-5.36.
-#7 29.54 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 29.54 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 29.55 Preparing to unpack .../0-perl-modules-5.36_5.36.0-7+deb12u3_all.deb ...
 #7 29.55 Unpacking perl-modules-5.36 (5.36.0-7+deb12u3) ...
 #7 29.74 Selecting previously unselected package libgdbm-compat4:arm64.
@@ -1260,7 +1407,28 @@ Total reclaimed space: 5.028GB
 #7 30.32 Setting up libpython3.11-minimal:arm64 (3.11.2-6+deb12u6) ...
 #7 30.32 Setting up python3.11-minimal (3.11.2-6+deb12u6) ...
 #7 30.67 Selecting previously unselected package python3-minimal.
-#7 30.67 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9002 files and directories currently installed.)
+#7 30.67 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9002 files and directories currently installed.)
 #7 30.67 Preparing to unpack .../python3-minimal_3.11.2-1+b1_arm64.deb ...
 #7 30.67 Unpacking python3-minimal (3.11.2-1+b1) ...
 #7 30.68 Selecting previously unselected package media-types.
@@ -1270,7 +1438,28 @@ Total reclaimed space: 5.028GB
 #7 30.71 Unpacking liblzma5:arm64 (5.4.1-1) over (5.4.1-0.2) ...
 #7 30.73 Setting up liblzma5:arm64 (5.4.1-1) ...
 #7 30.74 Selecting previously unselected package libpython3.11-stdlib:arm64.
-#7 30.74 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9030 files and directories currently installed.)
+#7 30.74 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9030 files and directories currently installed.)
 #7 30.75 Preparing to unpack .../libpython3.11-stdlib_3.11.2-6+deb12u6_arm64.deb ...
 #7 30.75 Unpacking libpython3.11-stdlib:arm64 (3.11.2-6+deb12u6) ...
 #7 30.85 Selecting previously unselected package python3.11.
@@ -1281,7 +1470,28 @@ Total reclaimed space: 5.028GB
 #7 30.88 Unpacking libpython3-stdlib:arm64 (3.11.2-1+b1) ...
 #7 30.89 Setting up python3-minimal (3.11.2-1+b1) ...
 #7 30.97 Selecting previously unselected package python3.
-#7 30.97 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9412 files and directories currently installed.)
+#7 30.97 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9412 files and directories currently installed.)
 #7 30.98 Preparing to unpack .../000-python3_3.11.2-1+b1_arm64.deb ...
 #7 30.98 Unpacking python3 (3.11.2-1+b1) ...
 #7 30.99 Selecting previously unselected package bzip2.
@@ -3506,14 +3716,14 @@ Switched to a new branch 'codex/daily-issue-1484'
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.107.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.3-codex
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR]
-reasoning effort: high
-reasoning summaries: none
-session id: 019cb997-5255-7bc1-9a92-61b613c69b2a
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are implementing GitHub issue #1484 in scidsg/hushline.
@@ -3627,8 +3837,8 @@ mcp startup: no servers
 codex
 I’ll inspect the repository for existing public-record listing code, tests, and any deeper `AGENTS.md` files, then implement a minimal generator/refresh path with deterministic output and test coverage for the new behavior.
 exec
-/bin/zsh -lc "rg --files -g 'AGENTS.md'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg --files | rg 'public_record|listing|law_firm|directory' | head -n 200" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "rg --files -g 'AGENTS.md'" in [redacted-path]
+/bin/zsh -lc "rg --files | rg 'public_record|listing|law_firm|directory' | head -n 200" in [redacted-path] succeeded in 52ms:
 AGENTS.md
  succeeded in 51ms:
 assets/js/directory_verified.js
@@ -3642,7 +3852,7 @@ hushline/model/public_record_listing.py
 codex
 I found the relevant listing/model/routes files and only one `AGENTS.md`. Next I’ll read the current JSON loader and tests, then add the smallest possible refresh pipeline plus workflow automation.
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/model/public_record_listing.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/model/public_record_listing.py" in [redacted-path] succeeded in 51ms:
 from __future__ import annotations
 
 import json
@@ -3664,7 +3874,7 @@ class PublicRecordListing:
     description: str
     city: str
 exec
-/bin/zsh -lc "sed -n '1,260p' tests/test_directory.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' tests/test_directory.py" in [redacted-path] succeeded in 52ms:
 import time
 
 import pytest
@@ -3686,7 +3896,7 @@ def test_directory_accessible(client: FlaskClient) -> None:
     assert "🤖 Automated" in response.text
 
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/data/public_record_law_firms.json" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/data/public_record_law_firms.json" in [redacted-path] succeeded in 53ms:
 [
   {
     "id": "seed-allens",
@@ -3708,7 +3918,7 @@ exec
     "description": "A Singapore firm advising on whistleblowing systems, investigations, and employment issues.",
     "city": "Singapore",
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/routes/directory.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/routes/directory.py" in [redacted-path] succeeded in 51ms:
 from flask import (
     Flask,
     abort,
@@ -3730,7 +3940,7 @@ from hushline.routes.common import get_directory_usernames
 
 def _directory_user_row(username: Username) -> dict[str, object | None]:
 exec
-/bin/zsh -lc "sed -n '260,520p' tests/test_directory.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '260,520p' tests/test_directory.py" in [redacted-path] succeeded in 53ms:
             "website": listing.website,
             "source": listing.source_url,
         }.items():
@@ -3762,8 +3972,8 @@ keys=sorted({k for r in rows for k in r})
 print('keys',keys)
 print('unique id',len({r['id'] for r in rows})==len(rows))
 print('unique slug',len({r['slug'] for r in rows})==len(rows))
-PY" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "public_record_law_firms|public_record.*json|public record" .github scripts hushline tests docs | head -n 200' in /Users/scidsg/hushline exited 127 in 52ms:
+PY" in [redacted-path]
+/bin/zsh -lc 'rg -n "public_record_law_firms|public_record.*json|public record" .github scripts hushline tests docs | head -n 200' in [redacted-path] exited 127 in 52ms:
 zsh:1: command not found: python
  succeeded in 53ms:
 Total output lines: 200
@@ -3774,22 +3984,22 @@ hushline/templates/directory.html:189:        🤖 These are automated listings 
 tests/test_directory.py:35:    assert "These are automated listings pulled from public records." in banner_text
 tests/test_directory.py:68:    assert all(not row["is_public_record"] for row in (response.json or []))
 tests/test_directory.py:296:    assert not failures, "Broken public record links:\n" + "\n".join(failures)
-docs/agent-logs/run-20260228T193005Z-issue-1458.txt:3923:/bin/zsh -lc 'rg -n "directory|Verified|All|Send Message|message-capable|public record|badge" .' in /Users/scidsg/hushline succeeded in 52ms:
+docs/agent-logs/run-20260228T193005Z-issue-1458.txt:3923:/bin/zsh -lc 'rg -n "directory|Verified|All|Send Message|message-capable|public record|badge" .' in [redacted-path] succeeded in 52ms:
 docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4368:**Scoping model and UI for public records**
-docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4435:/bin/zsh -lc 'rg -n "law firm|law-firm|attorney|lawyer|public record|public records|practice tag|source label" .' in /Users/scidsg/hushline succeeded in 52ms:
+docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4435:/bin/zsh -lc 'rg -n "law firm|law-firm|attorney|lawyer|public record|public records|practice tag|source label" .' in [redacted-path] succeeded in 52ms:
 docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4484:**Defining public record listing data model**
 docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4486:**Designing public records tab integration**
 docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4571:**Designing public records loader**
 docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4683:**Designing public record model and templates**
 docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4731:    return Path(__file__).resolve().parent.parent / "data" / "public_record_law_firms.json"
-docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4761:A /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
-docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4800:A /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
+docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4761:A [redacted-path]
+docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4800:A [redacted-path]
 docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4802:diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
 docs/agent-logs/run-20260228T193005Z-issue-1458.txt:4806:+++ b/hushline/data/public_record_law_firms.json
 exec
-/bin/zsh -lc 'command -v python3 || true' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' .github/workflows/public-record-link-check.yml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"public-record|public record|law_firm|directory\" .github/workflows | sed -n '1,200p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'command -v python3 || true' in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' .github/workflows/public-record-link-check.yml" in [redacted-path]
+/bin/zsh -lc "rg -n \"public-record|public record|law_firm|directory\" .github/workflows | sed -n '1,200p'" in [redacted-path] succeeded in 53ms:
 name: Public Record Link Check
 
 permissions:
@@ -3833,8 +4043,8 @@ jobs:
 codex
 I found an existing workflow that only validates live links weekly. I’ll now inspect `Makefile` and nearby scripts to hook in a true refresh/generation entrypoint and quarterly PR automation with minimal new surface area.
 exec
-/bin/zsh -lc "sed -n '1,320p' Makefile" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"test-public-record-links|public-record|refresh|directory\" Makefile scripts tests hushline | sed -n '1,240p'" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,320p' Makefile" in [redacted-path]
+/bin/zsh -lc "rg -n \"test-public-record-links|public-record|refresh|directory\" Makefile scripts tests hushline | sed -n '1,240p'" in [redacted-path] succeeded in 51ms:
 .DEFAULT_GOAL := help
 
 ifndef IS_DOCKER
@@ -3877,8 +4087,8 @@ tests/test_accessibility.py:45:    assert public_records_tab.get("aria-controls"
 tests/test_accessibility.py:55:    assert public_records_panel.get("aria-labelledby") == "public-records-tab"
 tests/test_accessibility.py:105:    response = client.get(url_for("directory"))
 exec
-/bin/zsh -lc "rg -n \"create-pull-request|peter-evans|gh pr|pull request\" .github/workflows scripts | sed -n '1,220p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"schedule:\" .github/workflows | sed -n '1,220p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "rg -n \"create-pull-request|peter-evans|gh pr|pull request\" .github/workflows scripts | sed -n '1,220p'" in [redacted-path]
+/bin/zsh -lc "rg -n \"schedule:\" .github/workflows | sed -n '1,220p'" in [redacted-path] succeeded in 52ms:
 scripts/agent_daily_issue_runner.sh:289:  gh pr list \
 scripts/agent_daily_issue_runner.sh:299:  gh pr list \
 scripts/agent_daily_issue_runner.sh:375:  gh project item-list \
@@ -3892,9 +4102,9 @@ scripts/agent_daily_issue_runner.sh:1164:  gh pr create \
 codex
 I only found one scheduled public-record workflow today; there’s no existing refresh/PR automation for this dataset yet. I’ll inspect an existing PR-automation workflow pattern in this repo and mirror it for a quarterly refresh job.
 exec
-/bin/zsh -lc "sed -n '1,280p' .github/workflows/bump-staging-after-release.yml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "ls -la scripts | sed -n '1,260p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"public_record|law_firm|listing\" scripts docs/tests docs | sed -n '1,260p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,280p' .github/workflows/bump-staging-after-release.yml" in [redacted-path]
+/bin/zsh -lc "ls -la scripts | sed -n '1,260p'" in [redacted-path]
+/bin/zsh -lc "rg -n \"public_record|law_firm|listing\" scripts docs/tests docs | sed -n '1,260p'" in [redacted-path] succeeded in 52ms:
 name: Bump staging infra after release
 
 on:
@@ -3949,8 +4159,8 @@ docs/agent-logs/run-20260228T160005Z-issue-1378.txt:8932:+Choose whether to appe
 docs/agent-logs/run-20260228T160005Z-issue-1378.txt:9053:+- your public Hush Line directory listing
 docs/agent-logs/run-20260228T160005Z-issue-1378.txt:9103:+- A distribution plan: public directory listing, direct profile link, or both
 exec
-/bin/zsh -lc "rg -n \"scripts/|workflow|yaml|yml|Makefile|refresh\" tests | sed -n '1,260p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg --files tests | sed -n '1,260p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "rg -n \"scripts/|workflow|yaml|yml|Makefile|refresh\" tests | sed -n '1,260p'" in [redacted-path]
+/bin/zsh -lc "rg --files tests | sed -n '1,260p'" in [redacted-path] succeeded in 53ms:
 tests/test_make_admin.py:29:    db.session.refresh(user)
 tests/test_make_admin.py:33:    db.session.refresh(user)
 tests/test_coverage_push.py:527:    db.session.refresh(tier)
@@ -3993,7 +4203,7 @@ tests/test_config.py
 tests/test_behavior_contracts.py
 tests/test_frontend_compat.py
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/model/__init__.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/model/__init__.py" in [redacted-path] succeeded in 52ms:
 # ruff: noqa: F401
 
 from hushline.model.authentication_log import AuthenticationLog
@@ -4015,11 +4225,11 @@ from hushline.model.public_record_listing import (
     PublicRecordListing,
     get_public_record_listing,
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 52ms:
 
 exec
-/bin/zsh -lc "rg -n \"public_record_law_firms.json\" .github scripts tests hushline docs --glob '"'!docs/agent-logs/**'"' | sed -n '1,220p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"slug|slugify|canonical|deterministic|normalize\" hushline scripts tests | sed -n '1,220p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "rg -n \"public_record_law_firms.json\" .github scripts tests hushline docs --glob '"'!docs/agent-logs/**'"' | sed -n '1,220p'" in [redacted-path]
+/bin/zsh -lc "rg -n \"slug|slugify|canonical|deterministic|normalize\" hushline scripts tests | sed -n '1,220p'" in [redacted-path] succeeded in 52ms:
 .github/workflows/public-record-link-check.yml:14:      - "hushline/data/public_record_law_firms.json"
 hushline/model/public_record_listing.py:41:    return Path(__file__).resolve().parent.parent / "data" / "public_record_law_firms.json"
  succeeded in 51ms:
@@ -4055,7 +4265,7 @@ print('unique ids',len({r['id'] for r in rows}),len(rows))
 print('unique slugs',len({r['slug'] for r in rows}),len(rows))
 print('first',rows[0]['id'],rows[0]['slug'],rows[0]['name'])
 print('last',rows[-1]['id'],rows[-1]['slug'],rows[-1]['name'])
-PY" in /Users/scidsg/hushline succeeded in 93ms:
+PY" in [redacted-path] succeeded in 93ms:
 count 59
 keys ['city', 'description', 'id', 'name', 'practice_tags', 'slug', 'source_label', 'source_url', 'state', 'website']
 all keys same True
@@ -4073,7 +4283,7 @@ states=Counter(r['state'] for r in rows)
 print('states',len(states))
 for s,c in sorted(states.items()):
     print(f'{s}: {c}')
-PY" in /Users/scidsg/hushline succeeded in 53ms:
+PY" in [redacted-path] succeeded in 53ms:
 states 22
 Australia: 10
 Austria: 2
@@ -4105,7 +4315,7 @@ apac={\"Australia\",\"India\",\"Japan\",\"Singapore\"}
 for name,states in [('US',us),('EU',eu),('APAC',apac)]:
     print(name,sum(1 for r in rows if r['state'] in states))
 print('other',sum(1 for r in rows if r['state'] not in us|eu|apac))
-PY" in /Users/scidsg/hushline succeeded in 53ms:
+PY" in [redacted-path] succeeded in 53ms:
 US 20
 EU 20
 APAC 19
@@ -4113,13 +4323,13 @@ other 0
 codex
 I’ve identified a minimal implementation path: add a dedicated refresh module + script, make target, and a quarterly workflow that regenerates JSON and opens a PR only when data changes. Next I’m designing the generator API so tests can fully cover determinism, schema compatibility, duplicates, regional target enforcement, and link validation without network access.
 exec
-/bin/zsh -lc "sed -n '1,320p' pyproject.toml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,240p' tests/conftest.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,320p' pyproject.toml" in [redacted-path]
+/bin/zsh -lc "sed -n '1,240p' tests/conftest.py" in [redacted-path] succeeded in 52ms:
 [tool.poetry]
 name = "hushline"
 version = "0.0.1"
 description = "A lightweight, secure, and anonymous tip line for organizations and individuals."
-authors = ["Science & Design, Inc. <hello@scidsg.org>"]
+authors = ["Science & Design, Inc. <[redacted-email]>"]
 license = "AGPL 3.0"
 readme = "README.md"
 
@@ -4157,9 +4367,9 @@ from sqlalchemy.orm import Session, sessionmaker
 from hushline import create_app
 from hushline.crypto import _SCRYPT_PARAMS
 exec
-/bin/zsh -lc "sed -n '1,260p' .github/workflows/lint-and-test.yml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "ls .github/workflows | sed -n '1,220p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' .github/workflows/dependency-security-audit.yml" in /Users/scidsg/hushline exited 1 in 53ms:
+/bin/zsh -lc "sed -n '1,260p' .github/workflows/lint-and-test.yml" in [redacted-path]
+/bin/zsh -lc "ls .github/workflows | sed -n '1,220p'" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' .github/workflows/dependency-security-audit.yml" in [redacted-path] exited 1 in 53ms:
 sed: .github/workflows/lint-and-test.yml: No such file or directory
  succeeded in 53ms:
 build-latest.yml
@@ -4200,7 +4410,7 @@ on:
       - "package-lock.json"
       - ".github/workflows/dependency-security-audit.yml"
 exec
-/bin/zsh -lc "sed -n '1,320p' .github/workflows/tests.yml" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,320p' .github/workflows/tests.yml" in [redacted-path] succeeded in 53ms:
 ---
 name: Run Linter and Tests
 permissions:
@@ -4238,7 +4448,7 @@ Plan for the implementation:
 codex
 I’m starting file edits now by adding the core refresh module. This will be pure logic so tests can validate behavior without requiring network or app runtime.
 file update
-A /Users/scidsg/hushline/hushline/public_record_refresh.py
+A [redacted-path]
 from __future__ import annotations
 
 import re
@@ -5710,7 +5920,7 @@ index 0000000000000000000000000000000000000000..011566a81e95b53ab23f466fdc5c3a57
 codex
 Core refresh logic is in place. Next I’m adding the CLI entrypoint script that uses this module, writes the JSON artifact, and returns non-zero when link failures are flagged and not explicitly allowed.
 file update
-A /Users/scidsg/hushline/scripts/refresh_public_record_law_firms.py
+A [redacted-path]
 #!/usr/bin/env python3
 from __future__ import annotations
 
@@ -7315,7 +7525,7 @@ index 0000000000000000000000000000000000000000..b669b7737447461bf96f330dab5d7432
 +        raise SystemExit(1) from exc
 
 file update
-M /Users/scidsg/hushline/Makefile
+M [redacted-path]
 @@ -10,2 +10,3 @@
  RUNNER_APP_WAIT_ATTEMPTS ?= 30
 +REFRESH_PUBLIC_RECORD_ARGS ?=
@@ -8777,7 +8987,7 @@ index 0000000000000000000000000000000000000000..b669b7737447461bf96f330dab5d7432
 codex
 I’m adding the quarterly automation workflow now. It will run the refresh target, capture a summary, and open/update a PR only when the generated JSON changes.
 file update
-A /Users/scidsg/hushline/.github/workflows/public-record-quarterly-refresh.yml
+A [redacted-path]
 name: Quarterly Public Record Refresh
 
 on:
@@ -10424,7 +10634,7 @@ index 0000000000000000000000000000000000000000..b669b7737447461bf96f330dab5d7432
 +        raise SystemExit(1) from exc
 
 file update
-A /Users/scidsg/hushline/tests/test_public_record_refresh.py
+A [redacted-path]
 from __future__ import annotations
 
 from typing import Any
@@ -12887,9 +13097,9 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 codex
 I’ve added tests and now I’m doing a pass for type/lint safety (typed dict return types, key handling, and small CLI edge cases) before finalizing.
 exec
-/bin/zsh -lc "sed -n '1,360p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,320p' scripts/refresh_public_record_law_firms.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,320p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,360p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,320p' scripts/refresh_public_record_law_firms.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,320p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 53ms:
 #!/usr/bin/env python3
 from __future__ import annotations
 
@@ -14037,7 +14247,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 file update
-M /Users/scidsg/hushline/scripts/refresh_public_record_law_firms.py
+M [redacted-path]
 @@ -5,4 +5,5 @@
  import json
 +import sys
@@ -16251,7 +16461,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 file update
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 @@ -35,15 +35,2 @@
  
 -_OUTPUT_FIELD_ORDER: tuple[str, ...] = (
@@ -18433,7 +18643,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "sed -n '1,360p' hushline/public_record_refresh.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,360p' hushline/public_record_refresh.py" in [redacted-path] succeeded in 52ms:
 from __future__ import annotations
 
 import re
@@ -19531,7 +19741,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "sed -n '360,520p' hushline/public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '360,520p' hushline/public_record_refresh.py" in [redacted-path] succeeded in 53ms:
             failures=failures,
             dropped_record_ids=[],
         )
@@ -20629,7 +20839,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc 'chmod +x scripts/refresh_public_record_law_firms.py' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc 'chmod +x scripts/refresh_public_record_law_firms.py' in [redacted-path] succeeded in 51ms:
 
 file update:
 diff --git a/.github/workflows/public-record-quarterly-refresh.yml b/.github/workflows/public-record-quarterly-refresh.yml
@@ -21708,8 +21918,8 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff --stat' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc 'git diff --stat' in [redacted-path] succeeded in 53ms:
  M Makefile
 ?? .github/workflows/public-record-quarterly-refresh.yml
 ?? hushline/public_record_refresh.py
@@ -22797,7 +23007,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 codex
 I’m doing one final repository process check before wrapping up: confirming whether Dependabot PR triage data is locally available via `gh` in this environment.
 exec
-/bin/zsh -lc "gh pr list --repo scidsg/hushline --search 'author:app/dependabot' --state open --json number,title,url" in /Users/scidsg/hushline succeeded in 594ms:
+/bin/zsh -lc "gh pr list --repo scidsg/hushline --search 'author:app/dependabot' --state open --json number,title,url" in [redacted-path] succeeded in 594ms:
 []
 file update:
 diff --git a/.github/workflows/public-record-quarterly-refresh.yml b/.github/workflows/public-record-quarterly-refresh.yml
@@ -23876,7 +24086,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "gh issue list --repo scidsg/hushline --search 'author:app/dependabot' --state open --json number,title,url" in /Users/scidsg/hushline succeeded in 800ms:
+/bin/zsh -lc "gh issue list --repo scidsg/hushline --search 'author:app/dependabot' --state open --json number,title,url" in [redacted-path] succeeded in 800ms:
 []
 file update:
 diff --git a/.github/workflows/public-record-quarterly-refresh.yml b/.github/workflows/public-record-quarterly-refresh.yml
@@ -24955,7 +25165,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "gh api repos/scidsg/hushline/dependabot/alerts?state=open --jq 'map({number,dependency:.dependency.package.name,severity:.security_advisory.severity})'" in /Users/scidsg/hushline exited 1 in 53ms:
+/bin/zsh -lc "gh api repos/scidsg/hushline/dependabot/alerts?state=open --jq 'map({number,dependency:.dependency.package.name,severity:.security_advisory.severity})'" in [redacted-path] exited 1 in 53ms:
 zsh:1: no matches found: repos/scidsg/hushline/dependabot/alerts?state=open
 file update:
 diff --git a/.github/workflows/public-record-quarterly-refresh.yml b/.github/workflows/public-record-quarterly-refresh.yml
@@ -26034,7 +26244,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "gh api 'repos/scidsg/hushline/dependabot/alerts?state=open' --jq 'map({number,dependency:.dependency.package.name,severity:.security_advisory.severity})'" in /Users/scidsg/hushline exited 1 in 51ms:
+/bin/zsh -lc "gh api 'repos/scidsg/hushline/dependabot/alerts?state=open' --jq 'map({number,dependency:.dependency.package.name,severity:.security_advisory.severity})'" in [redacted-path] exited 1 in 51ms:
 error connecting to api.github.com
 check your internet connection or https://githubstatus.com
 file update:
@@ -27114,9 +27324,9 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' hushline/public_record_refresh.py | sed -n '1,120p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' scripts/refresh_public_record_law_firms.py | sed -n '1,120p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' tests/test_public_record_refresh.py | sed -n '1,120p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' hushline/public_record_refresh.py | sed -n '1,120p'" in [redacted-path]
+/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' scripts/refresh_public_record_law_firms.py | sed -n '1,120p'" in [redacted-path]
+/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' tests/test_public_record_refresh.py | sed -n '1,120p'" in [redacted-path] succeeded in 52ms:
 236:    slug = _optional_string(raw_row.get("slug")) or f"{_PUBLIC_RECORD_SLUG_PREFIX}{_slug_base(name)}"
  succeeded in 51ms:
 110:        missing_defaults = [region for region in selected_regions if region not in DEFAULT_REGION_TARGETS]
@@ -28199,7 +28409,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 file update
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 @@ -235,3 +235,5 @@
      listing_id = _optional_string(raw_row.get("id")) or f"seed-{_slug_base(name)}"
 -    slug = _optional_string(raw_row.get("slug")) or f"{_PUBLIC_RECORD_SLUG_PREFIX}{_slug_base(name)}"
@@ -30367,7 +30577,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 file update
-M /Users/scidsg/hushline/scripts/refresh_public_record_law_firms.py
+M [redacted-path]
 @@ -109,3 +109,5 @@
      if not values:
 -        missing_defaults = [region for region in selected_regions if region not in DEFAULT_REGION_TARGETS]
@@ -32539,7 +32749,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' hushline/public_record_refresh.py scripts/refresh_public_record_law_firms.py tests/test_public_record_refresh.py .github/workflows/public-record-quarterly-refresh.yml Makefile | sed -n '1,120p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' hushline/public_record_refresh.py scripts/refresh_public_record_law_firms.py tests/test_public_record_refresh.py .github/workflows/public-record-quarterly-refresh.yml Makefile | sed -n '1,120p'" in [redacted-path] succeeded in 53ms:
 26:            REFRESH_PUBLIC_RECORD_ARGS="--summary-output /tmp/public-record-refresh-summary.md --allow-link-failures"
 15:	@awk 'BEGIN {FS = ":.*?## "} /^[0-9a-zA-Z_-]+:.*?## / {printf "\033[36m%s\033[0m : %s\n", $$1, $$2}' $(MAKEFILE_LIST) | \
 71:	$(CMD) sh -lc 'if [ -x node_modules/.bin/prettier ] && node_modules/.bin/prettier --version >/dev/null 2>&1; then node_modules/.bin/prettier --check $(PRETTIER_TARGETS); elif command -v prettier >/dev/null 2>&1 && prettier --version >/dev/null 2>&1; then prettier --check $(PRETTIER_TARGETS); else echo "Error: prettier/node is unavailable in this environment." >&2; exit 1; fi'
@@ -33634,7 +33844,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 file update
-M /Users/scidsg/hushline/.github/workflows/public-record-quarterly-refresh.yml
+M [redacted-path]
 @@ -24,4 +24,5 @@
          run: |
 +          REFRESH_ARGS="--summary-output /tmp/public-record-refresh-summary.md --allow-link-failures"
@@ -35808,7 +36018,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' .github/workflows/public-record-quarterly-refresh.yml hushline/public_record_refresh.py scripts/refresh_public_record_law_firms.py tests/test_public_record_refresh.py | sed -n '1,120p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' .github/workflows/public-record-quarterly-refresh.yml hushline/public_record_refresh.py scripts/refresh_public_record_law_firms.py tests/test_public_record_refresh.py | sed -n '1,120p'" in [redacted-path] succeeded in 52ms:
 25:          REFRESH_ARGS="--summary-output /tmp/public-record-refresh-summary.md --allow-link-failures"
 file update:
 diff --git a/.github/workflows/public-record-quarterly-refresh.yml b/.github/workflows/public-record-quarterly-refresh.yml
@@ -36892,7 +37102,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 file update
-M /Users/scidsg/hushline/.github/workflows/public-record-quarterly-refresh.yml
+M [redacted-path]
 @@ -24,3 +24,3 @@
          run: |
 -          REFRESH_ARGS="--summary-output /tmp/public-record-refresh-summary.md --allow-link-failures"
@@ -39073,7 +39283,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' .github/workflows/public-record-quarterly-refresh.yml hushline/public_record_refresh.py scripts/refresh_public_record_law_firms.py tests/test_public_record_refresh.py | sed -n '1,120p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' .github/workflows/public-record-quarterly-refresh.yml hushline/public_record_refresh.py scripts/refresh_public_record_law_firms.py tests/test_public_record_refresh.py | sed -n '1,120p'" in [redacted-path] succeeded in 53ms:
 
 file update:
 diff --git a/.github/workflows/public-record-quarterly-refresh.yml b/.github/workflows/public-record-quarterly-refresh.yml
@@ -40157,7 +40367,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 file update
-M /Users/scidsg/hushline/.github/workflows/public-record-link-check.yml
+M [redacted-path]
 @@ -14,2 +14,4 @@
        - "hushline/data/public_record_law_firms.json"
 +      - "hushline/public_record_refresh.py"
@@ -42369,9 +42579,9 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 codex
 I’ve finished the code changes and tuned workflow triggers for the new refresh script/module. Next I’ll do a final diff review for correctness and then summarize exactly what changed and what I did not run locally.
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "git diff -- hushline/public_record_refresh.py scripts/refresh_public_record_law_firms.py tests/test_public_record_refresh.py | sed -n '1,320p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "git diff -- Makefile .github/workflows/public-record-link-check.yml .github/workflows/public-record-quarterly-refresh.yml | sed -n '1,260p'" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc "git diff -- hushline/public_record_refresh.py scripts/refresh_public_record_law_firms.py tests/test_public_record_refresh.py | sed -n '1,320p'" in [redacted-path]
+/bin/zsh -lc "git diff -- Makefile .github/workflows/public-record-link-check.yml .github/workflows/public-record-quarterly-refresh.yml | sed -n '1,260p'" in [redacted-path] succeeded in 51ms:
 
  succeeded in 53ms:
  M .github/workflows/public-record-link-check.yml
@@ -43500,10 +43710,10 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "sed -n '1,260p' .github/workflows/public-record-quarterly-refresh.yml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,320p' scripts/refresh_public_record_law_firms.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,320p' tests/test_public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,360p' hushline/public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,260p' .github/workflows/public-record-quarterly-refresh.yml" in [redacted-path]
+/bin/zsh -lc "sed -n '1,320p' scripts/refresh_public_record_law_firms.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,320p' tests/test_public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,360p' hushline/public_record_refresh.py" in [redacted-path] succeeded in 53ms:
 name: Quarterly Public Record Refresh
 
 on:
@@ -44686,7 +44896,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc 'ls -l scripts/refresh_public_record_law_firms.py' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'ls -l scripts/refresh_public_record_law_firms.py' in [redacted-path] succeeded in 53ms:
 -rwxr-xr-x  1 scidsg  staff  7006 Mar  4 08:11 scripts/refresh_public_record_law_firms.py
 file update:
 diff --git a/.github/workflows/public-record-link-check.yml b/.github/workflows/public-record-link-check.yml
@@ -45789,7 +45999,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 codex
 I’m tightening one more type edge in the script loader so `mypy` won’t have to infer key types from generic JSON dicts.
 file update
-M /Users/scidsg/hushline/scripts/refresh_public_record_law_firms.py
+M [redacted-path]
 @@ -150,4 +150,10 @@
          raise PublicRecordRefreshError(f"Input array must contain only JSON objects: {path}")
 -    return [dict(row) for row in parsed]
@@ -48014,7 +48224,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' scripts/refresh_public_record_law_firms.py | sed -n '1,120p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "awk 'length("'$0)>100{print FNR":"$0}'"' scripts/refresh_public_record_law_firms.py | sed -n '1,120p'" in [redacted-path] succeeded in 52ms:
 
 file update:
 diff --git a/.github/workflows/public-record-link-check.yml b/.github/workflows/public-record-link-check.yml
@@ -49121,7 +49331,7 @@ index 0000000000000000000000000000000000000000..db05f65207dfecafa70aba6989a84f93
 +    assert sleep_calls == [1.0]
 
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 53ms:
  M .github/workflows/public-record-link-check.yml
  M Makefile
 ?? .github/workflows/public-record-quarterly-refresh.yml
@@ -50236,8 +50446,8 @@ codex
 Implemented issue #1484 with a minimal, focused diff.
 
 1. Added a deterministic refresh/generation pipeline:
-- Core logic: [hushline/public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py)
-- CLI entrypoint: [scripts/refresh_public_record_law_firms.py](/Users/scidsg/hushline/scripts/refresh_public_record_law_firms.py)
+- Core logic: [hushline/public_record_refresh.py]([redacted-path]
+- CLI entrypoint: [scripts/refresh_public_record_law_firms.py]([redacted-path]
 
 This now supports:
 - Deterministic output ordering
@@ -50249,19 +50459,19 @@ This now supports:
 - Emitting the existing JSON schema
 
 2. Added repo entrypoint for refresh:
-- [Makefile](/Users/scidsg/hushline/Makefile)
+- [Makefile]([redacted-path]
 - New target: `make refresh-public-record-listings` (with `REFRESH_PUBLIC_RECORD_ARGS` passthrough)
 
 3. Added quarterly automation + PR creation:
-- New workflow: [public-record-quarterly-refresh.yml](/Users/scidsg/hushline/.github/workflows/public-record-quarterly-refresh.yml)
+- New workflow: [public-record-quarterly-refresh.yml]([redacted-path]
 - Runs quarterly (`Jan/Apr/Jul/Oct`), refreshes artifact, captures summary, and opens/updates PR when artifact changes.
 
 4. Updated link-check workflow trigger coverage:
-- [public-record-link-check.yml](/Users/scidsg/hushline/.github/workflows/public-record-link-check.yml)
+- [public-record-link-check.yml]([redacted-path]
 - Added refresh script/module/workflow paths so link checks run when refresh pipeline code changes.
 
 5. Added tests for generator behavior:
-- [tests/test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py)
+- [tests/test_public_record_refresh.py]([redacted-path]
 
 Covers:
 - Determinism and schema compatibility
@@ -51381,8 +51591,8 @@ tokens used
 Implemented issue #1484 with a minimal, focused diff.
 
 1. Added a deterministic refresh/generation pipeline:
-- Core logic: [hushline/public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py)
-- CLI entrypoint: [scripts/refresh_public_record_law_firms.py](/Users/scidsg/hushline/scripts/refresh_public_record_law_firms.py)
+- Core logic: [hushline/public_record_refresh.py]([redacted-path]
+- CLI entrypoint: [scripts/refresh_public_record_law_firms.py]([redacted-path]
 
 This now supports:
 - Deterministic output ordering
@@ -51394,19 +51604,19 @@ This now supports:
 - Emitting the existing JSON schema
 
 2. Added repo entrypoint for refresh:
-- [Makefile](/Users/scidsg/hushline/Makefile)
+- [Makefile]([redacted-path]
 - New target: `make refresh-public-record-listings` (with `REFRESH_PUBLIC_RECORD_ARGS` passthrough)
 
 3. Added quarterly automation + PR creation:
-- New workflow: [public-record-quarterly-refresh.yml](/Users/scidsg/hushline/.github/workflows/public-record-quarterly-refresh.yml)
+- New workflow: [public-record-quarterly-refresh.yml]([redacted-path]
 - Runs quarterly (`Jan/Apr/Jul/Oct`), refreshes artifact, captures summary, and opens/updates PR when artifact changes.
 
 4. Updated link-check workflow trigger coverage:
-- [public-record-link-check.yml](/Users/scidsg/hushline/.github/workflows/public-record-link-check.yml)
+- [public-record-link-check.yml]([redacted-path]
 - Added refresh script/module/workflow paths so link checks run when refresh pipeline code changes.
 
 5. Added tests for generator behavior:
-- [tests/test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py)
+- [tests/test_public_record_refresh.py]([redacted-path]
 
 Covers:
 - Determinism and schema compatibility
@@ -51422,8 +51632,8 @@ Codex final message:
 Implemented issue #1484 with a minimal, focused diff.
 
 1. Added a deterministic refresh/generation pipeline:
-- Core logic: [hushline/public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py)
-- CLI entrypoint: [scripts/refresh_public_record_law_firms.py](/Users/scidsg/hushline/scripts/refresh_public_record_law_firms.py)
+- Core logic: [hushline/public_record_refresh.py]([redacted-path]
+- CLI entrypoint: [scripts/refresh_public_record_law_firms.py]([redacted-path]
 
 This now supports:
 - Deterministic output ordering
@@ -51435,19 +51645,19 @@ This now supports:
 - Emitting the existing JSON schema
 
 2. Added repo entrypoint for refresh:
-- [Makefile](/Users/scidsg/hushline/Makefile)
+- [Makefile]([redacted-path]
 - New target: `make refresh-public-record-listings` (with `REFRESH_PUBLIC_RECORD_ARGS` passthrough)
 
 3. Added quarterly automation + PR creation:
-- New workflow: [public-record-quarterly-refresh.yml](/Users/scidsg/hushline/.github/workflows/public-record-quarterly-refresh.yml)
+- New workflow: [public-record-quarterly-refresh.yml]([redacted-path]
 - Runs quarterly (`Jan/Apr/Jul/Oct`), refreshes artifact, captures summary, and opens/updates PR when artifact changes.
 
 4. Updated link-check workflow trigger coverage:
-- [public-record-link-check.yml](/Users/scidsg/hushline/.github/workflows/public-record-link-check.yml)
+- [public-record-link-check.yml]([redacted-path]
 - Added refresh script/module/workflow paths so link checks run when refresh pipeline code changes.
 
 5. Added tests for generator behavior:
-- [tests/test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py)
+- [tests/test_public_record_refresh.py]([redacted-path]
 
 Covers:
 - Determinism and schema compatibility
@@ -51566,14 +51776,14 @@ Workflow checks failed; Codex self-heal attempt 1.
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.107.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.3-codex
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR]
-reasoning effort: high
-reasoning summaries: none
-session id: 019cb9a0-5a1b-7ac1-af6b-332c1b1158c7
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are continuing GitHub issue #1484 in scidsg/hushline on branch codex/daily-issue-1484.
@@ -51606,8 +51816,8 @@ Most recent Codex implementation summary:
 Implemented issue #1484 with a minimal, focused diff.
 
 1. Added a deterministic refresh/generation pipeline:
-- Core logic: [hushline/public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py)
-- CLI entrypoint: [scripts/refresh_public_record_law_firms.py](/Users/scidsg/hushline/scripts/refresh_public_record_law_firms.py)
+- Core logic: [hushline/public_record_refresh.py]([redacted-path]
+- CLI entrypoint: [scripts/refresh_public_record_law_firms.py]([redacted-path]
 
 This now supports:
 - Deterministic output ordering
@@ -51619,19 +51829,19 @@ This now supports:
 - Emitting the existing JSON schema
 
 2. Added repo entrypoint for refresh:
-- [Makefile](/Users/scidsg/hushline/Makefile)
+- [Makefile]([redacted-path]
 - New target: `make refresh-public-record-listings` (with `REFRESH_PUBLIC_RECORD_ARGS` passthrough)
 
 3. Added quarterly automation + PR creation:
-- New workflow: [public-record-quarterly-refresh.yml](/Users/scidsg/hushline/.github/workflows/public-record-quarterly-refresh.yml)
+- New workflow: [public-record-quarterly-refresh.yml]([redacted-path]
 - Runs quarterly (`Jan/Apr/Jul/Oct`), refreshes artifact, captures summary, and opens/updates PR when artifact changes.
 
 4. Updated link-check workflow trigger coverage:
-- [public-record-link-check.yml](/Users/scidsg/hushline/.github/workflows/public-record-link-check.yml)
+- [public-record-link-check.yml]([redacted-path]
 - Added refresh script/module/workflow paths so link checks run when refresh pipeline code changes.
 
 5. Added tests for generator behavior:
-- [tests/test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py)
+- [tests/test_public_record_refresh.py]([redacted-path]
 
 Covers:
 - Determinism and schema compatibility
@@ -51777,10 +51987,10 @@ mcp startup: no servers
 codex
 I’m going to inspect the files already changed on this branch, then make the smallest lint-focused edits to clear the three Ruff failures without altering the implemented pipeline behavior.
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' tests/test_public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff -- .github/workflows/public-record-link-check.yml Makefile' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' tests/test_public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc 'git diff -- .github/workflows/public-record-link-check.yml Makefile' in [redacted-path]
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 51ms:
 from __future__ import annotations
 
 from typing import Any
@@ -51851,7 +52061,7 @@ index 1e714102..7a02aadf 100644
 ?? scripts/refresh_public_record_law_firms.py
 ?? tests/test_public_record_refresh.py
 exec
-/bin/zsh -lc "sed -n '260,520p' hushline/public_record_refresh.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '260,520p' hushline/public_record_refresh.py" in [redacted-path] succeeded in 52ms:
 
 
 def _validate_unique_ids_and_slugs(rows: Sequence[_NormalizedListing]) -> None:
@@ -51875,7 +52085,7 @@ def _apply_region_targets(
 codex
 I’ve confirmed the failures are isolated to `hushline/public_record_refresh.py` and `tests/test_public_record_refresh.py`; next I’ll patch only the Ruff violations (`PLR0913`, `PLR2004`) with behavior-preserving edits.
 exec
-/bin/zsh -lc "sed -n '220,520p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '220,520p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 53ms:
             name="Broken Firm",
             state="NY",
             website="https://broken.example",
@@ -51899,7 +52109,7 @@ exec
 codex
 I’m applying a very small lint-only patch: add explicit `noqa` for the two intentionally argument-rich helper APIs and replace the `500` comparison with a named constant.
 file update
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 @@ -37,2 +37,3 @@
  _BROKEN_STATUS_CODES = frozenset({404, 410})
 +_HTTP_SERVER_ERROR_MIN_STATUS = 500
@@ -51917,7 +52127,7 @@ M /Users/scidsg/hushline/hushline/public_record_refresh.py
          ):
 apply_patch(auto_approved=true) exited 0 in 40ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index b4469904d06f72b553ca7d3fca737500143a5215..6396a07090fc5e297adbd4af6701dd836728a736
@@ -51985,7 +52195,7 @@ index b4469904d06f72b553ca7d3fca737500143a5215..6396a07090fc5e297adbd4af6701dd83
          if last_error is not None and last_status_code is None:
 
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -22,3 +22,3 @@
      source_url: str | None = None,
 -) -> dict[str, object]:
@@ -51993,7 +52203,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
      row: dict[str, object] = {
 apply_patch(auto_approved=true) exited 0 in 53ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index b4469904d06f72b553ca7d3fca737500143a5215..6396a07090fc5e297adbd4af6701dd836728a736
@@ -52087,7 +52297,7 @@ index db05f65207dfecafa70aba6989a84f93c8295687..7731f82ae0a6b675932d56220ec99deb
          "website": website,
 
 exec
-/bin/zsh -lc 'git diff -- hushline/public_record_refresh.py tests/test_public_record_refresh.py' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git diff -- hushline/public_record_refresh.py tests/test_public_record_refresh.py' in [redacted-path] succeeded in 53ms:
 
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
@@ -52138,8 +52348,8 @@ index db05f65207dfecafa70aba6989a84f93c8295687..7731f82ae0a6b675932d56220ec99deb
 codex
 I patched the two files; I’ll quickly verify the exact edits are present in the current file contents, then summarize.
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "HTTP_SERVER_ERROR_MIN_STATUS|noqa: PLR0913" hushline/public_record_refresh.py tests/test_public_record_refresh.py' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc 'rg -n "HTTP_SERVER_ERROR_MIN_STATUS|noqa: PLR0913" hushline/public_record_refresh.py tests/test_public_record_refresh.py' in [redacted-path] succeeded in 53ms:
  M .github/workflows/public-record-link-check.yml
  M Makefile
 ?? .github/workflows/public-record-quarterly-refresh.yml
@@ -52198,8 +52408,8 @@ index db05f65207dfecafa70aba6989a84f93c8295687..7731f82ae0a6b675932d56220ec99deb
          "website": website,
 
 exec
-/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '30,190p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '1,40p'" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '30,190p'" in [redacted-path]
+/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '1,40p'" in [redacted-path] succeeded in 51ms:
      1	from __future__ import annotations
      2	
      3	from typing import Any
@@ -52288,10 +52498,10 @@ index db05f65207dfecafa70aba6989a84f93c8295687..7731f82ae0a6b675932d56220ec99deb
          "website": website,
 
 exec
-/bin/zsh -lc "sed -n '1,260p' .github/workflows/public-record-quarterly-refresh.yml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' scripts/refresh_public_record_law_firms.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' .github/workflows/public-record-link-check.yml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,180p' Makefile" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' .github/workflows/public-record-quarterly-refresh.yml" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' scripts/refresh_public_record_law_firms.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' .github/workflows/public-record-link-check.yml" in [redacted-path]
+/bin/zsh -lc "sed -n '1,180p' Makefile" in [redacted-path] succeeded in 52ms:
 name: Quarterly Public Record Refresh
 
 on:
@@ -52422,7 +52632,7 @@ index db05f65207dfecafa70aba6989a84f93c8295687..7731f82ae0a6b675932d56220ec99deb
          "website": website,
 
 exec
-/bin/zsh -lc 'git diff --name-only' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git diff --name-only' in [redacted-path] succeeded in 53ms:
 .github/workflows/public-record-link-check.yml
 Makefile
 file update:
@@ -52475,13 +52685,13 @@ codex
 Applied the smallest lint-focused fixes for the reported failures, preserving the existing issue implementation.
 
 1. Added a named constant for server-error threshold and used it instead of magic `500`:
-[public_record_refresh.py:38](/Users/scidsg/hushline/hushline/public_record_refresh.py:38) and [public_record_refresh.py:178](/Users/scidsg/hushline/hushline/public_record_refresh.py:178)
+[public_record_refresh.py:38]([redacted-path] and [public_record_refresh.py:178]([redacted-path]
 
 2. Marked the intentionally argument-heavy public refresh API with explicit Ruff suppression:
-[public_record_refresh.py:112](/Users/scidsg/hushline/hushline/public_record_refresh.py:112)
+[public_record_refresh.py:112]([redacted-path]
 
 3. Marked the test row-builder helper similarly:
-[test_public_record_refresh.py:23](/Users/scidsg/hushline/tests/test_public_record_refresh.py:23)
+[test_public_record_refresh.py:23]([redacted-path]
 
 I did not run local validation commands; this is ready for the runner to rerun the full CI-equivalent checks.
 file update:
@@ -52535,13 +52745,13 @@ tokens used
 Applied the smallest lint-focused fixes for the reported failures, preserving the existing issue implementation.
 
 1. Added a named constant for server-error threshold and used it instead of magic `500`:
-[public_record_refresh.py:38](/Users/scidsg/hushline/hushline/public_record_refresh.py:38) and [public_record_refresh.py:178](/Users/scidsg/hushline/hushline/public_record_refresh.py:178)
+[public_record_refresh.py:38]([redacted-path] and [public_record_refresh.py:178]([redacted-path]
 
 2. Marked the intentionally argument-heavy public refresh API with explicit Ruff suppression:
-[public_record_refresh.py:112](/Users/scidsg/hushline/hushline/public_record_refresh.py:112)
+[public_record_refresh.py:112]([redacted-path]
 
 3. Marked the test row-builder helper similarly:
-[test_public_record_refresh.py:23](/Users/scidsg/hushline/tests/test_public_record_refresh.py:23)
+[test_public_record_refresh.py:23]([redacted-path]
 
 I did not run local validation commands; this is ready for the runner to rerun the full CI-equivalent checks.
 Codex execution completed.
@@ -52549,13 +52759,13 @@ Codex final message:
 Applied the smallest lint-focused fixes for the reported failures, preserving the existing issue implementation.
 
 1. Added a named constant for server-error threshold and used it instead of magic `500`:
-[public_record_refresh.py:38](/Users/scidsg/hushline/hushline/public_record_refresh.py:38) and [public_record_refresh.py:178](/Users/scidsg/hushline/hushline/public_record_refresh.py:178)
+[public_record_refresh.py:38]([redacted-path] and [public_record_refresh.py:178]([redacted-path]
 
 2. Marked the intentionally argument-heavy public refresh API with explicit Ruff suppression:
-[public_record_refresh.py:112](/Users/scidsg/hushline/hushline/public_record_refresh.py:112)
+[public_record_refresh.py:112]([redacted-path]
 
 3. Marked the test row-builder helper similarly:
-[test_public_record_refresh.py:23](/Users/scidsg/hushline/tests/test_public_record_refresh.py:23)
+[test_public_record_refresh.py:23]([redacted-path]
 
 I did not run local validation commands; this is ready for the runner to rerun the full CI-equivalent checks.
 ==> Refresh local runtime after schema changes
@@ -52679,14 +52889,14 @@ Workflow checks failed; Codex self-heal attempt 2.
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.107.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.3-codex
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR]
-reasoning effort: high
-reasoning summaries: none
-session id: 019cb9a1-c78a-72a0-811f-4bf4bd524427
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are continuing GitHub issue #1484 in scidsg/hushline on branch codex/daily-issue-1484.
@@ -52719,13 +52929,13 @@ Most recent Codex implementation summary:
 Applied the smallest lint-focused fixes for the reported failures, preserving the existing issue implementation.
 
 1. Added a named constant for server-error threshold and used it instead of magic `500`:
-[public_record_refresh.py:38](/Users/scidsg/hushline/hushline/public_record_refresh.py:38) and [public_record_refresh.py:178](/Users/scidsg/hushline/hushline/public_record_refresh.py:178)
+[public_record_refresh.py:38]([redacted-path] and [public_record_refresh.py:178]([redacted-path]
 
 2. Marked the intentionally argument-heavy public refresh API with explicit Ruff suppression:
-[public_record_refresh.py:112](/Users/scidsg/hushline/hushline/public_record_refresh.py:112)
+[public_record_refresh.py:112]([redacted-path]
 
 3. Marked the test row-builder helper similarly:
-[test_public_record_refresh.py:23](/Users/scidsg/hushline/tests/test_public_record_refresh.py:23)
+[test_public_record_refresh.py:23]([redacted-path]
 
 I did not run local validation commands; this is ready for the runner to rerun the full CI-equivalent checks.
 ---END PRIOR CODEX SUMMARY---
@@ -52878,9 +53088,9 @@ mcp startup: no servers
 codex
 I’ll first inspect the currently changed files and the exact lint-failing functions to confirm root cause before making any edits. Then I’ll apply the smallest code/test change needed to satisfy the checks.
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff --stat' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg --files .github/workflows hushline scripts tests | rg 'public_record|refresh_public_record|public-record'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc 'git diff --stat' in [redacted-path]
+/bin/zsh -lc "rg --files .github/workflows hushline scripts tests | rg 'public_record|refresh_public_record|public-record'" in [redacted-path] succeeded in 52ms:
  .github/workflows/public-record-link-check.yml | 3 +++
  Makefile                                       | 5 +++++
  2 files changed, 8 insertions(+)
@@ -52903,9 +53113,9 @@ hushline/model/public_record_listing.py
 codex
 I confirmed the branch state matches your summary. Next I’m reading each changed file (including new ones) to pinpoint only the lint blockers and avoid disturbing valid issue work.
 exec
-/bin/zsh -lc "sed -n '1,260p' tests/test_public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff -- .github/workflows/public-record-link-check.yml Makefile' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,260p' tests/test_public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc 'git diff -- .github/workflows/public-record-link-check.yml Makefile' in [redacted-path] succeeded in 51ms:
 from __future__ import annotations
 
 import re
@@ -52969,9 +53179,9 @@ diff --git a/Makefile b/Makefile
 index 1e714102..7a02aadf 100644
 --- a/Makefile
 exec
-/bin/zsh -lc "sed -n '260,520p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '260,520p' tests/test_public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' scripts/refresh_public_record_law_firms.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '260,520p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '260,520p' tests/test_public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' scripts/refresh_public_record_law_firms.py" in [redacted-path] succeeded in 51ms:
         def __init__(self, status_code: int) -> None:
             self.status_code = status_code
 
@@ -53035,7 +53245,7 @@ from hushline.public_record_refresh import (
 def _project_root() -> Path:
     return Path(__file__).resolve().parent.parent
 exec
-/bin/zsh -lc "sed -n '1,280p' .github/workflows/public-record-quarterly-refresh.yml" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,280p' .github/workflows/public-record-quarterly-refresh.yml" in [redacted-path] succeeded in 53ms:
 name: Quarterly Public Record Refresh
 
 on:
@@ -53059,7 +53269,7 @@ jobs:
 codex
 Root cause is precise: Ruff reports `PLR0913` on the first `def` line, but the suppression was placed on the closing signature line, so it is treated as unused. I’m now making a minimal edit to move the two existing suppressions onto the correct `def` lines only.
 file update
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 @@ -103,3 +103,3 @@
  
 -def refresh_public_record_rows(
@@ -53099,7 +53309,7 @@ index 8c630f9ccde9751de264a614ccd0178871b0e85f..7df2aae515f6804b7b50198116a8d114
      selected_regions: Sequence[str] | None = None,
 
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -14,3 +14,3 @@
  
 -def _row(
@@ -53167,8 +53377,8 @@ index db05f65207dfecafa70aba6989a84f93c8295687..bf7537689b1d736e636519697392c5d7
 codex
 I’ve applied only the two suppression-placement fixes. I’ll quickly verify the resulting diff is minimal and limited to those lines.
 exec
-/bin/zsh -lc 'git diff -- hushline/public_record_refresh.py tests/test_public_record_refresh.py' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git diff -- hushline/public_record_refresh.py tests/test_public_record_refresh.py' in [redacted-path]
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 52ms:
 
  succeeded in 51ms:
  M .github/workflows/public-record-link-check.yml
@@ -53206,8 +53416,8 @@ index db05f65207dfecafa70aba6989a84f93c8295687..bf7537689b1d736e636519697392c5d7
      slug: str | None,
 
 exec
-/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '10,32p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '96,126p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '10,32p'" in [redacted-path]
+/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '96,126p'" in [redacted-path] succeeded in 53ms:
     10	    build_requests_link_checker,
     11	    refresh_public_record_rows,
     12	)
@@ -53280,8 +53490,8 @@ index db05f65207dfecafa70aba6989a84f93c8295687..bf7537689b1d736e636519697392c5d7
 codex
 Applied the minimal fix for the repeated lint failure: moved the existing Ruff suppressions to the exact lines Ruff flags.
 
-- Updated [`hushline/public_record_refresh.py:104`](/Users/scidsg/hushline/hushline/public_record_refresh.py:104) to place `# noqa: PLR0913` on the `def refresh_public_record_rows(` line.
-- Updated [`tests/test_public_record_refresh.py:15`](/Users/scidsg/hushline/tests/test_public_record_refresh.py:15) to place `# noqa: PLR0913` on the `def _row(` line.
+- Updated [`hushline/public_record_refresh.py:104`]([redacted-path] to place `# noqa: PLR0913` on the `def refresh_public_record_rows(` line.
+- Updated [`tests/test_public_record_refresh.py:15`]([redacted-path] to place `# noqa: PLR0913` on the `def _row(` line.
 
 Why this fixes it:
 - `PLR0913` is reported on the first `def` line; previously the comment was on the closing signature line, which Ruff marked as unused (`RUF100`).
@@ -53319,8 +53529,8 @@ tokens used
 18,807
 Applied the minimal fix for the repeated lint failure: moved the existing Ruff suppressions to the exact lines Ruff flags.
 
-- Updated [`hushline/public_record_refresh.py:104`](/Users/scidsg/hushline/hushline/public_record_refresh.py:104) to place `# noqa: PLR0913` on the `def refresh_public_record_rows(` line.
-- Updated [`tests/test_public_record_refresh.py:15`](/Users/scidsg/hushline/tests/test_public_record_refresh.py:15) to place `# noqa: PLR0913` on the `def _row(` line.
+- Updated [`hushline/public_record_refresh.py:104`]([redacted-path] to place `# noqa: PLR0913` on the `def refresh_public_record_rows(` line.
+- Updated [`tests/test_public_record_refresh.py:15`]([redacted-path] to place `# noqa: PLR0913` on the `def _row(` line.
 
 Why this fixes it:
 - `PLR0913` is reported on the first `def` line; previously the comment was on the closing signature line, which Ruff marked as unused (`RUF100`).
@@ -53330,8 +53540,8 @@ Codex execution completed.
 Codex final message:
 Applied the minimal fix for the repeated lint failure: moved the existing Ruff suppressions to the exact lines Ruff flags.
 
-- Updated [`hushline/public_record_refresh.py:104`](/Users/scidsg/hushline/hushline/public_record_refresh.py:104) to place `# noqa: PLR0913` on the `def refresh_public_record_rows(` line.
-- Updated [`tests/test_public_record_refresh.py:15`](/Users/scidsg/hushline/tests/test_public_record_refresh.py:15) to place `# noqa: PLR0913` on the `def _row(` line.
+- Updated [`hushline/public_record_refresh.py:104`]([redacted-path] to place `# noqa: PLR0913` on the `def refresh_public_record_rows(` line.
+- Updated [`tests/test_public_record_refresh.py:15`]([redacted-path] to place `# noqa: PLR0913` on the `def _row(` line.
 
 Why this fixes it:
 - `PLR0913` is reported on the first `def` line; previously the comment was on the closing signature line, which Ruff marked as unused (`RUF100`).
@@ -53406,7 +53616,7 @@ Success: no issues found in 152 source files
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run workflow security checks
-docker run --rm -v "/Users/scidsg/hushline:/work" -w /work rhysd/actionlint:1.7.7 -color
+docker run --rm -v "[redacted-path]" -w /work rhysd/actionlint:1.7.7 -color
 Unable to find image 'rhysd/actionlint:1.7.7' locally
 1.7.7: Pulling from rhysd/actionlint
 25d2e00cf929: Pulling fs layer

--- a/docs/agent-logs/run-20260305T160005Z-issue-1504.txt
+++ b/docs/agent-logs/run-20260305T160005Z-issue-1504.txt
@@ -3,7 +3,7 @@ Timestamp (UTC): 20260305T160005Z
 Issue: #1504
 Repository: scidsg/hushline
 
-Runner Codex config: model=gpt-5.3-codex reasoning_effort=high verbose_codex_output=0
+Runner Codex config: [redacted]
 ==> Fetch latest from origin
 From github.com:scidsg/hushline
    a26cfd08..6812c0af  main       -> origin/main
@@ -1273,23 +1273,128 @@ Total reclaimed space: 5.029GB
 #7 9.140 Get:460 http://deb.debian.org/debian bookworm/main arm64 pkg-config arm64 1.8.1-1 [13.7 kB]
 #7 9.272 debconf: delaying package configuration, since apt-utils is not installed
 #7 9.287 Fetched 162 MB in 4s (44.1 MB/s)
-#7 9.298 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6689 files and directories currently installed.)
+#7 9.298 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6689 files and directories currently installed.)
 #7 9.301 Preparing to unpack .../perl-base_5.36.0-7+deb12u3_arm64.deb ...
 #7 9.308 Unpacking perl-base (5.36.0-7+deb12u3) over (5.36.0-7+deb12u1) ...
 #7 9.878 Setting up perl-base (5.36.0-7+deb12u3) ...
-#7 9.891 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.891 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.895 Preparing to unpack .../gcc-12-base_12.2.0-14+deb12u1_arm64.deb ...
 #7 9.899 Unpacking gcc-12-base:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 9.914 Setting up gcc-12-base:arm64 (12.2.0-14+deb12u1) ...
-#7 9.927 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.927 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.930 Preparing to unpack .../libgcc-s1_12.2.0-14+deb12u1_arm64.deb ...
 #7 9.934 Unpacking libgcc-s1:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 9.947 Setting up libgcc-s1:arm64 (12.2.0-14+deb12u1) ...
-#7 9.963 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.963 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.966 Preparing to unpack .../libstdc++6_12.2.0-14+deb12u1_arm64.deb ...
 #7 9.974 Unpacking libstdc++6:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 10.03 Setting up libstdc++6:arm64 (12.2.0-14+deb12u1) ...
-#7 10.05 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.05 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.05 Preparing to unpack .../libc6_2.36-9+deb12u13_arm64.deb ...
 #7 10.09 debconf: unable to initialize frontend: Dialog
 #7 10.09 debconf: (TERM is not set, so the dialog frontend is not usable.)
@@ -1305,12 +1410,54 @@ Total reclaimed space: 5.029GB
 #7 10.51 debconf: unable to initialize frontend: Readline
 #7 10.51 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
 #7 10.51 debconf: falling back to frontend: Teletype
-#7 11.57 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 11.57 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 11.57 Preparing to unpack .../libc-bin_2.36-9+deb12u13_arm64.deb ...
 #7 11.58 Unpacking libc-bin (2.36-9+deb12u13) over (2.36-9+deb12u8) ...
 #7 11.65 Setting up libc-bin (2.36-9+deb12u13) ...
 #7 11.67 Selecting previously unselected package perl-modules-5.36.
-#7 11.67 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 11.67 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 11.68 Preparing to unpack .../0-perl-modules-5.36_5.36.0-7+deb12u3_all.deb ...
 #7 11.68 Unpacking perl-modules-5.36 (5.36.0-7+deb12u3) ...
 #7 11.87 Selecting previously unselected package libgdbm-compat4:arm64.
@@ -1334,7 +1481,28 @@ Total reclaimed space: 5.029GB
 #7 12.44 Setting up libpython3.11-minimal:arm64 (3.11.2-6+deb12u6) ...
 #7 12.44 Setting up python3.11-minimal (3.11.2-6+deb12u6) ...
 #7 12.79 Selecting previously unselected package python3-minimal.
-#7 12.79 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9002 files and directories currently installed.)
+#7 12.79 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9002 files and directories currently installed.)
 #7 12.80 Preparing to unpack .../python3-minimal_3.11.2-1+b1_arm64.deb ...
 #7 12.80 Unpacking python3-minimal (3.11.2-1+b1) ...
 #7 12.81 Selecting previously unselected package media-types.
@@ -1344,7 +1512,28 @@ Total reclaimed space: 5.029GB
 #7 12.83 Unpacking liblzma5:arm64 (5.4.1-1) over (5.4.1-0.2) ...
 #7 12.85 Setting up liblzma5:arm64 (5.4.1-1) ...
 #7 12.86 Selecting previously unselected package libpython3.11-stdlib:arm64.
-#7 12.86 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9030 files and directories currently installed.)
+#7 12.86 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9030 files and directories currently installed.)
 #7 12.86 Preparing to unpack .../libpython3.11-stdlib_3.11.2-6+deb12u6_arm64.deb ...
 #7 12.86 Unpacking libpython3.11-stdlib:arm64 (3.11.2-6+deb12u6) ...
 #7 12.97 Selecting previously unselected package python3.11.
@@ -1355,7 +1544,28 @@ Total reclaimed space: 5.029GB
 #7 12.99 Unpacking libpython3-stdlib:arm64 (3.11.2-1+b1) ...
 #7 13.00 Setting up python3-minimal (3.11.2-1+b1) ...
 #7 13.08 Selecting previously unselected package python3.
-#7 13.08 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9412 files and directories currently installed.)
+#7 13.08 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9412 files and directories currently installed.)
 #7 13.08 Preparing to unpack .../000-python3_3.11.2-1+b1_arm64.deb ...
 #7 13.08 Unpacking python3 (3.11.2-1+b1) ...
 #7 13.09 Selecting previously unselected package bzip2.
@@ -3581,14 +3791,14 @@ Switched to a new branch 'codex/daily-issue-1504'
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.107.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.3-codex
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR]
-reasoning effort: high
-reasoning summaries: none
-session id: 019cbebc-ce0f-7e00-a994-702e5c22947d
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are implementing GitHub issue #1504 in scidsg/hushline.
@@ -3657,8 +3867,8 @@ mcp startup: no servers
 codex
 I’m going to locate the existing state adapter implementation and current tests, then identify where to add a shared conformance harness with the smallest possible diff.
 exec
-/bin/zsh -lc 'find .. -name AGENTS.md -print' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'pwd && rg --files | head -n 200' in /Users/scidsg/hushline succeeded in 90ms:
+/bin/zsh -lc 'find .. -name AGENTS.md -print' in [redacted-path]
+/bin/zsh -lc 'pwd && rg --files | head -n 200' in [redacted-path] succeeded in 90ms:
 SECURITY.md
 docker-compose.staging.yaml
 assets/fonts/mono/IBMPlexMono-Medium.woff
@@ -3682,11 +3892,11 @@ assets/img/empty.png
 codex
 I found repo files and now I’m resolving any deeper `AGENTS.md` scope so edits stay compliant; the directory-wide `find` is still running and I’ll stop it to avoid unnecessary scan time.
 exec
-/bin/zsh -lc 'find . -name AGENTS.md -print' in /Users/scidsg/hushline succeeded in 178ms:
+/bin/zsh -lc 'find . -name AGENTS.md -print' in [redacted-path] succeeded in 178ms:
 ./AGENTS.md
 exec
-/bin/zsh -lc 'rg --files tests | head -n 300' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "US_STATE_AUTHORITATIVE_SOURCES|authoritative|state adapter|public record|source_label|source_url" hushline tests -S' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'rg --files tests | head -n 300' in [redacted-path]
+/bin/zsh -lc 'rg -n "US_STATE_AUTHORITATIVE_SOURCES|authoritative|state adapter|public record|source_label|source_url" hushline tests -S' in [redacted-path] succeeded in 53ms:
 tests/test_make_admin.py
 tests/test_accessibility.py
 tests/test_settings.py
@@ -3731,8 +3941,8 @@ hushline/public_record_refresh.py:153:        "source_url": "https://www.ctbar.o
 codex
 I found existing provenance checks already split across `tests/test_directory.py` and `tests/test_public_record_refresh.py`; next I’ll inspect those to extract a reusable harness and wire it into current state fixtures.
 exec
-/bin/zsh -lc "sed -n '1,260p' tests/test_directory.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,360p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,260p' tests/test_directory.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,360p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 53ms:
 from __future__ import annotations
 
 import re
@@ -3777,7 +3987,7 @@ def _first_public_record_listing_or_skip() -> PublicRecordListing:
 codex
 I’m now reading the remainder of `tests/test_public_record_refresh.py` to see whether state-specific adapter tests already exist that we can wrap with a shared helper rather than duplicating assertions.
 exec
-/bin/zsh -lc "sed -n '360,860p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '360,860p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 52ms:
         link_checker=checker,
         drop_failed_links=False,
     )
@@ -3799,7 +4009,7 @@ exec
     assert dropped.checked_url_count == 4
     assert checked_urls
 exec
-/bin/zsh -lc "sed -n '860,1320p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '860,1320p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 53ms:
                 "id": "seed-michael-joseph-lockman",
                 "name": "Michael Joseph Lockman",
                 "slug": "public-record~michael-joseph-lockman",
@@ -3821,8 +4031,8 @@ exec
 
     assert isinstance(result, OfficialStateDiscoveryResult)
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '260,560p' hushline/public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '260,560p' hushline/public_record_refresh.py" in [redacted-path] succeeded in 53ms:
 from __future__ import annotations
 
 import re
@@ -3865,8 +4075,8 @@ CHAMBERS_PUBLICATION_GROUP_BY_REGION: dict[str, int] = {
         "source_url": "https://iapps.courts.state.ny.us/attorneyservices/search?0",
         "allowed_domains": frozenset({"courts.state.ny.us"}),
 exec
-/bin/zsh -lc "sed -n '560,980p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '980,1400p' hushline/public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '560,980p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '980,1400p' hushline/public_record_refresh.py" in [redacted-path] succeeded in 53ms:
         {
             "User-Agent": (
                 "Mozilla/5.0 (compatible; HushlinePublicRecordRefresh/1.0; "
@@ -3909,8 +4119,8 @@ exec
         if seed_row["id"] in existing_ids:
             continue
 exec
-/bin/zsh -lc "sed -n '1900,2280p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1400,1900p' hushline/public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1900,2280p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1400,1900p' hushline/public_record_refresh.py" in [redacted-path] succeeded in 53ms:
             raise PublicRecordRefreshError(f"Duplicate listing slug detected: {row.slug}")
         seen_ids.add(row.id)
         seen_slugs.add(row.slug)
@@ -3953,7 +4163,7 @@ def _normalize_discovered_website(value: object) -> str | None:
 
 
 exec
-/bin/zsh -lc "sed -n '1,260p' tests/helpers.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,260p' tests/helpers.py" in [redacted-path] succeeded in 53ms:
 import random
 import string
 from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, TypeVar
@@ -4146,12 +4356,12 @@ def _host_matches_any_domain(host: str, domains: frozenset[str]) -> bool:
 def _normalized_name_key(name: str) -> str:
     normalized = unicodedata.normalize("NFKC", name).strip()
     return unidecode(normalized).casefold()
-EOF' in /Users/scidsg/hushline succeeded in 53ms:
+EOF' in [redacted-path] succeeded in 53ms:
 
 codex
 I’m about to edit `tests/test_public_record_refresh.py` to wire in the shared harness with parameterized tests for every non-noop state adapter, including collision-based skip checks for `id`, `slug`, and normalized `name`.
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -3,3 +3,3 @@
  import re
 -from typing import Any
@@ -4196,7 +4406,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -4205,8 +4415,8 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -4298,7 +4508,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -4307,8 +4517,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -4400,7 +4610,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -4409,8 +4619,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -4438,7 +4648,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
          [],
 
 exec
-/bin/zsh -lc "sed -n '1,120p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,120p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 51ms:
 from __future__ import annotations
 
 import re
@@ -4524,7 +4734,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -4533,8 +4743,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -4562,7 +4772,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
          [],
 
 exec
-/bin/zsh -lc "rg -n \"official_source_adapter_harness\" tests/test_public_record_refresh.py && sed -n '620,780p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "rg -n \"official_source_adapter_harness\" tests/test_public_record_refresh.py && sed -n '620,780p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 53ms:
 718:def test_official_source_adapter_harness_covers_current_implemented_states() -> None:
 723:def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 733:def test_official_source_adapter_harness_skips_existing_rows(
@@ -4648,7 +4858,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -4657,8 +4867,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -4686,7 +4896,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
          [],
 
 exec
-/bin/zsh -lc "sed -n '1,260p' tests/public_record_adapter_harness.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' tests/public_record_adapter_harness.py" in [redacted-path] succeeded in 52ms:
 from __future__ import annotations
 
 import re
@@ -4772,7 +4982,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -4781,8 +4991,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -4812,7 +5022,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 codex
 I spotted a bug in the new harness regex for Ohio record fragments (`\\d` was double-escaped), which would incorrectly fail valid OH adapter rows. I’m fixing that now.
 file update
-M /Users/scidsg/hushline/tests/public_record_adapter_harness.py
+M [redacted-path]
 @@ -24,3 +24,3 @@
  )
 -_OHIO_ATTORNEY_PROFILE_FRAGMENT_RE = re.compile(r"^/?\\d+/attyinfo/?$", re.IGNORECASE)
@@ -4917,7 +5127,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -4926,8 +5136,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -5043,7 +5253,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -5052,8 +5262,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -5081,7 +5291,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
          [],
 
 exec
-/bin/zsh -lc "sed -n '1,120p' tests/public_record_adapter_harness.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,120p' tests/public_record_adapter_harness.py" in [redacted-path] succeeded in 51ms:
 from __future__ import annotations
 
 import re
@@ -5191,7 +5401,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -5200,8 +5410,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -5229,7 +5439,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
          [],
 
 exec
-/bin/zsh -lc 'git status --short && git diff -- tests/public_record_adapter_harness.py tests/test_public_record_refresh.py' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git status --short && git diff -- tests/public_record_adapter_harness.py tests/test_public_record_refresh.py' in [redacted-path] succeeded in 53ms:
  M tests/test_public_record_refresh.py
 ?? tests/public_record_adapter_harness.py
 diff --git a/tests/test_public_record_refresh.py b/tests/test_public_record_refresh.py
@@ -5339,7 +5549,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -5348,8 +5558,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -5470,7 +5680,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -5479,8 +5689,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -5510,8 +5720,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 codex
 I’ve finished the implementation and reviewed the diff; next I’ll send a concise summary of the exact files changed and what checks were added.
 exec
-/bin/zsh -lc "nl -ba tests/public_record_adapter_harness.py | sed -n '1,220p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '1,130p' && nl -ba tests/test_public_record_refresh.py | sed -n '680,780p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "nl -ba tests/public_record_adapter_harness.py | sed -n '1,220p'" in [redacted-path]
+/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '1,130p' && nl -ba tests/test_public_record_refresh.py | sed -n '680,780p'" in [redacted-path] succeeded in 53ms:
      1	from __future__ import annotations
      2	
      3	import re
@@ -5642,7 +5852,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -5651,8 +5861,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -5684,7 +5894,7 @@ Implemented issue #1504 with a test-only, minimal diff.
 
 ### What changed
 1. Added a reusable official-source adapter conformance harness:
-- [public_record_adapter_harness.py](/Users/scidsg/hushline/tests/public_record_adapter_harness.py#L1)
+- [public_record_adapter_harness.py]([redacted-path]
 
 It now asserts per discovered row:
 - `source_label` matches `US_STATE_AUTHORITATIVE_SOURCES[state]`
@@ -5696,8 +5906,8 @@ It now asserts per discovered row:
 - duplicate protection on `id`, `slug`, and normalized-name collisions within adapter output
 
 2. Wired the harness into state adapter tests:
-- [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py#L27)
-- [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py#L718)
+- [test_public_record_refresh.py]([redacted-path]
+- [test_public_record_refresh.py]([redacted-path]
 
 New tests:
 - Ensure harness covers current implemented states (`CA`, `IL`, `OH`, `TN`, `WA`)
@@ -5795,7 +6005,7 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert {"CA", "IL", "OH", "TN", "WA"}.issubset(_IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
 +def test_official_source_adapter_harness_validates_state_outputs(state_code: str) -> None:
 +    result = _discover_rows_for_state(state_code=state_code, existing_rows=[])
 +
@@ -5804,8 +6014,8 @@ index 731b68010b89770e1ab70d6e755650972720df94..3ed5eafb662cf7e9739f53259d34bfc5
 +    assert_official_source_adapter_rows(state_code, result.rows)
 +
 +
-+@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-+@pytest.mark.parametrize("collision", ["id", "slug", "name"])
+[redacted-email]("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-email]("collision", ["id", "slug", "name"])
 +def test_official_source_adapter_harness_skips_existing_rows(
 +    state_code: str,
 +    collision: str,
@@ -5838,7 +6048,7 @@ Implemented issue #1504 with a test-only, minimal diff.
 
 ### What changed
 1. Added a reusable official-source adapter conformance harness:
-- [public_record_adapter_harness.py](/Users/scidsg/hushline/tests/public_record_adapter_harness.py#L1)
+- [public_record_adapter_harness.py]([redacted-path]
 
 It now asserts per discovered row:
 - `source_label` matches `US_STATE_AUTHORITATIVE_SOURCES[state]`
@@ -5850,8 +6060,8 @@ It now asserts per discovered row:
 - duplicate protection on `id`, `slug`, and normalized-name collisions within adapter output
 
 2. Wired the harness into state adapter tests:
-- [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py#L27)
-- [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py#L718)
+- [test_public_record_refresh.py]([redacted-path]
+- [test_public_record_refresh.py]([redacted-path]
 
 New tests:
 - Ensure harness covers current implemented states (`CA`, `IL`, `OH`, `TN`, `WA`)
@@ -5866,7 +6076,7 @@ Implemented issue #1504 with a test-only, minimal diff.
 
 ### What changed
 1. Added a reusable official-source adapter conformance harness:
-- [public_record_adapter_harness.py](/Users/scidsg/hushline/tests/public_record_adapter_harness.py#L1)
+- [public_record_adapter_harness.py]([redacted-path]
 
 It now asserts per discovered row:
 - `source_label` matches `US_STATE_AUTHORITATIVE_SOURCES[state]`
@@ -5878,8 +6088,8 @@ It now asserts per discovered row:
 - duplicate protection on `id`, `slug`, and normalized-name collisions within adapter output
 
 2. Wired the harness into state adapter tests:
-- [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py#L27)
-- [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py#L718)
+- [test_public_record_refresh.py]([redacted-path]
+- [test_public_record_refresh.py]([redacted-path]
 
 New tests:
 - Ensure harness covers current implemented states (`CA`, `IL`, `OH`, `TN`, `WA`)
@@ -6091,7 +6301,7 @@ Success: no issues found in 154 source files
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run workflow security checks
-docker run --rm -v "/Users/scidsg/hushline:/work" -w /work rhysd/actionlint:1.7.7 -color
+docker run --rm -v "[redacted-path]" -w /work rhysd/actionlint:1.7.7 -color
 Unable to find image 'rhysd/actionlint:1.7.7' locally
 1.7.7: Pulling from rhysd/actionlint
 25d2e00cf929: Pulling fs layer

--- a/docs/agent-logs/run-20260306T160005Z-issue-1505.txt
+++ b/docs/agent-logs/run-20260306T160005Z-issue-1505.txt
@@ -3,7 +3,7 @@ Timestamp (UTC): 20260306T160005Z
 Issue: #1505
 Repository: scidsg/hushline
 
-Runner Codex config: model=gpt-5.3-codex reasoning_effort=high verbose_codex_output=0
+Runner Codex config: [redacted]
 ==> Fetch latest from origin
 ==> Checkout main
 Already on 'main'
@@ -1384,23 +1384,128 @@ Total reclaimed space: 5.029GB
 #7 8.879 Get:460 http://deb.debian.org/debian bookworm/main arm64 pkg-config arm64 1.8.1-1 [13.7 kB]
 #7 9.013 debconf: delaying package configuration, since apt-utils is not installed
 #7 9.027 Fetched 162 MB in 4s (43.0 MB/s)
-#7 9.040 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6689 files and directories currently installed.)
+#7 9.040 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6689 files and directories currently installed.)
 #7 9.043 Preparing to unpack .../perl-base_5.36.0-7+deb12u3_arm64.deb ...
 #7 9.050 Unpacking perl-base (5.36.0-7+deb12u3) over (5.36.0-7+deb12u1) ...
 #7 9.660 Setting up perl-base (5.36.0-7+deb12u3) ...
-#7 9.673 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.673 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.676 Preparing to unpack .../gcc-12-base_12.2.0-14+deb12u1_arm64.deb ...
 #7 9.682 Unpacking gcc-12-base:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 9.698 Setting up gcc-12-base:arm64 (12.2.0-14+deb12u1) ...
-#7 9.711 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.711 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.713 Preparing to unpack .../libgcc-s1_12.2.0-14+deb12u1_arm64.deb ...
 #7 9.718 Unpacking libgcc-s1:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 9.733 Setting up libgcc-s1:arm64 (12.2.0-14+deb12u1) ...
-#7 9.753 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.753 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.756 Preparing to unpack .../libstdc++6_12.2.0-14+deb12u1_arm64.deb ...
 #7 9.765 Unpacking libstdc++6:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 9.826 Setting up libstdc++6:arm64 (12.2.0-14+deb12u1) ...
-#7 9.847 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.847 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.849 Preparing to unpack .../libc6_2.36-9+deb12u13_arm64.deb ...
 #7 9.888 debconf: unable to initialize frontend: Dialog
 #7 9.888 debconf: (TERM is not set, so the dialog frontend is not usable.)
@@ -1416,12 +1521,54 @@ Total reclaimed space: 5.029GB
 #7 10.33 debconf: unable to initialize frontend: Readline
 #7 10.33 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
 #7 10.33 debconf: falling back to frontend: Teletype
-#7 11.38 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 11.38 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 11.38 Preparing to unpack .../libc-bin_2.36-9+deb12u13_arm64.deb ...
 #7 11.39 Unpacking libc-bin (2.36-9+deb12u13) over (2.36-9+deb12u8) ...
 #7 11.46 Setting up libc-bin (2.36-9+deb12u13) ...
 #7 11.48 Selecting previously unselected package perl-modules-5.36.
-#7 11.48 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 11.48 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 11.49 Preparing to unpack .../0-perl-modules-5.36_5.36.0-7+deb12u3_all.deb ...
 #7 11.49 Unpacking perl-modules-5.36 (5.36.0-7+deb12u3) ...
 #7 11.68 Selecting previously unselected package libgdbm-compat4:arm64.
@@ -1445,7 +1592,28 @@ Total reclaimed space: 5.029GB
 #7 12.25 Setting up libpython3.11-minimal:arm64 (3.11.2-6+deb12u6) ...
 #7 12.26 Setting up python3.11-minimal (3.11.2-6+deb12u6) ...
 #7 12.62 Selecting previously unselected package python3-minimal.
-#7 12.62 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9002 files and directories currently installed.)
+#7 12.62 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9002 files and directories currently installed.)
 #7 12.63 Preparing to unpack .../python3-minimal_3.11.2-1+b1_arm64.deb ...
 #7 12.63 Unpacking python3-minimal (3.11.2-1+b1) ...
 #7 12.64 Selecting previously unselected package media-types.
@@ -1455,7 +1623,28 @@ Total reclaimed space: 5.029GB
 #7 12.66 Unpacking liblzma5:arm64 (5.4.1-1) over (5.4.1-0.2) ...
 #7 12.68 Setting up liblzma5:arm64 (5.4.1-1) ...
 #7 12.70 Selecting previously unselected package libpython3.11-stdlib:arm64.
-#7 12.70 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9030 files and directories currently installed.)
+#7 12.70 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9030 files and directories currently installed.)
 #7 12.70 Preparing to unpack .../libpython3.11-stdlib_3.11.2-6+deb12u6_arm64.deb ...
 #7 12.70 Unpacking libpython3.11-stdlib:arm64 (3.11.2-6+deb12u6) ...
 #7 12.81 Selecting previously unselected package python3.11.
@@ -1466,7 +1655,28 @@ Total reclaimed space: 5.029GB
 #7 12.83 Unpacking libpython3-stdlib:arm64 (3.11.2-1+b1) ...
 #7 12.84 Setting up python3-minimal (3.11.2-1+b1) ...
 #7 12.92 Selecting previously unselected package python3.
-#7 12.92 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9412 files and directories currently installed.)
+#7 12.92 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9412 files and directories currently installed.)
 #7 12.92 Preparing to unpack .../000-python3_3.11.2-1+b1_arm64.deb ...
 #7 12.92 Unpacking python3 (3.11.2-1+b1) ...
 #7 12.93 Selecting previously unselected package bzip2.
@@ -3688,14 +3898,14 @@ Switched to a new branch 'codex/daily-issue-1505'
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.107.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.3-codex
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR]
-reasoning effort: high
-reasoning summaries: none
-session id: 019cc3e3-891e-7741-9f10-013580b3a09d
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are implementing GitHub issue #1505 in scidsg/hushline.
@@ -3761,11 +3971,11 @@ mcp startup: no servers
 codex
 I’m going to inspect the existing public-record refresh adapters and tests first, then implement only the five state adapters (`AK`, `AL`, `AR`, `AZ`, `CO`) with matching strict-policy tests and minimal file changes.
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "pwd && rg --files | rg 'AGENTS\\.md|public_record_refresh\\.py|test_public_record_refresh\\.py|strict|public-record|record'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc "pwd && rg --files | rg 'AGENTS\\.md|public_record_refresh\\.py|test_public_record_refresh\\.py|strict|public-record|record'" in [redacted-path] succeeded in 52ms:
 
  succeeded in 52ms:
-/Users/scidsg/hushline
+[redacted-path]
 AGENTS.md
 scripts/refresh_public_record_law_firms.py
 scripts/public_record_provenance_report.py
@@ -3777,15 +3987,15 @@ hushline/model/public_record_listing.py
 tests/test_public_record_refresh.py
 tests/public_record_adapter_harness.py
 exec
-/bin/zsh -lc "rg --files | rg 'AGENTS\\.md"'$'"'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "rg --files | rg 'AGENTS\\.md"'$'"'" in [redacted-path] succeeded in 53ms:
 AGENTS.md
 codex
 I confirmed there’s only the root `AGENTS.md`; next I’m reading the current adapter implementations and test harness so I can mirror existing strict-source patterns for these five states.
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '261,620p' tests/test_public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '261,620p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' tests/public_record_adapter_harness.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '261,620p' tests/test_public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '261,620p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' tests/public_record_adapter_harness.py" in [redacted-path] succeeded in 51ms:
 from __future__ import annotations
 
 import re
@@ -3807,7 +4017,7 @@ CHAMBERS_PUBLICATION_GROUP_BY_REGION: dict[str, int] = {
 }
 
 exec
-/bin/zsh -lc "sed -n '1,260p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 52ms:
 from __future__ import annotations
 
 import re
@@ -3892,7 +4102,7 @@ from hushline.public_record_refresh import (
             region_targets={"US": 2},
         )
 exec
-/bin/zsh -lc 'rg -n "OFFICIAL_US_STATE_DISCOVERY_ADAPTERS|def _discover_.*official|discover_official_us_state_public_record_rows|strict|generic state source page|allowed_domains|source_url" hushline/public_record_refresh.py' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'rg -n "OFFICIAL_US_STATE_DISCOVERY_ADAPTERS|def _discover_.*official|discover_official_us_state_public_record_rows|strict|generic state source page|allowed_domains|source_url" hushline/public_record_refresh.py' in [redacted-path] succeeded in 52ms:
 13:LISTING_URL_FIELDS: tuple[str, str] = ("website", "source_url")
 116:    source_url: str
 117:    allowed_domains: frozenset[str]
@@ -3914,9 +4124,9 @@ exec
 159:        "allowed_domains": frozenset({"courts.delaware.gov"}),
 163:        "source_url": "https://www.floridabar.org/directories/find-mbr/",
 exec
-/bin/zsh -lc "sed -n '560,1165p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1166,1888p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '620,1320p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '560,1165p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1166,1888p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '620,1320p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 51ms:
         {
             "User-Agent": (
                 "Mozilla/5.0 (compatible; HushlinePublicRecordRefresh/1.0; "
@@ -3980,12 +4190,12 @@ def test_refresh_public_record_rows_allows_non_chambers_hosts_with_chambers_subs
 
     result = refresh_public_record_rows(
 exec
-/bin/zsh -lc "sed -n '1321,2200p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1321,2200p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 53ms:
 
 codex
 I’ve identified where adapters and adapter-harness tests live; I’m now checking for additional strict-policy test files that need updates so the new states are covered consistently.
 exec
-/bin/zsh -lc 'rg -n "official source|strict|public_record|adapter|discover_official_us_state|drop-failing-records|allowed_domains|generic state source" tests' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'rg -n "official source|strict|public_record|adapter|discover_official_us_state|drop-failing-records|allowed_domains|generic state source" tests' in [redacted-path] succeeded in 53ms:
 tests/test_accessibility.py:17:    public_records_tab = soup.find("button", {"id": "public-records-tab"})
 tests/test_accessibility.py:21:    public_records_panel = soup.find(id="public-records")
 tests/test_accessibility.py:31:    assert public_records_tab is not None
@@ -4007,7 +4217,7 @@ tests/test_public_record_refresh.py:29:    if adapter.__name__ != "_discover_noo
 tests/test_public_record_refresh.py:84:    return discover_official_us_state_public_record_rows(
 tests/test_public_record_refresh.py:152:def test_refresh_public_record_rows_is_deterministic_and_schema_compatible() -> None:
 exec
-/bin/zsh -lc "sed -n '340,620p' tests/test_directory.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '340,620p' tests/test_directory.py" in [redacted-path] succeeded in 53ms:
         "hushline.routes.directory.get_public_record_listings",
         lambda: mocked_public_records,
     )
@@ -4029,22 +4239,22 @@ exec
     assert "Info-Only Accounts" not in all_panel.get_text(" ", strip=True)
     assert "Public Record Attorneys" not in all_panel.get_text(" ", strip=True)
 exec
-/bin/zsh -lc "rg -n '\"state\": \"(AK|AL|AR|AZ|CO)\"' hushline/data/public_record_law_firms.json" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n '\"state\": \"(AK|AL|AR|AZ|CO)\"' hushline/data/public_record_law_firms_legacy.json" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n 'seed-.*(alaska|alabama|arkansas|arizona|colorado|\\bak\\b|\\bal\\b|\\bar\\b|\\baz\\b|\\bco\\b)' hushline/public_record_refresh.py tests/test_public_record_refresh.py" in /Users/scidsg/hushline exited 1 in 52ms:
+/bin/zsh -lc "rg -n '\"state\": \"(AK|AL|AR|AZ|CO)\"' hushline/data/public_record_law_firms.json" in [redacted-path]
+/bin/zsh -lc "rg -n '\"state\": \"(AK|AL|AR|AZ|CO)\"' hushline/data/public_record_law_firms_legacy.json" in [redacted-path]
+/bin/zsh -lc "rg -n 'seed-.*(alaska|alabama|arkansas|arizona|colorado|\\bak\\b|\\bal\\b|\\bar\\b|\\baz\\b|\\bco\\b)' hushline/public_record_refresh.py tests/test_public_record_refresh.py" in [redacted-path] exited 1 in 52ms:
 
  exited 1 in 52ms:
 
  exited 1 in 51ms:
 
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/data/public_record_law_firms.json" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'wc -l hushline/data/public_record_law_firms.json hushline/data/public_record_law_firms_legacy.json' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/data/public_record_law_firms.json" in [redacted-path]
+/bin/zsh -lc 'wc -l hushline/data/public_record_law_firms.json hushline/data/public_record_law_firms_legacy.json' in [redacted-path] succeeded in 51ms:
      326 hushline/data/public_record_law_firms.json
      706 hushline/data/public_record_law_firms_legacy.json
     1032 total
 exec
-/bin/zsh -lc "sed -n '1,220p' hushline/data/public_record_law_firms_legacy.json" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,220p' hushline/data/public_record_law_firms_legacy.json" in [redacted-path] succeeded in 51ms:
 [
   {
     "id": "seed-adam-j-levitt",
@@ -4087,9 +4297,9 @@ exec
     "description": "An Australian firm advising on whistleblowing, investigations, employment, and risk matters.",
     "city": "Sydney",
 exec
-/bin/zsh -lc "sed -n '1,260p' scripts/refresh_public_record_law_firms.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "refresh-public-record-listings|public_record|drop-failing-records|discover-official-us-state-firms" Makefile scripts/refresh_public_record_law_firms.py' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '260,620p' scripts/refresh_public_record_law_firms.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,260p' scripts/refresh_public_record_law_firms.py" in [redacted-path]
+/bin/zsh -lc 'rg -n "refresh-public-record-listings|public_record|drop-failing-records|discover-official-us-state-firms" Makefile scripts/refresh_public_record_law_firms.py' in [redacted-path]
+/bin/zsh -lc "sed -n '260,620p' scripts/refresh_public_record_law_firms.py" in [redacted-path] succeeded in 53ms:
 #!/usr/bin/env python3
 from __future__ import annotations
 
@@ -4148,14 +4358,14 @@ scripts/refresh_public_record_law_firms.py:333:        print(f"refresh_public_re
         source_rows,
         selected_regions=selected_regions,
 exec
-/bin/zsh -lc "rg -o '\"state\": \"["'^"]+"'"' hushline/data/public_record_law_firms.json | sed 's/\"state\": \"//; s/\""'$//'"' | sort | uniq -c | sort -nr" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "rg -o '\"state\": \"["'^"]+"'"' hushline/data/public_record_law_firms.json | sed 's/\"state\": \"//; s/\""'$//'"' | sort | uniq -c | sort -nr" in [redacted-path] succeeded in 53ms:
   16 CA
    5 TN
    4 IL
    1 WA
    1 OH
 exec
-/bin/zsh -lc "sed -n '1,180p' Makefile" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,180p' Makefile" in [redacted-path] succeeded in 53ms:
 .DEFAULT_GOAL := help
 
 ifndef IS_DOCKER
@@ -4177,18 +4387,18 @@ help: ## Print the help message
 
 .PHONY: install
 exec
-/bin/zsh -lc 'rg -n "addopts|local_only|markers|external_network" pyproject.toml pytest.ini setup.cfg' in /Users/scidsg/hushline exited 2 in 52ms:
+/bin/zsh -lc 'rg -n "addopts|local_only|markers|external_network" pyproject.toml pytest.ini setup.cfg' in [redacted-path] exited 2 in 52ms:
 rg: pytest.ini: No such file or directory (os error 2)
 pyproject.toml:61:markers = [
 pyproject.toml:62:    "local_only",
 pyproject.toml:63:    "external_network",
 exec
-/bin/zsh -lc "sed -n '1,140p' pyproject.toml" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,140p' pyproject.toml" in [redacted-path] succeeded in 53ms:
 [tool.poetry]
 name = "hushline"
 version = "0.0.1"
 description = "A lightweight, secure, and anonymous tip line for organizations and individuals."
-authors = ["Science & Design, Inc. <hello@scidsg.org>"]
+authors = ["Science & Design, Inc. <[redacted-email]>"]
 license = "AGPL 3.0"
 readme = "README.md"
 
@@ -4205,7 +4415,7 @@ flask = { extras = ["async"], version = "^3.1.3" }
 flask-migrate = "^4.0.7"
 flask-sqlalchemy = "^3.1.1"
 exec
-/bin/zsh -lc 'rg -n "Batch 1|AK|AL|AR|AZ|CO|official-source|public record|adapter" docs | head -n 200' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'rg -n "Batch 1|AK|AL|AR|AZ|CO|official-source|public record|adapter" docs | head -n 200' in [redacted-path] succeeded in 53ms:
 docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md:17:- `source_url` must point to the exact public record URL for that listing.
 docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md:25:- Discovery/additions must come from explicit state adapters only.
 docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md:26:- All 50 states now have explicit adapter entries in discovery code.
@@ -4237,7 +4447,7 @@ for st in ['AK','AL','AR','AZ','CO']:
     print(st,len(s))
     for r in s[:10]:
         print(' -',r.get('name'),'|',r.get('website'))
-PY" in /Users/scidsg/hushline exited 127 in 53ms:
+PY" in [redacted-path] exited 127 in 53ms:
 zsh:1: command not found: python
 exec
 /bin/zsh -lc "python3 - <<'PY'
@@ -4249,7 +4459,7 @@ for st in ['AK','AL','AR','AZ','CO']:
     print(st,len(s))
     for r in s:
         print(' -',r.get('name'),'|',r.get('website'))
-PY" in /Users/scidsg/hushline succeeded in 145ms:
+PY" in [redacted-path] succeeded in 145ms:
 AK 0
 AL 0
 AR 0
@@ -4263,7 +4473,7 @@ CO 0
 🌐 Searching the web...
 🌐 Searched: site:alaskabar.org attorney profile
 exec
-/bin/zsh -lc "sed -n '1,260p' docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,260p' docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md" in [redacted-path] succeeded in 53ms:
 # Public Record Provenance Roadmap (U.S.)
 
 ## Scope
@@ -4325,10 +4535,11 @@ exec
 codex
 I found reliable per-record URLs for Arizona and promising official records for Alaska/Arkansas; I’m now verifying whether I can fetch raw HTML in the shell to extract stable Alabama/Colorado profile URL patterns before I finalize adapter seed rows.
 exec
-/bin/zsh -lc "curl -I -L --max-time 20 'https://members.alabar.org/Member_Portal/Member_Portal/Member-Search.aspx' | sed -n '1,40p'" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "curl -I -L --max-time 20 'https://members.alabar.org/Member_Portal/Member_Portal/Member-Search.aspx' | sed -n '1,40p'" in [redacted-path] succeeded in 51ms:
   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                  Dload  Upload   Total   Spent    Left  Speed
-  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: members.alabar.org
+
+  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: members.alabar.org
 🌐 Searching the web...
 🌐 Searched: site:cobar.org "Licensed Lawyer" "ID="
 🌐 Searching the web...
@@ -4381,7 +4592,7 @@ exec
 /bin/zsh -lc "python3 - <<'PY'
 import unidecode,requests
 print('ok')
-PY" in /Users/scidsg/hushline exited 1 in 53ms:
+PY" in [redacted-path] exited 1 in 53ms:
 Traceback (most recent call last):
   File "<stdin>", line 1, in <module>
 ModuleNotFoundError: No module named 'unidecode'
@@ -4390,7 +4601,7 @@ I’ve confirmed the adapter architecture is seed-based and harness-driven, and 
 codex
 I’m about to edit `hushline/public_record_refresh.py` to add seed rows and non-noop adapter functions for `AK`, `AL`, `AR`, `AZ`, and `CO`, then register those adapters in the override map.
 file update
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 @@ -774,2 +774,110 @@
  
 +_ALASKA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS: tuple[PublicRecordRow, ...] = (
@@ -4591,7 +4802,7 @@ M /Users/scidsg/hushline/hushline/public_record_refresh.py
      "IL": _discover_illinois_official_public_record_rows,
 apply_patch(auto_approved=true) exited 0 in 59ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 02546829a377488cabdd279ed84c4c0d23540191..7a21dd103dd946f50af1e395f2011d8e0f7f9017
@@ -5027,8 +5238,8 @@ index 02546829a377488cabdd279ed84c4c0d23540191..7a21dd103dd946f50af1e395f2011d8e
 codex
 I’ve added the five new adapters and seed rows. Next I’m updating `tests/test_public_record_refresh.py` so the harness expects these states and so each new state has explicit discovery assertions.
 exec
-/bin/zsh -lc 'rg -n "test_official_source_adapter_harness_covers_current_implemented_states|adds_washington_seed|adds_ohio_seed|adds_illinois_seeds|skips_existing_washington_seed" tests/test_public_record_refresh.py' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '700,1060p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc 'rg -n "test_official_source_adapter_harness_covers_current_implemented_states|adds_washington_seed|adds_ohio_seed|adds_illinois_seeds|skips_existing_washington_seed" tests/test_public_record_refresh.py' in [redacted-path]
+/bin/zsh -lc "sed -n '700,1060p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 51ms:
 717:def test_official_source_adapter_harness_covers_current_implemented_states() -> None:
 792:def test_discover_official_us_state_public_record_rows_adds_washington_seed() -> None:
 812:def test_discover_official_us_state_public_record_rows_skips_existing_washington_seed() -> None:
@@ -5272,7 +5483,7 @@ index 02546829a377488cabdd279ed84c4c0d23540191..7a21dd103dd946f50af1e395f2011d8e
      "TN": _discover_tennessee_official_public_record_rows,
 
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -31,2 +31,55 @@
  
 +_BATCH_ONE_STATE_SEEDS: tuple[tuple[str, str, str, str, str, str], ...] = (
@@ -5338,7 +5549,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
  
 @@ -791,2 +846,57 @@
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -5369,7 +5580,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,existing_id,existing_slug,existing_name,_expected_source_label,_expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -5396,7 +5607,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
  def test_discover_official_us_state_public_record_rows_adds_washington_seed() -> None:
 apply_patch(auto_approved=true) exited 0 in 58ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 02546829a377488cabdd279ed84c4c0d23540191..7a21dd103dd946f50af1e395f2011d8e0f7f9017
@@ -5691,7 +5902,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -5722,7 +5933,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,existing_id,existing_slug,existing_name,_expected_source_label,_expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -6044,7 +6255,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -6075,7 +6286,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,existing_id,existing_slug,existing_name,_expected_source_label,_expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -6182,7 +6393,7 @@ for row in new_rows:
 
 ordered = [by_id[key] for key in sorted(by_id)]
 path.write_text(json.dumps(ordered, indent=2, ensure_ascii=False) + '\\n', encoding='utf-8')
-PY" in /Users/scidsg/hushline succeeded in 53ms:
+PY" in [redacted-path] succeeded in 53ms:
 
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
@@ -6478,7 +6689,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -6509,7 +6720,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,existing_id,existing_slug,existing_name,_expected_source_label,_expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -6538,7 +6749,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
          [],
 
 exec
-/bin/zsh -lc "sed -n '1,120p' tests/test_directory.py" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,120p' tests/test_directory.py" in [redacted-path] succeeded in 53ms:
 import re
 import time
 from types import SimpleNamespace
@@ -6853,7 +7064,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -6884,7 +7095,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,existing_id,existing_slug,existing_name,_expected_source_label,_expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -6915,14 +7126,14 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
 codex
 I’m adding one strict dataset-policy assertion in `tests/test_directory.py` to lock in coverage for this new adapter batch so regressions are caught at the artifact level.
 file update
-M /Users/scidsg/hushline/tests/test_directory.py
+M [redacted-path]
 @@ -389,2 +389,3 @@
          assert us_covered
 +        assert {"AK", "AL", "AR", "AZ", "CA", "CO", "IL", "OH", "TN", "WA"}.issubset(us_covered)
  
 apply_patch(auto_approved=true) exited 0 in 64ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_directory.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 02546829a377488cabdd279ed84c4c0d23540191..7a21dd103dd946f50af1e395f2011d8e0f7f9017
@@ -7229,7 +7440,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -7260,7 +7471,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,existing_id,existing_slug,existing_name,_expected_source_label,_expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -7594,7 +7805,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -7625,7 +7836,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,existing_id,existing_slug,existing_name,_expected_source_label,_expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -7666,7 +7877,7 @@ for p in paths:
         print(p)
         for i,n in bad[:20]:
             print(i,n)
-PY" in /Users/scidsg/hushline succeeded in 53ms:
+PY" in [redacted-path] succeeded in 53ms:
 hushline/public_record_refresh.py
 273 103
 318 107
@@ -7979,7 +8190,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -8010,7 +8221,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,existing_id,existing_slug,existing_name,_expected_source_label,_expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -8039,9 +8250,9 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
          [],
 
 exec
-/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '880,915p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '250,330p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '860,895p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '880,915p'" in [redacted-path]
+/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '250,330p'" in [redacted-path]
+/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '860,895p'" in [redacted-path] succeeded in 53ms:
    880	)
    881	
    882	
@@ -8410,7 +8621,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -8441,7 +8652,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,existing_id,existing_slug,existing_name,_expected_source_label,_expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -8470,7 +8681,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..e61581a16e557df44502ef7830524de5
          [],
 
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -878,3 +878,6 @@
  @pytest.mark.parametrize(
 -    "state_code,existing_id,existing_slug,existing_name,_expected_source_label,_expected_source_url",
@@ -8481,7 +8692,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
      _BATCH_ONE_STATE_SEEDS,
 apply_patch(auto_approved=true) exited 0 in 83ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 02546829a377488cabdd279ed84c4c0d23540191..7a21dd103dd946f50af1e395f2011d8e0f7f9017
@@ -8788,7 +8999,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -8819,7 +9030,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -9156,7 +9367,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -9187,7 +9398,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -9221,9 +9432,9 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 codex
 Core edits are in place. I’m doing a quick diff/consistency pass (file-level inspection and JSON validity) before I finalize so we don’t leave formatting or data-shape issues behind.
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "git diff -- hushline/public_record_refresh.py tests/test_public_record_refresh.py tests/test_directory.py hushline/data/public_record_law_firms.json | sed -n '1,280p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'python3 -m json.tool hushline/data/public_record_law_firms.json > /tmp/public_record_law_firms.pretty.json && echo ok' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc "git diff -- hushline/public_record_refresh.py tests/test_public_record_refresh.py tests/test_directory.py hushline/data/public_record_law_firms.json | sed -n '1,280p'" in [redacted-path]
+/bin/zsh -lc 'python3 -m json.tool hushline/data/public_record_law_firms.json > /tmp/public_record_law_firms.pretty.json && echo ok' in [redacted-path] succeeded in 52ms:
  M hushline/data/public_record_law_firms.json
  M hushline/public_record_refresh.py
  M tests/test_directory.py
@@ -9557,7 +9768,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -9588,7 +9799,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -9620,7 +9831,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
          [],
 
 exec
-/bin/zsh -lc 'git show HEAD:hushline/data/public_record_law_firms.json > hushline/data/public_record_law_firms.json' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git show HEAD:hushline/data/public_record_law_firms.json > hushline/data/public_record_law_firms.json' in [redacted-path] succeeded in 53ms:
 
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
@@ -9928,7 +10139,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -9959,7 +10170,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -9991,9 +10202,9 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
          [],
 
 exec
-/bin/zsh -lc "nl -ba hushline/data/public_record_law_firms.json | sed -n '1,140p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba hushline/data/public_record_law_firms.json | sed -n '140,280p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba hushline/data/public_record_law_firms.json | sed -n '280,360p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "nl -ba hushline/data/public_record_law_firms.json | sed -n '1,140p'" in [redacted-path]
+/bin/zsh -lc "nl -ba hushline/data/public_record_law_firms.json | sed -n '140,280p'" in [redacted-path]
+/bin/zsh -lc "nl -ba hushline/data/public_record_law_firms.json | sed -n '280,360p'" in [redacted-path] succeeded in 52ms:
    140	    "city": "Chicago",
    141	    "state": "IL",
    142	    "practice_tags": ["Whistleblowing", "Employment", "Litigation"],
@@ -10362,7 +10573,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -10393,7 +10604,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -10427,7 +10638,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 codex
 I reverted the broad JSON reformat and I’m now inserting only the five new rows into `public_record_law_firms.json` in-place to keep the dataset diff minimal.
 file update
-M /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
+M [redacted-path]
 @@ -38,2 +38,14 @@
    {
 +    "id": "seed-anthony-cali",
@@ -10502,7 +10713,7 @@ M /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
      "id": "seed-robert-aram-jigarjian",
 apply_patch(auto_approved=true) exited 0 in 72ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
+M [redacted-path]
 file update:
 diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
 index 0b713f72c68ddcc7b142684e852c30ce10ae28be..cf55be7484c21ac3d915492524445391d8dadf67
@@ -10901,7 +11112,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -10932,7 +11143,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -11361,7 +11572,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -11392,7 +11603,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -11424,8 +11635,8 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
          [],
 
 exec
-/bin/zsh -lc "git diff -- hushline/data/public_record_law_firms.json | sed -n '1,240p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff --stat' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "git diff -- hushline/data/public_record_law_firms.json | sed -n '1,240p'" in [redacted-path]
+/bin/zsh -lc 'git diff --stat' in [redacted-path] succeeded in 52ms:
 diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
 index 0b713f72..cf55be74 100644
 --- a/hushline/data/public_record_law_firms.json
@@ -11453,7 +11664,7 @@ index 0b713f72..cf55be74 100644
  tests/test_public_record_refresh.py        | 115 +++++++++++++++++-
  4 files changed, 363 insertions(+), 1 deletion(-)
 exec
-/bin/zsh -lc 'python3 -m json.tool hushline/data/public_record_law_firms.json > /tmp/public_record_law_firms.pretty.json && echo ok' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'python3 -m json.tool hushline/data/public_record_law_firms.json > /tmp/public_record_law_firms.pretty.json && echo ok' in [redacted-path] succeeded in 53ms:
 ok
 file update:
 diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
@@ -11853,7 +12064,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -11884,7 +12095,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -11918,10 +12129,10 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 codex
 I’m doing one last read-through of the modified adapter/test blocks to catch any naming or ordering mistakes before handing this back.
 exec
-/bin/zsh -lc 'rg -n "_ALASKA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARKANSAS_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_COLORADO_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_discover_alaska_official_public_record_rows|_discover_alabama_official_public_record_rows|_discover_arkansas_official_public_record_rows|_discover_arizona_official_public_record_rows|_discover_colorado_official_public_record_rows|_OFFICIAL_US_STATE_DISCOVERY_ADAPTER_OVERRIDES" hushline/public_record_refresh.py' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,180p' tests/test_public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '760,1160p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '700,980p' tests/test_public_record_refresh.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'rg -n "_ALASKA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARKANSAS_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_COLORADO_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_discover_alaska_official_public_record_rows|_discover_alabama_official_public_record_rows|_discover_arkansas_official_public_record_rows|_discover_arizona_official_public_record_rows|_discover_colorado_official_public_record_rows|_OFFICIAL_US_STATE_DISCOVERY_ADAPTER_OVERRIDES" hushline/public_record_refresh.py' in [redacted-path]
+/bin/zsh -lc "sed -n '1,180p' tests/test_public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '760,1160p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '700,980p' tests/test_public_record_refresh.py" in [redacted-path] succeeded in 52ms:
 775:_ALASKA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS: tuple[PublicRecordRow, ...] = (
 797:_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS: tuple[PublicRecordRow, ...] = (
 816:_ARKANSAS_OFFICIAL_PUBLIC_RECORD_SEED_ROWS: tuple[PublicRecordRow, ...] = (
@@ -12403,7 +12614,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -12434,7 +12645,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -12863,7 +13074,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -12894,7 +13105,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -12926,7 +13137,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
          [],
 
 exec
-/bin/zsh -lc 'PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile hushline/public_record_refresh.py tests/test_public_record_refresh.py tests/test_directory.py' in /Users/scidsg/hushline succeeded in 93ms:
+/bin/zsh -lc 'PYTHONPYCACHEPREFIX=/tmp/pycache python3 -m py_compile hushline/public_record_refresh.py tests/test_public_record_refresh.py tests/test_directory.py' in [redacted-path] succeeded in 93ms:
 
 file update:
 diff --git a/hushline/data/public_record_law_firms.json b/hushline/data/public_record_law_firms.json
@@ -13326,7 +13537,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -13357,7 +13568,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -13389,10 +13600,10 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
          [],
 
 exec
-/bin/zsh -lc 'rg -n "_BATCH_ONE_STATE_SEEDS|adds_batch_one_seed|skips_existing_batch_one_seed|covers_current_implemented_states" tests/test_public_record_refresh.py' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "_ALASKA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARKANSAS_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_COLORADO_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_discover_alaska_official_public_record_rows|_discover_alabama_official_public_record_rows|_discover_arkansas_official_public_record_rows|_discover_arizona_official_public_record_rows|_discover_colorado_official_public_record_rows|OFFICIAL_US_STATE_DISCOVERY_ADAPTER_OVERRIDES" hushline/public_record_refresh.py' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "seed-anthony-cali|seed-jon-marc-petersen|seed-kristin-l-pawlik|seed-marc-james-ayers|seed-rachel-brock" hushline/data/public_record_law_firms.json' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"AK|AL|AR|AZ|CO\" tests/test_directory.py | sed -n '1,20p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'rg -n "_BATCH_ONE_STATE_SEEDS|adds_batch_one_seed|skips_existing_batch_one_seed|covers_current_implemented_states" tests/test_public_record_refresh.py' in [redacted-path]
+/bin/zsh -lc 'rg -n "_ALASKA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARKANSAS_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_COLORADO_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_discover_alaska_official_public_record_rows|_discover_alabama_official_public_record_rows|_discover_arkansas_official_public_record_rows|_discover_arizona_official_public_record_rows|_discover_colorado_official_public_record_rows|OFFICIAL_US_STATE_DISCOVERY_ADAPTER_OVERRIDES" hushline/public_record_refresh.py' in [redacted-path]
+/bin/zsh -lc 'rg -n "seed-anthony-cali|seed-jon-marc-petersen|seed-kristin-l-pawlik|seed-marc-james-ayers|seed-rachel-brock" hushline/data/public_record_law_firms.json' in [redacted-path]
+/bin/zsh -lc "rg -n \"AK|AL|AR|AZ|CO\" tests/test_directory.py | sed -n '1,20p'" in [redacted-path] succeeded in 52ms:
 32:_BATCH_ONE_STATE_SEEDS: tuple[tuple[str, str, str, str, str, str], ...] = (
 770:def test_official_source_adapter_harness_covers_current_implemented_states() -> None:
 849:    _BATCH_ONE_STATE_SEEDS,
@@ -13829,7 +14040,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -13860,7 +14071,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -13892,7 +14103,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
          [],
 
 exec
-/bin/zsh -lc "rg -o '\"state\": \"["'^"]+"'"' hushline/data/public_record_law_firms.json | sed 's/\"state\": \"//; s/\""'$//'"' | sort | uniq -c | sort -k2" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "rg -o '\"state\": \"["'^"]+"'"' hushline/data/public_record_law_firms.json | sed 's/\"state\": \"//; s/\""'$//'"' | sort | uniq -c | sort -k2" in [redacted-path] succeeded in 52ms:
    1 AK
    1 AL
    1 AR
@@ -14301,7 +14512,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -14332,7 +14543,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -14364,7 +14575,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
          [],
 
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 51ms:
  M hushline/data/public_record_law_firms.json
  M hushline/public_record_refresh.py
  M tests/test_directory.py
@@ -14767,7 +14978,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -14798,7 +15009,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -14832,10 +15043,10 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 codex
 Implemented issue #1505 with minimal scoped changes for `AK`, `AL`, `AR`, `AZ`, and `CO`.
 
-- Added new official-source seed adapters and wired them into overrides in [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:775), [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:1144), and [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:1279).
-- Extended adapter tests with batch-1 state fixtures and parameterized add/skip assertions in [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:32), [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:849), and [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:885).
-- Updated strict dataset-policy coverage expectation to include the new states in [test_directory.py](/Users/scidsg/hushline/tests/test_directory.py:390).
-- Refreshed strict public-record data by adding five new records in [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:39), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:195), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:255), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:267), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:327).
+- Added new official-source seed adapters and wired them into overrides in [public_record_refresh.py]([redacted-path] [public_record_refresh.py]([redacted-path] and [public_record_refresh.py]([redacted-path]
+- Extended adapter tests with batch-1 state fixtures and parameterized add/skip assertions in [test_public_record_refresh.py]([redacted-path] [test_public_record_refresh.py]([redacted-path] and [test_public_record_refresh.py]([redacted-path]
+- Updated strict dataset-policy coverage expectation to include the new states in [test_directory.py]([redacted-path]
+- Refreshed strict public-record data by adding five new records in [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path]
 
 Quick checks run:
 - `python3 -m json.tool hushline/data/public_record_law_firms.json`
@@ -15240,7 +15451,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
      )
  
  
-+@pytest.mark.parametrize(
+[redacted-email](
 +    "state_code,expected_id,expected_slug,expected_name,expected_source_label,expected_source_url",
 +    _BATCH_ONE_STATE_SEEDS,
 +)
@@ -15271,7 +15482,7 @@ index e4cb43ab0241787bd081d50beb8d42289a09760f..ff8f121504c5e08051cc6cb5b896aca4
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code,existing_id,existing_slug,existing_name,"
 +        "_expected_source_label,_expected_source_url"
@@ -15306,10 +15517,10 @@ tokens used
 282,991
 Implemented issue #1505 with minimal scoped changes for `AK`, `AL`, `AR`, `AZ`, and `CO`.
 
-- Added new official-source seed adapters and wired them into overrides in [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:775), [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:1144), and [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:1279).
-- Extended adapter tests with batch-1 state fixtures and parameterized add/skip assertions in [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:32), [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:849), and [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:885).
-- Updated strict dataset-policy coverage expectation to include the new states in [test_directory.py](/Users/scidsg/hushline/tests/test_directory.py:390).
-- Refreshed strict public-record data by adding five new records in [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:39), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:195), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:255), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:267), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:327).
+- Added new official-source seed adapters and wired them into overrides in [public_record_refresh.py]([redacted-path] [public_record_refresh.py]([redacted-path] and [public_record_refresh.py]([redacted-path]
+- Extended adapter tests with batch-1 state fixtures and parameterized add/skip assertions in [test_public_record_refresh.py]([redacted-path] [test_public_record_refresh.py]([redacted-path] and [test_public_record_refresh.py]([redacted-path]
+- Updated strict dataset-policy coverage expectation to include the new states in [test_directory.py]([redacted-path]
+- Refreshed strict public-record data by adding five new records in [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path]
 
 Quick checks run:
 - `python3 -m json.tool hushline/data/public_record_law_firms.json`
@@ -15320,10 +15531,10 @@ Codex execution completed.
 Codex final message:
 Implemented issue #1505 with minimal scoped changes for `AK`, `AL`, `AR`, `AZ`, and `CO`.
 
-- Added new official-source seed adapters and wired them into overrides in [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:775), [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:1144), and [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:1279).
-- Extended adapter tests with batch-1 state fixtures and parameterized add/skip assertions in [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:32), [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:849), and [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:885).
-- Updated strict dataset-policy coverage expectation to include the new states in [test_directory.py](/Users/scidsg/hushline/tests/test_directory.py:390).
-- Refreshed strict public-record data by adding five new records in [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:39), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:195), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:255), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:267), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:327).
+- Added new official-source seed adapters and wired them into overrides in [public_record_refresh.py]([redacted-path] [public_record_refresh.py]([redacted-path] and [public_record_refresh.py]([redacted-path]
+- Extended adapter tests with batch-1 state fixtures and parameterized add/skip assertions in [test_public_record_refresh.py]([redacted-path] [test_public_record_refresh.py]([redacted-path] and [test_public_record_refresh.py]([redacted-path]
+- Updated strict dataset-policy coverage expectation to include the new states in [test_directory.py]([redacted-path]
+- Refreshed strict public-record data by adding five new records in [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path]
 
 Quick checks run:
 - `python3 -m json.tool hushline/data/public_record_law_firms.json`
@@ -15402,14 +15613,14 @@ Workflow checks failed; Codex self-heal attempt 1.
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.107.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.3-codex
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR]
-reasoning effort: high
-reasoning summaries: none
-session id: 019cc3ee-f7f3-77c1-8766-fe33cafe5cd6
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are continuing GitHub issue #1505 in scidsg/hushline on branch codex/daily-issue-1505.
@@ -15441,10 +15652,10 @@ Most recent Codex implementation summary:
 ---BEGIN PRIOR CODEX SUMMARY---
 Implemented issue #1505 with minimal scoped changes for `AK`, `AL`, `AR`, `AZ`, and `CO`.
 
-- Added new official-source seed adapters and wired them into overrides in [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:775), [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:1144), and [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:1279).
-- Extended adapter tests with batch-1 state fixtures and parameterized add/skip assertions in [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:32), [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:849), and [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:885).
-- Updated strict dataset-policy coverage expectation to include the new states in [test_directory.py](/Users/scidsg/hushline/tests/test_directory.py:390).
-- Refreshed strict public-record data by adding five new records in [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:39), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:195), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:255), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:267), [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json:327).
+- Added new official-source seed adapters and wired them into overrides in [public_record_refresh.py]([redacted-path] [public_record_refresh.py]([redacted-path] and [public_record_refresh.py]([redacted-path]
+- Extended adapter tests with batch-1 state fixtures and parameterized add/skip assertions in [test_public_record_refresh.py]([redacted-path] [test_public_record_refresh.py]([redacted-path] and [test_public_record_refresh.py]([redacted-path]
+- Updated strict dataset-policy coverage expectation to include the new states in [test_directory.py]([redacted-path]
+- Refreshed strict public-record data by adding five new records in [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path] [public_record_law_firms.json]([redacted-path]
 
 Quick checks run:
 - `python3 -m json.tool hushline/data/public_record_law_firms.json`
@@ -15550,10 +15761,10 @@ mcp startup: no servers
 codex
 I’m going to inspect the four modified files first, then make the smallest test-only adjustments to clear the reported lint failures while preserving the existing issue implementation.
 exec
-/bin/zsh -lc "git status --short && echo '---' && git diff --stat" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' /Users/scidsg/hushline/hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' /Users/scidsg/hushline/tests/test_public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,240p' /Users/scidsg/hushline/tests/test_directory.py && echo '---' && sed -n '1,260p' /Users/scidsg/hushline/hushline/data/public_record_law_firms.json" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "git status --short && echo '---' && git diff --stat" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' [redacted-path]" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' [redacted-path]" in [redacted-path]
+/bin/zsh -lc "sed -n '1,240p' [redacted-path] && echo '---' && sed -n '1,260p' [redacted-path]" in [redacted-path] succeeded in 53ms:
  M hushline/data/public_record_law_firms.json
  M hushline/public_record_refresh.py
  M tests/test_directory.py
@@ -15630,8 +15841,8 @@ from hushline.public_record_refresh import (
 codex
 I’ve confirmed the current diff and now I’m focusing on the exact failing section in `tests/test_public_record_refresh.py` around the reported Ruff line numbers to do a minimal lint-safe rewrite.
 exec
-/bin/zsh -lc "nl -ba /Users/scidsg/hushline/tests/test_public_record_refresh.py | sed -n '780,940p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "git diff -- /Users/scidsg/hushline/tests/test_public_record_refresh.py | sed -n '1,260p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "nl -ba [redacted-path] | sed -n '780,940p'" in [redacted-path]
+/bin/zsh -lc "git diff -- [redacted-path] | sed -n '1,260p'" in [redacted-path] succeeded in 53ms:
    780	    assert result.unsupported_states == ()
    781	    assert result.added_count_by_state == {state_code: len(result.rows)}
    782	    assert_official_source_adapter_rows(state_code, result.rows)
@@ -15676,7 +15887,7 @@ index e4cb43ab..ff8f1215 100644
 codex
 I found the lint root cause: the two new `parametrize` blocks use string-style arg lists (disallowed by project Ruff config), and one test currently has too many parameters. I’m now applying a minimal rewrite so each test takes a single seeded tuple and unpacks it internally.
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -84,2 +84,11 @@
  
 +_BATCH_ONE_SEED_PARAM_NAMES: tuple[str, str, str, str, str, str] = (
@@ -15738,7 +15949,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
      result = discover_official_us_state_public_record_rows(
 apply_patch(auto_approved=true) exited 0 in 49ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/tests/test_public_record_refresh.py b/tests/test_public_record_refresh.py
 index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..3e8193e21d84b7a2d3d3bf5bf099403c2071984c
@@ -15896,7 +16107,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..3e8193e21d84b7a2d3d3bf5bf099403c
 codex
 I spotted a mismatch in that first edit: one decorator still declared six parameter names while the test now expects one tuple. I’m fixing that immediately with a small follow-up patch.
 exec
-/bin/zsh -lc "nl -ba /Users/scidsg/hushline/tests/test_public_record_refresh.py | sed -n '20,120p;840,930p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "nl -ba [redacted-path] | sed -n '20,120p;840,930p'" in [redacted-path] succeeded in 53ms:
     20	)
     21	from tests.public_record_adapter_harness import (
     22	    assert_official_source_adapter_rows,
@@ -15995,7 +16206,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..3e8193e21d84b7a2d3d3bf5bf099403c
          selected_regions=["US"],
 
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -84,12 +84,2 @@
  
 -_BATCH_ONE_SEED_PARAM_NAMES: tuple[str, str, str, str, str, str] = (
@@ -16018,7 +16229,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
  )
 apply_patch(auto_approved=true) exited 0 in 58ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/tests/test_public_record_refresh.py b/tests/test_public_record_refresh.py
 index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..9eba5edc16d7e4e56029df5f245d7d379318c6d3
@@ -16162,8 +16373,8 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..9eba5edc16d7e4e56029df5f245d7d37
 codex
 I’m now checking the `public_record_refresh.py` diff for any remaining formatting-only drift, since the prior run also flagged that file for reformatting.
 exec
-/bin/zsh -lc "git diff -- /Users/scidsg/hushline/hushline/public_record_refresh.py | sed -n '1,280p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "git diff -- /Users/scidsg/hushline/tests/test_public_record_refresh.py | sed -n '1,260p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "git diff -- [redacted-path] | sed -n '1,280p'" in [redacted-path]
+/bin/zsh -lc "git diff -- [redacted-path] | sed -n '1,260p'" in [redacted-path] succeeded in 53ms:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 02546829..35651950 100644
 --- a/hushline/public_record_refresh.py
@@ -16278,7 +16489,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..9eba5edc16d7e4e56029df5f245d7d37
 codex
 I also found why `public_record_refresh.py` triggered `ruff format --check`: a few adjacent string literals are packed onto one line in the new seed rows. I’m making a tiny formatting-only patch there to eliminate that lint failure upfront.
 file update
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 @@ -803,3 +803,4 @@
          "description": (
 -            "Whistleblower attorney listing sourced from Alabama State Bar public " "directory."
@@ -16299,7 +16510,7 @@ M /Users/scidsg/hushline/hushline/public_record_refresh.py
          ),
 apply_patch(auto_approved=true) exited 0 in 56ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 35651950feb76a8850023f843d36d3e10cc8d938..7a21dd103dd946f50af1e395f2011d8e0f7f9017
@@ -16509,7 +16720,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..9eba5edc16d7e4e56029df5f245d7d37
 codex
 I’m doing one final small consistency tweak in the test decorators so both parameterized tests use the same concrete list form, reducing lint ambiguity.
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -882,3 +882,3 @@
      ("batch_one_seed",),
 -    ((seed,) for seed in _BATCH_ONE_STATE_SEEDS),
@@ -16517,7 +16728,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
  )
 apply_patch(auto_approved=true) exited 0 in 64ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 35651950feb76a8850023f843d36d3e10cc8d938..7a21dd103dd946f50af1e395f2011d8e0f7f9017
@@ -16725,8 +16936,8 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
          selected_regions=["US"],
 
 exec
-/bin/zsh -lc "nl -ba /Users/scidsg/hushline/tests/test_public_record_refresh.py | sed -n '836,920p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "git diff -- /Users/scidsg/hushline/hushline/public_record_refresh.py /Users/scidsg/hushline/tests/test_public_record_refresh.py | sed -n '1,320p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "nl -ba [redacted-path] | sed -n '836,920p'" in [redacted-path]
+/bin/zsh -lc "git diff -- [redacted-path] [redacted-path] | sed -n '1,320p'" in [redacted-path] succeeded in 52ms:
    836	    assert by_name["Elizabeth Aida Acevedo"]["source_url"] == (
    837	        "https://apps.calbar.ca.gov/attorney/Licensee/Detail/227347"
    838	    )
@@ -16872,7 +17083,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
          selected_regions=["US"],
 
 exec
-/bin/zsh -lc "git status --short && echo '---' && git diff --stat" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "git status --short && echo '---' && git diff --stat" in [redacted-path] succeeded in 53ms:
  M hushline/data/public_record_law_firms.json
  M hushline/public_record_refresh.py
  M tests/test_directory.py
@@ -16989,19 +17200,19 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
 codex
 I’ve finished the minimal code edits. I’m doing a quick line-reference pass now so you can see exactly what changed and where.
 exec
-/bin/zsh -lc "rg -n \"_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|@pytest.mark.parametrize\\(|test_discover_official_us_state_public_record_rows_adds_batch_one_seed|test_discover_official_us_state_public_record_rows_skips_existing_batch_one_seed\" /Users/scidsg/hushline/hushline/public_record_refresh.py /Users/scidsg/hushline/tests/test_public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba /Users/scidsg/hushline/hushline/public_record_refresh.py | sed -n '790,870p' && echo '---' && nl -ba /Users/scidsg/hushline/hushline/public_record_refresh.py | sed -n '890,940p' && echo '---' && nl -ba /Users/scidsg/hushline/tests/test_public_record_refresh.py | sed -n '840,910p'" in /Users/scidsg/hushline succeeded in 52ms:
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:775:@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:784:@pytest.mark.parametrize("state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:785:@pytest.mark.parametrize("collision", ["id", "slug", "name"])
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:846:@pytest.mark.parametrize(
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:850:def test_discover_official_us_state_public_record_rows_adds_batch_one_seed(
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:881:@pytest.mark.parametrize(
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:885:def test_discover_official_us_state_public_record_rows_skips_existing_batch_one_seed(
-/Users/scidsg/hushline/hushline/public_record_refresh.py:797:_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS: tuple[PublicRecordRow, ...] = (
-/Users/scidsg/hushline/hushline/public_record_refresh.py:838:_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS: tuple[PublicRecordRow, ...] = (
-/Users/scidsg/hushline/hushline/public_record_refresh.py:1168:        seed_rows=_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS,
-/Users/scidsg/hushline/hushline/public_record_refresh.py:1198:        seed_rows=_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS,
+/bin/zsh -lc "rg -n \"_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|@pytest.mark.parametrize\\(|test_discover_official_us_state_public_record_rows_adds_batch_one_seed|test_discover_official_us_state_public_record_rows_skips_existing_batch_one_seed\" [redacted-path] [redacted-path]" in [redacted-path]
+/bin/zsh -lc "nl -ba [redacted-path] | sed -n '790,870p' && echo '---' && nl -ba [redacted-path] | sed -n '890,940p' && echo '---' && nl -ba [redacted-path] | sed -n '840,910p'" in [redacted-path] succeeded in 52ms:
+[redacted-path]"state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-path]"state_code", _IMPLEMENTED_OFFICIAL_SOURCE_STATES)
+[redacted-path]"collision", ["id", "slug", "name"])
+[redacted-path]
+[redacted-path] test_discover_official_us_state_public_record_rows_adds_batch_one_seed(
+[redacted-path]
+[redacted-path] test_discover_official_us_state_public_record_rows_skips_existing_batch_one_seed(
+[redacted-path] tuple[PublicRecordRow, ...] = (
+[redacted-path] tuple[PublicRecordRow, ...] = (
+[redacted-path]        seed_rows=_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS,
+[redacted-path]        seed_rows=_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS,
  succeeded in 53ms:
    790	            "https://member.alaskabar.org/cv5/cgi-bin/memberdll.dll/Info"
    791	            "?CUSTOMERCD=8744&WRP=Customer_Profile.htm"
@@ -17129,7 +17340,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
 codex
 I’ve completed the minimal patches; I’m running `make lint` once to confirm the specific lint failures are resolved before handing this back.
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 35651950feb76a8850023f843d36d3e10cc8d938..7a21dd103dd946f50af1e395f2011d8e0f7f9017
 --- a/hushline/public_record_refresh.py
@@ -17465,7 +17676,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
 codex
 `make fix` could not run in this sandbox due Docker daemon permission denial, so I’ll finish by manually matching Ruff’s formatting expectations in the two flagged files and avoid further container calls.
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 35651950feb76a8850023f843d36d3e10cc8d938..7a21dd103dd946f50af1e395f2011d8e0f7f9017
 --- a/hushline/public_record_refresh.py
@@ -17799,13 +18010,13 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
 exec
 /bin/zsh -lc "python3 - <<'PY'
 from pathlib import Path
-for p in [Path('/Users/scidsg/hushline/hushline/public_record_refresh.py'), Path('/Users/scidsg/hushline/tests/test_public_record_refresh.py')]:
+for p in [Path('[redacted-path]'), Path('[redacted-path]')]:
     print('---', p)
     for i,l in enumerate(p.read_text().splitlines(),1):
         if len(l) > 88:
             print(i, len(l), l[:140])
-PY" in /Users/scidsg/hushline succeeded in 53ms:
---- /Users/scidsg/hushline/hushline/public_record_refresh.py
+PY" in [redacted-path] succeeded in 53ms:
+--- [redacted-path]
 30 93     "https://chamberssitemap.blob.core.windows.net/site-json/organisations/ranked/{group_id}"
 33 89     "https://chambers.com/law-firm/{slug_base}-{group_slug}-{group_id}:{organisation_id}"
 36 93     "https://profiles-portal.chambers.com/api/organisations/{organisation_id}/profile-basics"
@@ -17929,7 +18140,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
          selected_regions=["US"],
 
 exec
-/bin/zsh -lc "sed -n '1,260p' /Users/scidsg/hushline/Makefile" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '1,260p' [redacted-path]" in [redacted-path] succeeded in 53ms:
 .DEFAULT_GOAL := help
 
 ifndef IS_DOCKER
@@ -18159,7 +18370,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
          selected_regions=["US"],
 
 exec
-/bin/zsh -lc 'python3 -m black --version' in /Users/scidsg/hushline exited 1 in 53ms:
+/bin/zsh -lc 'python3 -m black --version' in [redacted-path] exited 1 in 53ms:
 /Library/Developer/CommandLineTools/usr/bin/python3: No module named black
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
@@ -18267,7 +18478,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
 codex
 I still can run single `make`-driven container commands reliably, so I’m executing a one-off `make` eval target that runs only `ruff format` on the two flagged files.
 exec
-/bin/zsh -lc "make --eval 'fmt-two-files: ; "'$(CMD) poetry run ruff format hushline/public_record_refresh.py tests/test_public_record_refresh.py'"' fmt-two-files" in /Users/scidsg/hushline exited 2 in 51ms:
+/bin/zsh -lc "make --eval 'fmt-two-files: ; "'$(CMD) poetry run ruff format hushline/public_record_refresh.py tests/test_public_record_refresh.py'"' fmt-two-files" in [redacted-path] exited 2 in 51ms:
 /Library/Developer/CommandLineTools/usr/bin/make: unrecognized option `--eval'
 Usage: make [options] [target] ...
 Options:
@@ -18497,7 +18708,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
          selected_regions=["US"],
 
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 35651950feb76a8850023f843d36d3e10cc8d938..7a21dd103dd946f50af1e395f2011d8e0f7f9017
 --- a/hushline/public_record_refresh.py
@@ -18829,7 +19040,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
          selected_regions=["US"],
 
 exec
-/bin/zsh -lc "nl -ba /Users/scidsg/hushline/tests/test_public_record_refresh.py | sed -n '20,110p;836,910p'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "nl -ba [redacted-path] | sed -n '20,110p;836,910p'" in [redacted-path] succeeded in 53ms:
     20	)
     21	from tests.public_record_adapter_harness import (
     22	    assert_official_source_adapter_rows,
@@ -18956,7 +19167,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a533c84e253acd4c913dcee723ff4563
 codex
 I’ve got the current exact block; I’m applying the same lint-driven rewrite again with corrected patch anchors.
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -84,2 +84,7 @@
  
 +_BATCH_ONE_EXISTING_COLLISION_CASES: tuple[tuple[str, str, str, str], ...] = tuple(
@@ -19018,7 +19229,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
      result = discover_official_us_state_public_record_rows(
 apply_patch(auto_approved=true) exited 0 in 48ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 35651950feb76a8850023f843d36d3e10cc8d938..7a21dd103dd946f50af1e395f2011d8e0f7f9017
@@ -19216,7 +19427,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..d417a638f0973e1d78b69ececa7759f0
 codex
 I’ve applied the test rewrite; I’m re-running `make lint` to see whether formatting drift is now limited to one file or fully resolved.
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 35651950feb76a8850023f843d36d3e10cc8d938..7a21dd103dd946f50af1e395f2011d8e0f7f9017
 --- a/hushline/public_record_refresh.py
@@ -19532,7 +19743,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..d417a638f0973e1d78b69ececa7759f0
 codex
 Custom one-off make targets are intermittently blocked by Docker permissions, so I’m using a temporary local tweak to the existing `lint` target (`--check --diff`) to extract Ruff’s exact formatting diff, then I’ll restore `Makefile` immediately.
 file update
-M /Users/scidsg/hushline/Makefile
+M [redacted-path]
 @@ -68,3 +68,3 @@
  lint: ## Lint the code
 -	$(CMD) poetry run ruff format --check && \
@@ -19540,7 +19751,7 @@ M /Users/scidsg/hushline/Makefile
  	$(CMD) poetry run ruff check --output-format full && \
 apply_patch(auto_approved=true) exited 0 in 66ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/Makefile
+M [redacted-path]
 file update:
 diff --git a/Makefile b/Makefile
 index 1de6d0ccd7332f752f51e05738c926ebdfdc67c7..04c1157cdbc0e50b7a45bf648a62952592f9aa92
@@ -19762,7 +19973,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..d417a638f0973e1d78b69ececa7759f0
          [{"id": existing_id, "name": existing_name, "slug": existing_slug}],
 
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/Makefile b/Makefile
 index 1de6d0ccd7332f752f51e05738c926ebdfdc67c7..04c1157cdbc0e50b7a45bf648a62952592f9aa92
 --- a/Makefile
@@ -20118,7 +20329,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..d417a638f0973e1d78b69ececa7759f0
 codex
 Ruff diff is clear now: it wants those adjacent literal joins collapsed back to single-line adjacency in `public_record_refresh.py`, and one extra blank line before `_row` in the test file. I’m applying exactly that, then restoring `Makefile` to its original lint command.
 file update
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 @@ -803,4 +803,3 @@
          "description": (
 -            "Whistleblower attorney listing sourced from Alabama State Bar public "
@@ -20139,7 +20350,7 @@ M /Users/scidsg/hushline/hushline/public_record_refresh.py
          ),
 apply_patch(auto_approved=true) exited 0 in 84ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/Makefile b/Makefile
 index 1de6d0ccd7332f752f51e05738c926ebdfdc67c7..04c1157cdbc0e50b7a45bf648a62952592f9aa92
@@ -20295,14 +20506,14 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..d417a638f0973e1d78b69ececa7759f0
          [{"id": existing_id, "name": existing_name, "slug": existing_slug}],
 
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -89,2 +89,3 @@
  
 +
  def _row(  # noqa: PLR0913
 apply_patch(auto_approved=true) exited 0 in 84ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/Makefile b/Makefile
 index 1de6d0ccd7332f752f51e05738c926ebdfdc67c7..04c1157cdbc0e50b7a45bf648a62952592f9aa92
@@ -20462,7 +20673,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..9728ee619b83f3749f0d9db2767ca0d3
 codex
 I’m restoring `Makefile` to its original `ruff format --check` lint command now, so no tooling config changes remain in the branch.
 file update
-M /Users/scidsg/hushline/Makefile
+M [redacted-path]
 @@ -68,3 +68,3 @@
  lint: ## Lint the code
 -	$(CMD) poetry run ruff format --check --diff && \
@@ -20470,7 +20681,7 @@ M /Users/scidsg/hushline/Makefile
  	$(CMD) poetry run ruff check --output-format full && \
 apply_patch(auto_approved=true) exited 0 in 81ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/Makefile
+M [redacted-path]
 file update:
 
 diff --git a/tests/test_public_record_refresh.py b/tests/test_public_record_refresh.py
@@ -20604,7 +20815,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..9728ee619b83f3749f0d9db2767ca0d3
          [{"id": existing_id, "name": existing_name, "slug": existing_slug}],
 
 exec
-/bin/zsh -lc "git status --short && echo '---' && git diff --stat" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "git status --short && echo '---' && git diff --stat" in [redacted-path] succeeded in 53ms:
  M hushline/data/public_record_law_firms.json
  M hushline/public_record_refresh.py
  M tests/test_directory.py
@@ -20684,7 +20895,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..9728ee619b83f3749f0d9db2767ca0d3
 codex
 The temporary lint-target tweak is fully reverted. I’m running `make lint` again to verify formatting and confirm there are no remaining Ruff/mypy/prettier blockers.
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 
 diff --git a/tests/test_public_record_refresh.py b/tests/test_public_record_refresh.py
 index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..9728ee619b83f3749f0d9db2767ca0d3374d4093
@@ -20908,7 +21119,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..9728ee619b83f3749f0d9db2767ca0d3
 codex
 Formatter now passes; remaining lint is one `PLR0913` hit because the `noqa` is on the return annotation line instead of the `def` line. I’m moving that suppression to the correct line and removing the stale directive.
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -862,3 +862,3 @@
  )
 -def test_discover_official_us_state_public_record_rows_adds_batch_one_seed(
@@ -20921,7 +21132,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
      result = discover_official_us_state_public_record_rows(
 apply_patch(auto_approved=true) exited 0 in 57ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 
 diff --git a/tests/test_public_record_refresh.py b/tests/test_public_record_refresh.py
@@ -21045,7 +21256,7 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a99c9564f3d4f6977b6a511ccc0ce54b
          [{"id": existing_id, "name": existing_name, "slug": existing_slug}],
 
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 
 diff --git a/tests/test_public_record_refresh.py b/tests/test_public_record_refresh.py
 index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a99c9564f3d4f6977b6a511ccc0ce54b1f5b5cf1
@@ -21498,9 +21709,9 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a99c9564f3d4f6977b6a511ccc0ce54b
 codex
 `make lint` now completes successfully end-to-end. I’m doing a final diff sanity check and then I’ll summarize exactly what changed.
 exec
-/bin/zsh -lc "git diff -- /Users/scidsg/hushline/hushline/public_record_refresh.py | sed -n '1,260p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "git diff -- /Users/scidsg/hushline/tests/test_public_record_refresh.py | sed -n '1,260p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "git diff -- [redacted-path] | sed -n '1,260p'" in [redacted-path]
+/bin/zsh -lc "git diff -- [redacted-path] | sed -n '1,260p'" in [redacted-path]
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 52ms:
 diff --git a/tests/test_public_record_refresh.py b/tests/test_public_record_refresh.py
 index e4cb43ab..a99c9564 100644
 --- a/tests/test_public_record_refresh.py
@@ -21609,15 +21820,15 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a99c9564f3d4f6977b6a511ccc0ce54b
          [{"id": existing_id, "name": existing_name, "slug": existing_slug}],
 
 exec
-/bin/zsh -lc 'rg -n "_BATCH_ONE_EXISTING_COLLISION_CASES|adds_batch_one_seed|skips_existing_batch_one_seed|_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS" /Users/scidsg/hushline/tests/test_public_record_refresh.py /Users/scidsg/hushline/hushline/public_record_refresh.py' in /Users/scidsg/hushline succeeded in 53ms:
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:85:_BATCH_ONE_EXISTING_COLLISION_CASES: tuple[tuple[str, str, str, str], ...] = tuple(
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:863:def test_discover_official_us_state_public_record_rows_adds_batch_one_seed(  # noqa: PLR0913
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:892:    _BATCH_ONE_EXISTING_COLLISION_CASES,
-/Users/scidsg/hushline/tests/test_public_record_refresh.py:894:def test_discover_official_us_state_public_record_rows_skips_existing_batch_one_seed(
-/Users/scidsg/hushline/hushline/public_record_refresh.py:797:_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS: tuple[PublicRecordRow, ...] = (
-/Users/scidsg/hushline/hushline/public_record_refresh.py:837:_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS: tuple[PublicRecordRow, ...] = (
-/Users/scidsg/hushline/hushline/public_record_refresh.py:1165:        seed_rows=_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS,
-/Users/scidsg/hushline/hushline/public_record_refresh.py:1195:        seed_rows=_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS,
+/bin/zsh -lc 'rg -n "_BATCH_ONE_EXISTING_COLLISION_CASES|adds_batch_one_seed|skips_existing_batch_one_seed|_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS" [redacted-path] [redacted-path]' in [redacted-path] succeeded in 53ms:
+[redacted-path] tuple[tuple[str, str, str, str], ...] = tuple(
+[redacted-path] test_discover_official_us_state_public_record_rows_adds_batch_one_seed(  # noqa: PLR0913
+[redacted-path]    _BATCH_ONE_EXISTING_COLLISION_CASES,
+[redacted-path] test_discover_official_us_state_public_record_rows_skips_existing_batch_one_seed(
+[redacted-path] tuple[PublicRecordRow, ...] = (
+[redacted-path] tuple[PublicRecordRow, ...] = (
+[redacted-path]        seed_rows=_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS,
+[redacted-path]        seed_rows=_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS,
 file update:
 
 diff --git a/tests/test_public_record_refresh.py b/tests/test_public_record_refresh.py
@@ -21682,12 +21893,12 @@ index ff8f121504c5e08051cc6cb5b896aca42d7e8f18..a99c9564f3d4f6977b6a511ccc0ce54b
 codex
 Applied minimal fixes to clear the failing local workflow-equivalent lint checks while preserving the issue implementation.
 
-- Updated the new batch-1 adapter tests in [tests/test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:85):
+- Updated the new batch-1 adapter tests in [tests/test_public_record_refresh.py]([redacted-path]
   - Added `_BATCH_ONE_EXISTING_COLLISION_CASES` for 4-field skip cases.
   - Switched `@pytest.mark.parametrize` argnames to tuple form (fixes `PT006`).
   - Removed `_expected_*` injected params by using explicit 4-arg skip parametrization (fixes `PT019`).
   - Kept the 6-arg add test and applied a scoped suppression on the `def` line (fixes `PLR0913` cleanly).
-- Restored Ruff’s expected literal formatting in [hushline/public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:797) (the Alabama/Arizona seed string-join style Ruff enforces), so formatter checks now pass.
+- Restored Ruff’s expected literal formatting in [hushline/public_record_refresh.py]([redacted-path] (the Alabama/Arizona seed string-join style Ruff enforces), so formatter checks now pass.
 
 Validation run:
 - `make lint` passed fully (ruff format/check, mypy, prettier).
@@ -21758,12 +21969,12 @@ tokens used
 77,294
 Applied minimal fixes to clear the failing local workflow-equivalent lint checks while preserving the issue implementation.
 
-- Updated the new batch-1 adapter tests in [tests/test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:85):
+- Updated the new batch-1 adapter tests in [tests/test_public_record_refresh.py]([redacted-path]
   - Added `_BATCH_ONE_EXISTING_COLLISION_CASES` for 4-field skip cases.
   - Switched `@pytest.mark.parametrize` argnames to tuple form (fixes `PT006`).
   - Removed `_expected_*` injected params by using explicit 4-arg skip parametrization (fixes `PT019`).
   - Kept the 6-arg add test and applied a scoped suppression on the `def` line (fixes `PLR0913` cleanly).
-- Restored Ruff’s expected literal formatting in [hushline/public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:797) (the Alabama/Arizona seed string-join style Ruff enforces), so formatter checks now pass.
+- Restored Ruff’s expected literal formatting in [hushline/public_record_refresh.py]([redacted-path] (the Alabama/Arizona seed string-join style Ruff enforces), so formatter checks now pass.
 
 Validation run:
 - `make lint` passed fully (ruff format/check, mypy, prettier).
@@ -21773,12 +21984,12 @@ Codex execution completed.
 Codex final message:
 Applied minimal fixes to clear the failing local workflow-equivalent lint checks while preserving the issue implementation.
 
-- Updated the new batch-1 adapter tests in [tests/test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py:85):
+- Updated the new batch-1 adapter tests in [tests/test_public_record_refresh.py]([redacted-path]
   - Added `_BATCH_ONE_EXISTING_COLLISION_CASES` for 4-field skip cases.
   - Switched `@pytest.mark.parametrize` argnames to tuple form (fixes `PT006`).
   - Removed `_expected_*` injected params by using explicit 4-arg skip parametrization (fixes `PT019`).
   - Kept the 6-arg add test and applied a scoped suppression on the `def` line (fixes `PLR0913` cleanly).
-- Restored Ruff’s expected literal formatting in [hushline/public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py:797) (the Alabama/Arizona seed string-join style Ruff enforces), so formatter checks now pass.
+- Restored Ruff’s expected literal formatting in [hushline/public_record_refresh.py]([redacted-path] (the Alabama/Arizona seed string-join style Ruff enforces), so formatter checks now pass.
 
 Validation run:
 - `make lint` passed fully (ruff format/check, mypy, prettier).
@@ -21853,7 +22064,7 @@ Success: no issues found in 158 source files
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run workflow security checks
-docker run --rm -v "/Users/scidsg/hushline:/work" -w /work rhysd/actionlint:1.7.7 -color
+docker run --rm -v "[redacted-path]" -w /work rhysd/actionlint:1.7.7 -color
 Unable to find image 'rhysd/actionlint:1.7.7' locally
 1.7.7: Pulling from rhysd/actionlint
 25d2e00cf929: Pulling fs layer

--- a/docs/agent-logs/run-20260307T191925Z-issue-1506.txt
+++ b/docs/agent-logs/run-20260307T191925Z-issue-1506.txt
@@ -3,7 +3,7 @@ Timestamp (UTC): 20260307T191925Z
 Issue: #1506
 Repository: scidsg/hushline
 
-Runner Codex config: model=gpt-5.4 reasoning_effort=high verbose_codex_output=0
+Runner Codex config: [redacted]
 ==> Fetch latest from origin
 ==> Checkout main
 Already on 'main'
@@ -1365,23 +1365,128 @@ Total reclaimed space: 9.7GB
 #7 7.483 Get:460 http://deb.debian.org/debian bookworm/main arm64 pkg-config arm64 1.8.1-1 [13.7 kB]
 #7 7.597 debconf: delaying package configuration, since apt-utils is not installed
 #7 7.610 Fetched 162 MB in 2s (66.4 MB/s)
-#7 7.622 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6689 files and directories currently installed.)
+#7 7.622 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6689 files and directories currently installed.)
 #7 7.625 Preparing to unpack .../perl-base_5.36.0-7+deb12u3_arm64.deb ...
 #7 7.632 Unpacking perl-base (5.36.0-7+deb12u3) over (5.36.0-7+deb12u1) ...
 #7 8.231 Setting up perl-base (5.36.0-7+deb12u3) ...
-#7 8.244 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 8.244 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 8.247 Preparing to unpack .../gcc-12-base_12.2.0-14+deb12u1_arm64.deb ...
 #7 8.252 Unpacking gcc-12-base:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 8.266 Setting up gcc-12-base:arm64 (12.2.0-14+deb12u1) ...
-#7 8.280 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 8.280 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 8.283 Preparing to unpack .../libgcc-s1_12.2.0-14+deb12u1_arm64.deb ...
 #7 8.288 Unpacking libgcc-s1:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 8.303 Setting up libgcc-s1:arm64 (12.2.0-14+deb12u1) ...
-#7 8.319 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 8.319 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 8.322 Preparing to unpack .../libstdc++6_12.2.0-14+deb12u1_arm64.deb ...
 #7 8.331 Unpacking libstdc++6:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 8.386 Setting up libstdc++6:arm64 (12.2.0-14+deb12u1) ...
-#7 8.408 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 8.408 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 8.411 Preparing to unpack .../libc6_2.36-9+deb12u13_arm64.deb ...
 #7 8.449 debconf: unable to initialize frontend: Dialog
 #7 8.449 debconf: (TERM is not set, so the dialog frontend is not usable.)
@@ -1397,12 +1502,54 @@ Total reclaimed space: 9.7GB
 #7 8.864 debconf: unable to initialize frontend: Readline
 #7 8.864 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
 #7 8.864 debconf: falling back to frontend: Teletype
-#7 9.915 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.915 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.921 Preparing to unpack .../libc-bin_2.36-9+deb12u13_arm64.deb ...
 #7 9.925 Unpacking libc-bin (2.36-9+deb12u13) over (2.36-9+deb12u8) ...
 #7 10.01 Setting up libc-bin (2.36-9+deb12u13) ...
 #7 10.03 Selecting previously unselected package perl-modules-5.36.
-#7 10.03 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.03 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.04 Preparing to unpack .../0-perl-modules-5.36_5.36.0-7+deb12u3_all.deb ...
 #7 10.04 Unpacking perl-modules-5.36 (5.36.0-7+deb12u3) ...
 #7 10.22 Selecting previously unselected package libgdbm-compat4:arm64.
@@ -1426,7 +1573,28 @@ Total reclaimed space: 9.7GB
 #7 10.79 Setting up libpython3.11-minimal:arm64 (3.11.2-6+deb12u6) ...
 #7 10.80 Setting up python3.11-minimal (3.11.2-6+deb12u6) ...
 #7 11.14 Selecting previously unselected package python3-minimal.
-#7 11.14 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9002 files and directories currently installed.)
+#7 11.14 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9002 files and directories currently installed.)
 #7 11.14 Preparing to unpack .../python3-minimal_3.11.2-1+b1_arm64.deb ...
 #7 11.14 Unpacking python3-minimal (3.11.2-1+b1) ...
 #7 11.15 Selecting previously unselected package media-types.
@@ -1436,7 +1604,28 @@ Total reclaimed space: 9.7GB
 #7 11.17 Unpacking liblzma5:arm64 (5.4.1-1) over (5.4.1-0.2) ...
 #7 11.19 Setting up liblzma5:arm64 (5.4.1-1) ...
 #7 11.20 Selecting previously unselected package libpython3.11-stdlib:arm64.
-#7 11.20 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9030 files and directories currently installed.)
+#7 11.20 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9030 files and directories currently installed.)
 #7 11.20 Preparing to unpack .../libpython3.11-stdlib_3.11.2-6+deb12u6_arm64.deb ...
 #7 11.21 Unpacking libpython3.11-stdlib:arm64 (3.11.2-6+deb12u6) ...
 #7 11.31 Selecting previously unselected package python3.11.
@@ -1447,7 +1636,28 @@ Total reclaimed space: 9.7GB
 #7 11.33 Unpacking libpython3-stdlib:arm64 (3.11.2-1+b1) ...
 #7 11.34 Setting up python3-minimal (3.11.2-1+b1) ...
 #7 11.42 Selecting previously unselected package python3.
-#7 11.42 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9412 files and directories currently installed.)
+#7 11.42 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9412 files and directories currently installed.)
 #7 11.42 Preparing to unpack .../000-python3_3.11.2-1+b1_arm64.deb ...
 #7 11.43 Unpacking python3 (3.11.2-1+b1) ...
 #7 11.44 Selecting previously unselected package bzip2.
@@ -3676,14 +3886,14 @@ Switched to and reset branch 'codex/daily-issue-1506'
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.111.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.4
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR, /Users/scidsg/.codex/memories]
-reasoning effort: high
-reasoning summaries: none
-session id: 019cc9bf-c707-77c0-8df6-81ae00e6b1db
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are implementing GitHub issue #1506 in scidsg/hushline.
@@ -3747,8 +3957,8 @@ mcp startup: no servers
 codex
 I’m implementing the Batch 2 official-source adapters for `CT`, `DE`, `FL`, `GA`, and `HI`. I’ll first locate the public-record discovery code, state adapter patterns from earlier batches, and any deeper `AGENTS.md` files that apply before editing.
 exec
-/bin/zsh -lc "rg --files -g 'AGENTS.md' -g '"'!node_modules'"' -g '"'!dist'"'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "discover-official-us-state-firms|public-record|adapter" .' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "rg --files -g 'AGENTS.md' -g '"'!node_modules'"' -g '"'!dist'"'" in [redacted-path]
+/bin/zsh -lc 'rg -n "discover-official-us-state-firms|public-record|adapter" .' in [redacted-path] succeeded in 51ms:
 AGENTS.md
  succeeded in 51ms:
 Total output lines: 2935
@@ -3774,10 +3984,10 @@ Total output lines: 2935
 codex
 I confirmed there’s only the repository-root `AGENTS.md`. Next I’m reading the adapter code, test harness, and current dataset patterns so the new state implementations match the existing strict-source behavior without broadening scope.
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' tests/public_record_adapter_harness.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,420p' tests/test_public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' tests/public_record_adapter_harness.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,420p' tests/test_public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md" in [redacted-path] succeeded in 52ms:
 
  succeeded in 52ms:
 from __future__ import annotations
@@ -3845,8 +4055,8 @@ from hushline.public_record_refresh import (
 codex
 I’ve got the shared harness and roadmap. I’m now pulling the implemented adapter patterns from the refresh module and the existing batch tests so the new states fit the same discovery/add/skip structure rather than inventing a new path.
 exec
-/bin/zsh -lc 'rg -n "def _discover_.*official_public_record_rows|OFFICIAL_US_STATE_DISCOVERY_ADAPTERS|US_STATE_AUTHORITATIVE_SOURCES|OfficialStateDiscoveryResult|requests" hushline/public_record_refresh.py' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "BATCH_ONE|state_code.*AK|state_code.*AL|state_code.*AR|state_code.*AZ|state_code.*CO|assert_official_source_adapter_rows|collision" tests/test_public_record_refresh.py' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'rg -n "def _discover_.*official_public_record_rows|OFFICIAL_US_STATE_DISCOVERY_ADAPTERS|US_STATE_AUTHORITATIVE_SOURCES|OfficialStateDiscoveryResult|requests" hushline/public_record_refresh.py' in [redacted-path]
+/bin/zsh -lc 'rg -n "BATCH_ONE|state_code.*AK|state_code.*AL|state_code.*AR|state_code.*AZ|state_code.*CO|assert_official_source_adapter_rows|collision" tests/test_public_record_refresh.py' in [redacted-path] succeeded in 52ms:
 22:    assert_official_source_adapter_rows,
 23:    build_existing_row_for_collision,
 28:    for state_code, adapter in sorted(OFFICIAL_US_STATE_DISCOVERY_ADAPTERS.items())
@@ -3886,10 +4096,10 @@ exec
 1174:    session: requests.Session | None,
 1184:def _discover_arizona_official_public_record_rows(
 exec
-/bin/zsh -lc "sed -n '720,940p' tests/test_public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1080,1325p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1820,2060p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1500,1820p' hushline/public_record_refresh.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '720,940p' tests/test_public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1080,1325p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1820,2060p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1500,1820p' hushline/public_record_refresh.py" in [redacted-path] succeeded in 52ms:
     existing_ids: set[str] = set()
     existing_slugs: set[str] = set()
     existing_name_keys: set[str] = set()
@@ -3976,9 +4186,9 @@ def _canonicalize_source_url(
 codex
 The discovery adapters are still seed-based, so this issue is likely another small batch of strict seed additions plus adapter-map/test coverage. I’m checking the authoritative-source rules and existing seed blocks now to add the five new states in the same shape and avoid touching unrelated refresh logic.
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/public_record_refresh.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "_ALASKA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARKANSAS_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_COLORADO_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_WASHINGTON_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ILLINOIS_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_OHIO_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_TENNESSEE_OFFICIAL_PUBLIC_RECORD_SEED_ROWS" hushline/public_record_refresh.py' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '260,1085p' hushline/public_record_refresh.py" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/public_record_refresh.py" in [redacted-path]
+/bin/zsh -lc 'rg -n "_ALASKA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ALABAMA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARKANSAS_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ARIZONA_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_COLORADO_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_WASHINGTON_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_ILLINOIS_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_OHIO_OFFICIAL_PUBLIC_RECORD_SEED_ROWS|_TENNESSEE_OFFICIAL_PUBLIC_RECORD_SEED_ROWS" hushline/public_record_refresh.py' in [redacted-path]
+/bin/zsh -lc "sed -n '260,1085p' hushline/public_record_refresh.py" in [redacted-path] succeeded in 52ms:
 from __future__ import annotations
 
 import re
@@ -4042,8 +4252,8 @@ CHAMBERS_PUBLICATION_GROUP_BY_REGION: dict[str, int] = {
 codex
 The missing piece is the exact per-record URLs for the new states. Since network access is restricted here, I’m checking the repository’s existing logs and artifacts for already-captured official record URLs before deciding whether this batch can be completed purely from local context.
 exec
-/bin/zsh -lc "rg -n \"courts\\.delaware\\.gov|ctbar\\.org|floridabar\\.org|gabar\\.org|hsba\\.org\" ." in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n \"CT|DE|FL|GA|HI|Connecticut|Delaware|Florida|Georgia|Hawaii\" docs/agent-logs hushline/data tests docs -g '"'!docs/agent-logs/run-*issue-1505.txt'"'" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "rg -n \"courts\\.delaware\\.gov|ctbar\\.org|floridabar\\.org|gabar\\.org|hsba\\.org\" ." in [redacted-path]
+/bin/zsh -lc "rg -n \"CT|DE|FL|GA|HI|Connecticut|Delaware|Florida|Georgia|Hawaii\" docs/agent-logs hushline/data tests docs -g '"'!docs/agent-logs/run-*issue-1505.txt'"'" in [redacted-path] succeeded in 53ms:
 ./hushline/public_record_refresh.py:153:        "source_url": "https://www.ctbar.org/",
 ./hushline/public_record_refresh.py:154:        "allowed_domains": frozenset({"ctbar.org"}),
 ./hushline/public_record_refresh.py:158:        "source_url": "https://courts.delaware.gov/odc/",
@@ -4088,13 +4298,13 @@ docs/agent-logs/run-20260305T160005Z-issue-1504.txt:3744:    DEFAULT_REGION_STAT
 codex
 I haven’t found any captured Batch 2 record URLs in the repo itself. I’m checking local git history and agent logs for a prior partial attempt on issue `#1506`; if nothing exists, the blocker will be source data availability rather than implementation shape.
 exec
-/bin/zsh -lc 'git branch --all' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "issue-1506|Batch 2 Adapters: CT, DE, FL, GA, HI|Connecticut Bar Association public directory|Delaware Courts attorney regulation records|The Florida Bar public directory|State Bar of Georgia public directory|Hawaii State Bar Association public directory" docs/agent-logs .git' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git branch --all' in [redacted-path]
+/bin/zsh -lc 'rg -n "issue-1506|Batch 2 Adapters: CT, DE, FL, GA, HI|Connecticut Bar Association public directory|Delaware Courts attorney regulation records|The Florida Bar public directory|State Bar of Georgia public directory|Hawaii State Bar Association public directory" docs/agent-logs .git' in [redacted-path] succeeded in 52ms:
 docs/agent-logs/run-20260305T160005Z-issue-1504.txt:3729:hushline/public_record_refresh.py:152:        "source_label": "Connecticut Bar Association public directory",
 .git/HEAD:1:ref: refs/heads/codex/daily-issue-1506
-.git/logs/HEAD:431:c73fec53d1b7031b80323ad4d9ddd0bbcb0adcfa c73fec53d1b7031b80323ad4d9ddd0bbcb0adcfa hushline-dev <git-dev@scidsg.org> 1772899364 -0800	checkout: moving from main to codex/daily-issue-1506
-.git/logs/HEAD:432:c73fec53d1b7031b80323ad4d9ddd0bbcb0adcfa c73fec53d1b7031b80323ad4d9ddd0bbcb0adcfa hushline-dev <git-dev@scidsg.org> 1772899368 -0800	checkout: moving from codex/daily-issue-1506 to main
-.git/logs/HEAD:444:64fd8702354d1274f61201a7da84103e0d0c5c10 64fd8702354d1274f61201a7da84103e0d0c5c10 hushline-dev <git-dev@scidsg.org> 1772911314 -0800	checkout: moving from main to codex/daily-issue-1506
+.git/logs/HEAD:431:c73fec53d1b7031b80323ad4d9ddd0bbcb0adcfa c73fec53d1b7031b80323ad4d9ddd0bbcb0adcfa hushline-dev <[redacted-email]> 1772899364 -0800	checkout: moving from main to codex/daily-issue-1506
+.git/logs/HEAD:432:c73fec53d1b7031b80323ad4d9ddd0bbcb0adcfa c73fec53d1b7031b80323ad4d9ddd0bbcb0adcfa hushline-dev <[redacted-email]> 1772899368 -0800	checkout: moving from codex/daily-issue-1506 to main
+.git/logs/HEAD:444:64fd8702354d1274f61201a7da84103e0d0c5c10 64fd8702354d1274f61201a7da84103e0d0c5c10 hushline-dev <[redacted-email]> 1772911314 -0800	checkout: moving from main to codex/daily-issue-1506
  succeeded in 52ms:
   chore/runner-cleaner-codex-logs
   chore/runner-rerun-pr
@@ -4117,7 +4327,7 @@ docs/agent-logs/run-20260305T160005Z-issue-1504.txt:3729:hushline/public_record_
   codex/daily-issue-1488
   codex/daily-issue-1504
 exec
-/bin/zsh -lc "git log --oneline --decorate --all --grep='1506\\|Batch 2\\|CT, DE, FL, GA, HI'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "git log --oneline --decorate --all --grep='1506\\|Batch 2\\|CT, DE, FL, GA, HI'" in [redacted-path] succeeded in 52ms:
 
 🌐 Searching the web...
 🌐 Searched: site:ctbar.org Connecticut Bar member profile whistleblower attorney CT detail
@@ -4197,8 +4407,8 @@ Implement the next seed-based official-source batch with matching tests and arti
 codex
 I’m about to edit the seed definitions, adapter map, tests, dataset artifact, and roadmap table. Before patching, I’m checking the current dataset ordering so the manual refresh stays deterministic and minimal.
 exec
-/bin/zsh -lc "sed -n '1,260p' hushline/data/public_record_law_firms.json" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n '\"state\": \"(AK|AL|AR|AZ|CA|CO|IL|OH|TN|WA)\"' hushline/data/public_record_law_firms.json" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' hushline/data/public_record_law_firms.json" in [redacted-path]
+/bin/zsh -lc "rg -n '\"state\": \"(AK|AL|AR|AZ|CA|CO|IL|OH|TN|WA)\"' hushline/data/public_record_law_firms.json" in [redacted-path] succeeded in 52ms:
 [
   {
     "id": "seed-adam-j-levitt",
@@ -4241,8 +4451,8 @@ exec
 225:    "state": "TN",
 237:    "state": "CA",
 exec
-/bin/zsh -lc "sed -n '260,520p' hushline/data/public_record_law_firms.json" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n 'bruce-w-leppla|charles-henry-field-jr|marlene-koury|menaka-nirmalie-fernando|rachael-ga-yue-jung|robert-aram-jigarjian|stephen-shinobu-hasegawa' hushline/public_record_refresh.py tests" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '260,520p' hushline/data/public_record_law_firms.json" in [redacted-path]
+/bin/zsh -lc "rg -n 'bruce-w-leppla|charles-henry-field-jr|marlene-koury|menaka-nirmalie-fernando|rachael-ga-yue-jung|robert-aram-jigarjian|stephen-shinobu-hasegawa' hushline/public_record_refresh.py tests" in [redacted-path] succeeded in 53ms:
     "city": "Fayetteville",
     "state": "AR",
     "practice_tags": ["Whistleblowing", "Investigations", "Litigation"],
@@ -4274,7 +4484,7 @@ exec
 codex
 I’m patching the discovery module now: new seed rows for the five states, adapter functions, and source-rule updates where the official record type differs from the original placeholder label. After that I’ll extend the batch seed tests and refresh the checked-in dataset.
 file update
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 @@ -156,4 +156,4 @@
      "DE": {
 -        "source_label": "Delaware Courts attorney regulation records",
@@ -4484,7 +4694,7 @@ M /Users/scidsg/hushline/hushline/public_record_refresh.py
      "IL": _discover_illinois_official_public_record_rows,
 apply_patch(auto_approved=true) exited 0 in 36ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 4d35029a2d23e31a2c60508e6aae1519b18ca549..4aa190e73cfdeb20fa5c98fceebceee860a1f897
@@ -4954,7 +5164,7 @@ index 4d35029a2d23e31a2c60508e6aae1519b18ca549..4aa190e73cfdeb20fa5c98fceebceee8
 codex
 The adapter wiring is in. I’m extending the seed expectations next so each of the five new states is covered by the same add/skip assertions as batch one, and the implemented-state harness set stays explicit.
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -89,3 +89,51 @@
  
 +_BATCH_TWO_STATE_SEEDS: tuple[tuple[str, str, str, str, str, str], ...] = (
@@ -5060,7 +5270,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -5094,7 +5304,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -5102,7 +5312,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
      state_code: str,
 apply_patch(auto_approved=true) exited 0 in 45ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/hushline/public_record_refresh.py b/hushline/public_record_refresh.py
 index 4d35029a2d23e31a2c60508e6aae1519b18ca549..4aa190e73cfdeb20fa5c98fceebceee860a1f897
@@ -5454,7 +5664,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -5492,7 +5702,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -5852,7 +6062,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -5890,7 +6100,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -5902,7 +6112,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 codex
 I’ve moved on to the artifact/docs refresh. The roadmap is stale for the prior batch too, so I’m updating the state matrix through `HI` and noting the weaker-record blockers for `DE` and `HI` instead of leaving inaccurate “scaffolded” entries behind.
 file update
-M /Users/scidsg/hushline/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md
+M [redacted-path]
 @@ -8,6 +8,6 @@
  
 -## Current Baseline (March 5, 2026)
@@ -5939,7 +6149,7 @@ M /Users/scidsg/hushline/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md
  | IA    | Iowa State Bar Association public directory (`iowabar.org`)                    | Official search flow -> resolve exact result URL    | Adapter scaffolded       |
 apply_patch(auto_approved=true) exited 0 in 43ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md
+M [redacted-path]
 file update:
 diff --git a/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md b/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md
 index ecdde14e4c0d0ce24a9af16431fb01d332a74a8d..cbd133e7e1c5f98ec655758cbad256e183f5fa0c
@@ -6337,7 +6547,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -6375,7 +6585,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -6781,7 +6991,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -6819,7 +7029,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -6831,7 +7041,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 codex
 I’m patching the checked-in dataset artifact manually rather than running the full refresh locally. The file is alphabetized by slug, so I’m inserting only the five new records in place to keep the diff deterministic.
 file update
-M /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
+M [redacted-path]
 @@ -182,2 +182,26 @@
    {
 +    "id": "seed-eric-r-brown",
@@ -6906,7 +7116,7 @@ M /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
    }
 apply_patch(auto_approved=true) exited 0 in 61ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/data/public_record_law_firms.json
+M [redacted-path]
 file update:
 diff --git a/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md b/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md
 index ecdde14e4c0d0ce24a9af16431fb01d332a74a8d..cbd133e7e1c5f98ec655758cbad256e183f5fa0c
@@ -7395,7 +7605,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -7433,7 +7643,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -7930,7 +8140,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -7968,7 +8178,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -7980,8 +8190,8 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 codex
 The code and artifact edits are in place. I’m doing a read-through of the diff now for consistency issues only, without kicking off the container-backed validation loop.
 exec
-/bin/zsh -lc 'git diff -- hushline/public_record_refresh.py tests/test_public_record_refresh.py hushline/data/public_record_law_firms.json docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg -n 'seed-eric-r-brown|seed-richard-l-abbott|seed-jerry-ray-poole-jr|seed-todd-h-stanton|seed-eric-seitz|Delaware Courts published opinion|State Bar of Georgia speaker profile|Hawaii State Bar Association attorney recognition record' hushline/public_record_refresh.py tests/test_public_record_refresh.py hushline/data/public_record_law_firms.json docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc 'git diff -- hushline/public_record_refresh.py tests/test_public_record_refresh.py hushline/data/public_record_law_firms.json docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md' in [redacted-path]
+/bin/zsh -lc "rg -n 'seed-eric-r-brown|seed-richard-l-abbott|seed-jerry-ray-poole-jr|seed-todd-h-stanton|seed-eric-seitz|Delaware Courts published opinion|State Bar of Georgia speaker profile|Hawaii State Bar Association attorney recognition record' hushline/public_record_refresh.py tests/test_public_record_refresh.py hushline/data/public_record_law_firms.json docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md" in [redacted-path] succeeded in 51ms:
 hushline/data/public_record_law_firms.json:183:    "id": "seed-eric-r-brown",
 hushline/data/public_record_law_firms.json:195:    "id": "seed-eric-seitz",
 hushline/data/public_record_law_firms.json:199:    "description": "Whistleblower attorney listing sourced from a Hawaii State Bar Association attorney recognition record.",
@@ -8511,7 +8721,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -8549,7 +8759,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -8561,8 +8771,8 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 codex
 I found a likely lint risk in the new Python blocks: a few long string lines aren’t wrapped like the existing seed data. I’m tightening those now so the batch lands cleanly without needing a formatter pass.
 exec
-/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '880,980p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '88,140p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '880,980p'" in [redacted-path]
+/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '88,140p'" in [redacted-path] succeeded in 52ms:
    880	        "id": "seed-eric-r-brown",
    881	        "slug": "public-record~eric-r-brown",
    882	        "name": "Eric R. Brown",
@@ -9092,7 +9302,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -9130,7 +9340,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -9140,7 +9350,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
      existing_slug: str,
 
 file update
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 @@ -910,3 +910,5 @@
          "source_label": "Delaware Courts published opinion",
 -        "source_url": "https://courts.delaware.gov/Opinions/Download.aspx?id=342050",
@@ -9164,7 +9374,7 @@ M /Users/scidsg/hushline/hushline/public_record_refresh.py
          "source_url": (
 apply_patch(auto_approved=true) exited 0 in 66ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/hushline/public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md b/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md
 index ecdde14e4c0d0ce24a9af16431fb01d332a74a8d..cbd133e7e1c5f98ec655758cbad256e183f5fa0c
@@ -9659,7 +9869,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -9697,7 +9907,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -10200,7 +10410,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -10238,7 +10448,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -10248,7 +10458,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..bde6a04f712d94d28b9b215297df1f9c
      existing_slug: str,
 
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -96,3 +96,3 @@
          "Connecticut Bar Association public directory",
 -        "https://members.ctbar.org/member/thelaborlawyer",
@@ -10276,7 +10486,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
      ),
 apply_patch(auto_approved=true) exited 0 in 68ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md b/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md
 index ecdde14e4c0d0ce24a9af16431fb01d332a74a8d..cbd133e7e1c5f98ec655758cbad256e183f5fa0c
@@ -10771,7 +10981,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..d45ed6136d78c6dcbcf0b2e3fa8f9946
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -10809,7 +11019,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..d45ed6136d78c6dcbcf0b2e3fa8f9946
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -11312,7 +11522,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..d45ed6136d78c6dcbcf0b2e3fa8f9946
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    (
 +        "state_code",
 +        "expected_id",
@@ -11350,7 +11560,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..d45ed6136d78c6dcbcf0b2e3fa8f9946
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -11362,7 +11572,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..d45ed6136d78c6dcbcf0b2e3fa8f9946
 codex
 Those first wraps didn’t actually shorten the tuple literals, so I’m fixing them with real multi-line string concatenation before I close out the diff review.
 file update
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 @@ -96,3 +96,5 @@
          "Connecticut Bar Association public directory",
 -        ("https://members.ctbar.org/member/thelaborlawyer"),
@@ -11400,7 +11610,7 @@ M /Users/scidsg/hushline/tests/test_public_record_refresh.py
      ),
 apply_patch(auto_approved=true) exited 0 in 65ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_public_record_refresh.py
+M [redacted-path]
 file update:
 diff --git a/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md b/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md
 index ecdde14e4c0d0ce24a9af16431fb01d332a74a8d..cbd133e7e1c5f98ec655758cbad256e183f5fa0c
@@ -11923,7 +12133,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
      ("state_code", "existing_id", "existing_slug", "existing_name"),
      _BATCH_ONE_EXISTING_COLLISION_CASES,
  )
@@ -11946,7 +12156,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -12477,7 +12687,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
      ("state_code", "existing_id", "existing_slug", "existing_name"),
      _BATCH_ONE_EXISTING_COLLISION_CASES,
  )
@@ -12500,7 +12710,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -12510,9 +12720,9 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
      existing_slug: str,
 
 exec
-/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '90,145p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '900,975p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff --stat' in /Users/scidsg/hushline succeeded in 50ms:
+/bin/zsh -lc "nl -ba tests/test_public_record_refresh.py | sed -n '90,145p'" in [redacted-path]
+/bin/zsh -lc "nl -ba hushline/public_record_refresh.py | sed -n '900,975p'" in [redacted-path]
+/bin/zsh -lc 'git diff --stat' in [redacted-path] succeeded in 50ms:
    900	        "slug": "public-record~richard-l-abbott",
    901	        "name": "Richard L. Abbott",
    902	        "website": "https://richabbottlawfirm.com/",
@@ -13082,7 +13292,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
      ("state_code", "existing_id", "existing_slug", "existing_name"),
      _BATCH_ONE_EXISTING_COLLISION_CASES,
  )
@@ -13105,7 +13315,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -13642,7 +13852,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
      ("state_code", "existing_id", "existing_slug", "existing_name"),
      _BATCH_ONE_EXISTING_COLLISION_CASES,
  )
@@ -13665,7 +13875,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -13675,7 +13885,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
      existing_slug: str,
 
 codex
-Implemented the Batch 2 seed adapters in [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py), covering `CT`, `DE`, `FL`, `GA`, and `HI`, and wired them into the official-state adapter map. I also extended the add/skip seed coverage in [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py), refreshed the checked-in dataset in [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json), and updated the status matrix/baseline in [PUBLIC-RECORD-PROVENANCE-ROADMAP.md](/Users/scidsg/hushline/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md).
+Implemented the Batch 2 seed adapters in [public_record_refresh.py]([redacted-path] covering `CT`, `DE`, `FL`, `GA`, and `HI`, and wired them into the official-state adapter map. I also extended the add/skip seed coverage in [test_public_record_refresh.py]([redacted-path] refreshed the checked-in dataset in [public_record_law_firms.json]([redacted-path] and updated the status matrix/baseline in [PUBLIC-RECORD-PROVENANCE-ROADMAP.md]([redacted-path]
 
 For `DE`, `GA`, and `HI`, the roadmap now documents the current blocker clearly: the public official systems exposed weaker per-person records than a normal public member-directory detail page, so the seeded records use the strongest exact official URLs I could verify from those authorities rather than generic landers.
 
@@ -14209,7 +14419,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 +    assert row["source_url"] == expected_source_url
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
      ("state_code", "existing_id", "existing_slug", "existing_name"),
      _BATCH_ONE_EXISTING_COLLISION_CASES,
  )
@@ -14232,7 +14442,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 +    assert result.unsupported_states == ()
 +
 +
-+@pytest.mark.parametrize(
+[redacted-email](
 +    ("state_code", "existing_id", "existing_slug", "existing_name"),
 +    _BATCH_TWO_EXISTING_COLLISION_CASES,
 +)
@@ -14243,7 +14453,7 @@ index b6d91eae74102aa8763f8cd85a331c2ef3a9180d..a83f1237d3cb59cb71b669b4893524db
 
 tokens used
 227,661
-Implemented the Batch 2 seed adapters in [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py), covering `CT`, `DE`, `FL`, `GA`, and `HI`, and wired them into the official-state adapter map. I also extended the add/skip seed coverage in [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py), refreshed the checked-in dataset in [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json), and updated the status matrix/baseline in [PUBLIC-RECORD-PROVENANCE-ROADMAP.md](/Users/scidsg/hushline/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md).
+Implemented the Batch 2 seed adapters in [public_record_refresh.py]([redacted-path] covering `CT`, `DE`, `FL`, `GA`, and `HI`, and wired them into the official-state adapter map. I also extended the add/skip seed coverage in [test_public_record_refresh.py]([redacted-path] refreshed the checked-in dataset in [public_record_law_firms.json]([redacted-path] and updated the status matrix/baseline in [PUBLIC-RECORD-PROVENANCE-ROADMAP.md]([redacted-path]
 
 For `DE`, `GA`, and `HI`, the roadmap now documents the current blocker clearly: the public official systems exposed weaker per-person records than a normal public member-directory detail page, so the seeded records use the strongest exact official URLs I could verify from those authorities rather than generic landers.
 
@@ -14257,7 +14467,7 @@ Official sources used:
 - HI: https://hsba.org/HSBA_2020/About_Us/Living_Legend_Lawyers_.aspx
 Codex execution completed.
 Codex final message:
-Implemented the Batch 2 seed adapters in [public_record_refresh.py](/Users/scidsg/hushline/hushline/public_record_refresh.py), covering `CT`, `DE`, `FL`, `GA`, and `HI`, and wired them into the official-state adapter map. I also extended the add/skip seed coverage in [test_public_record_refresh.py](/Users/scidsg/hushline/tests/test_public_record_refresh.py), refreshed the checked-in dataset in [public_record_law_firms.json](/Users/scidsg/hushline/hushline/data/public_record_law_firms.json), and updated the status matrix/baseline in [PUBLIC-RECORD-PROVENANCE-ROADMAP.md](/Users/scidsg/hushline/docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md).
+Implemented the Batch 2 seed adapters in [public_record_refresh.py]([redacted-path] covering `CT`, `DE`, `FL`, `GA`, and `HI`, and wired them into the official-state adapter map. I also extended the add/skip seed coverage in [test_public_record_refresh.py]([redacted-path] refreshed the checked-in dataset in [public_record_law_firms.json]([redacted-path] and updated the status matrix/baseline in [PUBLIC-RECORD-PROVENANCE-ROADMAP.md]([redacted-path]
 
 For `DE`, `GA`, and `HI`, the roadmap now documents the current blocker clearly: the public official systems exposed weaker per-person records than a normal public member-directory detail page, so the seeded records use the strongest exact official URLs I could verify from those authorities rather than generic landers.
 
@@ -14479,7 +14689,7 @@ Success: no issues found in 160 source files
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run workflow security checks
-docker run --rm -v "/Users/scidsg/hushline:/work" -w /work rhysd/actionlint:1.7.7 -color
+docker run --rm -v "[redacted-path]" -w /work rhysd/actionlint:1.7.7 -color
 Unable to find image 'rhysd/actionlint:1.7.7' locally
 1.7.7: Pulling from rhysd/actionlint
 25d2e00cf929: Pulling fs layer

--- a/docs/agent-logs/run-20260308T033005Z-issue-1556.txt
+++ b/docs/agent-logs/run-20260308T033005Z-issue-1556.txt
@@ -3,7 +3,7 @@ Timestamp (UTC): 20260308T033005Z
 Issue: #1556
 Repository: scidsg/hushline
 
-Runner Codex config: model=gpt-5.4 reasoning_effort=high verbose_codex_output=0
+Runner Codex config: [redacted]
 ==> Fetch latest from origin
 From github.com:scidsg/hushline
    4330e3dd..6afc30ba  main       -> origin/main
@@ -1414,23 +1414,128 @@ Total reclaimed space: 5.041GB
 #7 8.763 Get:460 http://deb.debian.org/debian bookworm/main arm64 pkg-config arm64 1.8.1-1 [13.7 kB]
 #7 8.897 debconf: delaying package configuration, since apt-utils is not installed
 #7 8.916 Fetched 162 MB in 4s (44.7 MB/s)
-#7 8.940 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6689 files and directories currently installed.)
+#7 8.940 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6689 files and directories currently installed.)
 #7 8.943 Preparing to unpack .../perl-base_5.36.0-7+deb12u3_arm64.deb ...
 #7 8.957 Unpacking perl-base (5.36.0-7+deb12u3) over (5.36.0-7+deb12u1) ...
 #7 10.26 Setting up perl-base (5.36.0-7+deb12u3) ...
-#7 10.29 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.29 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.30 Preparing to unpack .../gcc-12-base_12.2.0-14+deb12u1_arm64.deb ...
 #7 10.31 Unpacking gcc-12-base:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 10.33 Setting up gcc-12-base:arm64 (12.2.0-14+deb12u1) ...
-#7 10.36 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.36 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.36 Preparing to unpack .../libgcc-s1_12.2.0-14+deb12u1_arm64.deb ...
 #7 10.37 Unpacking libgcc-s1:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 10.40 Setting up libgcc-s1:arm64 (12.2.0-14+deb12u1) ...
-#7 10.43 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.43 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.43 Preparing to unpack .../libstdc++6_12.2.0-14+deb12u1_arm64.deb ...
 #7 10.45 Unpacking libstdc++6:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 10.53 Setting up libstdc++6:arm64 (12.2.0-14+deb12u1) ...
-#7 10.57 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.57 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.58 Preparing to unpack .../libc6_2.36-9+deb12u13_arm64.deb ...
 #7 10.62 debconf: unable to initialize frontend: Dialog
 #7 10.62 debconf: (TERM is not set, so the dialog frontend is not usable.)
@@ -1446,12 +1551,54 @@ Total reclaimed space: 5.041GB
 #7 11.52 debconf: unable to initialize frontend: Readline
 #7 11.52 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
 #7 11.52 debconf: falling back to frontend: Teletype
-#7 12.57 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 12.57 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 12.57 Preparing to unpack .../libc-bin_2.36-9+deb12u13_arm64.deb ...
 #7 12.58 Unpacking libc-bin (2.36-9+deb12u13) over (2.36-9+deb12u8) ...
 #7 12.69 Setting up libc-bin (2.36-9+deb12u13) ...
 #7 12.74 Selecting previously unselected package perl-modules-5.36.
-#7 12.74 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 12.74 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 12.74 Preparing to unpack .../0-perl-modules-5.36_5.36.0-7+deb12u3_all.deb ...
 #7 12.75 Unpacking perl-modules-5.36 (5.36.0-7+deb12u3) ...
 #7 12.95 Selecting previously unselected package libgdbm-compat4:arm64.
@@ -1475,7 +1622,28 @@ Total reclaimed space: 5.041GB
 #7 13.65 Setting up libpython3.11-minimal:arm64 (3.11.2-6+deb12u6) ...
 #7 13.66 Setting up python3.11-minimal (3.11.2-6+deb12u6) ...
 #7 14.06 Selecting previously unselected package python3-minimal.
-#7 14.06 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9002 files and directories currently installed.)
+#7 14.06 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9002 files and directories currently installed.)
 #7 14.06 Preparing to unpack .../python3-minimal_3.11.2-1+b1_arm64.deb ...
 #7 14.07 Unpacking python3-minimal (3.11.2-1+b1) ...
 #7 14.09 Selecting previously unselected package media-types.
@@ -1485,7 +1653,28 @@ Total reclaimed space: 5.041GB
 #7 14.13 Unpacking liblzma5:arm64 (5.4.1-1) over (5.4.1-0.2) ...
 #7 14.17 Setting up liblzma5:arm64 (5.4.1-1) ...
 #7 14.19 Selecting previously unselected package libpython3.11-stdlib:arm64.
-#7 14.19 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9030 files and directories currently installed.)
+#7 14.19 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9030 files and directories currently installed.)
 #7 14.20 Preparing to unpack .../libpython3.11-stdlib_3.11.2-6+deb12u6_arm64.deb ...
 #7 14.20 Unpacking libpython3.11-stdlib:arm64 (3.11.2-6+deb12u6) ...
 #7 14.32 Selecting previously unselected package python3.11.
@@ -1496,7 +1685,28 @@ Total reclaimed space: 5.041GB
 #7 14.36 Unpacking libpython3-stdlib:arm64 (3.11.2-1+b1) ...
 #7 14.38 Setting up python3-minimal (3.11.2-1+b1) ...
 #7 14.48 Selecting previously unselected package python3.
-#7 14.48 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9412 files and directories currently installed.)
+#7 14.48 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9412 files and directories currently installed.)
 #7 14.48 Preparing to unpack .../000-python3_3.11.2-1+b1_arm64.deb ...
 #7 14.49 Unpacking python3 (3.11.2-1+b1) ...
 #7 14.51 Selecting previously unselected package bzip2.
@@ -3718,14 +3928,14 @@ Switched to and reset branch 'codex/daily-issue-1556'
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.111.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.4
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR, /Users/scidsg/.codex/memories]
-reasoning effort: high
-reasoning summaries: none
-session id: 019ccb81-4bfb-7570-9910-ddcca9a634d7
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are implementing GitHub issue #1556 in scidsg/hushline.
@@ -3749,7 +3959,7 @@ The runner now pipes Codex execution output through `tee`, and the script alread
 Metadata:
 Repo: scidsg/hushline
 Commit: 02e1896
-Author: 166439242+hushline-dev@users.noreply.github.com
+Author: [redacted-email]
 Created: 3/7/2026, 6:46:15 PM
 Assignee: Unassigned
 Signals: Security
@@ -3846,8 +4056,8 @@ mcp startup: no servers
 codex
 I’m checking the repository instructions and the runner script paths involved in issue #1556 first, then I’ll make the minimal fix and add tests around the logging behavior.
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg --files -g 'AGENTS.md' -g 'agent_daily_issue_runner.sh' -g '*agent*runner*test*' -g '*daily*runner*test*'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc "rg --files -g 'AGENTS.md' -g 'agent_daily_issue_runner.sh' -g '*agent*runner*test*' -g '*daily*runner*test*'" in [redacted-path] succeeded in 52ms:
 
  succeeded in 51ms:
 AGENTS.md
@@ -3855,7 +4065,7 @@ scripts/agent_daily_issue_runner.sh
 codex
 I found only the repo-root `AGENTS.md`, so there’s no deeper override under `scripts/`. Next I’m reading the runner implementation and looking for any existing test coverage around its log persistence and Codex execution flow.
 exec
-/bin/zsh -lc "sed -n '1,240p' AGENTS.md" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,240p' AGENTS.md" in [redacted-path] succeeded in 51ms:
 # AGENTS.md
 
 This file provides operating guidance for coding agents working in the Hush Line repository. We are a 501(c)(3) non-profit based in the United States, and consider this software safety-critical infrastructure protecting users’ operational, physical, and digital security.
@@ -3877,8 +4087,8 @@ This file provides operating guidance for coding agents working in the Hush Line
 | Concerned citizens | Lawyers and Law Offices      |                         |
 | Engaged citizens   | Employers and Boards         |                         |
 exec
-/bin/zsh -lc "sed -n '1,260p' scripts/agent_daily_issue_runner.sh" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "agent_daily_issue_runner|persist_run_log|run_codex_from_prompt|CODEX_TRANSCRIPT_FILE|RUN_LOG_TMP_FILE" -S .' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,260p' scripts/agent_daily_issue_runner.sh" in [redacted-path]
+/bin/zsh -lc 'rg -n "agent_daily_issue_runner|persist_run_log|run_codex_from_prompt|CODEX_TRANSCRIPT_FILE|RUN_LOG_TMP_FILE" -S .' in [redacted-path] succeeded in 52ms:
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -3923,10 +4133,10 @@ while [[ $# -gt 0 ]]; do
 codex
 I’ve confirmed the leak path: the runner globally tees stdout/stderr into the persisted run log, and `run_codex_from_prompt` now streams Codex transcript through stdout, so secret-bearing transcript content can land in `docs/agent-logs`. I’m checking the existing shell test setup so the fix is covered without broad refactoring.
 exec
-/bin/zsh -lc "sed -n '800,920p' scripts/agent_daily_issue_runner.sh" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1080,1185p' scripts/agent_daily_issue_runner.sh" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg --files tests scripts | rg '(runner|shell|bats|shunit|agent_daily_issue_runner)'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "shellcheck|bats|agent_daily_issue_runner|daily_issue_runner" tests scripts Makefile .github -S' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '800,920p' scripts/agent_daily_issue_runner.sh" in [redacted-path]
+/bin/zsh -lc "sed -n '1080,1185p' scripts/agent_daily_issue_runner.sh" in [redacted-path]
+/bin/zsh -lc "rg --files tests scripts | rg '(runner|shell|bats|shunit|agent_daily_issue_runner)'" in [redacted-path]
+/bin/zsh -lc 'rg -n "shellcheck|bats|agent_daily_issue_runner|daily_issue_runner" tests scripts Makefile .github -S' in [redacted-path] succeeded in 51ms:
 
   if (( NODE_FULL_AUDIT_REQUIRED != 0 )); then
     printf -- '- `make audit-node-full`\n' >> "$PR_BODY_FILE"
@@ -3976,10 +4186,10 @@ scripts/agent_daily_issue_runner.sh:282:      # shellcheck disable=SC2086
 codex
 There doesn’t seem to be existing shell-runner test coverage. I’m checking the repo’s normal test harness now so I can add a focused regression test in the format the suite already runs, rather than inventing a separate path.
 exec
-/bin/zsh -lc 'ls -1' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' Makefile" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "rg --files tests | sed -n '1,200p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "subprocess|scripts/|agent-logs|AGENT_RUNNER|daily runner|runner log" tests docs -S' in /Users/scidsg/hushline succeeded in 50ms:
+/bin/zsh -lc 'ls -1' in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' Makefile" in [redacted-path]
+/bin/zsh -lc "rg --files tests | sed -n '1,200p'" in [redacted-path]
+/bin/zsh -lc 'rg -n "subprocess|scripts/|agent-logs|AGENT_RUNNER|daily runner|runner log" tests docs -S' in [redacted-path] succeeded in 50ms:
 AGENTS.md
 Dockerfile.dev
 Dockerfile.prod
@@ -4066,9 +4276,9 @@ docs/agent-logs/run-20260306T160005Z-issue-1505.txt:3770:scripts/refresh_public_
 codex
 I have the likely fix direction: keep Codex transcripts out of the persisted run log entirely, while still allowing optional live verbose output via the original terminal file descriptor so it bypasses `RUN_LOG_TMP_FILE`. Before editing, I’m reading a couple of nearby tests and the runner docs so I can add a narrow regression test and update the documented behavior consistently.
 exec
-/bin/zsh -lc "sed -n '1,240p' tests/test_cli_commands.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' tests/test_deployment_migrations.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,280p' docs/AGENT_RUNNER.md" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,240p' tests/test_cli_commands.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' tests/test_deployment_migrations.py" in [redacted-path]
+/bin/zsh -lc "sed -n '1,280p' docs/AGENT_RUNNER.md" in [redacted-path] succeeded in 52ms:
 from unittest.mock import MagicMock, patch
 
 from flask import Flask
@@ -4139,8 +4349,8 @@ Implement the runner fix with test coverage and doc updates, keeping the behavio
   • Add regression tests covering transcript redaction behavior and document the updated logging semantics
   • Run focused validation for the changed files and review the resulting diff
 exec
-/bin/zsh -lc "sed -n '920,1010p' scripts/agent_daily_issue_runner.sh" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "VERBOSE_CODEX_OUTPUT|CODEX_TRANSCRIPT_FILE|streaming transcript|transcript output|verbose_codex_output" scripts/agent_daily_issue_runner.sh docs/AGENT_RUNNER.md -S' in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '920,1010p' scripts/agent_daily_issue_runner.sh" in [redacted-path]
+/bin/zsh -lc 'rg -n "VERBOSE_CODEX_OUTPUT|CODEX_TRANSCRIPT_FILE|streaming transcript|transcript output|verbose_codex_output" scripts/agent_daily_issue_runner.sh docs/AGENT_RUNNER.md -S' in [redacted-path] succeeded in 52ms:
     cat <<EOF2
 You are implementing GitHub issue #$issue_number in $REPO_SLUG.
 
@@ -4173,8 +4383,8 @@ scripts/agent_daily_issue_runner.sh:875:    - < "$PROMPT_FILE" 2>&1 | tee "$CODE
 codex
 I’ve got the test approach: make the runner sourceable, then exercise `run_codex_from_prompt` and `persist_run_log` through a controlled bash snippet with a stubbed `codex` command. I’m editing the runner now to restore transcript isolation and preserve optional console-only verbose output.
 exec
-/bin/zsh -lc 'wc -l scripts/agent_daily_issue_runner.sh' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1010,1195p' scripts/agent_daily_issue_runner.sh" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc 'wc -l scripts/agent_daily_issue_runner.sh' in [redacted-path]
+/bin/zsh -lc "sed -n '1010,1195p' scripts/agent_daily_issue_runner.sh" in [redacted-path] succeeded in 51ms:
     1183 scripts/agent_daily_issue_runner.sh
  succeeded in 51ms:
 1) Fix only what is required for checks to pass.
@@ -4198,7 +4408,7 @@ require_cmd gh
 require_cmd codex
 require_cmd docker
 file update
-M /Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh
+M [redacted-path]
 @@ -5,19 +5,2 @@
  
 -while [[ $# -gt 0 ]]; do
@@ -4601,7 +4811,7 @@ M /Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh
 -run_step "Return to $BASE_BRANCH" git checkout "$BASE_BRANCH"
 apply_patch(auto_approved=true) exited 0 in 99ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh
+M [redacted-path]
 file update:
 diff --git a/scripts/agent_daily_issue_runner.sh b/scripts/agent_daily_issue_runner.sh
 index f5ad7d66f5f8d20dd4756dce206fd940ae8c7ad3..1b297048228c662ea5233a6c1fb26ef3c1f569a7
@@ -5467,9 +5677,9 @@ index f5ad7d66f5f8d20dd4756dce206fd940ae8c7ad3..1b297048228c662ea5233a6c1fb26ef3
 -run_step "Return to $BASE_BRANCH" git checkout "$BASE_BRANCH"
 
 exec
-/bin/zsh -lc "sed -n '848,905p' scripts/agent_daily_issue_runner.sh" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,120p' scripts/agent_daily_issue_runner.sh" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1170,1205p' scripts/agent_daily_issue_runner.sh" in /Users/scidsg/hushline succeeded in 50ms:
+/bin/zsh -lc "sed -n '848,905p' scripts/agent_daily_issue_runner.sh" in [redacted-path]
+/bin/zsh -lc "sed -n '1,120p' scripts/agent_daily_issue_runner.sh" in [redacted-path]
+/bin/zsh -lc "sed -n '1170,1205p' scripts/agent_daily_issue_runner.sh" in [redacted-path] succeeded in 50ms:
   mkdir -p "$log_dir"
   {
     printf 'Daily runner log\n'
@@ -5501,7 +5711,7 @@ REPO_SLUG="${HUSHLINE_REPO_SLUG:-scidsg/hushline}"
 BASE_BRANCH="${HUSHLINE_BASE_BRANCH:-main}"
 BOT_LOGIN="${HUSHLINE_BOT_LOGIN:-hushline-dev}"
 BOT_GIT_NAME="${HUSHLINE_BOT_GIT_NAME:-$BOT_LOGIN}"
-BOT_GIT_EMAIL="${HUSHLINE_BOT_GIT_EMAIL:-git-dev@scidsg.org}"
+BOT_GIT_EMAIL="${HUSHLINE_BOT_GIT_EMAIL:[redacted-email]}"
 BOT_GIT_GPG_FORMAT="${HUSHLINE_BOT_GIT_GPG_FORMAT:-ssh}"
 BOT_GIT_SIGNING_KEY="${HUSHLINE_BOT_GIT_SIGNING_KEY:-}"
 BRANCH_PREFIX="${HUSHLINE_DAILY_BRANCH_PREFIX:-codex/daily-issue-}"
@@ -5967,7 +6177,7 @@ index f5ad7d66f5f8d20dd4756dce206fd940ae8c7ad3..1b297048228c662ea5233a6c1fb26ef3
 codex
 The runner change is in place. I’m adding two regression tests now: one that proves the persisted run log never contains the transcript, and one that proves verbose mode only writes the transcript to the console side channel, not the run log.
 file update
-A /Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py
+A [redacted-path]
 from __future__ import annotations
 
 import shlex
@@ -6082,7 +6292,7 @@ run_codex_from_prompt > {shlex.quote(str(run_log_file))} 2>&1
     assert "Safe final summary" in run_log_text
 apply_patch(auto_approved=true) exited 0 in 56ms:
 Success. Updated the following files:
-A /Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py
+A [redacted-path]
 file update:
 diff --git a/scripts/agent_daily_issue_runner.sh b/scripts/agent_daily_issue_runner.sh
 index f5ad7d66f5f8d20dd4756dce206fd940ae8c7ad3..1b297048228c662ea5233a6c1fb26ef3c1f569a7
@@ -7184,7 +7394,7 @@ index 0000000000000000000000000000000000000000..28256d4e8b166445a2149cd7e21d9346
 +    assert "Safe final summary" in run_log_text
 
 file update
-M /Users/scidsg/hushline/docs/AGENT_RUNNER.md
+M [redacted-path]
 @@ -33,2 +33,3 @@
      - The fix prompt also includes the current branch diff summary, the prior Codex summary, and an extracted failure signature so Codex can repair the current implementation instead of repeating a narrow patch against the same failing symptom.
 +    - Codex transcript output is captured in a temporary file for the duration of the run and is excluded from the persisted runner log; only the final Codex summary is written into the run log.
@@ -7196,7 +7406,7 @@ M /Users/scidsg/hushline/docs/AGENT_RUNNER.md
  
 apply_patch(auto_approved=true) exited 0 in 53ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/docs/AGENT_RUNNER.md
+M [redacted-path]
 file update:
 diff --git a/docs/AGENT_RUNNER.md b/docs/AGENT_RUNNER.md
 index 3571c6b7ff8d6152759fb4757de0f918802e56b5..bb74465b54754b42505c5fc0f38d538dd80686ac
@@ -8342,7 +8552,7 @@ index 0000000000000000000000000000000000000000..28256d4e8b166445a2149cd7e21d9346
 codex
 The code and tests are patched. I’m running focused validation through the repo `make` target now to catch any scripting or test-harness issues before I review the diff.
 exec
-/bin/zsh -lc 'make test TESTS="tests/test_agent_daily_issue_runner.py tests/test_deployment_migrations.py"' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make test TESTS="tests/test_agent_daily_issue_runner.py tests/test_deployment_migrations.py"' in [redacted-path] update:
 diff --git a/docs/AGENT_RUNNER.md b/docs/AGENT_RUNNER.md
 index 3571c6b7ff8d6152759fb4757de0f918802e56b5..bb74465b54754b42505c5fc0f38d538dd80686ac
 --- a/docs/AGENT_RUNNER.md
@@ -10081,7 +10291,7 @@ plugins: asyncio-0.25.3, cov-5.0.0, mock-3.14.0
 codex
 The focused tests passed. I’m running `make lint` as a second check because this change added a new Python test file and updated the runner docs.
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/docs/AGENT_RUNNER.md b/docs/AGENT_RUNNER.md
 index 3571c6b7ff8d6152759fb4757de0f918802e56b5..bb74465b54754b42505c5fc0f38d538dd80686ac
 --- a/docs/AGENT_RUNNER.md
@@ -12391,7 +12601,7 @@ index 0000000000000000000000000000000000000000..28256d4e8b166445a2149cd7e21d9346
 codex
 Lint failed on the new test helper’s `subprocess.run` usage. I’m tightening that helper to use an absolute shell path and documenting the controlled invocation so the security lint passes cleanly.
 file update
-M /Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py
+M [redacted-path]
 @@ -11,4 +11,4 @@
  def _run_bash(script: str) -> subprocess.CompletedProcess[str]:
 -    return subprocess.run(
@@ -12401,7 +12611,7 @@ M /Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py
          cwd=ROOT,
 apply_patch(auto_approved=true) exited 0 in 70ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py
+M [redacted-path]
 file update:
 diff --git a/docs/AGENT_RUNNER.md b/docs/AGENT_RUNNER.md
 index 3571c6b7ff8d6152759fb4757de0f918802e56b5..bb74465b54754b42505c5fc0f38d538dd80686ac
@@ -13545,7 +13755,7 @@ index 0000000000000000000000000000000000000000..18afb81f340a18958e0be48759fa37ce
 +    assert "Safe final summary" in run_log_text
 
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/docs/AGENT_RUNNER.md b/docs/AGENT_RUNNER.md
 index 3571c6b7ff8d6152759fb4757de0f918802e56b5..bb74465b54754b42505c5fc0f38d538dd80686ac
 --- a/docs/AGENT_RUNNER.md
@@ -15851,7 +16061,7 @@ index 0000000000000000000000000000000000000000..18afb81f340a18958e0be48759fa37ce
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
 file update
-M /Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py
+M [redacted-path]
 @@ -11,4 +11,4 @@
  def _run_bash(script: str) -> subprocess.CompletedProcess[str]:
 -    return subprocess.run(  # noqa: S603 - controlled test harness invocation
@@ -15861,7 +16071,7 @@ M /Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py
          cwd=ROOT,
 apply_patch(auto_approved=true) exited 0 in 70ms:
 Success. Updated the following files:
-M /Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py
+M [redacted-path]
 file update:
 diff --git a/docs/AGENT_RUNNER.md b/docs/AGENT_RUNNER.md
 index 3571c6b7ff8d6152759fb4757de0f918802e56b5..bb74465b54754b42505c5fc0f38d538dd80686ac
@@ -17005,7 +17215,7 @@ index 0000000000000000000000000000000000000000..00c656052016dfb8e8a2ebbc54825a24
 +    assert "Safe final summary" in run_log_text
 
 exec
-/bin/zsh -lc 'make lint' in /Users/scidsg/hushlinefile update:
+/bin/zsh -lc 'make lint' in [redacted-path] update:
 diff --git a/docs/AGENT_RUNNER.md b/docs/AGENT_RUNNER.md
 index 3571c6b7ff8d6152759fb4757de0f918802e56b5..bb74465b54754b42505c5fc0f38d538dd80686ac
 --- a/docs/AGENT_RUNNER.md
@@ -20455,9 +20665,9 @@ index 0000000000000000000000000000000000000000..00c656052016dfb8e8a2ebbc54825a24
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff --stat' in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff -- scripts/agent_daily_issue_runner.sh docs/AGENT_RUNNER.md tests/test_agent_daily_issue_runner.py' in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc 'git status --short' in [redacted-path]
+/bin/zsh -lc 'git diff --stat' in [redacted-path]
+/bin/zsh -lc 'git diff -- scripts/agent_daily_issue_runner.sh docs/AGENT_RUNNER.md tests/test_agent_daily_issue_runner.py' in [redacted-path] succeeded in 51ms:
  M docs/AGENT_RUNNER.md
  M scripts/agent_daily_issue_runner.sh
 ?? tests/test_agent_daily_issue_runner.py
@@ -21058,11 +21268,11 @@ index 0000000000000000000000000000000000000000..00c656052016dfb8e8a2ebbc54825a24
 +    assert "Safe final summary" in run_log_text
 
 exec
-/bin/zsh -lc "nl -ba scripts/agent_daily_issue_runner.sh | sed -n '1,110p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba scripts/agent_daily_issue_runner.sh | sed -n '870,910p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'nl -ba tests/test_agent_daily_issue_runner.py' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba docs/AGENT_RUNNER.md | sed -n '28,40p;210,218p'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "nl -ba scripts/agent_daily_issue_runner.sh | sed -n '1040,1210p'" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "nl -ba scripts/agent_daily_issue_runner.sh | sed -n '1,110p'" in [redacted-path]
+/bin/zsh -lc "nl -ba scripts/agent_daily_issue_runner.sh | sed -n '870,910p'" in [redacted-path]
+/bin/zsh -lc 'nl -ba tests/test_agent_daily_issue_runner.py' in [redacted-path]
+/bin/zsh -lc "nl -ba docs/AGENT_RUNNER.md | sed -n '28,40p;210,218p'" in [redacted-path]
+/bin/zsh -lc "nl -ba scripts/agent_daily_issue_runner.sh | sed -n '1040,1210p'" in [redacted-path] succeeded in 52ms:
    870	    fi
    871	  fi
    872	}
@@ -21094,7 +21304,7 @@ exec
      8	BASE_BRANCH="${HUSHLINE_BASE_BRANCH:-main}"
      9	BOT_LOGIN="${HUSHLINE_BOT_LOGIN:-hushline-dev}"
     10	BOT_GIT_NAME="${HUSHLINE_BOT_GIT_NAME:-$BOT_LOGIN}"
-    11	BOT_GIT_EMAIL="${HUSHLINE_BOT_GIT_EMAIL:-git-dev@scidsg.org}"
+    11	BOT_GIT_EMAIL="${HUSHLINE_BOT_GIT_EMAIL:[redacted-email]}"
     12	BOT_GIT_GPG_FORMAT="${HUSHLINE_BOT_GIT_GPG_FORMAT:-ssh}"
     13	BOT_GIT_SIGNING_KEY="${HUSHLINE_BOT_GIT_SIGNING_KEY:-}"
     14	BRANCH_PREFIX="${HUSHLINE_DAILY_BRANCH_PREFIX:-codex/daily-issue-}"
@@ -22315,9 +22525,9 @@ index 0000000000000000000000000000000000000000..00c656052016dfb8e8a2ebbc54825a24
 +    assert "Safe final summary" in run_log_text
 
 codex
-Changed the daily runner so Codex transcript output no longer gets written into persisted repo logs. In [scripts/agent_daily_issue_runner.sh](/Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh#L61), the runner now preserves the original stdout on FD `3` before teeing the main run log, and [run_codex_from_prompt](/Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh#L874) writes the transcript only to `CODEX_TRANSCRIPT_FILE`. When `HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT=1`, the transcript is sent to the live console via FD `3`, not through `RUN_LOG_TMP_FILE`. I also wrapped the script entrypoint in [main](/Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh#L1049) so the runner can be sourced safely for tests.
+Changed the daily runner so Codex transcript output no longer gets written into persisted repo logs. In [scripts/agent_daily_issue_runner.sh]([redacted-path] the runner now preserves the original stdout on FD `3` before teeing the main run log, and [run_codex_from_prompt]([redacted-path] writes the transcript only to `CODEX_TRANSCRIPT_FILE`. When `HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT=1`, the transcript is sent to the live console via FD `3`, not through `RUN_LOG_TMP_FILE`. I also wrapped the script entrypoint in [main]([redacted-path] so the runner can be sourced safely for tests.
 
-Added regression coverage in [tests/test_agent_daily_issue_runner.py](/Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py#L21) to prove persisted logs exclude transcript content, and in [tests/test_agent_daily_issue_runner.py](/Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py#L72) to prove verbose mode only mirrors transcript output to the console side channel. The behavior is documented in [docs/AGENT_RUNNER.md](/Users/scidsg/hushline/docs/AGENT_RUNNER.md#L31) and [docs/AGENT_RUNNER.md](/Users/scidsg/hushline/docs/AGENT_RUNNER.md#L216).
+Added regression coverage in [tests/test_agent_daily_issue_runner.py]([redacted-path] to prove persisted logs exclude transcript content, and in [tests/test_agent_daily_issue_runner.py]([redacted-path] to prove verbose mode only mirrors transcript output to the console side channel. The behavior is documented in [docs/AGENT_RUNNER.md]([redacted-path] and [docs/AGENT_RUNNER.md]([redacted-path]
 
 Validation run:
 - `make test TESTS="tests/test_agent_daily_issue_runner.py tests/test_deployment_migrations.py"`
@@ -22897,9 +23107,9 @@ index 0000000000000000000000000000000000000000..00c656052016dfb8e8a2ebbc54825a24
 
 tokens used
 93,368
-Changed the daily runner so Codex transcript output no longer gets written into persisted repo logs. In [scripts/agent_daily_issue_runner.sh](/Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh#L61), the runner now preserves the original stdout on FD `3` before teeing the main run log, and [run_codex_from_prompt](/Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh#L874) writes the transcript only to `CODEX_TRANSCRIPT_FILE`. When `HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT=1`, the transcript is sent to the live console via FD `3`, not through `RUN_LOG_TMP_FILE`. I also wrapped the script entrypoint in [main](/Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh#L1049) so the runner can be sourced safely for tests.
+Changed the daily runner so Codex transcript output no longer gets written into persisted repo logs. In [scripts/agent_daily_issue_runner.sh]([redacted-path] the runner now preserves the original stdout on FD `3` before teeing the main run log, and [run_codex_from_prompt]([redacted-path] writes the transcript only to `CODEX_TRANSCRIPT_FILE`. When `HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT=1`, the transcript is sent to the live console via FD `3`, not through `RUN_LOG_TMP_FILE`. I also wrapped the script entrypoint in [main]([redacted-path] so the runner can be sourced safely for tests.
 
-Added regression coverage in [tests/test_agent_daily_issue_runner.py](/Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py#L21) to prove persisted logs exclude transcript content, and in [tests/test_agent_daily_issue_runner.py](/Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py#L72) to prove verbose mode only mirrors transcript output to the console side channel. The behavior is documented in [docs/AGENT_RUNNER.md](/Users/scidsg/hushline/docs/AGENT_RUNNER.md#L31) and [docs/AGENT_RUNNER.md](/Users/scidsg/hushline/docs/AGENT_RUNNER.md#L216).
+Added regression coverage in [tests/test_agent_daily_issue_runner.py]([redacted-path] to prove persisted logs exclude transcript content, and in [tests/test_agent_daily_issue_runner.py]([redacted-path] to prove verbose mode only mirrors transcript output to the console side channel. The behavior is documented in [docs/AGENT_RUNNER.md]([redacted-path] and [docs/AGENT_RUNNER.md]([redacted-path]
 
 Validation run:
 - `make test TESTS="tests/test_agent_daily_issue_runner.py tests/test_deployment_migrations.py"`
@@ -22908,9 +23118,9 @@ Validation run:
 GitHub/Dependabot state was not checkable from this sandbox.
 Codex execution completed.
 Codex final message:
-Changed the daily runner so Codex transcript output no longer gets written into persisted repo logs. In [scripts/agent_daily_issue_runner.sh](/Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh#L61), the runner now preserves the original stdout on FD `3` before teeing the main run log, and [run_codex_from_prompt](/Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh#L874) writes the transcript only to `CODEX_TRANSCRIPT_FILE`. When `HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT=1`, the transcript is sent to the live console via FD `3`, not through `RUN_LOG_TMP_FILE`. I also wrapped the script entrypoint in [main](/Users/scidsg/hushline/scripts/agent_daily_issue_runner.sh#L1049) so the runner can be sourced safely for tests.
+Changed the daily runner so Codex transcript output no longer gets written into persisted repo logs. In [scripts/agent_daily_issue_runner.sh]([redacted-path] the runner now preserves the original stdout on FD `3` before teeing the main run log, and [run_codex_from_prompt]([redacted-path] writes the transcript only to `CODEX_TRANSCRIPT_FILE`. When `HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT=1`, the transcript is sent to the live console via FD `3`, not through `RUN_LOG_TMP_FILE`. I also wrapped the script entrypoint in [main]([redacted-path] so the runner can be sourced safely for tests.
 
-Added regression coverage in [tests/test_agent_daily_issue_runner.py](/Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py#L21) to prove persisted logs exclude transcript content, and in [tests/test_agent_daily_issue_runner.py](/Users/scidsg/hushline/tests/test_agent_daily_issue_runner.py#L72) to prove verbose mode only mirrors transcript output to the console side channel. The behavior is documented in [docs/AGENT_RUNNER.md](/Users/scidsg/hushline/docs/AGENT_RUNNER.md#L31) and [docs/AGENT_RUNNER.md](/Users/scidsg/hushline/docs/AGENT_RUNNER.md#L216).
+Added regression coverage in [tests/test_agent_daily_issue_runner.py]([redacted-path] to prove persisted logs exclude transcript content, and in [tests/test_agent_daily_issue_runner.py]([redacted-path] to prove verbose mode only mirrors transcript output to the console side channel. The behavior is documented in [docs/AGENT_RUNNER.md]([redacted-path] and [docs/AGENT_RUNNER.md]([redacted-path]
 
 Validation run:
 - `make test TESTS="tests/test_agent_daily_issue_runner.py tests/test_deployment_migrations.py"`
@@ -22986,7 +23196,7 @@ Success: no issues found in 161 source files
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run workflow security checks
-docker run --rm -v "/Users/scidsg/hushline:/work" -w /work rhysd/actionlint:1.7.7 -color
+docker run --rm -v "[redacted-path]" -w /work rhysd/actionlint:1.7.7 -color
 Unable to find image 'rhysd/actionlint:1.7.7' locally
 1.7.7: Pulling from rhysd/actionlint
 25d2e00cf929: Pulling fs layer

--- a/docs/agent-logs/run-20260308T040404Z-issue-1557.txt
+++ b/docs/agent-logs/run-20260308T040404Z-issue-1557.txt
@@ -3,7 +3,7 @@ Timestamp (UTC): 20260308T040404Z
 Issue: #1557
 Repository: scidsg/hushline
 
-Runner Codex config: model=gpt-5.4 reasoning_effort=high verbose_codex_output=0
+Runner Codex config: [redacted]
 ==> Fetch latest from origin
 From github.com:scidsg/hushline
    191552f6..67bd6680  main       -> origin/main
@@ -1366,23 +1366,128 @@ Total reclaimed space: 5.041GB
 #7 8.367 Get:460 http://deb.debian.org/debian bookworm/main arm64 pkg-config arm64 1.8.1-1 [13.7 kB]
 #7 8.492 debconf: delaying package configuration, since apt-utils is not installed
 #7 8.507 Fetched 162 MB in 3s (52.5 MB/s)
-#7 8.523 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6689 files and directories currently installed.)
+#7 8.523 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6689 files and directories currently installed.)
 #7 8.526 Preparing to unpack .../perl-base_5.36.0-7+deb12u3_arm64.deb ...
 #7 8.532 Unpacking perl-base (5.36.0-7+deb12u3) over (5.36.0-7+deb12u1) ...
 #7 9.199 Setting up perl-base (5.36.0-7+deb12u3) ...
-#7 9.213 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.213 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.219 Preparing to unpack .../gcc-12-base_12.2.0-14+deb12u1_arm64.deb ...
 #7 9.224 Unpacking gcc-12-base:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 9.240 Setting up gcc-12-base:arm64 (12.2.0-14+deb12u1) ...
-#7 9.255 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.255 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.258 Preparing to unpack .../libgcc-s1_12.2.0-14+deb12u1_arm64.deb ...
 #7 9.263 Unpacking libgcc-s1:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 9.279 Setting up libgcc-s1:arm64 (12.2.0-14+deb12u1) ...
-#7 9.297 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.297 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.301 Preparing to unpack .../libstdc++6_12.2.0-14+deb12u1_arm64.deb ...
 #7 9.309 Unpacking libstdc++6:arm64 (12.2.0-14+deb12u1) over (12.2.0-14) ...
 #7 9.366 Setting up libstdc++6:arm64 (12.2.0-14+deb12u1) ...
-#7 9.392 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 9.392 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 9.394 Preparing to unpack .../libc6_2.36-9+deb12u13_arm64.deb ...
 #7 9.434 debconf: unable to initialize frontend: Dialog
 #7 9.434 debconf: (TERM is not set, so the dialog frontend is not usable.)
@@ -1398,12 +1503,54 @@ Total reclaimed space: 5.041GB
 #7 9.892 debconf: unable to initialize frontend: Readline
 #7 9.892 debconf: (Can't locate Term/ReadLine.pm in @INC (you may need to install the Term::ReadLine module) (@INC contains: /etc/perl /usr/local/lib/aarch64-linux-gnu/perl/5.36.0 /usr/local/share/perl/5.36.0 /usr/lib/aarch64-linux-gnu/perl5/5.36 /usr/share/perl5 /usr/lib/aarch64-linux-gnu/perl-base /usr/lib/aarch64-linux-gnu/perl/5.36 /usr/share/perl/5.36 /usr/local/lib/site_perl) at /usr/share/perl5/Debconf/FrontEnd/Readline.pm line 7.)
 #7 9.892 debconf: falling back to frontend: Teletype
-#7 10.95 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 10.95 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 10.96 Preparing to unpack .../libc-bin_2.36-9+deb12u13_arm64.deb ...
 #7 10.96 Unpacking libc-bin (2.36-9+deb12u13) over (2.36-9+deb12u8) ...
 #7 11.04 Setting up libc-bin (2.36-9+deb12u13) ...
 #7 11.07 Selecting previously unselected package perl-modules-5.36.
-#7 11.07 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 6690 files and directories currently installed.)
+#7 11.07 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 6690 files and directories currently installed.)
 #7 11.07 Preparing to unpack .../0-perl-modules-5.36_5.36.0-7+deb12u3_all.deb ...
 #7 11.07 Unpacking perl-modules-5.36 (5.36.0-7+deb12u3) ...
 #7 11.28 Selecting previously unselected package libgdbm-compat4:arm64.
@@ -1427,7 +1574,28 @@ Total reclaimed space: 5.041GB
 #7 11.89 Setting up libpython3.11-minimal:arm64 (3.11.2-6+deb12u6) ...
 #7 11.90 Setting up python3.11-minimal (3.11.2-6+deb12u6) ...
 #7 12.25 Selecting previously unselected package python3-minimal.
-#7 12.25 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9002 files and directories currently installed.)
+#7 12.25 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9002 files and directories currently installed.)
 #7 12.25 Preparing to unpack .../python3-minimal_3.11.2-1+b1_arm64.deb ...
 #7 12.25 Unpacking python3-minimal (3.11.2-1+b1) ...
 #7 12.26 Selecting previously unselected package media-types.
@@ -1437,7 +1605,28 @@ Total reclaimed space: 5.041GB
 #7 12.29 Unpacking liblzma5:arm64 (5.4.1-1) over (5.4.1-0.2) ...
 #7 12.31 Setting up liblzma5:arm64 (5.4.1-1) ...
 #7 12.32 Selecting previously unselected package libpython3.11-stdlib:arm64.
-#7 12.32 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9030 files and directories currently installed.)
+#7 12.32 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9030 files and directories currently installed.)
 #7 12.32 Preparing to unpack .../libpython3.11-stdlib_3.11.2-6+deb12u6_arm64.deb ...
 #7 12.32 Unpacking libpython3.11-stdlib:arm64 (3.11.2-6+deb12u6) ...
 #7 12.45 Selecting previously unselected package python3.11.
@@ -1448,7 +1637,28 @@ Total reclaimed space: 5.041GB
 #7 12.47 Unpacking libpython3-stdlib:arm64 (3.11.2-1+b1) ...
 #7 12.48 Setting up python3-minimal (3.11.2-1+b1) ...
 #7 12.57 Selecting previously unselected package python3.
-#7 12.57 (Reading database ... (Reading database ... 5%(Reading database ... 10%(Reading database ... 15%(Reading database ... 20%(Reading database ... 25%(Reading database ... 30%(Reading database ... 35%(Reading database ... 40%(Reading database ... 45%(Reading database ... 50%(Reading database ... 55%(Reading database ... 60%(Reading database ... 65%(Reading database ... 70%(Reading database ... 75%(Reading database ... 80%(Reading database ... 85%(Reading database ... 90%(Reading database ... 95%(Reading database ... 100%(Reading database ... 9412 files and directories currently installed.)
+#7 12.57 (Reading database ... 
+(Reading database ... 5%
+(Reading database ... 10%
+(Reading database ... 15%
+(Reading database ... 20%
+(Reading database ... 25%
+(Reading database ... 30%
+(Reading database ... 35%
+(Reading database ... 40%
+(Reading database ... 45%
+(Reading database ... 50%
+(Reading database ... 55%
+(Reading database ... 60%
+(Reading database ... 65%
+(Reading database ... 70%
+(Reading database ... 75%
+(Reading database ... 80%
+(Reading database ... 85%
+(Reading database ... 90%
+(Reading database ... 95%
+(Reading database ... 100%
+(Reading database ... 9412 files and directories currently installed.)
 #7 12.57 Preparing to unpack .../000-python3_3.11.2-1+b1_arm64.deb ...
 #7 12.57 Unpacking python3 (3.11.2-1+b1) ...
 #7 12.58 Selecting previously unselected package bzip2.
@@ -3670,14 +3880,14 @@ Switched to a new branch 'codex/daily-issue-1557'
 Codex execution started; streaming transcript output.
 OpenAI Codex v0.111.0 (research preview)
 --------
-workdir: /Users/scidsg/hushline
-model: gpt-5.4
-provider: openai
-approval: never
-sandbox: workspace-write [workdir, /tmp, $TMPDIR, /Users/scidsg/.codex/memories]
-reasoning effort: high
-reasoning summaries: none
-session id: 019ccba0-3d52-7271-93de-106986a70c42
+workdir: [redacted]
+model: [redacted]
+provider: [redacted]
+approval: [redacted]
+sandbox: [redacted]
+reasoning effort: [redacted]
+reasoning summaries: [redacted]
+session id: [redacted]
 --------
 user
 You are implementing GitHub issue #1557 in scidsg/hushline.
@@ -3702,7 +3912,7 @@ The new PR-based automation uses `gh pr list --head <branch>` without specifying
 Metadata:
 Repo: scidsg/hushline
 Commit: 4a5b138
-Author: glenn.sorrentino@proton.me
+Author: [redacted-email]
 Created: 3/7/2026, 6:32:40 PM
 Assignee: Unassigned
 Signals: Security, Validated, Patch generated, Attack-path
@@ -4006,8 +4216,8 @@ mcp startup: no servers
 codex
 I’m inspecting the existing workflows and test coverage around GitHub Action PR selection so I can make the narrow fix and add the smallest test coverage that locks it in.
 exec
-/bin/zsh -lc "rg --files -g 'AGENTS.md' -g '.github/workflows/*.yml' -g '.github/workflows/*.yaml' -g 'tests/**'" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "rg --files -g 'AGENTS.md' -g '.github/workflows/*.yml' -g '.github/workflows/*.yaml' -g 'tests/**'" in [redacted-path]
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 53ms:
 AGENTS.md
 tests/test_make_admin.py
 tests/test_accessibility.py
@@ -4033,9 +4243,9 @@ tests/test_vision.py
 codex
 I’ve confirmed there isn’t a deeper `AGENTS.md` overriding the root guidance. Next I’m locating any existing tests around these workflows so the fix lands with behavior coverage instead of a raw YAML edit.
 exec
-/bin/zsh -lc 'rg -n "public-directory-weekly-report|publish-docs-screenshots|gh pr list|--head" tests .github/workflows' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' .github/workflows/public-directory-weekly-report.yml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,320p' .github/workflows/publish-docs-screenshots.yml" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'rg -n "public-directory-weekly-report|publish-docs-screenshots|gh pr list|--head" tests .github/workflows' in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' .github/workflows/public-directory-weekly-report.yml" in [redacted-path]
+/bin/zsh -lc "sed -n '1,320p' .github/workflows/publish-docs-screenshots.yml" in [redacted-path] succeeded in 53ms:
 .github/workflows/public-directory-weekly-report.yml:17:  group: public-directory-weekly-report
 .github/workflows/public-directory-weekly-report.yml:120:          pr_url="$(gh pr list \
 .github/workflows/public-directory-weekly-report.yml:122:            --head "${stats_owner}:${STATS_BRANCH}" \
@@ -4101,9 +4311,9 @@ jobs:
 codex
 The vulnerable owner-qualified head filter is already present in the workflow files on this branch, so the remaining gap is test coverage. I’m checking how this repo tests workflow invariants and whether there are adjacent workflows using the same pattern that should be covered by the same guard.
 exec
-/bin/zsh -lc "sed -n '1,260p' tests/test_agent_daily_issue_runner.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'rg -n "workflow|yaml|yml|gh pr create|gh pr merge|actions/checkout|--repo" tests' in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,260p' tests/test_docs_library_mirror.py" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,260p' tests/test_agent_daily_issue_runner.py" in [redacted-path]
+/bin/zsh -lc 'rg -n "workflow|yaml|yml|gh pr create|gh pr merge|actions/checkout|--repo" tests' in [redacted-path]
+/bin/zsh -lc "sed -n '1,260p' tests/test_docs_library_mirror.py" in [redacted-path] succeeded in 51ms:
 from __future__ import annotations
 
 import shlex
@@ -4151,8 +4361,8 @@ REQUIRED_DOCS = [
 codex
 I found no existing workflow-specific tests. I’m checking the other `gh pr list --head` call sites now to confirm whether this issue is scoped to the two cited workflows or whether there’s another unprotected auto-merge path that needs the same fix in this patch.
 exec
-/bin/zsh -lc "sed -n '165,255p' .github/workflows/bump-personal-server-after-release.yml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '130,230p' .github/workflows/bump-staging-after-release.yml" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '165,255p' .github/workflows/bump-personal-server-after-release.yml" in [redacted-path]
+/bin/zsh -lc "sed -n '130,230p' .github/workflows/bump-staging-after-release.yml" in [redacted-path] succeeded in 52ms:
         if: steps.update_personal_server.outputs.changed == 'true'
         working-directory: hushline-personal-server
         shell: bash
@@ -4197,7 +4407,7 @@ exec
 codex
 There are two additional auto-merge workflows with the same ambiguous `gh pr list --head "$BRANCH"` pattern in cross-repo PR automation. I’m broadening the fix to those call sites as well so the repository doesn’t keep the same fork-hijack exposure under a different workflow name.
 exec
-/bin/zsh -lc "rg -n \"gh pr list \\\\\\\\|gh pr create \\\\\\\\|gh pr merge\" .github/workflows" in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "rg -n \"gh pr list \\\\\\\\|gh pr create \\\\\\\\|gh pr merge\" .github/workflows" in [redacted-path] succeeded in 53ms:
 .github/workflows/public-directory-weekly-report.yml:120:          pr_url="$(gh pr list \
 .github/workflows/public-directory-weekly-report.yml:134:            pr_url="$(gh pr create \
 .github/workflows/public-directory-weekly-report.yml:142:          if gh pr merge "$pr_url" \
@@ -4219,7 +4429,7 @@ Plan:
 2. Add a focused test file that reads the workflow YAML as text and asserts every cross-repo auto-merge path uses `owner:branch` instead of a bare branch name.
 3. Skip local validation unless I hit a syntax ambiguity; the runner will execute the full suite afterward.
 exec
-/bin/zsh -lc "sed -n '1,240p' .github/workflows/bump-staging-after-release.yml" in /Users/scidsg/hushline succeeded in 52ms:
+/bin/zsh -lc "sed -n '1,240p' .github/workflows/bump-staging-after-release.yml" in [redacted-path] succeeded in 52ms:
 name: Bump staging infra after release
 
 on:
@@ -4241,7 +4451,7 @@ jobs:
     env:
       RELEASE_TAG: ${{ github.event.release.tag_name }}
 exec
-/bin/zsh -lc "sed -n '1,280p' .github/workflows/bump-personal-server-after-release.yml" in /Users/scidsg/hushline succeeded in 51ms:
+/bin/zsh -lc "sed -n '1,280p' .github/workflows/bump-personal-server-after-release.yml" in [redacted-path] succeeded in 51ms:
 name: Bump personal server after release
 
 on:
@@ -4265,7 +4475,7 @@ jobs:
 codex
 I have the exact remaining call sites. I’m patching those workflows now and adding a text-level regression test that fails if any of these auto-merge jobs ever falls back to a bare branch head again.
 file update
-A /Users/scidsg/hushline/tests/test_workflow_pr_head_qualification.py
+A [redacted-path]
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -4314,7 +4524,7 @@ def test_cross_repo_auto_merge_workflows_use_owner_qualified_pr_heads() -> None:
 
         assert owner_assignment in workflow_text
         assert workflow_text.count(head_filter) == expected_count
-M /Users/scidsg/hushline/.github/workflows/bump-personal-server-after-release.yml
+M [redacted-path]
 @@ -190,5 +190,6 @@
  
 +          personal_server_owner="${PERSONAL_SERVER_REPOSITORY%%/*}"
@@ -4328,7 +4538,7 @@ M /Users/scidsg/hushline/.github/workflows/bump-personal-server-after-release.ym
 -            --head "$PERSONAL_SERVER_BRANCH" \
 +            --head "${personal_server_owner}:${PERSONAL_SERVER_BRANCH}" \
              --title "$pr_title" \
-M /Users/scidsg/hushline/.github/workflows/bump-staging-after-release.yml
+M [redacted-path]
 @@ -156,5 +156,6 @@
  
 +          infra_owner="${INFRA_REPOSITORY%%/*}"
@@ -4344,9 +4554,9 @@ M /Users/scidsg/hushline/.github/workflows/bump-staging-after-release.yml
              --title "$pr_title" \
 apply_patch(auto_approved=true) exited 0 in 47ms:
 Success. Updated the following files:
-A /Users/scidsg/hushline/tests/test_workflow_pr_head_qualification.py
-M /Users/scidsg/hushline/.github/workflows/bump-staging-after-release.yml
-M /Users/scidsg/hushline/.github/workflows/bump-personal-server-after-release.yml
+A [redacted-path]
+M [redacted-path]
+M [redacted-path]
 file update:
 diff --git a/.github/workflows/bump-personal-server-after-release.yml b/.github/workflows/bump-personal-server-after-release.yml
 index 2f0ca02528d110f11bf1123fed9a6809eac18554..69e962499bdc19078eee1cdeb6d2c62803029cd5
@@ -4562,10 +4772,10 @@ index 0000000000000000000000000000000000000000..e4a7f7d58c9b9e409b3082ba0b4f3a98
 codex
 The patch is in. I’m doing a quick read-back of the edited sections and the new regression test to catch any quoting or count mistakes before I stop.
 exec
-/bin/zsh -lc "sed -n '150,210p' .github/workflows/bump-staging-after-release.yml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '1,220p' tests/test_workflow_pr_head_qualification.py" in /Users/scidsg/hushlineexec
-/bin/zsh -lc "sed -n '185,225p' .github/workflows/bump-personal-server-after-release.yml" in /Users/scidsg/hushlineexec
-/bin/zsh -lc 'git diff -- .github/workflows/bump-staging-after-release.yml .github/workflows/bump-personal-server-after-release.yml tests/test_workflow_pr_head_qualification.py' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc "sed -n '150,210p' .github/workflows/bump-staging-after-release.yml" in [redacted-path]
+/bin/zsh -lc "sed -n '1,220p' tests/test_workflow_pr_head_qualification.py" in [redacted-path]
+/bin/zsh -lc "sed -n '185,225p' .github/workflows/bump-personal-server-after-release.yml" in [redacted-path]
+/bin/zsh -lc 'git diff -- .github/workflows/bump-staging-after-release.yml .github/workflows/bump-personal-server-after-release.yml tests/test_workflow_pr_head_qualification.py' in [redacted-path] succeeded in 53ms:
         working-directory: hushline-infra
         shell: bash
         env:
@@ -4758,7 +4968,7 @@ index 0000000000000000000000000000000000000000..e4a7f7d58c9b9e409b3082ba0b4f3a98
 codex
 The read-back looks clean. I’m checking the final file set now so I can close with exactly what changed and note that I did not run local make targets.
 exec
-/bin/zsh -lc 'git status --short' in /Users/scidsg/hushline succeeded in 53ms:
+/bin/zsh -lc 'git status --short' in [redacted-path] succeeded in 53ms:
  M .github/workflows/bump-personal-server-after-release.yml
  M .github/workflows/bump-staging-after-release.yml
 ?? tests/test_workflow_pr_head_qualification.py
@@ -4869,9 +5079,9 @@ index 0000000000000000000000000000000000000000..e4a7f7d58c9b9e409b3082ba0b4f3a98
 +        assert workflow_text.count(head_filter) == expected_count
 
 codex
-Patched the remaining cross-repo auto-merge workflows to derive the target owner from the repo slug and use `owner:branch` for both PR lookup and PR creation in [bump-staging-after-release.yml](/Users/scidsg/hushline/.github/workflows/bump-staging-after-release.yml) and [bump-personal-server-after-release.yml](/Users/scidsg/hushline/.github/workflows/bump-personal-server-after-release.yml). That closes the same fork-PR hijack path the already-fixed screenshot and stats workflows were avoiding.
+Patched the remaining cross-repo auto-merge workflows to derive the target owner from the repo slug and use `owner:branch` for both PR lookup and PR creation in [bump-staging-after-release.yml]([redacted-path] and [bump-personal-server-after-release.yml]([redacted-path] That closes the same fork-PR hijack path the already-fixed screenshot and stats workflows were avoiding.
 
-Added [test_workflow_pr_head_qualification.py](/Users/scidsg/hushline/tests/test_workflow_pr_head_qualification.py), which asserts all current cross-repo auto-merge workflow paths use owner-qualified PR heads, including the existing protections in [public-directory-weekly-report.yml](/Users/scidsg/hushline/.github/workflows/public-directory-weekly-report.yml) and [publish-docs-screenshots.yml](/Users/scidsg/hushline/.github/workflows/publish-docs-screenshots.yml).
+Added [test_workflow_pr_head_qualification.py]([redacted-path] which asserts all current cross-repo auto-merge workflow paths use owner-qualified PR heads, including the existing protections in [public-directory-weekly-report.yml]([redacted-path] and [publish-docs-screenshots.yml]([redacted-path]
 
 I did not run local `make` validation targets.
 file update:
@@ -4982,16 +5192,16 @@ index 0000000000000000000000000000000000000000..e4a7f7d58c9b9e409b3082ba0b4f3a98
 
 tokens used
 30,861
-Patched the remaining cross-repo auto-merge workflows to derive the target owner from the repo slug and use `owner:branch` for both PR lookup and PR creation in [bump-staging-after-release.yml](/Users/scidsg/hushline/.github/workflows/bump-staging-after-release.yml) and [bump-personal-server-after-release.yml](/Users/scidsg/hushline/.github/workflows/bump-personal-server-after-release.yml). That closes the same fork-PR hijack path the already-fixed screenshot and stats workflows were avoiding.
+Patched the remaining cross-repo auto-merge workflows to derive the target owner from the repo slug and use `owner:branch` for both PR lookup and PR creation in [bump-staging-after-release.yml]([redacted-path] and [bump-personal-server-after-release.yml]([redacted-path] That closes the same fork-PR hijack path the already-fixed screenshot and stats workflows were avoiding.
 
-Added [test_workflow_pr_head_qualification.py](/Users/scidsg/hushline/tests/test_workflow_pr_head_qualification.py), which asserts all current cross-repo auto-merge workflow paths use owner-qualified PR heads, including the existing protections in [public-directory-weekly-report.yml](/Users/scidsg/hushline/.github/workflows/public-directory-weekly-report.yml) and [publish-docs-screenshots.yml](/Users/scidsg/hushline/.github/workflows/publish-docs-screenshots.yml).
+Added [test_workflow_pr_head_qualification.py]([redacted-path] which asserts all current cross-repo auto-merge workflow paths use owner-qualified PR heads, including the existing protections in [public-directory-weekly-report.yml]([redacted-path] and [publish-docs-screenshots.yml]([redacted-path]
 
 I did not run local `make` validation targets.
 Codex execution completed.
 Codex final message:
-Patched the remaining cross-repo auto-merge workflows to derive the target owner from the repo slug and use `owner:branch` for both PR lookup and PR creation in [bump-staging-after-release.yml](/Users/scidsg/hushline/.github/workflows/bump-staging-after-release.yml) and [bump-personal-server-after-release.yml](/Users/scidsg/hushline/.github/workflows/bump-personal-server-after-release.yml). That closes the same fork-PR hijack path the already-fixed screenshot and stats workflows were avoiding.
+Patched the remaining cross-repo auto-merge workflows to derive the target owner from the repo slug and use `owner:branch` for both PR lookup and PR creation in [bump-staging-after-release.yml]([redacted-path] and [bump-personal-server-after-release.yml]([redacted-path] That closes the same fork-PR hijack path the already-fixed screenshot and stats workflows were avoiding.
 
-Added [test_workflow_pr_head_qualification.py](/Users/scidsg/hushline/tests/test_workflow_pr_head_qualification.py), which asserts all current cross-repo auto-merge workflow paths use owner-qualified PR heads, including the existing protections in [public-directory-weekly-report.yml](/Users/scidsg/hushline/.github/workflows/public-directory-weekly-report.yml) and [publish-docs-screenshots.yml](/Users/scidsg/hushline/.github/workflows/publish-docs-screenshots.yml).
+Added [test_workflow_pr_head_qualification.py]([redacted-path] which asserts all current cross-repo auto-merge workflow paths use owner-qualified PR heads, including the existing protections in [public-directory-weekly-report.yml]([redacted-path] and [publish-docs-screenshots.yml]([redacted-path]
 
 I did not run local `make` validation targets.
 ==> Refresh local runtime after schema changes
@@ -5063,7 +5273,7 @@ Success: no issues found in 162 source files
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run workflow security checks
-docker run --rm -v "/Users/scidsg/hushline:/work" -w /work rhysd/actionlint:1.7.7 -color
+docker run --rm -v "[redacted-path]" -w /work rhysd/actionlint:1.7.7 -color
 Unable to find image 'rhysd/actionlint:1.7.7' locally
 1.7.7: Pulling from rhysd/actionlint
 25d2e00cf929: Pulling fs layer

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 FORCE_ISSUE_NUMBER=""
+SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
 
 REPO_DIR="${HUSHLINE_REPO_DIR:-$HOME/hushline}"
 REPO_SLUG="${HUSHLINE_REPO_SLUG:-scidsg/hushline}"
@@ -855,7 +856,9 @@ EOF2
 persist_run_log() {
   local issue_number="$1"
   local log_dir="$REPO_DIR/docs/agent-logs"
+  local raw_log_file
   RUN_LOG_GIT_PATH="docs/agent-logs/run-${RUN_LOG_TIMESTAMP}-issue-${issue_number}.txt"
+  raw_log_file="$(mktemp)"
 
   mkdir -p "$log_dir"
   {
@@ -864,7 +867,9 @@ persist_run_log() {
     printf 'Issue: #%s\n' "$issue_number"
     printf 'Repository: %s\n\n' "$REPO_SLUG"
     cat "$RUN_LOG_TMP_FILE"
-  } > "$REPO_DIR/$RUN_LOG_GIT_PATH"
+  } > "$raw_log_file"
+  python3 "$SCRIPT_DIR/sanitize_agent_run_log.py" "$raw_log_file" "$REPO_DIR/$RUN_LOG_GIT_PATH"
+  rm -f "$raw_log_file"
 
   if [[ "$RUN_LOG_RETENTION_COUNT" =~ ^[0-9]+$ ]] && (( RUN_LOG_RETENTION_COUNT > 0 )); then
     local -a logs_to_delete=()

--- a/scripts/sanitize_agent_run_log.py
+++ b/scripts/sanitize_agent_run_log.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Redact developer and environment metadata from persisted agent run logs."""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+EMAIL_RE = re.compile(r"(?<![\w.+-])[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}(?![\w.-])")
+USER_PATH_RE = re.compile(r"/(?:Users|home)/[^\s\"']+")
+EXPECTED_ARGC = 3
+KEY_REPLACEMENTS = {
+    "Runner Codex config:": "Runner Codex config: [redacted]",
+    "Configured git identity:": "Configured git identity: [redacted]",
+    "Run log file:": "Run log file: [redacted]",
+    "Global log file:": "Global log file: [redacted]",
+    "workdir:": "workdir: [redacted]",
+    "model:": "model: [redacted]",
+    "provider:": "provider: [redacted]",
+    "approval:": "approval: [redacted]",
+    "sandbox:": "sandbox: [redacted]",
+    "reasoning effort:": "reasoning effort: [redacted]",
+    "reasoning summaries:": "reasoning summaries: [redacted]",
+    "session id:": "session id: [redacted]",
+}
+
+
+def sanitize_text(text: str) -> str:
+    sanitized_lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        replacement = next(
+            (value for prefix, value in KEY_REPLACEMENTS.items() if stripped.startswith(prefix)),
+            None,
+        )
+        if replacement is not None:
+            indent = line[: len(line) - len(stripped)]
+            sanitized_lines.append(f"{indent}{replacement}")
+            continue
+
+        sanitized_line = EMAIL_RE.sub("[redacted-email]", line)
+        sanitized_line = USER_PATH_RE.sub("[redacted-path]", sanitized_line)
+        sanitized_lines.append(sanitized_line)
+
+    return "\n".join(sanitized_lines) + ("\n" if text.endswith("\n") else "")
+
+
+def main() -> int:
+    if len(sys.argv) != EXPECTED_ARGC:
+        print("usage: sanitize_agent_run_log.py <input> <output>", file=sys.stderr)
+        return 1
+
+    input_path = Path(sys.argv[1])
+    output_path = Path(sys.argv[2])
+    sanitized = sanitize_text(input_path.read_text(encoding="utf-8"))
+    output_path.write_text(sanitized, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -69,6 +69,73 @@ printf '%s\\n' "$RUN_LOG_GIT_PATH"
     assert console_file.read_text(encoding="utf-8") == ""
 
 
+def test_persisted_runner_log_redacts_developer_metadata(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    run_log_file = tmp_path / "run-log.txt"
+
+    repo_dir.mkdir()
+    run_log_file.write_text(
+        "\n".join(
+            [
+                "Runner Codex config: model=gpt-5.4 reasoning_effort=high verbose_codex_output=0",
+                "Configured git identity: hushline-dev <git-dev@scidsg.org>",
+                "Run log file: /Users/scidsg/hushline/docs/agent-logs/run.log",
+                "Global log file: /Users/scidsg/.codex/logs/hushline-agent-runner.log",
+                "workdir: /Users/scidsg/hushline",
+                "model: gpt-5.4",
+                "provider: openai",
+                "approval: never",
+                "sandbox: workspace-write [workdir, /tmp, $TMPDIR, /Users/scidsg/.codex/memories]",
+                "reasoning effort: high",
+                "reasoning summaries: none",
+                "session id: 019ccba0-3d52-7271-93de-106986a70c42",
+                "Home path: /Users/scidsg/hushline",
+                "Email: hello@example.com",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(repo_dir))}
+RUN_LOG_TMP_FILE={shlex.quote(str(run_log_file))}
+RUN_LOG_TIMESTAMP=20260308T000000Z
+RUN_LOG_RETENTION_COUNT=10
+RUN_LOG_GIT_PATH=""
+REPO_SLUG=scidsg/hushline
+persist_run_log 1556
+printf '%s\\n' "$RUN_LOG_GIT_PATH"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+
+    persisted_log = repo_dir / result.stdout.strip()
+    persisted_text = persisted_log.read_text(encoding="utf-8")
+
+    assert persisted_log.exists()
+    assert "git-dev@scidsg.org" not in persisted_text
+    assert "hello@example.com" not in persisted_text
+    assert "/Users/scidsg" not in persisted_text
+    assert "Runner Codex config: [redacted]" in persisted_text
+    assert "Configured git identity: [redacted]" in persisted_text
+    assert "Run log file: [redacted]" in persisted_text
+    assert "Global log file: [redacted]" in persisted_text
+    assert "workdir: [redacted]" in persisted_text
+    assert "model: [redacted]" in persisted_text
+    assert "provider: [redacted]" in persisted_text
+    assert "approval: [redacted]" in persisted_text
+    assert "sandbox: [redacted]" in persisted_text
+    assert "reasoning effort: [redacted]" in persisted_text
+    assert "reasoning summaries: [redacted]" in persisted_text
+    assert "session id: [redacted]" in persisted_text
+    assert "Home path: [redacted-path]" in persisted_text
+    assert "Email: [redacted-email]" in persisted_text
+
+
 def test_verbose_codex_output_streams_to_console_only(tmp_path: Path) -> None:
     prompt_file = tmp_path / "prompt.txt"
     output_file = tmp_path / "codex-output.txt"


### PR DESCRIPTION
## Summary

- sanitize persisted daily runner logs before they are written into `docs/agent-logs/`
- redact developer filesystem paths, email addresses, git identity lines, and Codex session metadata from future committed logs
- backfill the same sanitizer across the currently tracked historical runner logs so the repository head no longer exposes the previously committed metadata
- document the sanitization step and add regression coverage around `persist_run_log` redaction behavior

## Why

- tracked runner logs were committing developer and environment metadata such as absolute workstation paths, git identity emails, and Codex session details
- this change removes that information from both new and existing tracked log artifacts while preserving the runner log workflow itself

## Risk summary

- affected path: `scripts/agent_daily_issue_runner.sh` persisted logs under `docs/agent-logs/`
- prior risk: repository readers could see operator path/email/session metadata from committed runner logs
- mitigation: deterministic sanitizer applied at persist time, plus one-time cleanup of the tracked historical logs

## Validation

- `make lint`
- `make test TESTS="tests/test_agent_daily_issue_runner.py"`
- targeted `rg` scan confirmed no remaining raw `/Users/scidsg`, `git-dev@scidsg.org`, or unsanitized session-id/path lines in `docs/agent-logs`

## Manual testing

- Not applicable; the log persistence and redaction path is covered by automated tests

## Known risks / follow-up

- This PR rewrites the tracked runner log artifacts in `docs/agent-logs/`, so the diff is large even though the rule set is narrow and mechanical
- I did not run the full `make test` suite for this runner/logging change

Refs 9335f3dc74088191a737a12c4fec3c47
