### PR TITLE
Format GlobaLeaks directory seed

### DIFF
--- a/hushline/data/globaleaks_instances.json
+++ b/hushline/data/globaleaks_instances.json
@@ -7,12 +7,8 @@
     "description": "Italy's Agency for Digital Italy operates a public whistleblowing channel on GlobaLeaks.",
     "submission_url": "https://whistleblowing.agid.gov.it/",
     "host": "whistleblowing.agid.gov.it",
-    "countries": [
-      "Italy"
-    ],
-    "languages": [
-      "Italian"
-    ],
+    "countries": ["Italy"],
+    "languages": ["Italian"],
     "source_label": "GlobaLeaks anti-corruption use case page",
     "source_url": "https://www.globaleaks.org/usecases/anti-corruption/"
   },
@@ -24,13 +20,8 @@
     "description": "Madagascar's anti-corruption agency BIANCO uses a GlobaLeaks-based online reporting platform for corruption complaints.",
     "submission_url": "https://doleances.bianco-mg.org/",
     "host": "doleances.bianco-mg.org",
-    "countries": [
-      "Madagascar"
-    ],
-    "languages": [
-      "French",
-      "Malagasy"
-    ],
+    "countries": ["Madagascar"],
+    "languages": ["French", "Malagasy"],
     "source_label": "GlobaLeaks anti-corruption use case page",
     "source_url": "https://www.globaleaks.org/usecases/anti-corruption/"
   },
@@ -42,12 +33,8 @@
     "description": "Denmark's data protection authority uses GlobaLeaks for whistleblower reporting.",
     "submission_url": "https://dt.sit-wb.dk/",
     "host": "dt.sit-wb.dk",
-    "countries": [
-      "Denmark"
-    ],
-    "languages": [
-      "Danish"
-    ],
+    "countries": ["Denmark"],
+    "languages": ["Danish"],
     "source_label": "GlobaLeaks anti-corruption use case page",
     "source_url": "https://www.globaleaks.org/usecases/anti-corruption/"
   },
@@ -59,12 +46,8 @@
     "description": "Germany's Federal Office of Justice runs a GlobaLeaks-backed external reporting channel.",
     "submission_url": "https://bfj-hinweisgeberstelle.dataport.de/",
     "host": "bfj-hinweisgeberstelle.dataport.de",
-    "countries": [
-      "Germany"
-    ],
-    "languages": [
-      "German"
-    ],
+    "countries": ["Germany"],
+    "languages": ["German"],
     "source_label": "GlobaLeaks anti-corruption use case page",
     "source_url": "https://www.globaleaks.org/usecases/anti-corruption/"
   },
@@ -76,12 +59,8 @@
     "description": "IndonesiaLeaks is a collaborative investigative journalism platform that uses GlobaLeaks for secure document submission.",
     "submission_url": "https://secure.leaks.id/",
     "host": "secure.leaks.id",
-    "countries": [
-      "Indonesia"
-    ],
-    "languages": [
-      "Indonesian"
-    ],
+    "countries": ["Indonesia"],
+    "languages": ["Indonesian"],
     "source_label": "GlobaLeaks investigative journalism use case page",
     "source_url": "https://www.globaleaks.org/usecases/investigative-journalism/"
   },
@@ -93,12 +72,8 @@
     "description": "MakaLeaks is an Angolan platform for reporting criminal or illegal activity through GlobaLeaks.",
     "submission_url": "https://www.makaleaks.org/",
     "host": "www.makaleaks.org",
-    "countries": [
-      "Angola"
-    ],
-    "languages": [
-      "Portuguese"
-    ],
+    "countries": ["Angola"],
+    "languages": ["Portuguese"],
     "source_label": "GlobaLeaks investigative journalism use case page",
     "source_url": "https://www.globaleaks.org/usecases/investigative-journalism/"
   },
@@ -123,12 +98,8 @@
     "description": "Italy's National Anticorruption Authority operates a GlobaLeaks-based whistleblowing portal.",
     "submission_url": "https://whistleblowing.anticorruzione.it/",
     "host": "whistleblowing.anticorruzione.it",
-    "countries": [
-      "Italy"
-    ],
-    "languages": [
-      "Italian"
-    ],
+    "countries": ["Italy"],
+    "languages": ["Italian"],
     "source_label": "GlobaLeaks anti-corruption use case page",
     "source_url": "https://www.globaleaks.org/usecases/anti-corruption/"
   },
@@ -140,12 +111,8 @@
     "description": "Italy's National Cybersecurity Agency uses GlobaLeaks for secure whistleblowing submissions.",
     "submission_url": "https://whistleblowing.acn.gov.it/",
     "host": "whistleblowing.acn.gov.it",
-    "countries": [
-      "Italy"
-    ],
-    "languages": [
-      "Italian"
-    ],
+    "countries": ["Italy"],
+    "languages": ["Italian"],
     "source_label": "GlobaLeaks anti-corruption use case page",
     "source_url": "https://www.globaleaks.org/usecases/anti-corruption/"
   },
@@ -157,12 +124,8 @@
     "description": "Greece's National Transparency Authority provides an external GlobaLeaks whistleblowing channel.",
     "submission_url": "https://extwhistle.aead.gr/",
     "host": "extwhistle.aead.gr",
-    "countries": [
-      "Greece"
-    ],
-    "languages": [
-      "Greek"
-    ],
+    "countries": ["Greece"],
+    "languages": ["Greek"],
     "source_label": "GlobaLeaks anti-corruption use case page",
     "source_url": "https://www.globaleaks.org/usecases/anti-corruption/"
   },
@@ -174,12 +137,8 @@
     "description": "PubLeaks is a Dutch multi-newsroom tip line built on GlobaLeaks for anonymous source submissions.",
     "submission_url": "https://secure.publeaks.nl/",
     "host": "secure.publeaks.nl",
-    "countries": [
-      "Netherlands"
-    ],
-    "languages": [
-      "Dutch"
-    ],
+    "countries": ["Netherlands"],
+    "languages": ["Dutch"],
     "source_label": "GlobaLeaks investigative journalism use case page",
     "source_url": "https://www.globaleaks.org/usecases/investigative-journalism/"
   },
@@ -204,12 +163,8 @@
     "description": "Le Monde's Sourcesure platform uses GlobaLeaks for secure investigative journalism submissions.",
     "submission_url": "https://ensecurite.sourcesure.eu/",
     "host": "ensecurite.sourcesure.eu",
-    "countries": [
-      "France"
-    ],
-    "languages": [
-      "French"
-    ],
+    "countries": ["France"],
+    "languages": ["French"],
     "source_label": "GlobaLeaks investigative journalism use case page",
     "source_url": "https://www.globaleaks.org/usecases/investigative-journalism/"
   },


### PR DESCRIPTION
## Summary
- rewrite `hushline/data/globaleaks_instances.json` with Prettier so `make lint` passes again on `main`

## Why
- the merged GlobaLeaks seed artifact is failing the Prettier portion of lint in CI
- this PR is intentionally formatting-only

## What changed
- ran Prettier write on `hushline/data/globaleaks_instances.json`

## Validation
- `docker compose run --rm --no-deps app sh -lc 'if [ -x node_modules/.bin/prettier ]; then node_modules/.bin/prettier --check hushline/data/globaleaks_instances.json; else prettier --check hushline/data/globaleaks_instances.json; fi'`

## Manual testing
- not applicable; formatting-only change

## Known risks / follow-up
- none
