### PR TITLE
Replace gh project subcommands in issue runner

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -816,31 +816,215 @@ set_issue_project_status() {
     return 0
   fi
 
-  gh project item-edit \
-    --id "$item_id" \
-    --project-id "$project_id" \
-    --field-id "$field_id" \
-    --single-select-option-id "$option_id" >/dev/null
+  gh api graphql \
+    -f projectId="$project_id" \
+    -f itemId="$item_id" \
+    -f fieldId="$field_id" \
+    -f optionId="$option_id" \
+    -f query='
+      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+        updateProjectV2ItemFieldValue(
+          input: {
+            projectId: $projectId
+            itemId: $itemId
+            fieldId: $fieldId
+            value: { singleSelectOptionId: $optionId }
+          }
+        ) {
+          projectV2Item {
+            id
+          }
+        }
+      }
+    ' >/dev/null
 }
 
 collect_issue_candidates_from_project() {
   local project_number="$1"
-  gh project item-list \
-    "$project_number" \
-    --owner "$PROJECT_OWNER" \
-    --limit "$PROJECT_ITEM_LIMIT" \
-    --query "is:issue is:open status:\"$PROJECT_COLUMN\"" \
-    --format json 2>/dev/null \
-    | REPO_SLUG="$REPO_SLUG" node -e '
+  local cursor=""
+  local has_next_page="1"
+  local next_cursor=""
+  local collected=0
+  local page_size=100
+  local seen_file=""
+  local response=""
+  local page_output=""
+  local line=""
+  local kind=""
+  local value=""
+  local extra=""
+
+  seen_file="$(mktemp)"
+
+  while [[ "$has_next_page" == "1" ]] && (( collected < PROJECT_ITEM_LIMIT )); do
+    if [[ -n "$cursor" ]]; then
+      response="$({
+        gh api graphql \
+          -f owner="$PROJECT_OWNER" \
+          -F projectNumber="$project_number" \
+          -F itemLimit="$page_size" \
+          -f cursor="$cursor" \
+          -f query='
+            query($owner: String!, $projectNumber: Int!, $itemLimit: Int!, $cursor: String) {
+              user(login: $owner) {
+                projectV2(number: $projectNumber) {
+                  items(first: $itemLimit, after: $cursor) {
+                    nodes {
+                      fieldValueByName(name: "'"$PROJECT_STATUS_FIELD_NAME"'") {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          name
+                        }
+                      }
+                      content {
+                        ... on Issue {
+                          number
+                          state
+                          url
+                          repository {
+                            owner {
+                              login
+                            }
+                            name
+                          }
+                        }
+                      }
+                    }
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
+                  }
+                }
+              }
+              organization(login: $owner) {
+                projectV2(number: $projectNumber) {
+                  items(first: $itemLimit, after: $cursor) {
+                    nodes {
+                      fieldValueByName(name: "'"$PROJECT_STATUS_FIELD_NAME"'") {
+                        ... on ProjectV2ItemFieldSingleSelectValue {
+                          name
+                        }
+                      }
+                      content {
+                        ... on Issue {
+                          number
+                          state
+                          url
+                          repository {
+                            owner {
+                              login
+                            }
+                            name
+                          }
+                        }
+                      }
+                    }
+                    pageInfo {
+                      hasNextPage
+                      endCursor
+                    }
+                  }
+                }
+              }
+            }
+          ' 2>/dev/null
+      } || true)"
+    else
+      response="$({
+        gh api graphql \
+          -f owner="$PROJECT_OWNER" \
+          -F projectNumber="$project_number" \
+          -F itemLimit="$page_size" \
+          -f query='
+          query($owner: String!, $projectNumber: Int!, $itemLimit: Int!, $cursor: String) {
+            user(login: $owner) {
+              projectV2(number: $projectNumber) {
+                items(first: $itemLimit, after: $cursor) {
+                  nodes {
+                    fieldValueByName(name: "'"$PROJECT_STATUS_FIELD_NAME"'") {
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        name
+                      }
+                    }
+                    content {
+                      ... on Issue {
+                        number
+                        state
+                        url
+                        repository {
+                          owner {
+                            login
+                          }
+                          name
+                        }
+                      }
+                    }
+                  }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                }
+              }
+            }
+            organization(login: $owner) {
+              projectV2(number: $projectNumber) {
+                items(first: $itemLimit, after: $cursor) {
+                  nodes {
+                    fieldValueByName(name: "'"$PROJECT_STATUS_FIELD_NAME"'") {
+                      ... on ProjectV2ItemFieldSingleSelectValue {
+                        name
+                      }
+                    }
+                    content {
+                      ... on Issue {
+                        number
+                        state
+                        url
+                        repository {
+                          owner {
+                            login
+                          }
+                          name
+                        }
+                      }
+                    }
+                  }
+                  pageInfo {
+                    hasNextPage
+                    endCursor
+                  }
+                }
+              }
+            }
+          }
+        ' 2>/dev/null
+      } || true)"
+    fi
+
+    if [[ -z "$response" ]]; then
+      break
+    fi
+
+    page_output="$(printf '%s' "$response" | REPO_SLUG="$REPO_SLUG" PROJECT_COLUMN="$PROJECT_COLUMN" node -e '
       const fs = require("fs");
       const payload = JSON.parse(fs.readFileSync(0, "utf8"));
