### PR TITLE
Fix workflow test for direct screenshot archive publishing

### DIFF
--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -22,12 +22,6 @@ def test_cross_repo_auto_merge_workflows_use_owner_qualified_pr_heads() -> None:
             2,
         ),
         (
-            ".github/workflows/publish-docs-screenshots.yml",
-            'screenshots_owner="${SCREENSHOTS_REPOSITORY%%/*}"',
-            '--head "${screenshots_owner}:${SCREENSHOTS_BRANCH}"',
-            2,
-        ),
-        (
             ".github/workflows/bump-staging-after-release.yml",
             'infra_owner="${INFRA_REPOSITORY%%/*}"',
             '--head "${infra_owner}:${INFRA_BRANCH}"',
@@ -46,3 +40,16 @@ def test_cross_repo_auto_merge_workflows_use_owner_qualified_pr_heads() -> None:
 
         assert owner_assignment in workflow_text
         assert workflow_text.count(head_filter) == expected_count
+
+
+def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> None:
+    workflow_text = _workflow_text(".github/workflows/publish-docs-screenshots.yml")
+    archive_section = workflow_text.split('      - name: Publish screenshots to hushline-screenshots', 1)[1]
+
+    assert 'SCREENSHOTS_DEFAULT_BRANCH: main' in archive_section
+    assert 'git checkout -B "${SCREENSHOTS_DEFAULT_BRANCH}" "origin/${SCREENSHOTS_DEFAULT_BRANCH}"' in archive_section
+    assert 'git push origin "HEAD:${SCREENSHOTS_DEFAULT_BRANCH}"' in archive_section
+    assert "Published screenshot archive directly to ${SCREENSHOTS_REPOSITORY}@${SCREENSHOTS_DEFAULT_BRANCH}." in archive_section
+    assert 'screenshots_owner="${SCREENSHOTS_REPOSITORY%%/*}"' not in archive_section
+    assert 'gh pr create \\' not in archive_section
+    assert 'gh pr merge "$pr_url" \\' not in archive_section


### PR DESCRIPTION
## What changed
Updated the workflow regression test to match the new direct-publish behavior for `scidsg/hushline-screenshots`.

The old test still expected the removed archive PR flow variables and owner-qualified PR head logic, which caused both `test` and `test-with-alembic` to fail after `#1581` merged.

## Why
`#1581` intentionally removed the archive repo PR path and switched that half of the workflow to direct publish on `main`. The test needed to be narrowed so it still checks owner-qualified PR heads for PR-based workflows while separately asserting that the screenshots archive section has no PR flow.

## Validation
- `make workflow-security-checks`
- `docker compose run --rm --no-deps app poetry run pytest tests/test_workflow_pr_head_qualification.py -q`

## Manual testing
- Not applicable; workflow test-only change.

## Known issue
- Full local `make test` in the temporary post-merge worktree was blocked before pytest by a `dev_data` seeding/Docker networking issue (`postgres` hostname resolution) unrelated to this regression. The actual GitHub failure was the single stale workflow test fixed here.