### PR TITLE
Clarify SecureDrop Tor Browser copy

### DIFF
--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -237,8 +237,10 @@
       <p class="meta dirMeta">
         🛡️ Synced automatically from the
         <a href="https://securedrop.org/api/v1/directory/?format=json" target="_blank" rel="noopener noreferrer"
-          >SecureDrop directory API</a
-        >.
+          >SecureDrop directory API</a>. Onion addresses require 
+        <a href="https://www.torproject.org/download/" target="_blank" rel="noopener noreferrer">
+          Tor Browser
+        </a> to access.
       </p>
 
       {% if securedrop_listings %}

--- a/hushline/templates/directory_securedrop.html
+++ b/hushline/templates/directory_securedrop.html
@@ -12,6 +12,14 @@
 
   <p class="bio">{{ listing.description }}</p>
 
+  <p class="meta dirMeta">
+    🧅 Onion addresses require 
+    <a href="https://www.torproject.org/download/" target="_blank" rel="noopener noreferrer">
+      Tor Browser
+    </a> to access, which may carry risk in your jurisdiction.
+    Do your research before downloading.
+  </p>
+
   <div class="extra-fields">
     <p class="extra-field">
       <span class="extra-field-label">Website</span>

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -89,13 +89,18 @@ def test_directory_securedrop_banner_links_to_api(client: FlaskClient) -> None:
     securedrop_panel = soup.find(id="securedrop")
     assert securedrop_panel is not None
 
-    banner_link = securedrop_panel.select_one(".dirMeta a")
-    assert banner_link is not None
-    assert banner_link.text.strip() == "SecureDrop directory API"
-    assert banner_link.get("href") == "https://securedrop.org/api/v1/directory/?format=json"
+    banner_links = securedrop_panel.select(".dirMeta a")
+    assert len(banner_links) == 2
+    assert banner_links[0].text.strip() == "SecureDrop directory API"
+    assert banner_links[0].get("href") == "https://securedrop.org/api/v1/directory/?format=json"
+    assert banner_links[1].text.strip() == "Tor Browser"
+    assert banner_links[1].get("href") == "https://www.torproject.org/download/"
     banner_text = securedrop_panel.get_text(" ", strip=True)
     assert "Synced automatically from the" in banner_text
     assert "SecureDrop directory API" in banner_text
+    assert "Onion addresses require" in banner_text
+    assert "Tor Browser" in banner_text
+    assert "to access." in banner_text
 
 
 def test_directory_hides_tab_bar_when_verified_tabs_disabled(client: FlaskClient) -> None:
@@ -512,6 +517,20 @@ def test_securedrop_listing_page_is_read_only(client: FlaskClient) -> None:
     assert listing.source_url in response.text
     assert 'id="messageForm"' not in response.text
     assert "Send Message" not in response.text
+
+    dir_meta = soup.select_one(".dirMeta")
+    assert dir_meta is not None
+    dir_meta_text = dir_meta.get_text(" ", strip=True)
+    assert dir_meta_text.startswith("🧅")
+    assert "Onion addresses require" in dir_meta_text
+    assert "Tor Browser" in dir_meta_text
+    assert "risk in your jurisdiction" in dir_meta_text
+    assert "Do your research before downloading." in dir_meta_text
+
+    dir_meta_link = dir_meta.find("a")
+    assert dir_meta_link is not None
+    assert dir_meta_link.text.strip() == "Tor Browser"
+    assert dir_meta_link.get("href") == "https://www.torproject.org/download/"
 
 
 def test_securedrop_listing_page_omits_landing_page_link_when_missing(


### PR DESCRIPTION
## What changed
- clarifies the SecureDrop tab banner that onion listings require Tor Browser
- adds matching dirMeta guidance on SecureDrop listing pages
- fixes the listing-page copy typo in that new guidance block
- updates directory tests to cover both the tab banner and listing-page metadata

## Why
- keeps the SecureDrop directory UX explicit about the Tor Browser requirement
- locks the new copy into tests so future edits do not silently drop the warning or link targets

## Validation
- make lint
- make test TESTS=tests/test_directory.py
- make test

## Manual testing
- not applicable; copy/template change covered by rendered-page tests

## Risks / follow-up
- low risk; copy-only template change plus matching test updates