### PR TITLE
fix: route child issue PRs into epic branches

### DIFF
--- a/.github/workflows/close-epic-child-issue-on-merge.yml
+++ b/.github/workflows/close-epic-child-issue-on-merge.yml
@@ -1,0 +1,62 @@
+name: Close Epic Child Issue on Merge
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+permissions:
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-child-issue:
+    if: ${{ github.event.pull_request.merged == true && startsWith(github.event.pull_request.base.ref, 'codex/epic-') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close linked child issue
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
+        with:
+          script: |
+            const body = String(context.payload.pull_request.body || "");
+            const match = body.match(/(?:^|\n)Linked issue:\s*#(\d+)\b/i);
+
+            if (!match) {
+              core.info("No linked child issue marker found in PR body.");
+              return;
+            }
+
+            const issueNumber = Number(match[1]);
+            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+              core.info("Linked child issue marker did not contain a valid issue number.");
+              return;
+            }
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+            const baseRef = String(context.payload.pull_request.base.ref || "");
+            const issue = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: issueNumber,
+            });
+
+            if (issue.data.state === "closed") {
+              core.info(`Issue #${issueNumber} is already closed.`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              body: `Closed automatically after PR #${prNumber} merged into epic branch \`${baseRef}\`.`,
+            });
+
+            await github.rest.issues.update({
+              owner,
+              repo,
+              issue_number: issueNumber,
+              state: "closed",
+            });

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,7 @@ This file provides operating guidance for coding agents working in the Hush Line
   - The shared epic branch should be the only long-lived PR that targets `main` for that epic.
   - Move the selected issue's project status to `In Progress` while work is underway.
   - Move the selected issue's project status to `Ready for Review` after the PR is open.
+  - For child PRs that target an epic branch, do not rely on GitHub auto-close keywords alone; the child issue must be explicitly closed when that PR is merged into the epic branch.
   - Return to `main` after PR creation.
 
 ## Required Checks Before PR

--- a/docs/AGENT_RUNNER.md
+++ b/docs/AGENT_RUNNER.md
@@ -61,9 +61,11 @@ This runner runs directly in the local repo and performs a narrow local gate bef
     - child issues under a parent epic open/update a child PR whose base branch is the shared epic branch
     - the long-lived epic PR, when present, remains the only PR that targets `main`
 15. Move the selected issue into project status `Ready for Review` once the PR exists.
-16. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`).
-17. Refresh run log after PR creation (including opened PR URL and post-check steps), commit/push that log update when changed.
-18. Return to `main` on exit (explicit checkout + cleanup trap fallback).
+16. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
+17. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
+18. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`).
+19. Refresh run log after PR creation (including opened PR URL and post-check steps), commit/push that log update when changed.
+20. Return to `main` on exit (explicit checkout + cleanup trap fallback).
     - Exit cleanup force-resets the repo to `origin/main` and removes untracked files so interrupted runs do not leave bot work on `main`.
 
 ## ASCII Workflow (Current)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -1227,12 +1227,17 @@ $(if [[ -n "$epic_issue_number" ]]; then
   printf '%s\n' "- Automated daily runner update for child issue #$issue_number."
   printf '%s\n' "- Part of epic #$epic_issue_number: ${epic_issue_title}"
   printf '%s\n' "- This PR targets the epic integration branch \`$base_branch_name\`."
+  printf '%s\n' "- The child issue is closed explicitly by workflow after this PR merges into the epic branch."
 else
   printf '%s\n' "- Automated daily issue runner implementation for #$issue_number."
   printf '%s\n' "- Implements issue goal: ${issue_title}"
 fi)
 
-Closes #$issue_number
+$(if [[ -n "$epic_issue_number" ]]; then
+  printf 'Linked issue: #%s\n' "$issue_number"
+else
+  printf 'Closes #%s\n' "$issue_number"
+fi)
 
 ## Context
 $(if [[ -n "$epic_issue_number" ]]; then

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -477,7 +477,8 @@ cat "$PR_BODY_FILE"
 
     assert result.returncode == 0, result.stderr
     assert "This PR implements child issue #1732" in result.stdout
-    assert "Closes #1732" in result.stdout
+    assert "Linked issue: #1732" in result.stdout
+    assert "Closes #1732" not in result.stdout
     assert "Closes #1735" not in result.stdout
     assert "- Epic: https://github.com/scidsg/hushline/issues/1735" in result.stdout
     assert "- Child issue: https://github.com/scidsg/hushline/issues/1732" in result.stdout


### PR DESCRIPTION
## Summary
- keep child issue work on per-issue branches
- target child PRs at a shared epic branch when the issue has a parent epic
- update runner docs and tests to match the new epic workflow

## Validation
- bash -n scripts/agent_daily_issue_runner.sh
- make test TESTS='tests/test_agent_daily_issue_runner.py'
- make lint