### PR TITLE
fix runner local self-heal validation order

### DIFF
--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -2,7 +2,7 @@
 
 Script: `scripts/agent_daily_issue_runner.sh`
 
-This runner runs directly in the local repo and now executes the full local CI-equivalent gate set before opening a PR.
+This runner runs directly in the local repo and performs a narrow local gate before opening a PR.
 
 ## Execution Flow
 
@@ -39,24 +39,12 @@ This runner runs directly in the local repo and now executes the full local CI-e
 11. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
     - Before lint/test validation, if the working tree includes schema-affecting changes (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), rebuild the local runtime and reseed dev data so the live stack matches the current code.
     - `make lint`
-    - `make workflow-security-checks`
     - `make test` (full suite)
-    - `make test-ci-alembic`
-    - `make test-ccpa-compliance` when CCPA workflow trigger paths change
-    - `make test-gdpr-compliance` when GDPR workflow trigger paths change
-    - `make test-e2ee-privacy-regressions` when E2EE/privacy workflow trigger paths change
-    - `make test-migration-smoke` when migration workflow trigger paths change
-    - `make audit-python`
-    - `make audit-node-runtime`
-    - `make audit-node-full` when Node dependency manifests change (`package.json` / `package-lock.json` / `npm-shrinkwrap.json`)
-    - `make w3c-validators`
-    - `make lighthouse-accessibility`
-    - `make lighthouse-performance` when lighthouse-performance workflow trigger paths change
-    - Every executed check gets a local self-heal retry before handing failures to Codex.
+    - The runner stops at the first failing gate, hands that failure back to Codex, and reruns from `make lint` on the next self-heal attempt.
     - Lint failures only run deterministic `make fix` self-heal when the failure looks auto-fixable (for example Ruff formatting/check or Prettier); non-auto-fixable lint failures go straight back to Codex.
-    - Runtime-dependent checks (tests, W3C, Lighthouse) self-heal by restarting the local stack and reseeding dev data, then retrying once.
+    - Runtime-dependent tests self-heal by restarting the local stack and reseeding dev data, then retrying once.
     - If the issue has label `test-gap`, require the referenced file in the issue title/body to show `0` misses and `100%` coverage in the test output table.
-    - If local dependency audits are blocked by environment/network issues, continue with explicit PR note and require a passing `Dependency Security Audit` workflow before merge.
+    - The broader CI workflow matrix still runs on the PR after branch push; the runner no longer tries to mirror that entire matrix locally.
 12. Persist run log to `docs/agent-logs/run-<timestamp>-issue-<n>.txt`.
     - After each persist, prune older runner logs and keep only the newest `10` by default.
     - Persisted logs are sanitized before commit to remove developer filesystem paths, emails, and Codex session metadata.
@@ -145,7 +133,7 @@ This runner runs directly in the local repo and now executes the full local CI-e
       v
 +-----------------------------------------------+
 | Fix/self-heal loop                            |
