### PR TITLE
Keep the daily issue runner on the PR branch until the PR closes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,7 +111,8 @@ This file provides operating guidance for coding agents working in the Hush Line
   - Move the selected issue's project status to `In Progress` while work is underway.
   - Move the selected issue's project status to `Ready for Review` after the PR is open.
   - For child PRs that target an epic branch, do not rely on GitHub auto-close keywords alone; the child issue must be explicitly closed when that PR is merged into the epic branch.
-  - Return to `main` after PR creation.
+  - Keep the PR branch checked out and poll the open PR for feedback every 60 seconds until it closes.
+  - Return to `main` only after that PR is closed.
 
 ## Required Checks Before PR
 

--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -291,7 +291,7 @@ The runner now performs an SSH signing preflight immediately after configuring g
 - `HUSHLINE_DAILY_RUN_LOG_RETENTION` (default `10`)
 - `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS` (default `10`; positive integer)
 - `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS` (default `8`; positive integer)
-- `HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS` (default `900`; non-negative integer; set `0` to skip the delayed PR feedback check)
+- `HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS` (default `60`; non-negative integer; set `0` to skip continuous PR feedback monitoring; when enabled, the issue runner keeps the PR branch checked out and polls until the PR closes)
 - `HUSHLINE_CODEX_MODEL` (default `gpt-5.4`)
 - `HUSHLINE_CODEX_REASONING_EFFORT` (default `high`)
 - `HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT` (default `0`; set `1` to print full Codex transcript output to the live console only, without writing it into persisted runner logs)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -59,7 +59,7 @@ MAX_ISSUE_ATTEMPTS="${HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS:-10}"
 MAX_FIX_ATTEMPTS="${HUSHLINE_DAILY_MAX_FIX_ATTEMPTS:-8}"
 RUNTIME_BOOTSTRAP_ATTEMPTS="${HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_ATTEMPTS:-3}"
 RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS="${HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS:-10}"
-POST_PR_FEEDBACK_DELAY_SECONDS="${HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS:-900}"
+POST_PR_FEEDBACK_DELAY_SECONDS="${HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS:-60}"
 
 CHECK_LOG_FILE=""
 PROMPT_FILE=""
@@ -79,6 +79,10 @@ LIGHTHOUSE_PERFORMANCE_REQUIRED=0
 CCPA_COMPLIANCE_REQUIRED=0
 GDPR_COMPLIANCE_REQUIRED=0
 E2EE_PRIVACY_REQUIRED=0
