### PR TITLE
Prevent resend message PGP substring bypass

### DIFF
--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -1,3 +1,4 @@
+import re
 from datetime import UTC, datetime
 
 from flask import (
@@ -23,6 +24,16 @@ from hushline.model import (
     Username,
 )
 from hushline.routes.common import do_send_email
+
+_ARMORED_PGP_MESSAGE_PATTERN = re.compile(
+    r"^\s*-----BEGIN PGP MESSAGE-----\r?\n"
+    r"(?:[!-~]+: .*\r?\n)*\r?\n?[\s\S]*\r?\n"
+    r"-----END PGP MESSAGE-----\s*$"
+)
+
+
+def _is_armored_pgp_message(value: str) -> bool:
+    return bool(_ARMORED_PGP_MESSAGE_PATTERN.fullmatch(value))
 
 
 def register_message_routes(app: Flask) -> None:
@@ -117,7 +128,7 @@ def register_message_routes(app: Flask) -> None:
                 if not value:
                     continue
                 if user.email_encrypt_entire_body:
-                    if "-----BEGIN PGP MESSAGE-----" in value:
+                    if _is_armored_pgp_message(value):
                         email_body = value
                     else:
                         try:

--- a/tests/test_resend_message.py
+++ b/tests/test_resend_message.py
@@ -231,6 +231,57 @@ def test_resend_message_full_body_uses_existing_armored_value_without_reencrypti
 @pytest.mark.usefixtures("_authenticated_user")
 @pytest.mark.usefixtures("_pgp_user")
 @patch("hushline.routes.message.encrypt_message")
+def test_resend_message_full_body_encrypts_value_with_embedded_pgp_header_substring(
+    mock_encrypt_message: MagicMock,
+    client: FlaskClient,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.enable_email_notifications = True
+    user.email_include_message_content = True
+    user.email_encrypt_entire_body = True
+    user.email = "test@example.com"
+    db.session.commit()
+
+    message = Message(username_id=user.primary_username.id)
+    db.session.add(message)
+    db.session.flush()
+
+    plaintext_value = "Hello -----BEGIN PGP MESSAGE----- world"
+    encrypted_value = (
+        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted resend\n\n-----END PGP MESSAGE-----"
+    )
+    mock_encrypt_message.return_value = encrypted_value
+
+    field_def = user.primary_username.message_fields[0]
+    field_def.encrypted = False
+    db.session.add(FieldValue(field_def, message, plaintext_value, field_def.encrypted))
+    db.session.commit()
+
+    sent: list[tuple[int, str]] = []
+
+    def fake_send_email(sent_user: User, body: str) -> None:
+        sent.append((sent_user.id, body))
+
+    monkeypatch.setattr("hushline.routes.message.do_send_email", fake_send_email)
+
+    csrf_token = _csrf_token_from_message_page(client, message.public_id)
+    post_data = {"csrf_token": csrf_token} if csrf_token else {}
+    response = client.post(
+        url_for("resend_message", public_id=message.public_id),
+        data=post_data,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Message resent to your email inbox" in response.text
+    mock_encrypt_message.assert_called_once_with(plaintext_value, user.pgp_key)
+    assert sent == [(user.id, encrypted_value)]
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+@pytest.mark.usefixtures("_pgp_user")
+@patch("hushline.routes.message.encrypt_message")
 def test_resend_message_full_body_encrypts_plaintext_value(
     mock_encrypt_message: MagicMock,
     client: FlaskClient,


### PR DESCRIPTION
## Summary
- replace the resend path's `-----BEGIN PGP MESSAGE-----` substring heuristic with a full armored-message check
- keep truly armored resend payloads unmodified while forcing plaintext values with embedded markers back through server-side encryption
- add a regression test proving embedded marker text no longer bypasses resend encryption

## Why
`/message/<public_id>/resend` was treating any field value containing the PGP header substring as already encrypted. A submitter could include that marker in plaintext, and a recipient using full-body encrypted email resend would then send the raw content to SMTP unchanged.

## Risk Summary
- threat: resend-to-email could skip PGP encryption on attacker-controlled plaintext
- affected data path: authenticated resend flow at `/message/<public_id>/resend` when `email_include_message_content` and `email_encrypt_entire_body` are enabled
- impact: message content could be resent in plaintext to SMTP/email providers despite the recipient's encryption preference

## Mitigation
- add a strict armored PGP message matcher in the resend route
- only reuse field values that match a whole armored message block
- otherwise re-encrypt the field value server-side or fall back to the generic body on encryption failure

## Tests
- preserve the existing armored resend no-reencryption case
- add a regression proving embedded header substrings still trigger `encrypt_message`

## Validation
- `make lint`
- `make test TESTS="tests/test_resend_message.py"`
- `make test`

## Manual Testing
- Not applicable; covered by automated resend route tests and the full project suite.

## Risks / Follow-up
- low risk; the change is isolated to resend encryption detection and aligns resend behavior with the stricter armored-message validation already used in the profile submission path
