### PR TITLE
Fix SecureDrop refresh summary output handling

### DIFF
--- a/.github/workflows/securedrop-directory-refresh.yml
+++ b/.github/workflows/securedrop-directory-refresh.yml
@@ -30,21 +30,23 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          delimiter="SECUREDROP_SUMMARY_$(date +%s)"
+
           if [ -f /tmp/securedrop-refresh.md ]; then
             {
-              echo "body<<'EOF'"
+              echo "body<<${delimiter}"
               cat /tmp/securedrop-refresh.md
-              echo "EOF"
+              echo "${delimiter}"
             } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           {
-            echo "body<<'EOF'"
+            echo "body<<${delimiter}"
             echo "## SecureDrop Directory Refresh Summary"
             echo
             echo "- Refresh completed."
-            echo "EOF"
+            echo "${delimiter}"
           } >> "$GITHUB_OUTPUT"
 
       - name: Create or update refresh PR


### PR DESCRIPTION
## Summary
- fix the SecureDrop directory refresh workflow's multiline `GITHUB_OUTPUT` formatting
- replace the invalid quoted heredoc delimiter with a unique unquoted delimiter that GitHub Actions can parse
- leave the refresh logic and PR creation flow unchanged otherwise

## Why
The `Read refresh summary` step was writing `body<<'EOF'` to `$GITHUB_OUTPUT`. GitHub's file-command parser treated that delimiter literally and failed with `Matching delimiter not found ''EOF''`, which broke the scheduled SecureDrop refresh before PR creation.

## Risk Summary
- threat: scheduled SecureDrop refresh workflow fails before opening its update PR
- affected path: `.github/workflows/securedrop-directory-refresh.yml` summary output step
- impact: automation outage for SecureDrop directory refreshes

## Mitigation
- use a unique runtime delimiter
- emit `body<<${delimiter}` / `${delimiter}` in the format GitHub Actions expects for multiline step outputs

## Validation
- `make workflow-security-checks`
- inspected failing run `22824753487` and confirmed the parser error source in the `Read refresh summary` step

## Manual Testing
- Not applicable; this is a workflow file-command formatting fix.

## Risks / Follow-up
- low risk; scoped to one workflow step and does not change refresh data generation
