### PR TITLE
Require invite codes by default on fresh installs

### DIFF
--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -217,7 +217,7 @@ def configure_jinja(app: Flask) -> None:
             registration_settings_enabled=app.config["REGISTRATION_SETTINGS_ENABLED"],
             registration_enabled=data.get(OrganizationSetting.REGISTRATION_ENABLED, False),
             registration_codes_required=data.get(
-                OrganizationSetting.REGISTRATION_CODES_REQUIRED, False
+                OrganizationSetting.REGISTRATION_CODES_REQUIRED, True
             ),
             setup_incomplete=False,
             user=None,

--- a/hushline/model/organization_setting.py
+++ b/hushline/model/organization_setting.py
@@ -43,7 +43,7 @@ class OrganizationSetting(Model):
         GUIDANCE_PROMPTS: [{"heading_text": "", "prompt_text": "", "index": 0}],
         HIDE_DONATE_BUTTON: False,
         REGISTRATION_ENABLED: False,
-        REGISTRATION_CODES_REQUIRED: False,
+        REGISTRATION_CODES_REQUIRED: True,
     }
 
     key: Mapped[str] = mapped_column(primary_key=True)

--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -82,6 +82,8 @@ def _authenticate_as(client: FlaskClient, user: User) -> None:
 
 def test_contract_register_login_and_2fa_challenge(client: FlaskClient, app: Flask) -> None:
     app.config["STRIPE_SECRET_KEY"] = ""
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
+    db.session.commit()
     username = f"contract-{uuid.uuid4().hex[:8]}"
     password = "SecurePassword123!"
     captcha_answer = get_captcha_from_session_register(client)

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -13,7 +13,7 @@ def test_reg_settings_command_outputs_current_values(app: Flask) -> None:
 
     assert result.exit_code == 0
     assert "Registration Enabled: False" in result.output
-    assert "Registration Codes Required: False" in result.output
+    assert "Registration Codes Required: True" in result.output
 
 
 def test_reg_toggle_commands_update_org_settings(app: Flask) -> None:

--- a/tests/test_first_user.py
+++ b/tests/test_first_user.py
@@ -1,5 +1,3 @@
-import os
-
 from flask import url_for
 from flask.testing import FlaskClient
 from helpers import get_captcha_from_session_register
@@ -52,7 +50,8 @@ def test_first_user_is_admin(client: FlaskClient) -> None:
     user_count = db.session.query(User).count()
     assert user_count == 0
 
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
+    db.session.commit()
     username = "test_user"
 
     captcha_answer = get_captcha_from_session_register(client)
@@ -82,8 +81,8 @@ def test_registration_does_not_grant_admin_after_stale_first_user_check(
         key=OrganizationSetting.REGISTRATION_ENABLED,
         value=True,
     )
-
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
+    db.session.commit()
 
     captcha_answer = get_captcha_from_session_register(client)
 
@@ -132,7 +131,8 @@ def test_second_user_is_not_admin(client: FlaskClient, user_password: str) -> No
     db.session.commit()
     assert db.session.query(User).count() == 1
 
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
+    db.session.commit()
     username = "test_user"
 
     captcha_answer = get_captcha_from_session_register(client)

--- a/tests/test_registration_and_login.py
+++ b/tests/test_registration_and_login.py
@@ -1,4 +1,3 @@
-import os
 from unittest.mock import MagicMock, patch
 
 from flask import Flask, url_for
@@ -60,7 +59,8 @@ def test_user_registration_disabled_first_user(client: FlaskClient) -> None:
 
 def test_user_registration_with_invite_code_disabled(client: FlaskClient) -> None:
     """Test registration without requiring an invite code."""
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
+    db.session.commit()
     username = "test_user"
 
     captcha_answer = get_captcha_from_session_register(client)
@@ -85,7 +85,8 @@ def test_user_registration_with_invite_code_disabled(client: FlaskClient) -> Non
 def test_user_registration_writes_pinned_werkzeug_scrypt_hash_when_enabled(
     app: Flask, client: FlaskClient
 ) -> None:
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
+    db.session.commit()
     app.config[PASSWORD_HASH_WRITE_USE_WERKZEUG_SCRYPT] = True
     username = "test_user"
     password = "SecurePassword123!"
@@ -129,7 +130,8 @@ def test_user_registration_writes_pinned_werkzeug_scrypt_hash_when_enabled(
 
 def test_user_registration_with_invite_code_enabled(client: FlaskClient) -> None:
     """Test registration when an invite code is required."""
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "True"
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, True)
+    db.session.commit()
     username = "newuser"
 
     # Generate an invite code