-| Run: lint, test, dependency audits, test-gap  |
+| Run: lint, test, test-gap                     |
 +-----------------------------------------------+
       |
       v

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -650,14 +650,6 @@ configure_bot_git_identity() {
 
 run_local_workflow_checks() {
   : > "$CHECK_LOG_FILE"
-  AUDIT_STATUS="ok"
-  AUDIT_NOTE=""
-  NODE_FULL_AUDIT_REQUIRED=0
-  MIGRATION_SMOKE_REQUIRED=0
-  LIGHTHOUSE_PERFORMANCE_REQUIRED=0
-  CCPA_COMPLIANCE_REQUIRED=0
-  GDPR_COMPLIANCE_REQUIRED=0
-  E2EE_PRIVACY_REQUIRED=0
   local lint_failure_tail=""
   refresh_runtime_after_schema_changes || return 1
   if ! run_check_capture "Run lint" make lint; then
@@ -670,99 +662,8 @@ run_local_workflow_checks() {
     fi
     run_check_capture "Re-run lint after deterministic auto-fix" make lint || return 1
   fi
-  run_check_with_self_heal_retry "Run workflow security checks" make workflow-security-checks || return 1
+
   run_runtime_check_with_self_heal "Run test (full suite)" make test || return 1
-  run_runtime_check_with_self_heal "Run test with alembic (CI)" make test-ci-alembic || return 1
-
-  if ccpa_compliance_files_changed; then
-    CCPA_COMPLIANCE_REQUIRED=1
-    run_runtime_check_with_self_heal "Run CCPA compliance tests (CI)" make test-ccpa-compliance || return 1
-  else
-    echo "==> Run CCPA compliance tests (CI)" | tee -a "$CHECK_LOG_FILE"
-    echo "Skipped: no CCPA compliance workflow trigger paths changed." | tee -a "$CHECK_LOG_FILE"
-  fi
-
-  if gdpr_compliance_files_changed; then
-    GDPR_COMPLIANCE_REQUIRED=1
-    run_runtime_check_with_self_heal "Run GDPR compliance tests (CI)" make test-gdpr-compliance || return 1
-  else
-    echo "==> Run GDPR compliance tests (CI)" | tee -a "$CHECK_LOG_FILE"
-    echo "Skipped: no GDPR compliance workflow trigger paths changed." | tee -a "$CHECK_LOG_FILE"
-  fi
-
-  if e2ee_privacy_files_changed; then
-    E2EE_PRIVACY_REQUIRED=1
-    run_runtime_check_with_self_heal "Run E2EE/privacy regression tests (CI)" make test-e2ee-privacy-regressions || return 1
-  else
-    echo "==> Run E2EE/privacy regression tests (CI)" | tee -a "$CHECK_LOG_FILE"
-    echo "Skipped: no E2EE/privacy workflow trigger paths changed." | tee -a "$CHECK_LOG_FILE"
-  fi
-
-  if migration_smoke_files_changed; then
-    MIGRATION_SMOKE_REQUIRED=1
-    run_runtime_check_with_self_heal "Run migration smoke tests (CI)" make test-migration-smoke || return 1
-  else
-    echo "==> Run migration smoke tests (CI)" | tee -a "$CHECK_LOG_FILE"
-    echo "Skipped: no migration-smoke workflow trigger paths changed." | tee -a "$CHECK_LOG_FILE"
-  fi
-
-  local audit_failure_tail=""
-  local audit_blocked=0
-  local -a audit_blocked_reasons=()
-
-  if ! run_check_with_self_heal_retry "Run dependency audit (python)" make audit-python; then
-    audit_failure_tail="$(tail -n 200 "$CHECK_LOG_FILE")"
-    if audit_failure_looks_environmental "$audit_failure_tail"; then
-      audit_blocked=1
-      audit_blocked_reasons+=("make audit-python")
-    else
-      return 1
-    fi
-  fi
-
-  if ! run_check_with_self_heal_retry "Run dependency audit (node runtime)" make audit-node-runtime; then
-    audit_failure_tail="$(tail -n 200 "$CHECK_LOG_FILE")"
-    if audit_failure_looks_environmental "$audit_failure_tail"; then
-      audit_blocked=1
-      audit_blocked_reasons+=("make audit-node-runtime")
-    else
-      return 1
-    fi
-  fi
-
-  if node_runtime_dependency_files_changed; then
-    NODE_FULL_AUDIT_REQUIRED=1
-    if ! run_check_with_self_heal_retry "Run dependency audit (node full)" make audit-node-full; then
-      audit_failure_tail="$(tail -n 200 "$CHECK_LOG_FILE")"
-      if audit_failure_looks_environmental "$audit_failure_tail"; then
-        audit_blocked=1
-        audit_blocked_reasons+=("make audit-node-full")
-      else
-        return 1
-      fi
-    fi
-  else
-    echo "==> Run dependency audit (node full)" | tee -a "$CHECK_LOG_FILE"
-    echo "Skipped: no Node dependency manifest changes detected." | tee -a "$CHECK_LOG_FILE"
-  fi
-
-  if (( audit_blocked != 0 )); then
-    AUDIT_STATUS="blocked"
-    AUDIT_NOTE="Blocked local dependency audits: ${audit_blocked_reasons[*]}"
-    echo "Dependency audits were blocked by environment/network constraints; continuing with CI gate requirement." \
-      | tee -a "$CHECK_LOG_FILE"
-  fi
-
-  run_runtime_check_with_self_heal "Run W3C validators" make w3c-validators || return 1
-  run_runtime_check_with_self_heal "Run Lighthouse accessibility" make lighthouse-accessibility || return 1
-
-  if lighthouse_performance_files_changed; then
-    LIGHTHOUSE_PERFORMANCE_REQUIRED=1
-    run_runtime_check_with_self_heal "Run Lighthouse performance" make lighthouse-performance || return 1
-  else
-    echo "==> Run Lighthouse performance" | tee -a "$CHECK_LOG_FILE"
-    echo "Skipped: no lighthouse-performance workflow trigger paths changed." | tee -a "$CHECK_LOG_FILE"
-  fi
 }
 
 issue_has_label() {
@@ -1150,58 +1051,11 @@ EOF2
 
 ## Validation
 - `make lint`
-- `make workflow-security-checks`
 - `make test` (full suite)
-- `make test-ci-alembic`
-- `make audit-python`
-- `make audit-node-runtime`
-- `make w3c-validators`
-- `make lighthouse-accessibility`
 EOF2
-
-  if (( CCPA_COMPLIANCE_REQUIRED != 0 )); then
-    printf -- '- `make test-ccpa-compliance`\n' >> "$PR_BODY_FILE"
-  else
-    printf -- '- `make test-ccpa-compliance` (not required: no CCPA compliance workflow trigger paths changed)\n' >> "$PR_BODY_FILE"
-  fi
-
-  if (( GDPR_COMPLIANCE_REQUIRED != 0 )); then
-    printf -- '- `make test-gdpr-compliance`\n' >> "$PR_BODY_FILE"
-  else
-    printf -- '- `make test-gdpr-compliance` (not required: no GDPR compliance workflow trigger paths changed)\n' >> "$PR_BODY_FILE"
-  fi
-
-  if (( E2EE_PRIVACY_REQUIRED != 0 )); then
-    printf -- '- `make test-e2ee-privacy-regressions`\n' >> "$PR_BODY_FILE"
-  else
-    printf -- '- `make test-e2ee-privacy-regressions` (not required: no E2EE/privacy workflow trigger paths changed)\n' >> "$PR_BODY_FILE"
-  fi
-
-  if (( MIGRATION_SMOKE_REQUIRED != 0 )); then
-    printf -- '- `make test-migration-smoke`\n' >> "$PR_BODY_FILE"
-  else
-    printf -- '- `make test-migration-smoke` (not required: no migration-smoke workflow trigger paths changed)\n' >> "$PR_BODY_FILE"
-  fi
-
-  if (( NODE_FULL_AUDIT_REQUIRED != 0 )); then
-    printf -- '- `make audit-node-full`\n' >> "$PR_BODY_FILE"
-  else
-    printf -- '- `make audit-node-full` (not required: no Node dependency manifest changes)\n' >> "$PR_BODY_FILE"
-  fi
-
-  if (( LIGHTHOUSE_PERFORMANCE_REQUIRED != 0 )); then
-    printf -- '- `make lighthouse-performance`\n' >> "$PR_BODY_FILE"
-  else
-    printf -- '- `make lighthouse-performance` (not required: no lighthouse-performance workflow trigger paths changed)\n' >> "$PR_BODY_FILE"
-  fi
-
-  if [[ "$AUDIT_STATUS" == "blocked" ]]; then
-    cat >> "$PR_BODY_FILE" <<EOF2
-- Local dependency audits were blocked by environment/network constraints.
-- Merge gate: require a passing \`Dependency Security Audit\` workflow before merge.
-- Blocked commands: ${AUDIT_NOTE}
+  cat >> "$PR_BODY_FILE" <<'EOF2'
+- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.
 EOF2
-  fi
 
   if issue_has_label "$issue_labels" "test-gap"; then
     if [[ -n "$test_gap_target" ]]; then

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -844,3 +844,71 @@ printf 'rc=%s\\n' "$rc"
         "Blocked: workflow checks failed after 2 self-heal attempt(s) for issue #1558."
         in result.stderr
     )
+
+
+def test_run_local_workflow_checks_runs_lint_then_test_only(tmp_path: Path) -> None:
+    calls_file = tmp_path / "calls.txt"
+    check_log_file = tmp_path / "check.log"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CHECK_LOG_FILE={shlex.quote(str(check_log_file))}
+refresh_runtime_after_schema_changes() {{ :; }}
+run_check_capture() {{
+  printf 'capture:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(calls_file))}
+  return 0
+}}
+run_runtime_check_with_self_heal() {{
+  printf 'runtime:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(calls_file))}
+  return 0
+}}
+run_local_workflow_checks
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert calls_file.read_text(encoding="utf-8").splitlines() == [
+        "capture:Run lint:make",
+        "runtime:Run test (full suite):make",
+    ]
+
+
+def test_run_local_workflow_checks_stops_after_non_fixable_lint_failure(
+    tmp_path: Path,
+) -> None:
+    calls_file = tmp_path / "calls.txt"
+    check_log_file = tmp_path / "check.log"
+    check_log_file.write_text("lint failure\n", encoding="utf-8")
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CHECK_LOG_FILE={shlex.quote(str(check_log_file))}
+refresh_runtime_after_schema_changes() {{ :; }}
+run_check_capture() {{
+  printf 'capture:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(calls_file))}
+  return 1
+}}
+lint_failure_looks_auto_fixable() {{ return 1; }}
+auto_fix_lint_with_containerized_tooling() {{
+  printf 'autofix\\n' >> {shlex.quote(str(calls_file))}
+  return 0
+}}
+run_runtime_check_with_self_heal() {{
+  printf 'runtime:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(calls_file))}
+  return 0
+}}
+set +e
+run_local_workflow_checks
+rc=$?
+set -e
+printf 'rc=%s\\n' "$rc"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "rc=1\n"
+    assert calls_file.read_text(encoding="utf-8").splitlines() == [
+        "capture:Run lint:make",
+    ]


### PR DESCRIPTION
## Summary
- narrow runner self-heal validation to `make lint` followed by `make test`
- stop at the first local validation failure and hand that failure back to Codex on the next attempt
- update runner docs and regression tests to match the new local gate behavior

## Why
The previous runner tried to mirror too much of the CI matrix locally, which made self-heal loops slow and inefficient. This change makes the runner behave more like a human first pass: fix lint or test failures first, then rerun from the beginning.

## Validation
- `bash -n scripts/agent_daily_issue_runner.sh`
- `make test TESTS='tests/test_agent_daily_issue_runner.py'`
- `make lint`

## Manual testing
- Not run

## Risks / follow-ups
- The broader CI workflow matrix still runs on the PR after push, so failures there will still need follow-up if local `lint` and `test` pass.