### PR TITLE
Add regression test for onboarding directory opt-out

### DIFF
--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -122,6 +122,34 @@ def test_onboarding_directory_opt_out_persists_false(client: FlaskClient, user: 
 
 
 @pytest.mark.usefixtures("_authenticated_user")
+def test_onboarding_directory_opt_out_overrides_prepopulated_true(
+    client: FlaskClient, user: User
+) -> None:
+    user.onboarding_complete = False
+    user.primary_username.display_name = "Test User"
+    user.primary_username.bio = "Short bio"
+    user.primary_username.show_in_directory = True
+    user.pgp_key = _load_test_pgp_key()
+    user.enable_email_notifications = True
+    user.email_include_message_content = True
+    user.email_encrypt_entire_body = True
+    user.email = "test@example.com"
+    db.session.commit()
+
+    response = client.post(
+        url_for("onboarding"),
+        data={"step": "directory"},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(url_for("inbox"))
+
+    db.session.refresh(user)
+    assert user.onboarding_complete is True
+    assert user.primary_username.show_in_directory is False
+
+
+@pytest.mark.usefixtures("_authenticated_user")
 def test_onboarding_skip(client: FlaskClient, user: User) -> None:
     user.onboarding_complete = False
     db.session.commit()


### PR DESCRIPTION
## Summary
- add an onboarding regression test that starts from `show_in_directory=True` and submits the directory step with the checkbox omitted
- verify the route still persists `False` and completes onboarding, despite the form's default and prepopulated `True`

## Why
This finding appears to be a false positive. WTForms treats an omitted checkbox as unchecked when form data is present, so the onboarding opt-out path already works. The new test locks that behavior in so the route semantics stay explicit and future changes cannot accidentally reintroduce the issue.

## Risk Summary
- Threat reviewed: unintended public directory exposure during onboarding
- Affected data path: `/onboarding` directory step -> `OnboardingDirectoryForm.show_in_directory` -> `Username.show_in_directory`
- Result: current runtime behavior is correct; mitigation here is regression coverage proving unchecked submissions persist `False`

## Validation
- `make lint`
- `make test TESTS="tests/test_onboarding.py"`
- `make test`

## Manual Testing
- Not applicable; covered by automated onboarding route tests

## Known Risks / Follow-ups
- No production code changed because the reported behavior could not be reproduced in the current route implementation
