### PR TITLE
Align All tab correction banner wording

### DIFF
--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -446,7 +446,7 @@
     {% if directory_verified_tab_enabled %}
       <p class="meta dirMeta">
         🧪 Beta: This list contains automated entries.
-        Contact the <a href="/to/admin">Hush Line admin</a> for any corrections.
+        <a href="/to/admin">Request a correction</a>.
       </p>
     {% endif %}
     <div class="user-list">

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -209,12 +209,12 @@ def test_directory_all_tab_banner_links_to_admin(client: FlaskClient) -> None:
     assert banner is not None
     banner_link = banner.select_one("a")
     assert banner_link is not None
-    assert banner_link.text.strip() == "Hush Line admin"
+    assert banner_link.text.strip() == "Request a correction"
     assert banner_link.get("href") == "/to/admin"
     banner_text = " ".join(banner.get_text(" ", strip=True).split())
     assert banner_text.startswith("🧪 Beta:")
     assert "This list contains automated entries." in banner_text
-    assert "Contact the Hush Line admin for any corrections." in banner_text
+    assert "Request a correction" in banner_text
 
 
 def test_directory_hides_tab_bar_when_verified_tabs_disabled(client: FlaskClient) -> None:


### PR DESCRIPTION
## What changed
- update the All tab `dirMeta` banner to use the same correction CTA wording as the other beta directory tabs
- replace the All-tab copy with `Request a correction`
- update the banner assertion to match

## Why
The All tab still used different correction language than the Attorneys, SecureDrop, and GlobaLeaks tabs. This keeps the CTA consistent across directory tabs.

## Validation
- `make lint`
- `make test TESTS="tests/test_directory.py::test_directory_all_tab_banner_links_to_admin"`

## Manual testing
- Visit `/directory`
- Open the All tab
- Confirm the beta banner ends with `Request a correction`
- Confirm the link still points to `/to/admin`

## Risks / follow-up
- Copy-only change; no behavior change beyond the visible banner text.