### PR TITLE
Harden public record link refresh retries

### DIFF
--- a/.github/workflows/globaleaks-directory-refresh.yml
+++ b/.github/workflows/globaleaks-directory-refresh.yml
@@ -3,7 +3,7 @@ name: GlobaLeaks Directory Refresh
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 16 * * *"
+    - cron: "0 16 1 1,4,7,10 *"
 
 permissions:
   contents: write

--- a/.github/workflows/public-record-link-check.yml
+++ b/.github/workflows/public-record-link-check.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 15 * * 1"
+    - cron: "0 15 1 1,4,7,10 *"
 
 jobs:
   public-record-links:

--- a/.github/workflows/securedrop-directory-refresh.yml
+++ b/.github/workflows/securedrop-directory-refresh.yml
@@ -3,7 +3,7 @@ name: SecureDrop Directory Refresh
 on:
   workflow_dispatch:
   schedule:
-    - cron: "0 16 * * *"
+    - cron: "0 17 1 1,4,7,10 *"
 
 permissions:
   contents: write

--- a/docs/GLOBALEAKS-DIRECTORY-SYNC.md
+++ b/docs/GLOBALEAKS-DIRECTORY-SYNC.md
@@ -31,7 +31,7 @@ make refresh-globaleaks-listings REFRESH_GLOBALEAKS_ARGS="--check"
 ## Scheduled refresh
 
 - Workflow: `.github/workflows/globaleaks-directory-refresh.yml`
-- Trigger: daily cron + manual dispatch.
+- Trigger: quarterly cron (`Jan/Apr/Jul/Oct`) + manual dispatch.
 - Behavior: refreshes the local artifact from the public GlobaLeaks source pages and opens or
   updates a PR when data changes.
 

--- a/docs/SECUREDROP-DIRECTORY-SYNC.md
+++ b/docs/SECUREDROP-DIRECTORY-SYNC.md
@@ -24,7 +24,7 @@ make refresh-securedrop-listings REFRESH_SECUREDROP_ARGS="--check"
 ## Scheduled refresh
 
 - Workflow: `.github/workflows/securedrop-directory-refresh.yml`
-- Trigger: daily cron + manual dispatch.
+- Trigger: quarterly cron (`Jan/Apr/Jul/Oct`) + manual dispatch.
 - Behavior: refreshes the local artifact and opens/updates a PR when data changes.
 
 ## UI note