@@ -158,11 +160,11 @@ def test_user_registration_with_invite_code_enabled(client: FlaskClient) -> None
 
 def test_user_registration_rejects_case_insensitive_duplicate(client: FlaskClient) -> None:
     """Usernames should be unique regardless of case."""
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
     OrganizationSetting.upsert(
         key=OrganizationSetting.REGISTRATION_ENABLED,
         value=True,
     )
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
     db.session.commit()
 
     existing_user = User(password="SecurePassword123!")  # noqa: S106
@@ -208,11 +210,11 @@ def test_username_db_constraint_rejects_case_insensitive_duplicate(client: Flask
 def test_user_registration_handles_case_insensitive_race_integrity_error(
     client: FlaskClient,
 ) -> None:
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
     OrganizationSetting.upsert(
         key=OrganizationSetting.REGISTRATION_ENABLED,
         value=True,
     )
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
     db.session.commit()
 
     captcha_answer = get_captcha_from_session_register(client)
@@ -259,7 +261,8 @@ def test_login_page_loads(client: FlaskClient) -> None:
 
 def test_user_login_after_registration(client: FlaskClient) -> None:
     """Test successful login after user registration."""
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
+    db.session.commit()
     username = "newuser"
     password = "SecurePassword123!"
 
@@ -284,7 +287,8 @@ def test_user_login_after_registration(client: FlaskClient) -> None:
 
 def test_user_login_case_insensitive(client: FlaskClient) -> None:
     """Login should accept username case-insensitively."""
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
+    db.session.commit()
     username = "newuser"
     password = "SecurePassword123!"
 
@@ -309,7 +313,8 @@ def test_user_login_case_insensitive(client: FlaskClient) -> None:
 
 def test_user_login_with_incorrect_password(client: FlaskClient) -> None:
     """Test failed login with an incorrect password."""
-    os.environ["REGISTRATION_CODES_REQUIRED"] = "False"
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_CODES_REQUIRED, False)
+    db.session.commit()
     username = "newuser"
     password = "SecurePassword123!"
 

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -104,6 +104,28 @@ def test_register_rejects_expired_invite_code(client: FlaskClient, user: User) -
     assert "Invalid or expired invite code" in response.text
 
 
+def test_register_requires_invite_code_by_default_for_first_user(client: FlaskClient) -> None:
+    response = client.get(url_for("register"))
+
+    assert response.status_code == 200
+    assert "Invite Code" in response.text
+
+    captcha_answer = get_captcha_from_session_register(client)
+    response = client.post(
+        url_for("register"),
+        data={
+            "username": "first-user-without-invite",
+            "password": "SecurePassword123!",
+            "captcha_answer": captcha_answer,
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "This field is required." in response.text
+    assert db.session.scalar(db.select(db.func.count()).select_from(User)) == 0
+
+
 def test_register_valid_invite_code_deletes_code(client: FlaskClient, user: User) -> None:
     _ = user
     OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_ENABLED, True)


### PR DESCRIPTION
## Summary
- require invite codes by default when no explicit `registration_codes_required` organization setting exists
- keep the register page and global template context aligned with that secure default
- update registration-related tests and contracts to opt out explicitly when they need open registration

## Why
Fresh installs were treating invite codes as optional because the organization-setting default for `registration_codes_required` was `False`. That allowed unauthenticated registration on a new instance, including first-user admin takeover.

## Threat summary
- Risk: unauthorized registration on fresh or partially configured installs
- Impacted path: unauthenticated `GET/POST /register` and the rendered register page state
- Mitigation: secure default for `registration_codes_required`, plus regression coverage for first-user registration without an invite code

## Validation
- `COMPOSE_PROJECT_NAME=hushline docker compose run --rm app poetry run pytest tests/test_routes_auth.py tests/test_registration_and_login.py tests/test_first_user.py tests/test_settings_registration.py -q`
- `COMPOSE_PROJECT_NAME=hushline make lint`
- `COMPOSE_PROJECT_NAME=hushline make test`
- `COMPOSE_PROJECT_NAME=hushline make audit-python`
- `COMPOSE_PROJECT_NAME=hushline make audit-node-runtime`

## Manual testing
- Verified by automated coverage that a fresh first-user registration now renders the invite-code field and rejects a submit without one.
- Verified that flows which intentionally disable invite codes still work after setting `registration_codes_required` to `False` explicitly in tests.

## Risks / follow-ups
- Existing deployments that intentionally want open registration must now persist `registration_codes_required = False` explicitly instead of relying on the old implicit default.
- No schema migration is required.