### PR TITLE
Pin actionlint installation in workflow security checks

### DIFF
--- a/.github/workflows/workflow-security.yml
+++ b/.github/workflows/workflow-security.yml
@@ -21,8 +21,10 @@ jobs:
       - name: install actionlint
         run: |
           set -euo pipefail
-          curl -sSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash | bash
-          echo "$PWD" >> "$GITHUB_PATH"
+          export GOBIN="$RUNNER_TEMP/actionlint-bin"
+          mkdir -p "$GOBIN"
+          go install github.com/rhysd/actionlint/cmd/actionlint@v1.7.7
+          echo "$GOBIN" >> "$GITHUB_PATH"
 
       - name: run actionlint
         run: actionlint -color


### PR DESCRIPTION
## Summary
- replace the workflow-security job's `curl | bash` installer with a version-pinned `go install` for `actionlint`
- install the binary into a temporary runner-local bin directory and add only that directory to `PATH`
- keep the existing actionlint invocation and workflow-security behavior unchanged otherwise

## Why
The workflow was downloading and executing `https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash` directly from a mutable branch. That introduced an unnecessary CI supply-chain risk because upstream script compromise would run attacker-controlled code on the GitHub Actions runner.

## Risk Summary
- threat: mutable remote installer script executed in CI
- affected data path: `.github/workflows/workflow-security.yml` actionlint job on `pull_request` and `push`
- impact: upstream compromise could execute arbitrary code in the workflow-security job

## Mitigation
- remove the `curl | bash` installer entirely
- pin the `actionlint` tool install to `github.com/rhysd/actionlint/cmd/actionlint@v1.7.7`
- write the binary into `$RUNNER_TEMP/actionlint-bin` and add that directory to `PATH`

## Validation
- `make workflow-security-checks`
- `make lint`
- `make test`

## Manual Testing
- Not applicable; this change only affects CI workflow setup and was validated with the local workflow-security checks plus the full test suite.

## Risks / Follow-up
- low risk; the change is isolated to the CI installer path and does not alter application runtime behavior