--- a/hushline/data/public_record_law_firms.json
+++ b/hushline/data/public_record_law_firms.json
@@ -48,6 +48,18 @@
     "source_url": "https://www.azbar.org/for-legal-professionals/practice-tools-management/member-directory/?m=Anthony-Cali-177781"
   },
   {
+    "id": "seed-andrew-clarke-weeks",
+    "slug": "public-record~andrew-clarke-weeks",
+    "name": "Andrew Clarke Weeks",
+    "website": "https://legaljusticeatwork.com/",
+    "description": "Whistleblower attorney listing sourced from Kentucky Bar Association public directory.",
+    "city": "Louisville",
+    "state": "KY",
+    "practice_tags": ["Whistleblowing", "Employment", "Litigation"],
+    "source_label": "Kentucky Bar Association public directory",
+    "source_url": "https://www.kybar.org/members/?id=42347567"
+  },
+  {
     "id": "seed-barbara-mahoney",
     "slug": "public-record~barbara-mahoney",
     "name": "Barbara Mahoney",
@@ -192,6 +204,18 @@
     "source_url": "https://members.ctbar.org/member/thelaborlawyer"
   },
   {
+    "id": "seed-eric-seitz",
+    "slug": "public-record~eric-seitz",
+    "name": "Eric Seitz",
+    "website": "https://www.ericseitz.com/",
+    "description": "Whistleblower attorney listing sourced from a Hawaii State Bar Association attorney recognition record.",
+    "city": "Honolulu",
+    "state": "HI",
+    "practice_tags": ["Whistleblowing", "Civil Rights", "Litigation"],
+    "source_label": "Hawaii State Bar Association attorney recognition record",
+    "source_url": "https://hsba.org/HSBA_2020/About_Us/Living_Legend_Lawyers_.aspx"
+  },
+  {
     "id": "seed-georgianna-quinn-tutwiler",
     "slug": "public-record~georgianna-quinn-tutwiler",
     "name": "Georgianna Quinn Tutwiler",
@@ -214,6 +238,18 @@
     "practice_tags": ["Whistleblowing", "Employment", "Litigation"],
     "source_label": "State Bar of California attorney profile",
     "source_url": "https://apps.calbar.ca.gov/attorney/Licensee/Detail/148005"
+  },
+  {
+    "id": "seed-jerry-ray-poole-jr",
+    "slug": "public-record~jerry-ray-poole-jr",
+    "name": "Jerry Ray Poole, Jr.",
+    "website": "https://www.constangy.com/people-jerry-poole",
+    "description": "Whistleblower attorney listing sourced from The Florida Bar public directory.",
+    "city": "Tampa",
+    "state": "FL",
+    "practice_tags": ["Whistleblowing", "Employment", "Litigation"],
+    "source_label": "The Florida Bar public directory",
+    "source_url": "https://www.floridabar.org/directories/find-mbr/profile/?num=123000"
   },
   {
     "id": "seed-jon-marc-petersen",
@@ -396,6 +432,18 @@
     "source_url": "https://apps.calbar.ca.gov/attorney/Licensee/Detail/238491"
   },
   {
+    "id": "seed-richard-l-abbott",
+    "slug": "public-record~richard-l-abbott",
+    "name": "Richard L. Abbott",
+    "website": "https://richabbottlawfirm.com/",
+    "description": "Whistleblower attorney listing sourced from a Delaware Courts published opinion.",
+    "city": "Hockessin",
+    "state": "DE",
+    "practice_tags": ["Whistleblowing", "Investigations", "Litigation"],
+    "source_label": "Delaware Courts published opinion",
+    "source_url": "https://courts.delaware.gov/Opinions/Download.aspx?id=342050"
+  },
+  {
     "id": "seed-roxanne-barton-conlin",
     "slug": "public-record~roxanne-barton-conlin",
     "name": "Roxanne Barton Conlin",
@@ -442,5 +490,17 @@
     "practice_tags": ["Whistleblowing", "Employment", "Litigation"],
     "source_label": "State Bar of Georgia speaker profile",
     "source_url": "https://icle.gabar.org/speaker/todd-stanton-1261014"
+  },
+  {
+    "id": "seed-trudy-hanson-fouser",
+    "slug": "public-record~trudy-hanson-fouser",
+    "name": "Trudy Hanson Fouser",
+    "website": "https://gfidaholaw.com/",
+    "description": "Whistleblower attorney listing sourced from an Idaho State Bar attorney profile.",
+    "city": "Boise",
+    "state": "ID",
+    "practice_tags": ["Employment", "Litigation", "Investigations"],
+    "source_label": "Idaho State Bar attorney profile",
+    "source_url": "https://isb.idaho.gov/blog/trudy-hanson-fouser/"
   }
 ]

--- a/hushline/public_record_refresh.py
+++ b/hushline/public_record_refresh.py
@@ -459,6 +459,7 @@ class PublicRecordRow(TypedDict):
 class LinkCheckResult:
     ok: bool
     reason: str | None = None
+    definitive_failure: bool = False
 
 
 @dataclass(frozen=True)
@@ -590,10 +591,13 @@ def build_requests_link_checker(
             if attempt < max_attempts:
                 sleep_fn(float(attempt))
 
-        if last_status_code is not None and (
-            last_status_code >= _HTTP_SERVER_ERROR_MIN_STATUS
-            or last_status_code in _BROKEN_STATUS_CODES
-        ):
+        if last_status_code is not None and last_status_code in _BROKEN_STATUS_CODES:
+            return LinkCheckResult(
+                ok=False,
+                reason=f"HTTP {last_status_code}",
+                definitive_failure=True,
+            )
+        if last_status_code is not None and last_status_code >= _HTTP_SERVER_ERROR_MIN_STATUS:
             return LinkCheckResult(ok=False, reason=f"HTTP {last_status_code}")
         if last_error is not None and last_status_code is None:
             return LinkCheckResult(ok=False, reason=str(last_error))
@@ -2519,7 +2523,8 @@ def _validate_links(
                         reason=check_result.reason or "unknown link validation failure",
                     )
                 )
