### PR TITLE
Make daily runner portable for manual invocation

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -197,16 +197,42 @@ Optional forced issue:
 ./scripts/agent_daily_issue_runner.sh --issue 1389
 ```
 
+## Machine Setup
+
+Each runner host needs its own signed-commit configuration. The daily runner defaults to SSH signing and resolves the signing key in this order:
+
+1. `HUSHLINE_BOT_GIT_SIGNING_KEY`
+2. Existing git config when `gpg.format=ssh` and `user.signingkey` is already set for the checkout
+3. `HUSHLINE_BOT_GIT_DEFAULT_SSH_SIGNING_KEY_PATH`, if explicitly set to a local `.pub` file path
+
+Recommended per-host setup:
+
+```bash
+git -C /path/to/hushline config gpg.format ssh
+git -C /path/to/hushline config user.signingkey "$HOME/.ssh/hushline_bot_signing.pub"
+ssh-add "$HOME/.ssh/hushline_bot_signing"
+```
+
+Requirements:
+
+- The matching public key must be added to the GitHub bot account as an SSH signing key.
+- The matching private key must be available to `ssh-agent` before the runner starts.
+- If the machine still has a global GPG signing key from another environment (for example `git config --global user.signingkey 102783C80AF9335A`), do not reuse it with the runner's SSH signing mode.
+- On macOS, using `ssh-add --apple-use-keychain` is optional but not required by the runner.
+
+The runner now performs an SSH signing preflight immediately after configuring git identity and fails early with an actionable error if the host is missing the expected key or the key is not loaded into `ssh-agent`.
+
 ## Environment Variables
 
-- `HUSHLINE_REPO_DIR` (default `$HOME/hushline`)
+- `HUSHLINE_REPO_DIR` (default the repository checkout containing `scripts/agent_daily_issue_runner.sh`)
 - `HUSHLINE_REPO_SLUG` (default `scidsg/hushline`)
 - `HUSHLINE_BASE_BRANCH` (default `main`)
 - `HUSHLINE_BOT_LOGIN` (default `hushline-dev`)
 - `HUSHLINE_BOT_GIT_NAME` (default `HUSHLINE_BOT_LOGIN`)
 - `HUSHLINE_BOT_GIT_EMAIL` (default `git-dev@scidsg.org`)
 - `HUSHLINE_BOT_GIT_GPG_FORMAT` (default `ssh`)
-- `HUSHLINE_BOT_GIT_SIGNING_KEY` (optional)
+- `HUSHLINE_BOT_GIT_SIGNING_KEY` (optional; when unset the runner reuses existing SSH git signing config if available)
+- `HUSHLINE_BOT_GIT_DEFAULT_SSH_SIGNING_KEY_PATH` (optional; no default)
 - `HUSHLINE_DAILY_PROJECT_OWNER` (default owner from `HUSHLINE_REPO_SLUG`)
 - `HUSHLINE_DAILY_PROJECT_TITLE` (default `Hush Line Roadmap`)
 - `HUSHLINE_DAILY_PROJECT_COLUMN` (default `Agent Eligible`)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -3,8 +3,9 @@ set -euo pipefail
 
 FORCE_ISSUE_NUMBER=""
 SCRIPT_DIR="$(CDPATH= cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_REPO_DIR="$(CDPATH= cd -- "$SCRIPT_DIR/.." && pwd)"
 
-REPO_DIR="${HUSHLINE_REPO_DIR:-$HOME/hushline}"
+REPO_DIR="${HUSHLINE_REPO_DIR:-$DEFAULT_REPO_DIR}"
 REPO_SLUG="${HUSHLINE_REPO_SLUG:-scidsg/hushline}"
 BASE_BRANCH="${HUSHLINE_BASE_BRANCH:-main}"
 BOT_LOGIN="${HUSHLINE_BOT_LOGIN:-hushline-dev}"
@@ -12,6 +13,7 @@ BOT_GIT_NAME="${HUSHLINE_BOT_GIT_NAME:-$BOT_LOGIN}"
 BOT_GIT_EMAIL="${HUSHLINE_BOT_GIT_EMAIL:-git-dev@scidsg.org}"
 BOT_GIT_GPG_FORMAT="${HUSHLINE_BOT_GIT_GPG_FORMAT:-ssh}"
 BOT_GIT_SIGNING_KEY="${HUSHLINE_BOT_GIT_SIGNING_KEY:-}"
+DEFAULT_BOT_GIT_SSH_SIGNING_KEY_PATH="${HUSHLINE_BOT_GIT_DEFAULT_SSH_SIGNING_KEY_PATH:-}"
 BRANCH_PREFIX="${HUSHLINE_DAILY_BRANCH_PREFIX:-codex/daily-issue-}"
 CODEX_MODEL="${HUSHLINE_CODEX_MODEL:-gpt-5.4}"
 CODEX_REASONING_EFFORT="${HUSHLINE_CODEX_REASONING_EFFORT:-high}"
@@ -111,6 +113,98 @@ require_positive_integer() {
     echo "${name} must be a positive integer (got '${value}')." >&2
     return 1
   fi
+}
+
+resolve_bot_git_signing_key() {
+  local configured_signing_key=""
+  local configured_gpg_format=""
+
+  if [[ "$BOT_GIT_GPG_FORMAT" != "ssh" ]]; then
+    printf '%s\n' "$BOT_GIT_SIGNING_KEY"
+    return 0
+  fi
+
+  if [[ -n "$BOT_GIT_SIGNING_KEY" ]]; then
+    printf '%s\n' "$BOT_GIT_SIGNING_KEY"
+    return 0
+  fi
+
+  configured_signing_key="$(git config --get user.signingkey 2>/dev/null || true)"
+  configured_gpg_format="$(git config --get gpg.format 2>/dev/null || true)"
+  if [[ -n "$configured_signing_key" ]]; then
+    if [[ "$configured_gpg_format" == "ssh" ]] \
+      || signing_key_looks_like_public_key_literal "$configured_signing_key" \
+      || [[ "$configured_signing_key" == *.pub ]]; then
+      printf '%s\n' "$configured_signing_key"
+      return 0
+    fi
+  fi
+
+  if [[ -n "$DEFAULT_BOT_GIT_SSH_SIGNING_KEY_PATH" && -f "$DEFAULT_BOT_GIT_SSH_SIGNING_KEY_PATH" ]]; then
+    printf '%s\n' "$DEFAULT_BOT_GIT_SSH_SIGNING_KEY_PATH"
+    return 0
+  fi
+
+  return 1
+}
+
+signing_key_looks_like_public_key_literal() {
+  local signing_key="$1"
+  [[ "$signing_key" == ssh-*' '* ]]
+}
+
+assert_ssh_signing_ready() {
+  local signing_key="$1"
+  local private_key_hint=""
+  local smoke_dir=""
+  local smoke_output=""
+
+  if [[ -z "$signing_key" ]]; then
+    printf '%s\n' "Blocked: SSH signing key is not configured." >&2
+    return 1
+  fi
+
+  if ! signing_key_looks_like_public_key_literal "$signing_key" && [[ ! -f "$signing_key" ]]; then
+    printf '%s\n' "Blocked: SSH signing key file not found: $signing_key" >&2
+    return 1
+  fi
+
+  if [[ "$signing_key" == *.pub ]]; then
+    private_key_hint="${signing_key%.pub}"
+  fi
+
+  smoke_dir="$(mktemp -d)"
+  set +e
+  smoke_output="$(
+    cd "$smoke_dir" &&
+      git init -q &&
+      git config user.name "$BOT_GIT_NAME" &&
+      git config user.email "$BOT_GIT_EMAIL" &&
+      git config commit.gpgsign true &&
+      git config gpg.format ssh &&
+      git config user.signingkey "$signing_key" &&
+      git commit --allow-empty -m "runner signing preflight" 2>&1
+  )"
+  local smoke_rc=$?
+  set -e
+  rm -rf "$smoke_dir"
+
+  if (( smoke_rc == 0 )); then
+    return 0
+  fi
+
+  if printf '%s\n' "$smoke_output" | grep -Eqi '(incorrect passphrase supplied to decrypt private key|enter passphrase for)'; then
+    if [[ -n "$private_key_hint" ]]; then
+      printf '%s\n' "Blocked: SSH signing key is present but unavailable to Git. Load the matching private key into ssh-agent first, for example: ssh-add $private_key_hint" >&2
+    else
+      printf '%s\n' "Blocked: SSH signing key is present but unavailable to Git. Load the matching private key into ssh-agent first." >&2
+    fi
+    return 1
+  fi
+
+  printf '%s\n' "Blocked: SSH signing preflight failed for $signing_key" >&2
+  printf '%s\n' "$smoke_output" >&2
+  return 1
 }
 
 run_step() {
@@ -524,14 +618,24 @@ collect_issue_candidates() {
 }
 
 configure_bot_git_identity() {
+  local resolved_signing_key=""
   git config user.name "$BOT_GIT_NAME"
   git config user.email "$BOT_GIT_EMAIL"
   git config commit.gpgsign true
   if [[ -n "$BOT_GIT_GPG_FORMAT" ]]; then
     git config gpg.format "$BOT_GIT_GPG_FORMAT"
   fi
-  if [[ -n "$BOT_GIT_SIGNING_KEY" ]]; then
+  if resolved_signing_key="$(resolve_bot_git_signing_key)"; then
+    git config user.signingkey "$resolved_signing_key"
+  elif [[ "$BOT_GIT_GPG_FORMAT" == "ssh" ]]; then
+    printf '%s\n' "Blocked: SSH commit signing is enabled, but no signing key is configured. Set HUSHLINE_BOT_GIT_SIGNING_KEY, configure git with gpg.format=ssh and user.signingkey, or set HUSHLINE_BOT_GIT_DEFAULT_SSH_SIGNING_KEY_PATH to a local .pub file." >&2
+    return 1
+  elif [[ -n "$BOT_GIT_SIGNING_KEY" ]]; then
     git config user.signingkey "$BOT_GIT_SIGNING_KEY"
+  fi
+
+  if [[ "$BOT_GIT_GPG_FORMAT" == "ssh" ]]; then
+    assert_ssh_signing_ready "$resolved_signing_key"
   fi
 }
 

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -18,6 +18,18 @@ def _run_bash(script: str) -> subprocess.CompletedProcess[str]:
     )
 
 
+def test_runner_defaults_repo_dir_to_checkout_root() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+printf '%s\\n' "$REPO_DIR"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert Path(result.stdout.strip()) == ROOT
+
+
 def test_persisted_runner_log_excludes_codex_transcript(tmp_path: Path) -> None:
     repo_dir = tmp_path / "repo"
     prompt_file = tmp_path / "prompt.txt"
@@ -348,6 +360,88 @@ printf 'rc=%s\\n' "$rc"
     assert docker_calls.count("compose up -d --build") == 1
     assert docker_calls.count("compose run --rm dev_data") == 1
     assert "compose down -v --remove-orphans" not in docker_calls
+
+
+def test_resolve_bot_git_signing_key_uses_existing_ssh_git_config(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    shell_script = f"""
+repo_dir={shlex.quote(str(repo_dir))}
+source {shlex.quote(str(RUNNER_SCRIPT))}
+cd "$repo_dir"
+BOT_GIT_GPG_FORMAT=ssh
+BOT_GIT_SIGNING_KEY=""
+DEFAULT_BOT_GIT_SSH_SIGNING_KEY_PATH=""
+git() {{
+  if [[ "$1" == "config" && "$2" == "--get" && "$3" == "user.signingkey" ]]; then
+    printf '%s\\n' "$repo_dir/.ssh/bot-signing.pub"
+    return 0
+  fi
+  if [[ "$1" == "config" && "$2" == "--get" && "$3" == "gpg.format" ]]; then
+    printf 'ssh\\n'
+    return 0
+  fi
+  printf 'unexpected git invocation: %s\\n' "$*" >&2
+  return 99
+}}
+resolve_bot_git_signing_key
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(repo_dir / ".ssh" / "bot-signing.pub")
+
+
+def test_resolve_bot_git_signing_key_ignores_non_ssh_git_config(tmp_path: Path) -> None:
+    repo_dir = tmp_path / "repo"
+    repo_dir.mkdir()
+
+    shell_script = f"""
+repo_dir={shlex.quote(str(repo_dir))}
+git -C "$repo_dir" init -q
+git -C "$repo_dir" config user.signingkey 102783C80AF9335A
+source {shlex.quote(str(RUNNER_SCRIPT))}
+cd "$repo_dir"
+BOT_GIT_GPG_FORMAT=ssh
+BOT_GIT_SIGNING_KEY=""
+DEFAULT_BOT_GIT_SSH_SIGNING_KEY_PATH=""
+if resolve_bot_git_signing_key; then
+  printf 'resolved\\n'
+else
+  printf 'missing\\n'
+fi
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "missing\n"
+
+
+def test_assert_ssh_signing_ready_does_not_require_local_private_key_file(tmp_path: Path) -> None:
+    public_key_file = tmp_path / "bot-signing.pub"
+    public_key_file.write_text(
+        "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIBotSigningKeyExample hushline-dev\n",
+        encoding="utf-8",
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+git() {{
+  if [[ "$1" == "init" || "$1" == "config" || "$1" == "commit" ]]; then
+    return 0
+  fi
+  printf 'unexpected git invocation: %s\\n' "$*" >&2
+  return 99
+}}
+assert_ssh_signing_ready {shlex.quote(str(public_key_file))}
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
 
 
 def test_require_positive_integer_rejects_zero() -> None:


### PR DESCRIPTION
## What changed
- Defaulted the daily issue runner to the repository checkout that contains the script so manual invocation no longer assumes `$HOME/hushline`.
- Made SSH signing resolution host-agnostic by preferring explicit env config, then existing checkout git SSH signing config, with an optional explicit fallback path.
- Updated runner docs and added focused tests covering repo discovery, signing-key resolution, and signing preflight behavior across host/container environments.

## Why
- The runner needs to work both when invoked manually from a normal clone and when used by Codex automation on different machines, without depending on one-off local paths or a hardcoded signing key filename.

## Validation
- `make lint`
- `make test`

## Manual testing
- Not applicable; this change is limited to runner shell logic, documentation, and automated test coverage.

## Known risks or follow-ups
- The runner still requires each host to have a valid commit-signing setup before use; this PR only makes discovery and failure modes portable.
