### PR TITLE
Withhold failed check output from Codex prompts

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -30,7 +30,8 @@ This runner runs directly in the local repo and now executes the full local CI-e
 10. Create/update issue branch `codex/daily-issue-<issue_number>` from `main`.
 11. Run a bounded Codex issue loop until repository changes exist (max attempts configurable via `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS`, default `10`).
     - The issue/fix prompts tell Codex to avoid local container-backed make validation by default, and to defer validation entirely to the runner when schema-affecting files are touched (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`).
-    - The fix prompt also includes the current branch diff summary, the prior Codex summary, and an extracted failure signature so Codex can repair the current implementation instead of repeating a narrow patch against the same failing symptom.
+    - The fix prompt includes the current branch diff summary, the prior Codex summary, and an extracted failure signature so Codex can repair the current implementation instead of repeating a narrow patch against the same failing symptom.
+    - Raw failed check output is intentionally withheld from Codex prompts because local check logs may contain sensitive operational data.
     - Codex transcript output is captured in a temporary file for the duration of the run and is excluded from the persisted runner log; only the final Codex summary is written into the run log.
 12. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
     - Before lint/test validation, if the working tree includes schema-affecting changes (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), rebuild the local runtime and reseed dev data so the live stack matches the current code.

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -945,10 +945,33 @@ current_change_summary() {
 
 failure_signature_from_text() {
   local text="$1"
+  local -a markers=()
 
-  {
-    printf '%s\n' "$text" | grep -E 'FAILED tests/|AssertionError:|sqlalchemy\.exc\.|psycopg\.errors\.|Traceback|Error:' || true
-  } | head -n 20
+  if printf '%s\n' "$text" | grep -Eq 'FAILED tests/'; then
+    markers+=("pytest-test-failures")
+  fi
+  if printf '%s\n' "$text" | grep -Eq 'AssertionError:'; then
+    markers+=("assertion-error")
+  fi
+  if printf '%s\n' "$text" | grep -Eq 'sqlalchemy\.exc\.'; then
+    markers+=("sqlalchemy-error")
+  fi
+  if printf '%s\n' "$text" | grep -Eq 'psycopg\.errors\.'; then
+    markers+=("psycopg-error")
+  fi
+  if printf '%s\n' "$text" | grep -Eq 'Traceback'; then
+    markers+=("python-traceback")
+  fi
+  if printf '%s\n' "$text" | grep -Eq '(^|[^[:alpha:]])Error:'; then
+    markers+=("generic-error")
+  fi
+
+  if (( ${#markers[@]} == 0 )); then
+    echo "no-structured-signature"
+    return 0
+  fi
+
+  printf '%s\n' "${markers[@]}"
 }
 
 build_issue_prompt() {
@@ -994,11 +1017,10 @@ build_fix_prompt() {
   local issue_number="$1"
   local issue_title="$2"
   local branch_name="$3"
-  local failure_tail="$4"
-  local change_summary="$5"
-  local previous_codex_output="$6"
-  local failure_signature="$7"
-  local repeated_failure_count="$8"
+  local change_summary="$4"
+  local previous_codex_output="$5"
+  local failure_signature="$6"
+  local repeated_failure_count="$7"
 
   {
     cat <<EOF2
@@ -1039,12 +1061,8 @@ EOF2
     fi
     cat <<'EOF2'
 
-Most recent failed check output:
----BEGIN CHECK OUTPUT---
-EOF2
-    printf '%s\n' "$failure_tail"
-    cat <<'EOF2'
----END CHECK OUTPUT---
+Raw failed check output is intentionally withheld because local logs may contain sensitive data.
+Use the failure signature above together with the current repository state to identify and resolve the failing checks.
 
 Requirements:
 1) Fix only what is required for checks to pass.
@@ -1094,7 +1112,6 @@ run_fix_attempt_loop() {
       "$issue_number" \
       "$issue_title" \
       "$branch_name" \
-      "$FAILURE_LOG_TAIL" \
       "$(current_change_summary)" \
       "$(sed -n '1,80p' "$CODEX_OUTPUT_FILE")" \
       "$FAILURE_SIGNATURE" \

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -224,6 +224,60 @@ require_positive_integer "HUSHLINE_DAILY_MAX_FIX_ATTEMPTS" "0"
     assert "HUSHLINE_DAILY_MAX_FIX_ATTEMPTS must be a positive integer" in result.stderr
 
 
+def test_failure_signature_from_text_returns_structured_markers() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+failure_text=$'FAILED tests/test_example.py\\nAssertionError:\\nTraceback\\nError: boom'
+failure_signature_from_text "$failure_text"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "pytest-test-failures",
+        "assertion-error",
+        "python-traceback",
+        "generic-error",
+    ]
+
+
+def test_failure_signature_from_text_falls_back_when_no_marker_matches() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+failure_signature_from_text "totally unmatched output"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "no-structured-signature\n"
+
+
+def test_build_fix_prompt_withholds_raw_check_output(tmp_path: Path) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+PROMPT_FILE={shlex.quote(str(prompt_file))}
+build_fix_prompt \
+  1558 \
+  "Issue title" \
+  "branch-name" \
+  "status summary" \
+  "prior codex output" \
+  "generic-error" \
+  "2"
+cat "$PROMPT_FILE"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Raw failed check output is intentionally withheld" in result.stdout
+    assert "---BEGIN CHECK OUTPUT---" not in result.stdout
+    assert "generic-error" in result.stdout
+
+
 def test_issue_attempt_loop_stops_after_max_attempts() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}


### PR DESCRIPTION
## Summary

- stop embedding raw failed check output into the daily agent runner self-heal prompt sent to Codex
- replace raw log-line signatures with coarse structured failure markers such as `pytest-test-failures`, `python-traceback`, and `generic-error`
- document that raw failed check output is intentionally withheld from Codex prompts and add regression tests around the new behavior

## Why

- the active runner was tailing local lint/test/audit logs and injecting that raw output into the fix prompt, which could send sensitive local check output off-box during self-heal retries
- this change preserves enough signal for Codex to react to failures without transmitting raw logs

## Scope note

- the finding referenced `scripts/codex_daily_issue_runner.sh` and `scripts/codex_coverage_gap_runner.sh`, but those files are not present on current `main`
- the live leak path on current `main` was `scripts/agent_daily_issue_runner.sh`, and this PR fixes that active path

## Risk summary

- affected path: self-heal prompt construction in `scripts/agent_daily_issue_runner.sh`
- prior risk: raw failed check logs could be sent to Codex during retry loops
- mitigation: only structured failure markers and local repository context are included in the prompt

## Validation

- `make lint`
- `make test TESTS="tests/test_agent_daily_issue_runner.py"`

## Manual testing

- Not applicable; the prompt-building behavior is covered by automated tests

## Known risks / follow-up

- I did not run the full `make test` suite for this runner-focused change

Refs ae89c428c56081918052fd9382cf025b
