### PR TITLE
Handle invalid email headers export input

### DIFF
--- a/hushline/routes/email_headers.py
+++ b/hushline/routes/email_headers.py
@@ -56,7 +56,15 @@ def register_email_headers_routes(app: Flask) -> None:
             flash("⛔️ Could not generate report. Re-run validation first.")
             return redirect(url_for("email_headers"))
 
-        archive = create_evidence_zip(form.raw_headers.data)
+        try:
+            archive = create_evidence_zip(form.raw_headers.data)
+        except ValueError as e:
+            msg = str(e)
+            if not msg.endswith((".", "!", "?")):
+                msg += "."
+            flash(f"⛔️ {msg}")
+            return redirect(url_for("email_headers"))
+
         stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%SZ")
         return send_file(
             io.BytesIO(archive),

--- a/tests/test_email_headers.py
+++ b/tests/test_email_headers.py
@@ -322,6 +322,23 @@ def test_email_headers_export_invalid_form_redirects_with_flash(client: FlaskCli
     assert "Could not generate report. Re-run validation first." in response.text
 
 
+@pytest.mark.usefixtures("_authenticated_user")
+def test_email_headers_export_value_error_redirects_with_flash(
+    client: FlaskClient, mocker: MockFixture
+) -> None:
+    mocker.patch(
+        "hushline.routes.email_headers.create_evidence_zip",
+        side_effect=ValueError("No email headers detected. Paste the raw headers and try again."),
+    )
+    response = client.post(
+        url_for("email_headers_evidence_zip"),
+        data={"raw_headers": "foo"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "No email headers detected. Paste the raw headers and try again." in response.text
+
+
 def test_parse_tag_value_pairs_ignores_invalid_parts_and_empty_keys() -> None:
     tags = email_headers._parse_tag_value_pairs("no-equals; =blank; s=selector1; d=example.org")
     assert tags == {"s": "selector1", "d": "example.org"}


### PR DESCRIPTION
## Summary

- catch `ValueError` from `create_evidence_zip()` in the `/email-headers/evidence.zip` route and redirect back with the same user-facing flash pattern used by the analyzer page
- add a regression test proving invalid non-header input no longer 500s the export endpoint

## Why

- the export form only validates presence/length, so non-header text could still reach `create_evidence_zip()` and trigger the `ValueError` raised by `analyze_raw_email_headers()`
- without route-level handling, authenticated users got a 500 instead of a validation message

## Risk summary

- affected path: authenticated email-header export endpoint `/email-headers/evidence.zip`
- prior risk: invalid input caused an unhandled exception and 500 response
- mitigation: route now converts that `ValueError` into a flash + redirect and test coverage locks the behavior in

## Validation

- `make lint`
- `make test TESTS="tests/test_email_headers.py"`

## Manual testing

- Not applicable; covered by automated route tests

## Known risks / follow-up

- I reran the above validations successfully in the primary worktree before opening this PR
- A fresh temporary worktree for this PR could not reuse Docker-backed checks because localhost ports were already occupied by the existing local stack; I cleaned up the temp worktree containers and proceeded with the already-passing primary-worktree validation
- I did not run the full `make test` suite

Refs 2a94ecee5e2081919df97320b5962420
