### PR TITLE
Add GlobaLeaks directory tab and automated refresh

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ refresh-securedrop-listings: ## Refresh SecureDrop directory instance artifact
 
 .PHONY: refresh-globaleaks-listings
 refresh-globaleaks-listings: ## Refresh GlobaLeaks instance artifact from public source pages
-	$(CMD) poetry run ./scripts/refresh_globaleaks_directory_instances.py $(REFRESH_GLOBALEAKS_ARGS)
+	$(CMD) poetry run python ./scripts/refresh_globaleaks_directory_instances.py $(REFRESH_GLOBALEAKS_ARGS)
 
 .PHONY: audit-python
 audit-python: ## Run Python dependency audit (CI-equivalent)


### PR DESCRIPTION
## Summary
- add a read-only GlobaLeaks directory tab and listing pages alongside SecureDrop
- add a checked-in GlobaLeaks artifact model plus an automated refresh path that discovers live instances from GlobaLeaks public use-case pages
- add a scheduled workflow to refresh the GlobaLeaks artifact on a daily cron, matching the SecureDrop automation model
- exclude GlobaLeaks rows from the public-directory snapshot report so automated listings do not count as Hush Line users

## Why
- closes #1586
- expands the directory surface to include GlobaLeaks destinations without implying they are Hush Line-hosted
- keeps the dataset fresh through repository automation instead of an operator-managed import flow
- matches the SecureDrop pattern the project already uses for automated third-party directory refreshes

## What changed
- added `GlobaLeaks` directory rows, tab UI, listing template, JSON search payload support, and tests
- added `hushline/globaleaks_directory_refresh.py` to discover instance candidates from GlobaLeaks public use-case pages and preserve enriched checked-in metadata for known hosts
- replaced the earlier import-style refresh script with an automated refresh command in `scripts/refresh_globaleaks_directory_instances.py`
- added `make refresh-globaleaks-listings` and a new scheduled workflow at `.github/workflows/globaleaks-directory-refresh.yml`
- updated `docs/GLOBALEAKS-DIRECTORY-SYNC.md` to document the automated source and refresh model
- removed the `Shodan` badge path and removed Shodan-only rows from the checked-in GlobaLeaks seed
- fixed `scripts/public_directory_snapshot_report.py` so GlobaLeaks listings are excluded from public-user stats

## Validation
- `make workflow-security-checks`
- `make lint`
- `make test TESTS="tests/test_globaleaks_directory_refresh.py tests/test_directory.py"`
- `make test`

## Manual testing
- not applicable; covered by automated route/template, refresh, workflow, and stats tests in this branch

## Known risks / follow-up
- the automation currently discovers listings from GlobaLeaks public use-case pages, so coverage is bounded by what those pages link to
- if we later want a broader corpus than the public GlobaLeaks site exposes, that should be added as a separate, explicit source with its own review
