### PR TITLE
Require full PGP armor for email body notifications

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -1,3 +1,4 @@
+import re
 import secrets
 
 from flask import (
@@ -35,7 +36,15 @@ from hushline.safe_template import safe_render_template
 
 def register_profile_routes(app: Flask) -> None:
     def _is_armored_pgp_message(value: str) -> bool:
-        return "-----BEGIN PGP MESSAGE-----" in value and "-----END PGP MESSAGE-----" in value
+        stripped_value = value.strip()
+        return bool(
+            re.fullmatch(
+                r"-----BEGIN PGP MESSAGE-----\r?\n"
+                r"(?:[!-~]+: .*\r?\n)*\r?\n?[\s\S]*\r?\n"
+                r"-----END PGP MESSAGE-----",
+                stripped_value,
+            )
+        )
 
     def _get_math_problem(force_new: bool = False) -> str:
         if not force_new and session.get("math_problem") and session.get("math_answer"):

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -206,6 +206,51 @@ def test_notifications_enabled_yes_content_yes_encrypted_body(
 @pytest.mark.usefixtures("_pgp_user")
 @patch("hushline.routes.profile.encrypt_message")
 @patch("hushline.routes.profile.do_send_email")
+def test_notifications_full_body_encryption_embedded_markers_use_server_fallback(
+    mock_do_send_email: MagicMock,
+    mock_encrypt_message: MagicMock,
+    client: FlaskClient,
+    user: User,
+) -> None:
+    user.enable_email_notifications = True
+    user.email_include_message_content = True
+    user.email_encrypt_entire_body = True
+    db.session.commit()
+
+    encrypted_email_body = (
+        "prefix text\n-----BEGIN PGP MESSAGE-----\nnot actually armored\n"
+        "-----END PGP MESSAGE-----\nsuffix text"
+    )
+    server_encrypted_email_body = (
+        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
+    )
+    mock_encrypt_message.return_value = server_encrypted_email_body
+
+    response = client.post(
+        url_for("profile", username=user.primary_username.username),
+        data={
+            "encrypted_email_body": encrypted_email_body,
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            "username_user_id": user.id,
+            "captcha_answer": get_captcha_from_session(client, user.primary_username.username),
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200, response.text
+    assert "Message submitted successfully." in response.text
+
+    expected_fallback_body = format_full_message_email_body(
+        [("Contact Method", msg_contact_method), ("Message", msg_content)]
+    )
+    mock_encrypt_message.assert_called_once_with(expected_fallback_body, user.pgp_key)
+    mock_do_send_email.assert_called_once_with(user, server_encrypted_email_body)
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+@pytest.mark.usefixtures("_pgp_user")
+@patch("hushline.routes.profile.encrypt_message")
+@patch("hushline.routes.profile.do_send_email")
 def test_notifications_full_body_encryption_server_fallback(
     mock_do_send_email: MagicMock,
     mock_encrypt_message: MagicMock,


### PR DESCRIPTION
## Summary
- require the submitted `encrypted_email_body` to match a whole armored PGP message block before trusting it as already-encrypted email content
- preserve the existing server-side fallback encryption path when the client payload is missing or malformed
- add a regression test proving embedded PGP markers inside plaintext do not bypass fallback encryption

## Why
The previous substring check accepted plaintext containing `BEGIN/END PGP MESSAGE` markers anywhere in the hidden field. In the full-body notification path, that let malformed client input bypass server-side encryption and be sent as-is over email.

## Risk Summary
- Threat: attacker-controlled message submissions could smuggle plaintext through the full-body email notification path
- Affected data path: `/to/<username>` submission -> `encrypted_email_body` hidden field -> notification email body
- Mitigation: only accept a complete armored PGP message block; otherwise encrypt the formatted body server-side

## Validation
- `make lint`
- `make test TESTS="tests/test_notifications.py"`
- `make test`

## Manual Testing
- Not applicable; covered by automated route and notification tests

## Known Risks / Follow-ups
- This change tightens only the full-body notification path in `profile`; other routes were not changed because they were out of scope for this finding
