### PR TITLE
Reduce docs screenshot publish runner disk usage

### DIFF
--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -49,6 +49,7 @@ jobs:
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/actions/artifacts/${ARTIFACT_ID}/zip" \
             -o /tmp/docs-screenshots-artifact/artifact.zip
           unzip -q /tmp/docs-screenshots-artifact/artifact.zip -d /tmp/docs-screenshots-artifact/unpacked
+          rm -f /tmp/docs-screenshots-artifact/artifact.zip
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "artifact_dir=/tmp/docs-screenshots-artifact/unpacked" >> "$GITHUB_OUTPUT"
 
@@ -85,8 +86,16 @@ jobs:
             exit 1
           fi
 
-          git clone "https://x-access-token:${SCREENSHOTS_PUSH_TOKEN}@github.com/${SCREENSHOTS_REPOSITORY}.git" /tmp/hushline-screenshots
+          git clone \
+            --depth 1 \
+            --filter=blob:none \
+            --single-branch \
+            --branch "${SCREENSHOTS_DEFAULT_BRANCH}" \
+            "https://x-access-token:${SCREENSHOTS_PUSH_TOKEN}@github.com/${SCREENSHOTS_REPOSITORY}.git" \
+            /tmp/hushline-screenshots
           cd /tmp/hushline-screenshots
+          git sparse-checkout init --cone
+          git sparse-checkout set README.md badge-docs-screenshots.json releases/latest "releases/${RELEASE_KEY}"
           git checkout -B "${SCREENSHOTS_DEFAULT_BRANCH}" "origin/${SCREENSHOTS_DEFAULT_BRANCH}"
 
           mkdir -p "releases/${RELEASE_KEY}" "releases/latest"

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -38,11 +38,23 @@ def test_cross_repo_auto_merge_workflows_use_owner_qualified_pr_heads() -> None:
 
 def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> None:
     workflow_text = _workflow_text(".github/workflows/publish-docs-screenshots.yml")
+    artifact_section = workflow_text.split("      - name: Download screenshot artifact", 1)[
+        1
+    ].split("      - name: Publish screenshots to hushline-screenshots", 1)[0]
     archive_section = workflow_text.split(
         "      - name: Publish screenshots to hushline-screenshots", 1
     )[1]
 
+    assert "rm -f /tmp/docs-screenshots-artifact/artifact.zip" in artifact_section
     assert "SCREENSHOTS_DEFAULT_BRANCH: main" in archive_section
+    assert "--depth 1" in archive_section
+    assert "--filter=blob:none" in archive_section
+    assert "--single-branch" in archive_section
+    assert "git sparse-checkout init --cone" in archive_section
+    assert (
+        "git sparse-checkout set README.md badge-docs-screenshots.json releases/latest "
+        '"releases/${RELEASE_KEY}"' in archive_section
+    )
     assert (
         'git checkout -B "${SCREENSHOTS_DEFAULT_BRANCH}" "origin/${SCREENSHOTS_DEFAULT_BRANCH}"'
         in archive_section


### PR DESCRIPTION
## What changed
- remove the downloaded docs screenshot artifact zip immediately after unzip in the publish workflow
- switch the `hushline-screenshots` publish clone to a shallow, blob-filtered, single-branch clone
- use sparse checkout so the publish job only materializes `README.md`, `badge-docs-screenshots.json`, `releases/latest`, and the current `releases/<version>` path
- add workflow assertions that lock in those disk-usage reductions

## Why
The March 16, 2026 docs screenshots release run failed in the `publish-manual / publish` job with `No space left on device` after the artifact download step. The failure was in the publish path, not in screenshot capture. This change reduces the peak disk footprint on the GitHub runner without changing screenshot retention policy.

## Validation
- `poetry run pytest tests/test_workflow_pr_head_qualification.py`
- `make lint`
- `make test`

## Manual testing
- Not applicable; this change only affects GitHub Actions workflow behavior.

## Risks / follow-ups
- This keeps archive retention unchanged in `scidsg/hushline-screenshots`; if the repo itself grows beyond what a shallow sparse checkout can tolerate, archive pruning would need a separate policy decision.