-      const items = Array.isArray(payload)
-        ? payload
-        : Array.isArray(payload.items)
-          ? payload.items
+      const data = payload && payload.data ? payload.data : {};
+      const project =
+        (data.user && data.user.projectV2) ||
+        (data.organization && data.organization.projectV2) ||
+        null;
+      const itemsConnection = project && project.items ? project.items : null;
+      const items =
+        itemsConnection && Array.isArray(itemsConnection.nodes)
+          ? itemsConnection.nodes
           : [];
+      const pageInfo =
+        itemsConnection && itemsConnection.pageInfo
+          ? itemsConnection.pageInfo
+          : {};
       const expectedRepo = String(process.env.REPO_SLUG || "").trim().toLowerCase();
-      const seen = new Set();
+      const expectedStatus = String(process.env.PROJECT_COLUMN || "").trim().toLowerCase();
 
       function getRepositorySlug(content) {
         const repo = content && content.repository;
@@ -863,6 +1047,16 @@ collect_issue_candidates_from_project() {
 
         const contentType = String(content.type || "").toLowerCase();
         if (contentType && contentType !== "issue") continue;
+        if (String(content.state || "").toUpperCase() !== "OPEN") continue;
+
+        const statusName = String(
+          item &&
+          item.fieldValueByName &&
+          item.fieldValueByName.name
+            ? item.fieldValueByName.name
+            : "",
+        ).trim().toLowerCase();
+        if (expectedStatus && statusName !== expectedStatus) continue;
 
         const contentRepo = getRepositorySlug(content);
         if (expectedRepo && contentRepo && contentRepo !== expectedRepo) continue;
@@ -871,12 +1065,46 @@ collect_issue_candidates_from_project() {
         if (!Number.isInteger(number) || number <= 0) {
           number = getIssueNumberFromUrl(content.url);
         }
-        if (!Number.isInteger(number) || number <= 0 || seen.has(number)) continue;
+        if (!Number.isInteger(number) || number <= 0) continue;
 
-        seen.add(number);
-        process.stdout.write(`${number}\n`);
+        process.stdout.write(`issue\t${number}\n`);
       }
-    '
+
+      const hasNextPage = pageInfo && pageInfo.hasNextPage ? "1" : "0";
+      const endCursor = pageInfo && pageInfo.endCursor ? String(pageInfo.endCursor) : "";
+      process.stdout.write(`pageinfo\t${hasNextPage}\t${endCursor}\n`);
+    ')"
+
+    has_next_page="0"
+    next_cursor=""
+    while IFS= read -r line; do
+      [[ -n "$line" ]] || continue
+      IFS=$'\t' read -r kind value extra <<< "$line"
+      if [[ "$kind" == "issue" ]]; then
+        if ! grep -qx "$value" "$seen_file"; then
+          printf '%s\n' "$value" >> "$seen_file"
+          printf '%s\n' "$value"
+          collected=$((collected + 1))
+          if (( collected >= PROJECT_ITEM_LIMIT )); then
+            break
+          fi
+        fi
+      elif [[ "$kind" == "pageinfo" ]]; then
+        has_next_page="$value"
+        next_cursor="$extra"
+      fi
+    done <<< "$page_output"
+
+    if (( collected >= PROJECT_ITEM_LIMIT )); then
+      break
+    fi
+    if [[ "$has_next_page" != "1" || -z "$next_cursor" ]]; then
+      break
+    fi
+    cursor="$next_cursor"
+  done
+
+  rm -f "$seen_file"
 }
 
 collect_issue_candidates() {

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -378,6 +378,221 @@ resolve_issue_project_item_id 1732 7
     assert result.stdout == "PVTI_target"
 
 
+def test_set_issue_project_status_uses_graphql_mutation() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+resolve_project_number() {{ printf '7\\n'; }}
+resolve_project_status_edit_args() {{ printf 'PVT_project\\tPVTSSF_status\\topt_ready\\n'; }}
+resolve_issue_project_item_id() {{ printf 'PVTI_target\\n'; }}
+gh() {{
+  local saw_graphql=0
+  local project_id=""
+  local item_id=""
+  local field_id=""
+  local option_id=""
+  local query_text=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      api)
+        ;;
+      graphql)
+        saw_graphql=1
+        ;;
+      -f)
+        case "$2" in
+          projectId=*) project_id="${{2#projectId=}}" ;;
+          itemId=*) item_id="${{2#itemId=}}" ;;
+          fieldId=*) field_id="${{2#fieldId=}}" ;;
+          optionId=*) option_id="${{2#optionId=}}" ;;
+          query=*) query_text="${{2#query=}}" ;;
+        esac
+        shift
+        ;;
+    esac
+    shift || break
+  done
+
+  [[ "$saw_graphql" == "1" ]]
+  [[ "$project_id" == "PVT_project" ]]
+  [[ "$item_id" == "PVTI_target" ]]
+  [[ "$field_id" == "PVTSSF_status" ]]
+  [[ "$option_id" == "opt_ready" ]]
+  [[ "$query_text" == *"updateProjectV2ItemFieldValue"* ]]
+}}
+set_issue_project_status 1732 "Ready for Review"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_collect_issue_candidates_from_project_filters_open_issues_in_target_status() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+PROJECT_OWNER=scidsg
+PROJECT_COLUMN="Agent Eligible"
+PROJECT_STATUS_FIELD_NAME=Status
+PROJECT_ITEM_LIMIT=200
+REPO_SLUG=scidsg/hushline
+gh() {{
+  cat <<'EOF'
+{{
+  "data": {{
+    "organization": {{
+      "projectV2": {{
+        "items": {{
+          "nodes": [
+            {{
+              "fieldValueByName": {{"name": "Agent Eligible"}},
+              "content": {{
+                "type": "Issue",
+                "number": 1558,
+                "state": "OPEN",
+                "url": "https://github.com/scidsg/hushline/issues/1558",
+                "repository": {{"owner": {{"login": "scidsg"}}, "name": "hushline"}}
+              }}
+            }},
+            {{
+              "fieldValueByName": {{"name": "Done"}},
+              "content": {{
+                "type": "Issue",
+                "number": 1559,
+                "state": "OPEN",
+                "url": "https://github.com/scidsg/hushline/issues/1559",
+                "repository": {{"owner": {{"login": "scidsg"}}, "name": "hushline"}}
+              }}
+            }},
+            {{
+              "fieldValueByName": {{"name": "Agent Eligible"}},
+              "content": {{
+                "type": "Issue",
+                "number": 1560,
+                "state": "CLOSED",
+                "url": "https://github.com/scidsg/hushline/issues/1560",
+                "repository": {{"owner": {{"login": "scidsg"}}, "name": "hushline"}}
+              }}
+            }},
+            {{
+              "fieldValueByName": {{"name": "Agent Eligible"}},
+              "content": {{
+                "type": "Issue",
+                "number": 2001,
+                "state": "OPEN",
+                "url": "https://github.com/other/repo/issues/2001",
+                "repository": {{"owner": {{"login": "other"}}, "name": "repo"}}
+              }}
+            }}
+          ]
+        }}
+      }}
+    }}
+  }}
+}}
+EOF
+}}
+collect_issue_candidates_from_project 12
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "1558\n"
+
+
+def test_collect_issue_candidates_from_project_paginates_before_filtering() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+PROJECT_OWNER=scidsg
+PROJECT_COLUMN="Agent Eligible"
+PROJECT_STATUS_FIELD_NAME=Status
+PROJECT_ITEM_LIMIT=5
+REPO_SLUG=scidsg/hushline
+gh() {{
+  local cursor=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f)
+        case "$2" in
+          cursor=*) cursor="${{2#cursor=}}" ;;
+        esac
+        shift
+        ;;
+    esac
+    shift || break
+  done
+
+  if [[ -z "$cursor" ]]; then
+    cat <<'EOF'
+{{
+  "data": {{
+    "organization": {{
+      "projectV2": {{
+        "items": {{
+          "nodes": [
+            {{
+              "fieldValueByName": {{"name": "Done"}},
+              "content": {{
+                "type": "Issue",
+                "number": 1559,
+                "state": "OPEN",
+                "url": "https://github.com/scidsg/hushline/issues/1559",
+                "repository": {{"owner": {{"login": "scidsg"}}, "name": "hushline"}}
+              }}
+            }}
+          ],
+          "pageInfo": {{
+            "hasNextPage": true,
+            "endCursor": "cursor-2"
+          }}
+        }}
+      }}
+    }}
+  }}
+}}
+EOF
+    return 0
+  fi
+
+  cat <<'EOF'
+{{
+  "data": {{
+    "organization": {{
+      "projectV2": {{
+        "items": {{
+          "nodes": [
+            {{
+              "fieldValueByName": {{"name": "Agent Eligible"}},
+              "content": {{
+                "type": "Issue",
+                "number": 1558,
+                "state": "OPEN",
+                "url": "https://github.com/scidsg/hushline/issues/1558",
+                "repository": {{"owner": {{"login": "scidsg"}}, "name": "hushline"}}
+              }}
+            }}
+          ],
+          "pageInfo": {{
+            "hasNextPage": false,
+            "endCursor": null
+          }}
+        }}
+      }}
+    }}
+  }}
+}}
+EOF
+}}
+collect_issue_candidates_from_project 12
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "1558\n"
+
+
 def test_main_allows_existing_epic_pr_before_runtime_bootstrap(tmp_path: Path) -> None:
     call_log = tmp_path / "calls.txt"
     repo_dir = tmp_path / "repo"


### PR DESCRIPTION
## Summary
- replace `gh project item-list` with GraphQL-based project item selection in the daily issue runner
- replace `gh project item-edit` with the `updateProjectV2ItemFieldValue` GraphQL mutation
- add focused runner tests for project item filtering and status updates

## Why
The current `gh` token now has Projects scope again, but `gh project ... --owner scidsg` is still failing with `unknown owner type`. This patch removes the runner's dependency on those flaky subcommands and uses the GraphQL API path that is already working.

## Verification
- `bash -n scripts/agent_daily_issue_runner.sh`
- shell-level verification that status updates call `updateProjectV2ItemFieldValue`
- shell-level verification that candidate selection only returns open issues in the target project status

## Note
I could not run the Python test file through the repo's normal `pytest`/`poetry` harness in the temp worktree because those tools are not installed in this environment.