### PR TITLE
Add make serve target for local Docker rebuild

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,11 @@ install:
 run: ## Run the app in a limited mode
 	docker compose up --build
 
+.PHONY: serve
+serve: ## Tear down and rebuild the local Docker stack
+	docker compose down --remove-orphans
+	docker compose up --build
+
 .PHONY: run-full
 run-full: ## Run the app with all features enabled
 	docker compose -f docker-compose.stripe.yaml up --build


### PR DESCRIPTION
## What changed
- add a new `make serve` target to the root `Makefile`
- make the target run `docker compose down --remove-orphans` followed by `docker compose up --build`
- leave existing `make run` behavior unchanged

## Why
This adds a short, explicit command for tearing down and rebuilding the standard local Docker stack from the current repository without using the broader `clean` reset path.

## Validation
- `make lint`
- `make test`

## Manual testing
- not run locally beyond the automated validation above
- expected manual check: run `make serve` and confirm the local stack is torn down and rebuilt successfully

## Risks / follow-ups
- `make serve` does not remove volumes; it is intentionally narrower than `make clean`
- this only targets the default compose stack, not the Stripe-specific stack
