### PR TITLE
Add correction copy to automated directory tabs

### DIFF
--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -252,6 +252,7 @@
     <div id="globaleaks" class="tab-content" role="tabpanel" aria-labelledby="globaleaks-tab">
       <p class="meta dirMeta">
         🧪 Beta: These listings are automated.
+        Contact the <a href="/to/admin">Hush Line admin</a> for any corrections.
         {% if globaleaks_has_onion_submission %}
           Onion addresses require
           <a href="https://www.torproject.org/download/" target="_blank" rel="noopener noreferrer">Tor Browser</a>
@@ -287,6 +288,7 @@
       <p class="meta dirMeta">
         🧪 Beta: These listings are automated and synced from the
         <a href="https://securedrop.org/api/v1/directory/?format=json" target="_blank" rel="noopener noreferrer">SecureDrop directory API</a>.
+        Contact the <a href="/to/admin">Hush Line admin</a> for any corrections.
         Onion addresses require
         <a href="https://www.torproject.org/download/" target="_blank" rel="noopener noreferrer">Tor Browser</a>
         to access.

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -134,21 +134,26 @@ def test_directory_securedrop_banner_links_to_api(client: FlaskClient) -> None:
     assert securedrop_panel is not None
 
     banner_links = securedrop_panel.select(".dirMeta a")
-    assert len(banner_links) == 2
-    assert banner_links[0].text.strip() == "SecureDrop directory API"
-    assert banner_links[0].get("href") == "https://securedrop.org/api/v1/directory/?format=json"
-    assert banner_links[1].text.strip() == "Tor Browser"
-    assert banner_links[1].get("href") == "https://www.torproject.org/download/"
+    links_by_text = {link.text.strip(): link.get("href") for link in banner_links}
+    assert (
+        links_by_text["SecureDrop directory API"]
+        == "https://securedrop.org/api/v1/directory/?format=json"
+    )
+    assert links_by_text["Hush Line admin"] == "/to/admin"
+    assert links_by_text["Tor Browser"] == "https://www.torproject.org/download/"
     banner_text = securedrop_panel.get_text(" ", strip=True)
     assert banner_text.startswith("🧪 Beta:")
     assert "These listings are automated and synced from the" in banner_text
     assert "SecureDrop directory API" in banner_text
+    assert "Contact the Hush Line admin for any corrections." in banner_text
     assert "Onion addresses require" in banner_text
     assert "Tor Browser" in banner_text
     assert "to access." in banner_text
 
 
-def test_directory_globaleaks_banner_matches_securedrop_style(client: FlaskClient) -> None:
+def test_directory_globaleaks_banner_omits_tor_when_no_listing_uses_onion(
+    client: FlaskClient,
+) -> None:
     response = client.get(url_for("directory"))
     assert response.status_code == 200
 
@@ -159,10 +164,13 @@ def test_directory_globaleaks_banner_matches_securedrop_style(client: FlaskClien
     banner = globaleaks_panel.select_one(".dirMeta")
     assert banner is not None
     banner_links = globaleaks_panel.select(".dirMeta a")
-    assert banner_links == []
+    links_by_text = {link.text.strip(): link.get("href") for link in banner_links}
+    assert links_by_text["Hush Line admin"] == "/to/admin"
+    assert "Tor Browser" not in links_by_text
     banner_text = " ".join(banner.get_text(" ", strip=True).split())
     assert banner_text.startswith("🧪 Beta:")
     assert "These listings are automated." in banner_text
+    assert "Contact the Hush Line admin for any corrections." in banner_text
     assert "Onion addresses require" not in banner_text
 
 
@@ -184,12 +192,13 @@ def test_directory_globaleaks_banner_mentions_tor_when_any_listing_uses_onion(
     banner = globaleaks_panel.select_one(".dirMeta")
     assert banner is not None
     banner_links = globaleaks_panel.select(".dirMeta a")
-    assert len(banner_links) == 1
-    assert banner_links[0].text.strip() == "Tor Browser"
-    assert banner_links[0].get("href") == "https://www.torproject.org/download/"
+    links_by_text = {link.text.strip(): link.get("href") for link in banner_links}
+    assert links_by_text["Hush Line admin"] == "/to/admin"
+    assert links_by_text["Tor Browser"] == "https://www.torproject.org/download/"
     banner_text = " ".join(banner.get_text(" ", strip=True).split())
     assert banner_text.startswith("🧪 Beta:")
     assert "These listings are automated." in banner_text
+    assert "Contact the Hush Line admin for any corrections." in banner_text
     assert "Onion addresses require" in banner_text
     assert "Tor Browser" in banner_text
     assert "to access." in banner_text


### PR DESCRIPTION
## What changed
- add "Contact the Hush Line admin for any corrections." to the GlobaLeaks and SecureDrop tab banners
- keep GlobaLeaks Tor Browser guidance conditional so it only appears when any GlobaLeaks listing uses an onion submission URL
- update directory coverage for both GlobaLeaks states: with and without onion submissions

## Why
- gives automated directory tabs the same correction path users already have on the public-record tab
- keeps the GlobaLeaks copy shorter when no Tor-only listing is present

## Validation
- `make test TESTS=tests/test_directory.py`
- `make lint`
- `make test`

## Manual testing
- loaded `/directory` and verified the GlobaLeaks banner omits Tor Browser language when no listing has an onion submission
- verified the GlobaLeaks banner includes Tor Browser language when a listing has an onion submission
- verified the SecureDrop banner includes the admin correction copy

## Risks / follow-ups
- not applicable; copy and conditional template behavior only