+PR_FEEDBACK_MONITOR_ACTIVE=0
+PR_FEEDBACK_MONITOR_CLOSED=0
+PR_FEEDBACK_MONITOR_PR_NUMBER=""
+PR_FEEDBACK_MONITOR_BRANCH=""
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
@@ -123,6 +127,10 @@ cleanup() {
   rm -f "${CHECK_LOG_FILE:-}" "${PROMPT_FILE:-}" "${PR_BODY_FILE:-}" "${CODEX_OUTPUT_FILE:-}" "${CODEX_TRANSCRIPT_FILE:-}" "${RUN_LOG_TMP_FILE:-}"
   rm -f "${HUSHLINE_DAILY_RUNNER_SNAPSHOT_PATH:-}"
   if [[ -d "$REPO_DIR/.git" ]]; then
+    if [[ "${PR_FEEDBACK_MONITOR_ACTIVE:-0}" == "1" && "${PR_FEEDBACK_MONITOR_CLOSED:-0}" != "1" ]]; then
+      echo "Leaving branch ${PR_FEEDBACK_MONITOR_BRANCH:-current branch} checked out because PR #${PR_FEEDBACK_MONITOR_PR_NUMBER:-unknown} is still open."
+      return
+    fi
     if ! git -C "$REPO_DIR" checkout "$BASE_BRANCH" >/dev/null 2>&1; then
       echo "Warning: failed to switch back to $BASE_BRANCH during cleanup." >&2
       return
@@ -788,6 +796,7 @@ fetch_pr_feedback_json() {
         repository(owner: "'"$owner"'", name: "'"$repo"'") {
           pullRequest(number: $prNumber) {
             number
+            state
             url
             reviewDecision
             comments(last: 20) {
@@ -1040,38 +1049,90 @@ resolve_pr_number_from_ref() {
   return 1
 }
 
+pr_feedback_state() {
+  local feedback_json="$1"
+
+  PR_FEEDBACK_JSON="$feedback_json" node <<'EOF'
+const payload = JSON.parse(String(process.env.PR_FEEDBACK_JSON || "{}"));
+const pr =
+  payload &&
+  payload.data &&
+  payload.data.repository &&
+  payload.data.repository.pullRequest
+    ? payload.data.repository.pullRequest
+    : null;
+process.stdout.write(pr && pr.state ? String(pr.state) : "");
+EOF
+}
+
+pr_feedback_summary_has_actionable_items() {
+  local feedback_summary="$1"
+  local summary_line=""
+
+  summary_line="$(printf '%s\n' "$feedback_summary" | sed -n '1p')"
+  if [[ ! "$summary_line" =~ unresolved_review_threads=([0-9]+).*changes_requested_reviews=([0-9]+).*discussion_comments=([0-9]+).*failing_checks=([0-9]+).*pending_checks=([0-9]+) ]]; then
+    return 1
+  fi
+
+  (( BASH_REMATCH[1] + BASH_REMATCH[2] + BASH_REMATCH[3] + BASH_REMATCH[4] + BASH_REMATCH[5] > 0 ))
+}
+
 check_pr_feedback_after_delay() {
   local pr_number="$1"
   local feedback_json=""
   local checks_json="[]"
   local feedback_summary=""
+  local last_feedback_summary=""
+  local pr_state=""
+  local current_branch=""
 
   if [[ -z "$pr_number" ]]; then
-    echo "Post-PR feedback check skipped: PR number unavailable."
+    echo "Post-PR feedback monitor skipped: PR number unavailable."
     return 0
   fi
 
   if (( POST_PR_FEEDBACK_DELAY_SECONDS == 0 )); then
-    echo "Post-PR feedback check skipped: HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS=0."
+    echo "Post-PR feedback monitor skipped: HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS=0."
     return 0
   fi
 
-  echo "Waiting ${POST_PR_FEEDBACK_DELAY_SECONDS}s before checking PR #${pr_number} for review feedback."
-  sleep "$POST_PR_FEEDBACK_DELAY_SECONDS"
+  current_branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+  PR_FEEDBACK_MONITOR_ACTIVE=1
+  PR_FEEDBACK_MONITOR_CLOSED=0
+  PR_FEEDBACK_MONITOR_PR_NUMBER="$pr_number"
+  PR_FEEDBACK_MONITOR_BRANCH="$current_branch"
 
-  echo "==> Check PR #${pr_number} feedback and checks"
-  if ! feedback_json="$(fetch_pr_feedback_json "$pr_number" 2>/dev/null)"; then
-    echo "Warning: failed to fetch post-PR feedback for PR #${pr_number}."
-    return 0
-  fi
+  echo "Monitoring PR #${pr_number} until it closes; polling every ${POST_PR_FEEDBACK_DELAY_SECONDS}s while staying on ${current_branch:-the current branch}."
 
-  if ! checks_json="$(fetch_pr_checks_json "$pr_number" 2>/dev/null)"; then
-    echo "Warning: failed to fetch post-PR checks for PR #${pr_number}."
-    checks_json='[]'
-  fi
+  while :; do
+    echo "==> Check PR #${pr_number} feedback and checks"
+    if ! feedback_json="$(fetch_pr_feedback_json "$pr_number" 2>/dev/null)"; then
+      echo "Warning: failed to fetch post-PR feedback for PR #${pr_number}; retrying in ${POST_PR_FEEDBACK_DELAY_SECONDS}s."
+      sleep "$POST_PR_FEEDBACK_DELAY_SECONDS"
+      continue
+    fi
 
-  feedback_summary="$(summarize_pr_feedback "$feedback_json" "$checks_json")"
-  printf '%s\n' "$feedback_summary"
+    pr_state="$(pr_feedback_state "$feedback_json")"
+
+    if ! checks_json="$(fetch_pr_checks_json "$pr_number" 2>/dev/null)"; then
+      echo "Warning: failed to fetch post-PR checks for PR #${pr_number}."
+      checks_json='[]'
+    fi
+
+    feedback_summary="$(summarize_pr_feedback "$feedback_json" "$checks_json")"
+    if [[ "$feedback_summary" != "$last_feedback_summary" ]]; then
+      printf '%s\n' "$feedback_summary"
+      last_feedback_summary="$feedback_summary"
+    fi
+
+    if [[ "$pr_state" != "OPEN" && -n "$pr_state" ]]; then
+      PR_FEEDBACK_MONITOR_CLOSED=1
+      echo "PR #${pr_number} is ${pr_state}; returning to ${BASE_BRANCH}."
+      return 0
+    fi
+
+    sleep "$POST_PR_FEEDBACK_DELAY_SECONDS"
+  done
 }
 
 resolve_issue_parent_epic() {
@@ -2689,18 +2750,16 @@ main() {
     "$ISSUE_NUMBER" \
     "$PROJECT_STATUS_READY_FOR_REVIEW"
 
-  check_pr_feedback_after_delay "$PR_NUMBER"
-
   persist_run_log "$ISSUE_NUMBER"
 
-  # Ensure committed runner log includes PR creation and post-check execution details.
+  # Ensure committed runner log includes PR creation details before the long-lived PR monitor begins.
   git add "$RUN_LOG_GIT_PATH"
   if ! git diff --cached --quiet; then
     git commit -m "chore: append opened PR URL to runner log"
     git push origin "$BRANCH_NAME"
   fi
 
-  run_step "Return to $BASE_BRANCH" git checkout "$BASE_BRANCH"
+  check_pr_feedback_after_delay "$PR_NUMBER"
 }
 
 if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -2207,7 +2207,7 @@ check_pr_feedback_after_delay 2000
 
     assert result.returncode == 0, result.stderr
     assert (
-        "Post-PR feedback check skipped: HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS=0."
+        "Post-PR feedback monitor skipped: HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS=0."
         in result.stdout
     )
 
@@ -2221,7 +2221,7 @@ check_pr_feedback_after_delay ""
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
-    assert "Post-PR feedback check skipped: PR number unavailable." in result.stdout
+    assert "Post-PR feedback monitor skipped: PR number unavailable." in result.stdout
 
 
 def test_fetch_pr_checks_json_accepts_pending_exit_code() -> None:
@@ -2295,6 +2295,7 @@ def test_check_pr_feedback_after_delay_reports_pr_checks() -> None:
                 "repository": {
                     "pullRequest": {
                         "number": 2000,
+                        "state": "CLOSED",
                         "url": "https://github.com/scidsg/hushline/pull/2000",
                         "reviewDecision": None,
                         "comments": {"nodes": []},
@@ -2319,7 +2320,6 @@ def test_check_pr_feedback_after_delay_reports_pr_checks() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
 POST_PR_FEEDBACK_DELAY_SECONDS=1
-sleep() {{ :; }}
 fetch_pr_feedback_json() {{
   printf '%s\\n' {shlex.quote(feedback_json)}
 }}
@@ -2332,12 +2332,122 @@ check_pr_feedback_after_delay 2000
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
-    assert "Waiting 1s before checking PR #2000 for review feedback." in result.stdout
+    assert "Monitoring PR #2000 until it closes; polling every 1s while staying on" in result.stdout
     assert "==> Check PR #2000 feedback and checks" in result.stdout
     assert "failing_checks=1 pending_checks=0" in result.stdout
     assert (
         "Feedback check 1: failing PR check Run Linter and Tests / test (FAILURE)" in result.stdout
     )
+    assert "PR #2000 is CLOSED; returning to main." in result.stdout
+
+
+def test_check_pr_feedback_after_delay_polls_until_pr_closes(tmp_path: Path) -> None:
+    counter_file = tmp_path / "pr-feedback-counter.txt"
+    open_without_feedback_json = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 2000,
+                        "state": "OPEN",
+                        "url": "https://github.com/scidsg/hushline/pull/2000",
+                        "reviewDecision": None,
+                        "comments": {"nodes": []},
+                        "latestReviews": {"nodes": []},
+                        "reviewThreads": {"nodes": []},
+                    }
+                }
+            }
+        }
+    )
+    open_with_comment_json = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 2000,
+                        "state": "OPEN",
+                        "url": "https://github.com/scidsg/hushline/pull/2000",
+                        "reviewDecision": None,
+                        "comments": {
+                            "nodes": [
+                                {
+                                    "author": {"login": "reviewer1"},
+                                    "body": "Please fix the branch handling.",
+                                    "createdAt": "2026-04-15T00:00:00Z",
+                                    "url": "https://example.test/comment/1",
+                                }
+                            ]
+                        },
+                        "latestReviews": {"nodes": []},
+                        "reviewThreads": {"nodes": []},
+                    }
+                }
+            }
+        }
+    )
+    closed_with_comment_json = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 2000,
+                        "state": "MERGED",
+                        "url": "https://github.com/scidsg/hushline/pull/2000",
+                        "reviewDecision": None,
+                        "comments": {
+                            "nodes": [
+                                {
+                                    "author": {"login": "reviewer1"},
+                                    "body": "Please fix the branch handling.",
+                                    "createdAt": "2026-04-15T00:00:00Z",
+                                    "url": "https://example.test/comment/1",
+                                }
+                            ]
+                        },
+                        "latestReviews": {"nodes": []},
+                        "reviewThreads": {"nodes": []},
+                    }
+                }
+            }
+        }
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+POST_PR_FEEDBACK_DELAY_SECONDS=60
+counter_file={shlex.quote(str(counter_file))}
+rm -f "$counter_file"
+sleep() {{
+  printf 'sleep:%s\\n' "$1"
+}}
+fetch_pr_feedback_json() {{
+  local fetch_count=0
+  if [[ -f "$counter_file" ]]; then
+    fetch_count="$(cat "$counter_file")"
+  fi
+  fetch_count=$((fetch_count + 1))
+  printf '%s\\n' "$fetch_count" > "$counter_file"
+  case "$fetch_count" in
+    1) printf '%s\\n' {shlex.quote(open_without_feedback_json)} ;;
+    2) printf '%s\\n' {shlex.quote(open_with_comment_json)} ;;
+    *) printf '%s\\n' {shlex.quote(closed_with_comment_json)} ;;
+  esac
+}}
+fetch_pr_checks_json() {{
+  printf '[]\\n'
+}}
+check_pr_feedback_after_delay 2000
+rm -f "$counter_file"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.count("==> Check PR #2000 feedback and checks") == 3
+    assert result.stdout.count("sleep:60") == 2
+    assert "Feedback comment 1: @reviewer1 :: Please fix the branch handling." in result.stdout
+    assert "PR #2000 is MERGED; returning to main." in result.stdout
 
 
 def test_resolve_pr_number_from_ref_prefers_pr_url_without_gh_lookup() -> None:
