### PR TITLE
test: remove settings async DNS warning

### DIFF
--- a/tests/test_settings_common.py
+++ b/tests/test_settings_common.py
@@ -187,9 +187,10 @@ async def test_is_safe_verification_url_direct_private_ip_rejected(app: Flask) -
 async def test_is_safe_verification_url_resolved_blocked_ip_rejected(app: Flask) -> None:
     with app.app_context():
         app.config["TESTING"] = False
-        with patch(
-            "hushline.settings.common.asyncio.wait_for",
-            new=AsyncMock(return_value=[(0, 0, 0, "", ("10.0.0.1", 0))]),
+        with patch.object(
+            asyncio.get_running_loop(),
+            "getaddrinfo",
+            return_value=[(0, 0, 0, "", ("224.0.0.1", 0))],
         ):
             assert await _is_safe_verification_url("https://example.com") is False
 


### PR DESCRIPTION
## What changed
- patch the settings warning test to mock the event loop DNS lookup directly instead of mocking asyncio.wait_for
- eliminate the unawaited getaddrinfo coroutine warning during full test runs

## Why
- the previous test harness created a coroutine object that was never awaited, which produced a non-failing runtime warning in CI-style runs

## Validation
- make lint
- make test

## Manual testing
- Not applicable; test-only change

## Risks / follow-up
- low risk; this only changes test scaffolding