-                failed_record_ids.add(row.id)
+                if check_result.definitive_failure:
+                    failed_record_ids.add(row.id)
 
     if not drop_failed_links:
         return _LinkValidationResult(

--- a/tests/test_public_record_refresh.py
+++ b/tests/test_public_record_refresh.py
@@ -534,7 +534,11 @@ def test_refresh_public_record_rows_flags_and_drops_link_failures() -> None:
 
     def checker(url: str) -> LinkCheckResult:
         checked_urls.append(url)
-        return LinkCheckResult(ok=url != "https://broken.example", reason="HTTP 404")
+        return LinkCheckResult(
+            ok=url != "https://broken.example",
+            reason="HTTP 404",
+            definitive_failure=url == "https://broken.example",
+        )
 
     flagged = refresh_public_record_rows(
         rows,
@@ -561,6 +565,44 @@ def test_refresh_public_record_rows_flags_and_drops_link_failures() -> None:
     assert dropped.dropped_record_ids == ["seed-broken"]
     assert dropped.checked_url_count == 4
     assert checked_urls
+
+
+def test_refresh_public_record_rows_keeps_rows_on_transient_link_failures() -> None:
+    rows = [
+        _row(
+            id_value="seed-healthy",
+            slug="public-record~healthy",
+            name="Healthy Firm",
+            state="NY",
+            website="https://healthy.example",
+        ),
+        _row(
+            id_value="seed-transient",
+            slug="public-record~transient",
+            name="Transient Firm",
+            state="NY",
+            website="https://transient.example",
+        ),
+    ]
+
+    def checker(url: str) -> LinkCheckResult:
+        if url == "https://transient.example":
+            return LinkCheckResult(ok=False, reason="HTTP 503")
+        return LinkCheckResult(ok=True)
+
+    result = refresh_public_record_rows(
+        rows,
+        selected_regions=["US"],
+        region_state_map={"US": frozenset({"NY"})},
+        region_targets={"US": 2},
+        link_checker=checker,
+        drop_failed_links=True,
+    )
+
+    assert [row["id"] for row in result.rows] == ["seed-healthy", "seed-transient"]
+    assert len(result.link_failures) == 1
+    assert result.link_failures[0].listing_id == "seed-transient"
+    assert result.dropped_record_ids == []
 
 
 def test_refresh_public_record_rows_rejects_legacy_self_reported_source_label() -> None:
@@ -837,6 +879,34 @@ def test_build_requests_link_checker_retries_then_succeeds() -> None:
     assert result.ok is True
     assert fake_session._index == 2
     assert sleep_calls == [1.0]
+
+
+def test_build_requests_link_checker_marks_404_as_definitive_failure() -> None:
+    class _FakeResponse:
+        def __init__(self, status_code: int) -> None:
+            self.status_code = status_code
+
+        def close(self) -> None:
+            return None
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+        def get(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
+            return _FakeResponse(404)
+
+    checker = build_requests_link_checker(
+        session=_FakeSession(),  # type: ignore[arg-type]
+        max_attempts=1,
+        sleep_fn=lambda _seconds: None,
+    )
+
+    result = checker("https://missing.example")
+
+    assert result.ok is False
+    assert result.reason == "HTTP 404"
+    assert result.definitive_failure is True
 
 
 def test_discover_chambers_public_record_rows_is_disabled() -> None:


### PR DESCRIPTION
## What changed
- move the public-record, SecureDrop, and GlobaLeaks automated checks from weekly to quarterly cadence
- harden public-record link validation so transient connectivity or upstream server failures are retried and reported without dropping records
- restore the five law-firm listings removed by the last public-record link check until a definitive dead-link result is observed again
- document the quarterly refresh cadence in the SecureDrop and GlobaLeaks sync docs

## Why
The last public-record link check removed five rows on a run that may have been affected by connectivity issues. This keeps the automated cleanup behavior fail-closed: only definitive dead-link outcomes remove listings, while transient failures stay visible and surface as link-check failures instead.

## Validation
- make lint
- make test TESTS=tests/test_public_record_refresh.py
- make test

## Manual testing
- Not applicable; this change affects scheduled workflow cadence and refresh logic only.

## Risks / follow-ups
- 404 and 410 responses still remove records immediately because they are treated as definitive dead links.
- Other HTTP/request failures now preserve the rows, so stale links may linger until a later definitive failure or human review.
