### PR TITLE
test: raise repo coverage to 100%

### DIFF
--- a/tests/test_authentication_log_model.py
+++ b/tests/test_authentication_log_model.py
@@ -1,0 +1,15 @@
+from hushline.model import AuthenticationLog
+
+
+def test_authentication_log_init_sets_optional_fields() -> None:
+    log = AuthenticationLog(
+        user_id=42,
+        successful=False,
+        otp_code="123456",
+        timecode=12345678,
+    )
+
+    assert log.user_id == 42
+    assert log.successful is False
+    assert log.otp_code == "123456"
+    assert log.timecode == 12345678

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -4,7 +4,7 @@ from flask import Flask
 from werkzeug.security import generate_password_hash
 
 from hushline.db import db
-from hushline.model import InviteCode, OrganizationSetting, User
+from hushline.model import InviteCode, OrganizationSetting, Tier, User
 
 
 def test_reg_settings_command_outputs_current_values(app: Flask) -> None:
@@ -110,6 +110,34 @@ def test_password_hash_report_outputs_legacy_count_and_removal_gate(
     assert "Passlib removal readiness: blocked" in result.output
 
 
+def test_password_hash_report_blocks_when_measured_legacy_successes_non_zero(
+    app: Flask, user: User, user2: User, user_password: str
+) -> None:
+    runner = app.test_cli_runner()
+    native_hash = generate_password_hash(user_password, method="scrypt")
+    user._password_hash = native_hash
+    user2._password_hash = native_hash
+    db.session.commit()
+
+    result = runner.invoke(
+        args=[
+            "password-hash",
+            "report",
+            "--legacy-verification-successes",
+            "3",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert "Legacy passlib scrypt rows: 0" in result.output
+    assert "Measured legacy verification successes: 3" in result.output
+    assert "Legacy verifier path: passlib_dependency" in result.output
+    assert "Passlib removal readiness: blocked" in result.output
+    assert "Passlib removal reason: measured legacy verification success volume is non-zero" in (
+        result.output
+    )
+
+
 def test_password_hash_can_remove_passlib_blocks_when_legacy_rows_remain(
     app: Flask, user: User, user2: User, user_password: str
 ) -> None:
@@ -198,6 +226,27 @@ def test_stripe_configure_skips_when_secret_missing(app: Flask) -> None:
         result = runner.invoke(args=["stripe", "configure"])
 
     assert result.exit_code == 0
+    init_stripe.assert_not_called()
+    create_products.assert_not_called()
+
+
+def test_stripe_configure_creates_missing_tiers_when_lookup_returns_none(app: Flask) -> None:
+    app.config["STRIPE_SECRET_KEY"] = ""
+    runner = app.test_cli_runner()
+    db.session.execute(db.delete(Tier))
+    db.session.commit()
+
+    with (
+        patch("hushline.cli_stripe.Tier.free_tier", return_value=None),
+        patch("hushline.cli_stripe.Tier.business_tier", return_value=None),
+        patch("hushline.cli_stripe.premium.init_stripe") as init_stripe,
+        patch("hushline.cli_stripe.premium.create_products_and_prices") as create_products,
+    ):
+        result = runner.invoke(args=["stripe", "configure"])
+
+    assert result.exit_code == 0
+    assert db.session.scalar(db.select(Tier).filter_by(name="Free")) is not None
+    assert db.session.scalar(db.select(Tier).filter_by(name="Business")) is not None
     init_stripe.assert_not_called()
     create_products.assert_not_called()
 

--- a/tests/test_directory_listing_geography.py
+++ b/tests/test_directory_listing_geography.py
@@ -32,6 +32,10 @@ def test_build_directory_geography_normalizes_us_subdivision_codes(
     ("geography", "expected_location"),
     [
         (DirectoryListingGeography(subdivision="Illinois"), "Illinois"),
+        (
+            DirectoryListingGeography(subdivision="Illinois", country="United States"),
+            "Illinois, United States",
+        ),
         (DirectoryListingGeography(country="Australia"), "Australia"),
         (
             DirectoryListingGeography(countries=("All countries", "USA")),
@@ -58,3 +62,38 @@ def test_build_public_record_geography_uses_state_as_subdivision_when_country_pr
     assert geography.subdivision_code == "CA"
     assert geography.countries == ("United States",)
     assert geography.location == "Los Angeles, California, United States"
+
+
+def test_build_public_record_geography_uses_us_state_code_when_country_missing() -> None:
+    geography = build_public_record_geography(
+        city="Chicago",
+        state="IL",
+    )
+
+    assert geography.city == "Chicago"
+    assert geography.country == "United States"
+    assert geography.subdivision == "Illinois"
+    assert geography.subdivision_code == "IL"
+
+
+def test_build_public_record_geography_uses_non_us_state_value_as_country_when_missing() -> None:
+    geography = build_public_record_geography(
+        city="Paris",
+        state="France",
+    )
+
+    assert geography.city == "Paris"
+    assert geography.country == "France"
+    assert geography.subdivision is None
+    assert geography.subdivision_code is None
+
+
+def test_build_directory_geography_keeps_non_us_subdivision_strings() -> None:
+    geography = build_directory_geography(
+        country="France",
+        subdivision="Ile-de-France",
+    )
+
+    assert geography.country == "France"
+    assert geography.subdivision == "Ile-de-France"
+    assert geography.subdivision_code == "Ile-de-France"

--- a/tests/test_globaleaks_directory_listing_model.py
+++ b/tests/test_globaleaks_directory_listing_model.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import hushline.model.globaleaks_directory_listing as globaleaks_listing_module
+from hushline.model.globaleaks_directory_listing import (
+    GlobaLeaksDirectoryListing,
+    _build_listing,
+    _seed_path,
+    get_globaleaks_directory_listing,
+    get_globaleaks_directory_listings,
+)
+
+
+def test_globaleaks_directory_listings_returns_empty_tuple_when_seed_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    missing_path = tmp_path / "missing-globaleaks-seed.json"
+    get_globaleaks_directory_listings.cache_clear()
+    monkeypatch.setattr(globaleaks_listing_module, "_seed_path", lambda: missing_path)
+
+    assert get_globaleaks_directory_listings() == ()
+
+
+def test_globaleaks_directory_listings_returns_empty_tuple_for_non_list_seed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    seed_path = tmp_path / "globaleaks-seed.json"
+    seed_path.write_text(json.dumps({"unexpected": "shape"}), encoding="utf-8")
+    get_globaleaks_directory_listings.cache_clear()
+    monkeypatch.setattr(globaleaks_listing_module, "_seed_path", lambda: seed_path)
+
+    assert get_globaleaks_directory_listings() == ()
+
+
+def test_get_globaleaks_directory_listing_matches_slug_case_insensitively(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    seed_path = tmp_path / "globaleaks-seed.json"
+    seed_path.write_text(
+        json.dumps(
+            [
+                {
+                    "id": "globaleaks-sample",
+                    "slug": "globaleaks~sample-newsroom",
+                    "name": "Sample Newsroom",
+                    "website": "https://example.org",
+                    "description": "Sample",
+                    "submission_url": "https://submit.example.org",
+                    "host": "submit.example.org",
+                    "countries": ["Italy"],
+                    "languages": ["English"],
+                    "source_label": "Automated GlobaLeaks discovery dataset",
+                    "source_url": "https://example.org/source",
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+    get_globaleaks_directory_listings.cache_clear()
+    monkeypatch.setattr(globaleaks_listing_module, "_seed_path", lambda: seed_path)
+
+    listing = get_globaleaks_directory_listing("GLOBALEAKS~SAMPLE-NEWSROOM")
+
+    assert listing is not None
+    assert listing.id == "globaleaks-sample"
+
+
+def test_build_globaleaks_listing_infers_host_from_submission_url() -> None:
+    listing = _build_listing(
+        {
+            "id": "globaleaks-sample",
+            "slug": "globaleaks~sample-newsroom",
+            "name": "Sample Newsroom",
+            "website": "https://example.org",
+            "description": "Sample",
+            "submission_url": "https://submit.example.org/report",
+            "countries": ["Italy"],
+            "languages": ["English"],
+            "source_label": "Automated GlobaLeaks discovery dataset",
+            "source_url": "https://example.org/source",
+        }
+    )
+
+    assert listing.host == "submit.example.org"
+
+
+def test_globaleaks_directory_listing_properties_expose_geography_and_onion_detection() -> None:
+    listing = GlobaLeaksDirectoryListing(
+        id="globaleaks-sample",
+        slug="globaleaks~sample-newsroom",
+        name="Sample Newsroom",
+        website="https://example.org",
+        description="Sample",
+        submission_url="http://sampleonion1234567890abcdef.onion",
+        host="sampleonion1234567890abcdef.onion",
+        countries=("Italy",),
+        languages=("English",),
+        source_label="Automated GlobaLeaks discovery dataset",
+        source_url="https://example.org/source",
+        city="Rome",
+        country="Italy",
+    )
+
+    assert listing.geography.country == "Italy"
+    assert listing.location == "Rome, Italy"
+    assert listing.has_onion_submission is True
+
+
+def test_globaleaks_seed_path_points_to_committed_dataset() -> None:
+    assert _seed_path().name == "globaleaks_instances.json"

--- a/tests/test_globaleaks_directory_refresh.py
+++ b/tests/test_globaleaks_directory_refresh.py
@@ -7,6 +7,7 @@ from hushline import globaleaks_directory_refresh as refresh_module
 from hushline.globaleaks_directory_refresh import (
     GLOBALEAKS_SOURCE_URL,
     GlobaLeaksDirectoryRefreshError,
+    _candidate_hosts,
     _choose_host,
     _choose_submission_url,
     _extract_discovery_links,
@@ -61,6 +62,7 @@ def test_normalize_http_url_validates_required_and_optional_fields() -> None:
         == "https://submit.example.org/report"
     )
     assert _normalize_http_url("mailto:test@example.org", field="website", required=False) == ""
+    assert _normalize_http_url("   ", field="website", required=False) == ""
 
     with pytest.raises(
         GlobaLeaksDirectoryRefreshError, match="Missing required URL field: source_url"
@@ -106,6 +108,16 @@ def test_choose_host_falls_back_to_candidate_hosts_or_errors() -> None:
 
     with pytest.raises(GlobaLeaksDirectoryRefreshError, match="missing a usable host"):
         _choose_host({}, "mailto:test@example.org")
+
+
+def test_candidate_hosts_normalizes_and_skips_blank_or_duplicate_values() -> None:
+    assert _candidate_hosts(
+        {
+            "host": " Tips.Example.org ",
+            "domains": ["https://tips.example.org/report", ".", "tips.example.org"],
+            "_shodan": {"http": {"host": " "}},
+        }
+    ) == ["tips.example.org"]
 
 
 def test_refresh_globaleaks_directory_rows_rejects_empty_slug_after_normalization() -> None:

--- a/tests/test_invite_code_model.py
+++ b/tests/test_invite_code_model.py
@@ -1,0 +1,10 @@
+from unittest.mock import patch
+
+from hushline.model import InviteCode
+
+
+def test_invite_code_repr_includes_code() -> None:
+    with patch("hushline.model.invite_code.secrets.token_urlsafe", return_value="invite-123"):
+        invite_code = InviteCode()
+
+    assert repr(invite_code) == "<InviteCode invite-123>"

--- a/tests/test_md.py
+++ b/tests/test_md.py
@@ -1,0 +1,17 @@
+from markupsafe import Markup
+
+from hushline.md import md_to_html
+
+
+def test_md_to_html_returns_markup_input_unchanged() -> None:
+    html = Markup("<p>Safe</p>")
+
+    assert md_to_html(html) is html
+
+
+def test_md_to_html_sanitizes_disallowed_tags_and_keeps_links() -> None:
+    rendered = md_to_html('[link](https://example.org)<script>alert("x")</script>')
+
+    assert isinstance(rendered, Markup)
+    assert '<a href="https://example.org">' in str(rendered)
+    assert "<script>" not in str(rendered)

--- a/tests/test_password_hasher.py
+++ b/tests/test_password_hasher.py
@@ -10,9 +10,14 @@ from hushline.model import User
 from hushline.password_hasher import (
     LEGACY_PASSLIB_SCRYPT_PREFIX,
     PINNED_WERKZEUG_SCRYPT_METHOD,
+    _emit_password_hash_counter,
+    _emit_password_verification_telemetry,
     emit_password_rehash_on_auth_telemetry,
+    get_password_hash_prefix,
     hash_password,
+    prepare_password_rehash_on_auth,
     verify_password,
+    verify_primary_password_hash,
 )
 
 LEGACY_PASSLIB_SCRYPT_PASSWORD = "SecurePassword123!"
@@ -197,6 +202,10 @@ def test_verify_password_routes_non_scrypt_native_prefixes_to_primary_verifier(
         assert stored_hash not in logged_extra.values()
 
 
+def test_verify_primary_password_hash_rejects_non_scrypt_native_prefix() -> None:
+    assert verify_primary_password_hash("SecurePassword123!", "hl-v2:anything") is False
+
+
 def test_verify_password_unknown_prefix_fails_closed_without_mutating_user(
     app: Flask, user: User
 ) -> None:
@@ -251,6 +260,45 @@ def test_verify_password_malformed_legacy_hash_fails_closed(app: Flask) -> None:
     ]
 
 
+def test_prepare_password_rehash_on_auth_returns_none_without_app_context() -> None:
+    assert prepare_password_rehash_on_auth("SecurePassword123!", "$scrypt$pretend") is None
+
+
+def test_prepare_password_rehash_on_auth_skips_non_legacy_hashes(app: Flask) -> None:
+    app.config["PASSWORD_HASH_REHASH_ON_AUTH_ENABLED"] = True
+
+    assert (
+        prepare_password_rehash_on_auth(
+            "SecurePassword123!",
+            generate_password_hash("SecurePassword123!", method="scrypt"),
+        )
+        is None
+    )
+
+
+def test_prepare_password_rehash_on_auth_returns_none_when_disabled(app: Flask) -> None:
+    app.config["PASSWORD_HASH_REHASH_ON_AUTH_ENABLED"] = False
+
+    assert prepare_password_rehash_on_auth("SecurePassword123!", "$scrypt$pretend") is None
+
+
+def test_prepare_password_rehash_on_auth_rehashes_legacy_hash_when_enabled(app: Flask) -> None:
+    app.config["PASSWORD_HASH_REHASH_ON_AUTH_ENABLED"] = True
+
+    rehashed = prepare_password_rehash_on_auth(
+        LEGACY_PASSLIB_SCRYPT_PASSWORD,
+        scrypt.hash(LEGACY_PASSLIB_SCRYPT_PASSWORD),
+    )
+
+    assert rehashed is not None
+    assert rehashed.startswith(f"{PINNED_WERKZEUG_SCRYPT_METHOD}$")
+    assert verify_password(LEGACY_PASSLIB_SCRYPT_PASSWORD, rehashed) is True
+
+
+def test_get_password_hash_prefix_returns_unknown_for_plaintext_like_values() -> None:
+    assert get_password_hash_prefix("not-a-known-prefix") == "unknown"
+
+
 def test_hash_password_logs_write_counter_without_sensitive_data(app: Flask) -> None:
     plaintext_password = "SecurePassword123!"
 
@@ -299,6 +347,11 @@ def test_pinned_werkzeug_scrypt_method_matches_legacy_passlib_cost_baseline() ->
     assert int(n_value) == 2 ** int(legacy_cost_fields["ln"])
     assert int(r_value) == int(legacy_cost_fields["r"])
     assert int(p_value) == int(legacy_cost_fields["p"])
+
+
+def test_password_hash_telemetry_helpers_noop_without_app_context() -> None:
+    _emit_password_verification_telemetry("$scrypt$pretend", True)
+    _emit_password_hash_counter("password_hash_counter_test", hash_format="passlib_scrypt")
 
 
 @pytest.mark.parametrize(

--- a/tests/test_public_record_refresh.py
+++ b/tests/test_public_record_refresh.py
@@ -1,22 +1,40 @@
 from __future__ import annotations
 
 import re
-from typing import Any, Mapping, Sequence
+from typing import Any, Mapping, Sequence, cast
 
 import pytest
+import requests
 
+from hushline import public_record_refresh
 from hushline.public_record_refresh import (
     DEFAULT_REGION_STATE_MAP,
     OFFICIAL_US_STATE_DISCOVERY_ADAPTERS,
     US_STATE_AUTHORITATIVE_SOURCES,
     US_STATE_CODES,
     LinkCheckResult,
+    LinkValidationFailure,
     OfficialStateDiscoveryResult,
     PublicRecordRefreshError,
+    PublicRecordRefreshResult,
+    _apply_region_targets,
+    _chambers_public_profile_url,
+    _chambers_public_profile_url_from_source_url,
+    _ChambersIndexEntry,
+    _discovered_description,
+    _fetch_json_payload,
+    _normalize_practice_tags,
+    _NormalizedListing,
+    _optional_string,
+    _parse_chambers_index_entries,
+    _required_string,
+    _slug_base,
+    _validate_regions,
     build_requests_link_checker,
     discover_chambers_public_record_rows,
     discover_official_us_state_public_record_rows,
     refresh_public_record_rows,
+    render_refresh_summary,
 )
 from tests.public_record_adapter_harness import (
     assert_official_source_adapter_rows,
@@ -532,7 +550,7 @@ def _row(  # noqa: PLR0913
     state: str,
     website: str,
     source_url: str | None = None,
-) -> dict[str, object]:
+) -> public_record_refresh.PublicRecordRow:
     source_slug = re.sub(r"[^a-z0-9]+", "-", name.casefold()).strip("-")
     state_code = state.strip().upper()
     state_source = US_STATE_AUTHORITATIVE_SOURCES.get(state_code)
@@ -567,7 +585,7 @@ def _row(  # noqa: PLR0913
         row["id"] = id_value
     if slug is not None:
         row["slug"] = slug
-    return row
+    return cast(public_record_refresh.PublicRecordRow, row)
 
 
 def _discover_rows_for_state(
@@ -579,6 +597,28 @@ def _discover_rows_for_state(
         existing_rows,
         selected_regions=["US"],
         region_state_map={"US": frozenset({state_code})},
+    )
+
+
+def _normalized_listing(
+    *,
+    listing_id: str,
+    slug: str,
+    name: str,
+    region: str,
+) -> _NormalizedListing:
+    return _NormalizedListing(
+        id=listing_id,
+        slug=slug,
+        name=name,
+        website="https://example.test",
+        description=f"{name} description",
+        city="City",
+        state=region,
+        practice_tags=("Whistleblowing",),
+        source_label="Authoritative source",
+        source_url="https://records.example/source",
+        region=region,
     )
 
 
@@ -1240,6 +1280,709 @@ def test_build_requests_link_checker_marks_404_as_definitive_failure() -> None:
     assert result.ok is False
     assert result.reason == "HTTP 404"
     assert result.definitive_failure is True
+
+
+def test_build_requests_link_checker_rejects_invalid_arguments() -> None:
+    with pytest.raises(PublicRecordRefreshError, match="--max-attempts must be >= 1"):
+        build_requests_link_checker(max_attempts=0)
+
+    with pytest.raises(PublicRecordRefreshError, match="--timeout-seconds must be > 0"):
+        build_requests_link_checker(timeout_seconds=0)
+
+
+def test_build_requests_link_checker_returns_last_server_error_after_retries() -> None:
+    class _FakeResponse:
+        def __init__(self, status_code: int) -> None:
+            self.status_code = status_code
+
+        def close(self) -> None:
+            return None
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+        def get(self, *_args: Any, **_kwargs: Any) -> _FakeResponse:
+            return _FakeResponse(500)
+
+    checker = build_requests_link_checker(
+        session=_FakeSession(),  # type: ignore[arg-type]
+        max_attempts=1,
+        sleep_fn=lambda _seconds: None,
+    )
+
+    result = checker("https://retry.example")
+
+    assert result.ok is False
+    assert result.reason == "HTTP 500"
+    assert result.definitive_failure is False
+
+
+def test_build_requests_link_checker_returns_last_request_exception_reason() -> None:
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.headers: dict[str, str] = {}
+
+        def get(self, *_args: Any, **_kwargs: Any) -> object:
+            raise requests.RequestException("network timeout")
+
+    checker = build_requests_link_checker(
+        session=_FakeSession(),  # type: ignore[arg-type]
+        max_attempts=1,
+        sleep_fn=lambda _seconds: None,
+    )
+
+    result = checker("https://retry.example")
+
+    assert result.ok is False
+    assert result.reason == "network timeout"
+    assert result.definitive_failure is False
+
+
+def test_render_refresh_summary_includes_dropped_ids_and_link_failures() -> None:
+    summary = render_refresh_summary(
+        PublicRecordRefreshResult(
+            rows=[],
+            region_counts={"US": 2, "EU": 0},
+            checked_url_count=3,
+            link_failures=[
+                LinkValidationFailure(
+                    listing_id="seed-one",
+                    listing_name="Seed One",
+                    field="website",
+                    url="https://broken.example",
+                    reason="HTTP 404",
+                )
+            ],
+            dropped_record_ids=["seed-one"],
+        ),
+        regions=["US", "EU"],
+    )
+
+    assert "## Public Record Refresh Summary" in summary
+    assert "- Output records: 0" in summary
+    assert "- Regional counts:" in summary
+    assert "  - US: 2" in summary
+    assert "- Dropped IDs:" in summary
+    assert "  - `seed-one`" in summary
+    assert "- Link failures:" in summary
+    assert "  - `seed-one` `website` (HTTP 404): https://broken.example" in summary
+
+
+def test_parse_chambers_index_entries_skips_invalid_rows_and_sorts() -> None:
+    entries = _parse_chambers_index_entries(
+        [
+            "not-a-dict",
+            {"oid": "2", "on": "Zulu LLP"},
+            {"oid": "bad", "on": "Ignored LLP"},
+            {"oid": 1, "on": " Alpha LLP ", "ptgid": None},
+            {"oid": 3, "on": None},
+        ],
+        default_group_id=5,
+    )
+
+    assert entries == [
+        _ChambersIndexEntry(organisation_id=1, name="Alpha LLP", group_id=5),
+        _ChambersIndexEntry(organisation_id=2, name="Zulu LLP", group_id=5),
+    ]
+
+
+def test_fetch_json_payload_handles_non_200_and_successful_json() -> None:
+    closed: list[int] = []
+
+    class _Response:
+        def __init__(self, status_code: int, payload: object) -> None:
+            self.status_code = status_code
+            self._payload = payload
+
+        def json(self) -> object:
+            return self._payload
+
+        def close(self) -> None:
+            closed.append(self.status_code)
+
+    class _Session:
+        def __init__(self) -> None:
+            self._responses = iter(
+                [
+                    _Response(503, {"ignored": True}),
+                    _Response(200, {"ok": True}),
+                ]
+            )
+
+        def get(self, *_args: Any, **_kwargs: Any) -> _Response:
+            return next(self._responses)
+
+    session = cast(requests.Session, _Session())
+
+    assert _fetch_json_payload(session, "https://example.test/one", timeout_seconds=5) is None
+    assert _fetch_json_payload(session, "https://example.test/two", timeout_seconds=5) == {
+        "ok": True
+    }
+    assert closed == [503, 200]
+
+
+def test_discovered_description_handles_tag_list_shapes() -> None:
+    assert _discovered_description("Paris", "France", []) == (
+        "A Chambers-ranked law firm with a public profile in Paris, France."
+    )
+    assert _discovered_description("Paris", "France", ["Whistleblowing"]) == (
+        "A Chambers-ranked law firm with a public profile in Paris, France, "
+        "covering Whistleblowing matters."
+    )
+    assert _discovered_description("Paris", "France", ["Whistleblowing", "Employment"]) == (
+        "A Chambers-ranked law firm with a public profile in Paris, France, "
+        "covering Whistleblowing and Employment matters."
+    )
+    assert _discovered_description(
+        "Paris",
+        "France",
+        ["Whistleblowing", "Employment", "Investigations"],
+    ) == (
+        "A Chambers-ranked law firm with a public profile in Paris, France, "
+        "covering Whistleblowing, Employment, and Investigations matters."
+    )
+
+
+def test_validate_regions_rejects_unknown_region() -> None:
+    with pytest.raises(PublicRecordRefreshError, match="Unknown regions requested: LATAM"):
+        _validate_regions(["US", "LATAM"], {"US": frozenset({"CA"})})
+
+
+def test_chambers_public_profile_url_helpers_cover_supported_and_invalid_inputs() -> None:
+    assert _chambers_public_profile_url(name="Alpha LLP", organisation_id=7, group_id=999) is None
+    assert (
+        _chambers_public_profile_url(
+            name="Alpha LLP",
+            organisation_id=7,
+            group_id=5,
+        )
+        == "https://chambers.com/law-firm/alpha-llp-usa-5:7"
+    )
+    assert (
+        _chambers_public_profile_url_from_source_url(
+            name="Alpha LLP",
+            source_url="https://profiles-portal.chambers.com/api/organisations/7/profile-basics?groupId=5",
+        )
+        == "https://chambers.com/law-firm/alpha-llp-usa-5:7"
+    )
+    assert (
+        _chambers_public_profile_url_from_source_url(
+            name="Alpha LLP",
+            source_url="https://example.test/not-chambers",
+        )
+        is None
+    )
+
+
+def test_apply_region_targets_handles_none_and_invalid_target_configurations() -> None:
+    normalized_rows = [
+        _normalized_listing(
+            listing_id="seed-us",
+            slug="public-record~us",
+            name="US Firm",
+            region="US",
+        ),
+        _normalized_listing(
+            listing_id="seed-eu",
+            slug="public-record~eu",
+            name="EU Firm",
+            region="EU",
+        ),
+    ]
+
+    assert _apply_region_targets(normalized_rows, ["EU", "US"], None) == [
+        _normalized_listing(
+            listing_id="seed-eu",
+            slug="public-record~eu",
+            name="EU Firm",
+            region="EU",
+        ),
+        _normalized_listing(
+            listing_id="seed-us",
+            slug="public-record~us",
+            name="US Firm",
+            region="US",
+        ),
+    ]
+
+    with pytest.raises(PublicRecordRefreshError, match="Missing region target for EU"):
+        _apply_region_targets([normalized_rows[1]], ["EU"], {})
+
+    with pytest.raises(PublicRecordRefreshError, match="Region target must be >= 0 for EU"):
+        _apply_region_targets([normalized_rows[1]], ["EU"], {"EU": -1})
+
+
+def test_normalization_helpers_validate_and_filter_values() -> None:
+    assert _normalize_practice_tags([" Whistleblowing ", "", "Whistleblowing", "Employment"]) == (
+        "Whistleblowing",
+        "Employment",
+    )
+
+    with pytest.raises(PublicRecordRefreshError, match="practice_tags must be a list"):
+        _normalize_practice_tags("not-a-list")
+
+    with pytest.raises(PublicRecordRefreshError, match="practice_tags entries must be strings"):
+        _normalize_practice_tags(["Whistleblowing", 1])
+
+    with pytest.raises(
+        PublicRecordRefreshError,
+        match="practice_tags must contain at least one non-empty tag",
+    ):
+        _normalize_practice_tags([" ", "\t"])
+
+    assert _required_string({"name": " Alpha LLP "}, "name") == "Alpha LLP"
+
+    with pytest.raises(PublicRecordRefreshError, match="Missing required field: name"):
+        _required_string({}, "name")
+
+    with pytest.raises(PublicRecordRefreshError, match="Field 'name' must be a string"):
+        _required_string({"name": 1}, "name")
+
+    with pytest.raises(PublicRecordRefreshError, match="Field 'name' cannot be empty"):
+        _required_string({"name": "   "}, "name")
+
+    assert _optional_string(None) is None
+    assert _optional_string(" Alpha LLP ") == "Alpha LLP"
+
+    with pytest.raises(
+        PublicRecordRefreshError,
+        match="Optional string field must be a string or null",
+    ):
+        _optional_string(1)
+
+    assert _slug_base(" Alpha LLP ") == "alpha-llp"
+
+    with pytest.raises(PublicRecordRefreshError, match="Unable to derive slug from value"):
+        _slug_base("!!!")
+
+
+def test_discover_seed_rows_respects_zero_limit_and_maximum() -> None:
+    seed_rows: list[public_record_refresh.PublicRecordRow] = [
+        _row(
+            state="CA",
+            id_value="seed-one",
+            slug="public-record~seed-one",
+            name="Seed One",
+            website="https://seed-one.example",
+        ),
+        _row(
+            state="CA",
+            id_value="seed-two",
+            slug="public-record~seed-two",
+            name="Seed Two",
+            website="https://seed-two.example",
+        ),
+    ]
+
+    assert (
+        public_record_refresh._discover_seed_rows(
+            seed_rows=seed_rows,
+            existing_rows=[],
+            max_new_per_state=0,
+        )
+        == []
+    )
+    assert public_record_refresh._discover_seed_rows(
+        seed_rows=seed_rows,
+        existing_rows=[],
+        max_new_per_state=1,
+    ) == [seed_rows[0]]
+
+
+def test_discover_noop_official_public_record_rows_returns_empty_list() -> None:
+    assert (
+        public_record_refresh._discover_noop_official_public_record_rows(
+            existing_rows=[
+                _row(
+                    state="CA",
+                    id_value="seed-one",
+                    slug="public-record~seed-one",
+                    name="Seed One",
+                    website="https://seed-one.example",
+                )
+            ],
+            max_new_per_state=5,
+            timeout_seconds=5,
+            session=None,
+        )
+        == []
+    )
+
+
+def test_parse_chambers_index_entries_returns_empty_for_non_list_payload() -> None:
+    assert _parse_chambers_index_entries({"not": "a-list"}, default_group_id=5) == []
+
+
+def test_fetch_json_payload_handles_exceptions_and_invalid_json() -> None:
+    closed: list[str] = []
+
+    class _Response:
+        status_code = 200
+
+        def json(self) -> object:
+            raise ValueError("bad json")
+
+        def close(self) -> None:
+            closed.append("closed")
+
+    class _Session:
+        def __init__(self) -> None:
+            self._calls = 0
+
+        def get(self, *_args: Any, **_kwargs: Any) -> _Response:
+            self._calls += 1
+            if self._calls == 1:
+                raise requests.RequestException("network down")
+            return _Response()
+
+    session = cast(requests.Session, _Session())
+
+    assert _fetch_json_payload(session, "https://example.test/one", timeout_seconds=5) is None
+    assert _fetch_json_payload(session, "https://example.test/two", timeout_seconds=5) is None
+    assert closed == ["closed"]
+
+
+def test_chambers_discovery_helpers_cover_locations_tags_and_url_normalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    assert public_record_refresh._normalize_discovered_website(None) is None
+    assert (
+        public_record_refresh._normalize_discovered_website("https://example.test")
+        == "https://example.test"
+    )
+    assert (
+        public_record_refresh._normalize_discovered_website("www.example.test")
+        == "https://www.example.test"
+    )
+    assert (
+        public_record_refresh._normalize_discovered_website("example.test")
+        == "https://example.test"
+    )
+
+    assert public_record_refresh._iter_office_candidates({"locations": "bad"}) == []
+    assert public_record_refresh._iter_office_candidates(
+        {
+            "headOffice": {"town": "Headquarters", "country": "USA"},
+            "locations": [
+                "bad-location",
+                {"country": "France", "offices": [{"town": "Paris"}, "bad-office"]},
+                {"country": "Germany", "offices": "bad-list"},
+            ],
+        }
+    ) == [
+        {"town": "Headquarters", "country": "USA"},
+        {"town": "Paris", "country": "France"},
+    ]
+
+    assert (
+        public_record_refresh._pick_discovered_location(
+            {"locations": []},
+            region="US",
+            allowed_states=frozenset({"CA"}),
+        )
+        is None
+    )
+    assert (
+        public_record_refresh._pick_discovered_location(
+            {"headOffice": {"country": "Canada", "town": "Toronto", "region": "Ontario"}},
+            region="US",
+            allowed_states=frozenset({"CA"}),
+        )
+        is None
+    )
+    assert (
+        public_record_refresh._pick_discovered_location(
+            {"headOffice": {"country": "United States", "town": "Austin", "region": "Texas"}},
+            region="US",
+            allowed_states=frozenset({"CA"}),
+        )
+        is None
+    )
+    assert public_record_refresh._pick_discovered_location(
+        {
+            "headOffice": {
+                "country": "United States",
+                "town": "San Francisco",
+                "region": "California",
+            }
+        },
+        region="US",
+        allowed_states=frozenset({"CA"}),
+    ) == ("San Francisco", "CA")
+    assert public_record_refresh._pick_discovered_location(
+        {
+            "headOffice": {
+                "country": "USA",
+                "town": "Seattle",
+                "address": "123 Pike Street, Seattle WA",
+            }
+        },
+        region="US",
+        allowed_states=frozenset({"WA"}),
+    ) == ("Seattle", "WA")
+    assert (
+        public_record_refresh._pick_discovered_location(
+            {"headOffice": {"town": "Paris"}},
+            region="EU",
+            allowed_states=frozenset({"France"}),
+        )
+        is None
+    )
+    assert (
+        public_record_refresh._pick_discovered_location(
+            {"headOffice": {"country": "France", "town": "Paris"}},
+            region="EU",
+            allowed_states=frozenset({"Germany"}),
+        )
+        is None
+    )
+    assert public_record_refresh._pick_discovered_location(
+        {
+            "locations": [
+                {"country": "France", "offices": [{"town": "Paris"}]},
+                {"country": "Germany", "offices": [{"town": "Berlin"}]},
+            ]
+        },
+        region="EU",
+        allowed_states=frozenset({"France", "Germany"}),
+    ) == ("Paris", "France")
+
+    assert public_record_refresh._canonical_country(" Republic of Singapore ") == "Singapore"
+    assert public_record_refresh._canonical_country("U.S.A.") == "USA"
+    assert public_record_refresh._canonical_country("United States") == "USA"
+    assert public_record_refresh._canonical_country(None) is None
+
+    assert public_record_refresh._us_state_code_for_office({"region": "CA"}) == "CA"
+    assert public_record_refresh._us_state_code_for_office({"region": "Massachusetts"}) == "MA"
+    assert (
+        public_record_refresh._us_state_code_for_office(
+            {"address": "100 Main Street, New York, NY"}
+        )
+        == "NY"
+    )
+    assert public_record_refresh._us_state_code_for_office({}) is None
+    assert public_record_refresh._us_state_code_for_office({"address": "No state here"}) is None
+
+    ranked_offices_payload = {
+        "headOffice": {"website": "https://hq.example"},
+        "locations": [{"country": "France", "offices": [{"phone": "+33"}]}],
+    }
+    assert public_record_refresh._first_office_field(ranked_offices_payload, "website") == (
+        "https://hq.example"
+    )
+    assert public_record_refresh._first_office_field(ranked_offices_payload, "phone") == "+33"
+    assert public_record_refresh._first_office_field(ranked_offices_payload, "missing") is None
+
+    payloads = iter(
+        [
+            {"not": "a-list"},
+            [
+                "bad-item",
+                {"practiceAreaName": "Whistleblowing investigations"},
+                {"displayName": "Employment law"},
+                {"practiceAreaName": "White collar defense"},
+                {"practiceAreaName": "Employment law"},
+            ],
+            [
+                {"displayName": "Fraud matters"},
+                {"practiceAreaName": "Employment counseling"},
+            ],
+            [{"displayName": "Corporate advisory"}],
+        ]
+    )
+    monkeypatch.setattr(
+        public_record_refresh,
+        "_fetch_json_payload",
+        lambda *_args, **_kwargs: next(payloads),
+    )
+    session = cast(requests.Session, object())
+    assert public_record_refresh._discover_practice_tags(
+        session,
+        organisation_id=1,
+        group_id=5,
+        timeout_seconds=5,
+    ) == ("Whistleblowing", "Investigations", "Employment")
+    assert public_record_refresh._discover_practice_tags(
+        session,
+        organisation_id=1,
+        group_id=5,
+        timeout_seconds=5,
+    ) == ("Whistleblowing", "Investigations", "Employment")
+    assert public_record_refresh._discover_practice_tags(
+        session,
+        organisation_id=1,
+        group_id=5,
+        timeout_seconds=5,
+    ) == ("Fraud", "Employment")
+    assert public_record_refresh._discover_practice_tags(
+        session,
+        organisation_id=1,
+        group_id=5,
+        timeout_seconds=5,
+    ) == ("Whistleblowing", "Investigations", "Employment")
+
+
+def test_discover_official_us_state_public_record_rows_validates_arguments_and_missing_adapters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    with pytest.raises(PublicRecordRefreshError, match="Discovery timeout_seconds must be > 0"):
+        discover_official_us_state_public_record_rows([], timeout_seconds=0)
+
+    with pytest.raises(PublicRecordRefreshError, match="max_new_per_state must be >= 0"):
+        discover_official_us_state_public_record_rows([], max_new_per_state=-1)
+
+    no_us_result = discover_official_us_state_public_record_rows(
+        [],
+        selected_regions=["EU"],
+        region_state_map={"EU": frozenset({"France"})},
+    )
+    assert no_us_result == OfficialStateDiscoveryResult(
+        rows=[],
+        added_count_by_state={},
+        unsupported_states=(),
+    )
+
+    monkeypatch.setattr(
+        public_record_refresh,
+        "OFFICIAL_US_STATE_DISCOVERY_ADAPTERS",
+        {"CA": OFFICIAL_US_STATE_DISCOVERY_ADAPTERS["CA"]},
+    )
+    with pytest.raises(
+        PublicRecordRefreshError,
+        match="Official-source discovery adapters are missing for states: NY",
+    ):
+        discover_official_us_state_public_record_rows(
+            [],
+            selected_regions=["US"],
+            region_state_map={"US": frozenset({"CA", "NY"})},
+            strict_state_adapter_coverage=True,
+        )
+
+    result = discover_official_us_state_public_record_rows(
+        [],
+        selected_regions=["US"],
+        region_state_map={"US": frozenset({"CA", "NY"})},
+    )
+    assert result.unsupported_states == ("NY",)
+    assert result.added_count_by_state == {"CA": len(result.rows)}
+
+
+def test_authoritative_source_and_url_helper_branches(monkeypatch: pytest.MonkeyPatch) -> None:
+    with pytest.raises(
+        PublicRecordRefreshError,
+        match="Listing slug must start with 'public-record~': bad-slug",
+    ):
+        public_record_refresh._normalize_row(
+            _row(
+                state="CA",
+                id_value="seed-one",
+                slug="bad-slug",
+                name="Seed One",
+                website="https://seed-one.example",
+            ),
+            {"US": frozenset({"CA"})},
+        )
+
+    public_record_refresh._validate_authoritative_source(
+        name="Alpha Avocats",
+        state="France",
+        website="https://alpha.example",
+        source_label="French bar directory",
+        source_url=None,
+    )
+
+    assert public_record_refresh._url_host("not a url") is None
+    assert not public_record_refresh._is_chambers_search_url("not a url")
+    assert not public_record_refresh._is_chambers_source_url("not a url")
+    assert public_record_refresh._is_ohio_attorney_profile_source_url(
+        "https://www.ohiobar.org/attorneysearch#/12345/attyinfo"
+    )
+    assert not public_record_refresh._is_ohio_attorney_profile_source_url(
+        "https://www.ohiobar.org/not-attorneysearch#/12345/attyinfo"
+    )
+
+    monkeypatch.setattr(public_record_refresh, "_is_chambers_source_url", lambda _value: False)
+    monkeypatch.setattr(public_record_refresh, "_is_chambers_search_url", lambda _value: True)
+    with pytest.raises(PublicRecordRefreshError, match="uses a Chambers search URL"):
+        public_record_refresh._validate_authoritative_source(
+            name="Alpha LLP",
+            state="France",
+            website="https://alpha.example",
+            source_label="Official directory",
+            source_url="https://www.chambers.com/search?query=alpha",
+        )
+
+    ca_rule = US_STATE_AUTHORITATIVE_SOURCES["CA"]
+    monkeypatch.setattr(
+        public_record_refresh,
+        "US_STATE_AUTHORITATIVE_SOURCES",
+        {"NY": US_STATE_AUTHORITATIVE_SOURCES["NY"]},
+    )
+    with pytest.raises(
+        PublicRecordRefreshError,
+        match="missing an authoritative source rule for state 'CA'",
+    ):
+        public_record_refresh._validate_us_state_source_policy(
+            name="Alpha LLP",
+            state="CA",
+            source_label=ca_rule["source_label"],
+            source_url="https://apps.calbar.ca.gov/attorney/Licensee/Detail/350631",
+        )
+
+    monkeypatch.setattr(
+        public_record_refresh,
+        "US_STATE_AUTHORITATIVE_SOURCES",
+        {"CA": ca_rule},
+    )
+    with pytest.raises(PublicRecordRefreshError, match="invalid source_url hostname"):
+        public_record_refresh._validate_us_state_source_policy(
+            name="Alpha LLP",
+            state="CA",
+            source_label=ca_rule["source_label"],
+            source_url="not a url",
+        )
+    with pytest.raises(
+        PublicRecordRefreshError, match="source_url host 'example.test' is not allowed"
+    ):
+        public_record_refresh._validate_us_state_source_policy(
+            name="Alpha LLP",
+            state="CA",
+            source_label=ca_rule["source_label"],
+            source_url="https://example.test/record/alpha",
+        )
+
+
+def test_validate_links_skips_empty_fields_and_region_lookup_requires_mapping() -> None:
+    row = _NormalizedListing(
+        id="seed-one",
+        slug="public-record~seed-one",
+        name="Seed One",
+        website="https://example.test/profile",
+        description="Seed One description",
+        city="City",
+        state="CA",
+        practice_tags=("Whistleblowing",),
+        source_label="California Bar public directory",
+        source_url=None,
+        region="US",
+    )
+    checked_urls: list[str] = []
+
+    def link_checker(url: str) -> LinkCheckResult:
+        checked_urls.append(url)
+        return LinkCheckResult(ok=True, definitive_failure=False, reason=None)
+
+    result = public_record_refresh._validate_links([row], link_checker, drop_failed_links=True)
+    assert result.rows == [row]
+    assert result.checked_url_count == 1
+    assert checked_urls == ["https://example.test/profile"]
+
+    with pytest.raises(
+        PublicRecordRefreshError,
+        match="State/country 'Atlantis' does not map to any configured region",
+    ):
+        public_record_refresh._region_for_state("Atlantis", {"US": frozenset({"CA"})})
 
 
 def test_discover_chambers_public_record_rows_is_disabled() -> None:

--- a/tests/test_routes_init.py
+++ b/tests/test_routes_init.py
@@ -1,0 +1,27 @@
+from unittest.mock import patch
+
+from flask import Flask
+from flask.testing import FlaskClient
+
+
+def test_info_route_renders_server_ip(app: Flask) -> None:
+    with (
+        app.test_request_context("/info"),
+        patch("hushline.routes.get_ip_address", return_value="203.0.113.10") as get_ip_address,
+        patch("hushline.routes.render_template", return_value="rendered") as render_template,
+    ):
+        response = app.view_functions["server_info"]()
+
+    assert response == "rendered"
+    get_ip_address.assert_called_once_with()
+    render_template.assert_called_once_with(
+        "server_info.html",
+        ip_address="203.0.113.10",
+    )
+
+
+def test_health_json_route_returns_ok(client: FlaskClient) -> None:
+    response = client.get("/health.json")
+
+    assert response.status_code == 200
+    assert response.json == {"status": "ok"}

--- a/tests/test_settings_common.py
+++ b/tests/test_settings_common.py
@@ -177,6 +177,24 @@ async def test_is_safe_verification_url_resolved_public_allowed(app: Flask) -> N
 
 
 @pytest.mark.asyncio()
+async def test_is_safe_verification_url_direct_private_ip_rejected(app: Flask) -> None:
+    with app.app_context():
+        app.config["TESTING"] = False
+        assert await _is_safe_verification_url("https://10.0.0.1") is False
+
+
+@pytest.mark.asyncio()
+async def test_is_safe_verification_url_resolved_blocked_ip_rejected(app: Flask) -> None:
+    with app.app_context():
+        app.config["TESTING"] = False
+        with patch(
+            "hushline.settings.common.asyncio.wait_for",
+            new=AsyncMock(return_value=[(0, 0, 0, "", ("10.0.0.1", 0))]),
+        ):
+            assert await _is_safe_verification_url("https://example.com") is False
+
+
+@pytest.mark.asyncio()
 async def test_verify_url_handles_client_error(user: User) -> None:
     username = user.primary_username
     profile_url = "https://example.com/profile"
@@ -204,6 +222,26 @@ async def test_verify_url_handles_client_error(user: User) -> None:
         await verify_url(_Session(), username, 1, "https://example.com", profile_url)  # type: ignore[arg-type]
 
     db.session.refresh(username)
+    assert username.extra_field_verified1 is False
+
+
+@pytest.mark.asyncio()
+async def test_verify_url_returns_early_when_url_is_not_safe(user: User) -> None:
+    username = user.primary_username
+
+    class _Session:
+        def get(self, *_args: object, **_kwargs: object) -> object:
+            raise AssertionError("session.get should not be called for unsafe URLs")
+
+    with patch("hushline.settings.common._is_safe_verification_url", return_value=False):
+        await verify_url(
+            _Session(),  # type: ignore[arg-type]
+            username,
+            1,
+            "https://example.com",
+            "https://example.com/profile",
+        )
+
     assert username.extra_field_verified1 is False
 
 
@@ -427,6 +465,32 @@ def test_handle_change_username_form_unique_violation_flashes_taken(app: Flask, 
     assert result.status_code == 302
     assert ("message", "💔 This username is already taken.") in messages
     assert session_username == user.primary_username.username
+
+
+def test_handle_change_username_form_internal_error_flashes_generic_error(
+    app: Flask, user: User
+) -> None:
+    form = cast(
+        ChangeUsernameForm,
+        SimpleNamespace(new_username=SimpleNamespace(data="different-name", errors=[])),
+    )
+
+    with (
+        app.test_request_context("/settings/auth", method="POST"),
+        patch("hushline.settings.common.db.session.scalar", side_effect=[False, False]),
+        patch(
+            "hushline.settings.common.db.session.commit",
+            side_effect=IntegrityError("stmt", "params", Exception("boom")),
+        ),
+        patch("hushline.settings.common.current_app.logger.error") as logger_error,
+    ):
+        session["username"] = user.primary_username.username
+        result = handle_change_username_form(user.primary_username, form)
+        messages = session.get("_flashes", [])
+
+    assert result.status_code == 302
+    assert ("message", "⛔️ Internal server error. Username not changed.") in messages
+    logger_error.assert_called_once_with("Error updating username", exc_info=True)
 
 
 def test_handle_change_password_form_rejects_wrong_old_password(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,28 @@
+import pytest
+from flask import Flask
+
+from hushline.utils import if_not_none, parse_bool, redirect_to_self
+
+
+def test_redirect_to_self_uses_current_endpoint_and_view_args(app: Flask) -> None:
+    @app.route("/test-redirect/<username>")
+    def _test_redirect(username: str) -> object:
+        _ = username
+        return redirect_to_self()
+
+    client = app.test_client()
+    response = client.get("/test-redirect/demo")
+
+    assert response.status_code == 302
+    assert response.location == "/test-redirect/demo"
+
+
+def test_if_not_none_applies_to_falsey_values_by_default() -> None:
+    assert if_not_none("", lambda value: value + "z") == "z"
+
+
+def test_parse_bool_false_and_invalid_values() -> None:
+    assert parse_bool("false") is False
+
+    with pytest.raises(ValueError, match="Unparseable boolean value: 'maybe'"):
+        parse_bool("maybe")

--- a/tests/test_vision.py
+++ b/tests/test_vision.py
@@ -1,5 +1,3 @@
-from typing import Any
-
 import pytest
 from flask import get_flashed_messages, url_for
 from flask.testing import FlaskClient
@@ -27,19 +25,10 @@ def test_vision_redirects_to_login_when_session_user_missing(client: FlaskClient
 
 @pytest.mark.usefixtures("_authenticated_user")
 def test_vision_redirects_with_flash_when_user_missing_after_auth(
-    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+    client: FlaskClient, user: User, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    original_get = db.session.get
-    call_count = 0
-
-    def fake_get(model: type[User], ident: object, *args: Any, **kwargs: Any) -> User | None:
-        nonlocal call_count
-        call_count += 1
-        if call_count == 2 and model is User:
-            return None
-        return original_get(model, ident, *args, **kwargs)
-
-    monkeypatch.setattr(db.session, "get", fake_get)
+    monkeypatch.setattr("hushline.auth.get_session_user", lambda: user)
+    monkeypatch.setattr("hushline.routes.vision.db.session.get", lambda *_args, **_kwargs: None)
 
     response = client.get(url_for("vision"), follow_redirects=False)
     assert response.status_code == 302


### PR DESCRIPTION
## What changed
Added focused tests to close the remaining coverage gaps and bring repo-wide coverage to 100%.

The largest remaining gap was in public record refresh coverage, and this batch also adds small focused model/helper tests that lock in remaining edge cases.

## Why
The target for this work was 100% statement coverage across the codebase. This PR closes the remaining uncovered branches without changing production behavior.

## Validation
- make lint
- make test
- make audit-python
- make audit-node-runtime

Full test result after rebase:
- 1168 passed, 1 deselected, 1 xfailed
- total coverage: 100%

## Manual testing
Not applicable. This PR is test-only coverage work.

## Known risks or follow-ups
- The full suite still emits one non-failing RuntimeWarning in tests/test_settings_common.py::test_verify_url_handles_client_error about BaseEventLoop.getaddrinfo not being awaited. Coverage and tests pass, but the warning should be cleaned up separately.