### PR TITLE
fix: resolve epic parent routing in daily runner

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -571,7 +571,7 @@ resolve_issue_parent_epic() {
   local repo="${REPO_SLUG##*/}"
 
   gh api graphql \
-    -f issueNumber="$issue_number" \
+    -F issueNumber="$issue_number" \
     -f query='
       query($issueNumber: Int!) {
         repository(owner: "'"$owner"'", name: "'"$repo"'") {

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -284,6 +284,45 @@ resolve_issue_parent_epic 1732
     assert result.stdout == "1735\tEpic title\thttps://github.com/scidsg/hushline/issues/1735\n"
 
 
+def test_resolve_issue_parent_epic_passes_issue_number_as_graphql_int() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+gh() {{
+  local saw_graphql=0
+  local saw_issue_number=0
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      graphql)
+        saw_graphql=1
+        ;;
+      -F)
+        shift
+        if [[ "${{1-}}" == "issueNumber=1732" ]]; then
+          saw_issue_number=1
+        fi
+        ;;
+    esac
+    shift || break
+  done
+
+  if (( saw_graphql == 1 && saw_issue_number == 1 )); then
+    cat <<'EOF'
+{{"data":{{"repository":{{"issue":{{"parent":{{"number":1735,"title":"Epic title","url":"https://github.com/scidsg/hushline/issues/1735"}}}}}}}}}}
+EOF
+    return 0
+  fi
+
+  return 1
+}}
+resolve_issue_parent_epic 1732
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "1735\tEpic title\thttps://github.com/scidsg/hushline/issues/1735\n"
+
+
 def test_resolve_project_status_edit_args_outputs_project_field_and_option_ids() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}


### PR DESCRIPTION
## Summary
- fix the daily runner's epic parent lookup so GraphQL receives `issueNumber` as an `Int`
- restore child-issue routing to `codex/epic-<epic>` branches when a parent epic exists
- add a regression test covering the GraphQL argument type used by `resolve_issue_parent_epic`

## Validation
- `poetry run pytest tests/test_agent_daily_issue_runner.py -k 'resolve_issue_parent_epic or main_allows_existing_epic_pr_before_runtime_bootstrap'`