@@ -2537,6 +2647,97 @@ main
     assert "status:1558:Ready for Review" in calls
     assert "feedback:2000" in calls
     assert "Warning: opened PR but failed to resolve its number" not in result.stdout
+
+
+def test_main_keeps_pr_branch_checked_out_until_feedback_monitor_returns(
+    tmp_path: Path,
+) -> None:
+    call_log = tmp_path / "calls.txt"
+    repo_dir = tmp_path / "repo"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(repo_dir))}
+mkdir -p "$REPO_DIR/.git"
+parse_args() {{ :; }}
+initialize_run_state() {{ :; }}
+cleanup() {{ :; }}
+require_cmd() {{ :; }}
+require_positive_integer() {{ :; }}
+require_non_negative_integer() {{ :; }}
+assert_gh_auth() {{ :; }}
+assert_ssh_signing_ready() {{ :; }}
+assert_docker_running() {{ :; }}
+fetch_origin() {{ :; }}
+git() {{
+  printf 'git:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+  case "${{1-}} ${{2-}} ${{3-}} ${{4-}} ${{5-}}" in
+    "symbolic-ref --quiet --short HEAD ")
+      printf 'codex/daily-issue-1558\\n'
+      return 0
+      ;;
+    "rev-list --count main..codex/daily-issue-1558  ")
+      printf '1\\n'
+      return 0
+      ;;
+    "diff --cached --quiet  ")
+      return 1
+      ;;
+  esac
+  return 0
+}}
+docker() {{ :; }}
+collect_issue_candidates() {{ printf '1558\\n'; }}
+resolve_issue_parent_epic() {{ :; }}
+count_open_human_prs() {{ printf '0\\n'; }}
+count_open_bot_prs() {{ printf '0\\n'; }}
+set_issue_project_status() {{ :; }}
+configure_bot_git_identity() {{ :; }}
+start_runtime_stack_and_seed_dev_data() {{ :; }}
+kill_all_docker_containers() {{ :; }}
+kill_processes_on_ports() {{ :; }}
+remote_branch_exists() {{ return 1; }}
+build_issue_prompt() {{ :; }}
+run_issue_attempt_loop() {{ :; }}
+has_non_log_changes() {{ return 0; }}
+persist_run_log() {{
+  RUN_LOG_GIT_PATH="docs/agent-logs/run-test-issue-$1.txt"
+}}
+push_branch_for_pr() {{ :; }}
+write_pr_body() {{ :; }}
+build_pr_title() {{
+  printf '#1558 Title\\n'
+}}
+check_pr_feedback_after_delay() {{
+  printf 'monitor:%s\\n' "$1" >> {shlex.quote(str(call_log))}
+}}
+gh() {{
+  if [[ "${{1-}} ${{2-}} ${{3-}}" == "issue view 1558" ]]; then
+    local last_arg="${{@: -1}}"
+    case "$last_arg" in
+      .title) printf 'Title\\n' ;;
+      .body) printf 'Body\\n' ;;
+      .url) printf 'https://github.com/scidsg/hushline/issues/1558\\n' ;;
+      '.labels[].name // empty') printf '\\n' ;;
+    esac
+    return 0
+  fi
+  if [[ "${{1-}} ${{2-}}" == "pr create" ]]; then
+    printf 'https://github.com/scidsg/hushline/pull/2000\\n'
+    return 0
+  fi
+  return 0
+}}
+main
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert "monitor:2000" in calls
+    assert calls.count("git:checkout main") == 1
+    assert calls.index("monitor:2000") > calls.index("git:checkout -B codex/daily-issue-1558 main")
 
 
 def test_fix_attempt_loop_stops_after_max_attempts(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed
- keep the daily issue runner on the PR branch while it continuously polls PR feedback and checks until the PR closes
- lower `HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS` from `900` to `60` by default
- prevent cleanup from switching back to `main` while the PR feedback monitor is still active
- update `AGENTS.md`, the runner docs, and runner tests to match the new monitoring behavior

## Why
The documented runner contract requires the issue runner to keep the PR branch checked out and poll every 60 seconds until the PR closes. The previous implementation only waited once, checked feedback a single time, and then returned to `main`.

## Validation
- not confirmed from this environment while updating PR metadata
- local toolchain check failed because `poetry` is not available on the shell path, so I could not run `make lint` or `make test`

## Manual testing
- not run while performing this metadata update

## Risks / follow-ups
- long-lived PR monitoring now depends on stable GitHub CLI access for the full time the PR remains open
- if maintainers want less runner log output during long reviews, the polling summary may need a follow-up adjustment
