### PR TITLE
Fix All tab ordering to use real admin status and username

### DIFF
--- a/assets/js/directory_verified.js
+++ b/assets/js/directory_verified.js
@@ -200,6 +200,32 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   }
 
+  function allTabSortValue(user) {
+    const isUserEntry = !user.is_public_record && !user.is_globaleaks && !user.is_securedrop;
+    if (isUserEntry) {
+      return user.primary_username || user.display_name || "";
+    }
+
+    return user.display_name || user.primary_username || "";
+  }
+
+  function compareAllTabUsers(a, b) {
+    if (a.is_admin !== b.is_admin) {
+      return a.is_admin ? -1 : 1;
+    }
+
+    const aValue = allTabSortValue(a).normalize("NFKC");
+    const bValue = allTabSortValue(b).normalize("NFKC");
+    return aValue.localeCompare(bValue, undefined, {
+      sensitivity: "base",
+      numeric: true,
+    });
+  }
+
+  function sortAllTabUsers(users) {
+    return [...users].sort(compareAllTabUsers);
+  }
+
   function highlightMatch(text, query) {
     return userSearch.highlightQuery(text || "", query);
   }
@@ -368,7 +394,7 @@ document.addEventListener("DOMContentLoaded", function () {
     const infoOnly = realUsers.filter((user) => !user.has_pgp_key);
 
     if (tab === "all") {
-      appendSection(panel, "", users, query, tab);
+      appendSection(panel, "", sortAllTabUsers(users), query, tab);
       return;
     }
 

--- a/hushline/routes/directory.py
+++ b/hushline/routes/directory.py
@@ -374,12 +374,19 @@ def _securedrop_row(listing: SecureDropDirectoryListing) -> dict[str, object | N
     }
 
 
+def _all_directory_entry_identity(entry: dict[str, object | None]) -> str:
+    if str(entry.get("entry_type") or "") == "user":
+        return str(entry.get("primary_username") or entry.get("display_name") or "")
+
+    return str(entry.get("display_name") or entry.get("primary_username") or "")
+
+
 def _all_directory_entry_sort_key(entry: dict[str, object | None]) -> tuple[bool, str, str]:
     is_admin = bool(entry.get("is_admin"))
-    display_name = str(entry.get("display_name") or "")
-    normalized_name = unicodedata.normalize("NFKC", display_name).strip()
-    transliterated_name = unidecode(normalized_name).casefold()
-    return not is_admin, transliterated_name, normalized_name.casefold()
+    sort_identity = _all_directory_entry_identity(entry)
+    normalized_identity = unicodedata.normalize("NFKC", sort_identity).strip()
+    transliterated_identity = unidecode(normalized_identity).casefold()
+    return not is_admin, transliterated_identity, normalized_identity.casefold()
 
 
 def register_directory_routes(app: Flask) -> None:

--- a/hushline/static/js/directory_verified.js
+++ b/hushline/static/js/directory_verified.js
@@ -234,6 +234,34 @@
       });
     }
 
+    function allTabSortValue(user) {
+      const isUserEntry =
+        !user.is_public_record && !user.is_globaleaks && !user.is_securedrop;
+
+      if (isUserEntry) {
+        return user.primary_username || user.display_name || "";
+      }
+
+      return user.display_name || user.primary_username || "";
+    }
+
+    function compareAllTabUsers(a, b) {
+      if (a.is_admin !== b.is_admin) {
+        return a.is_admin ? -1 : 1;
+      }
+
+      const aValue = allTabSortValue(a).normalize("NFKC");
+      const bValue = allTabSortValue(b).normalize("NFKC");
+      return aValue.localeCompare(bValue, undefined, {
+        sensitivity: "base",
+        numeric: true,
+      });
+    }
+
+    function sortAllTabUsers(users) {
+      return [...users].sort(compareAllTabUsers);
+    }
+
     function highlightMatch(text, query) {
       return userSearch.highlightQuery(text || "", query);
     }
@@ -405,7 +433,7 @@
       const infoOnly = realUsers.filter((user) => !user.has_pgp_key);
 
       if (tab === "all") {
-        appendSection(panel, "", users, query, tab);
+        appendSection(panel, "", sortAllTabUsers(users), query, tab);
         return;
       }
 

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -1666,6 +1666,65 @@ def test_directory_all_tab_is_homogeneous_with_admin_first_and_info_only_badge(
     assert verified_panel.select_one('span.badge[aria-label="Info-only account"]') is None
 
 
+def test_directory_all_tab_does_not_promote_non_admin_named_admin(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    mocked_usernames = (
+        SimpleNamespace(
+            username="admin",
+            display_name="Hush Line Admin",
+            bio="official admin",
+            is_verified=True,
+            user=SimpleNamespace(is_admin=True, pgp_key="pgp-key"),
+        ),
+        SimpleNamespace(
+            username="pippo321",
+            display_name="admin",
+            bio="info only",
+            is_verified=False,
+            user=SimpleNamespace(is_admin=False, pgp_key=""),
+        ),
+        SimpleNamespace(
+            username="4allmn",
+            display_name="4allmn",
+            bio="four all",
+            is_verified=False,
+            user=SimpleNamespace(is_admin=False, pgp_key="pgp-key"),
+        ),
+        SimpleNamespace(
+            username="5a8er",
+            display_name="5a8er",
+            bio="five a8er",
+            is_verified=False,
+            user=SimpleNamespace(is_admin=False, pgp_key="pgp-key"),
+        ),
+    )
+
+    monkeypatch.setattr(
+        "hushline.routes.directory.get_directory_usernames", lambda: mocked_usernames
+    )
+    monkeypatch.setattr("hushline.routes.directory.get_public_record_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_securedrop_directory_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
+
+    response = client.get(url_for("directory"))
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    all_panel = soup.find(id="all")
+    assert all_panel is not None
+
+    all_titles = [
+        heading.get_text(" ", strip=True) for heading in all_panel.select("article.user h3")
+    ]
+    assert all_titles == [
+        "Hush Line Admin",
+        "4allmn",
+        "5a8er",
+        "admin",
+    ]
+
+
 def test_directory_users_json_preserves_grouped_feed_order_for_non_all_tabs(
     client: FlaskClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## What changed
- sort All-tab user entries by real `is_admin` status instead of a spoofable display label
- order the All tab as one mixed alphanumeric list across Hush Line accounts, attorney listings, SecureDrop listings, and GlobaLeaks listings
- keep non-All tabs on their existing grouped feed ordering
- add a regression for `@pippo321` displaying as `admin` without being promoted above `4allmn` and `5a8er`

## Why
PR #1779 limited admin-first ordering to the All tab, but it still did not match the intended behavior. The All tab should only pin actual app admins and should otherwise behave as one homogeneous alphanumeric list.

## Validation
- `make lint`
- `make test`

## Manual testing
- Visit `/directory` and open the All tab
- Confirm official admins render first with the admin badge
- Confirm a non-admin account whose display name is `admin` does not jump ahead of lower usernames like `4allmn`
- Confirm attorney, SecureDrop, and GlobaLeaks entries participate in the same mixed All-tab ordering

## Risks / follow-up
- This is a follow-up to merged PR #1779 because that PR head no longer reflected the corrected fix branch during review.