### PR TITLE
Restore onboarding JavaScript bundle

### DIFF
--- a/assets/js/onboarding.js
+++ b/assets/js/onboarding.js
@@ -1,0 +1,15 @@
+document.addEventListener("DOMContentLoaded", function () {
+  const bio = document.getElementById("bio");
+  const bioCountEl = document.querySelector(".bio-count");
+
+  if (!bio || !bioCountEl) {
+    return;
+  }
+
+  const updateCount = () => {
+    bioCountEl.textContent = String(bio.value.length);
+  };
+
+  updateCount();
+  bio.addEventListener("input", updateCount);
+});

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -555,3 +555,9 @@ def test_onboarding_skip_redirects_to_select_tier_when_enabled(
     response = client.post(url_for("onboarding_skip"), follow_redirects=False)
     assert response.status_code == 302
     assert response.headers["Location"].endswith(url_for("premium.select_tier"))
+
+
+def test_webpack_build_includes_onboarding_bundle() -> None:
+    webpack_config = Path("webpack.config.js").read_text(encoding="utf-8")
+
+    assert '"onboarding"' in webpack_config

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ modules = [
   "mailvelope",
   "message",
   "message_success",
+  "onboarding",
   "premium",
   "premium-waiting",
   "service-worker",


### PR DESCRIPTION
## Summary

- restore the missing `assets/js/onboarding.js` bundle used by the onboarding template bio character counter
- add `onboarding` back to the webpack entry list so production builds emit `hushline/static/js/onboarding.js` again
- add a regression test that locks the onboarding bundle entry into the webpack config

## Why

- `hushline/templates/onboarding.html` still loads `/static/js/onboarding.js`, but the source file and webpack entry had been removed
- on a clean asset build that meant the script 404ed and the onboarding bio count UI stopped updating

## Validation

- `make lint`
- `make test TESTS="tests/test_onboarding.py"`
- `npm run build:prod`
- verified `hushline/static/js/onboarding.js` is emitted after the production build

## Manual testing

- Not applicable; covered by automated tests plus a production asset build

## Known risks / follow-up

- I did not run the full `make test` suite

Refs 50ea64c98d708191be71fb409de2d437
