### PR TITLE
[codex] Fix forwarded notification email content mode

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -252,9 +252,11 @@ def register_profile_routes(app: Flask) -> None:
                                     )
                                     email_body = plaintext_new_message_body
                         else:
-                            # Keep the existing field-level email behavior
-                            # when full-body encryption is disabled.
-                            email_body = format_message_email_fields(extracted_fields)
+                            # Forward plaintext submitted values when recipients
+                            # want message content but not whole-body PGP email
+                            # encryption. Stored field values remain armored for
+                            # the Hush Line inbox.
+                            email_body = format_message_email_fields(raw_extracted_fields)
                             current_app.logger.debug("Sending email with unencrypted body")
                     else:
                         email_body = plaintext_new_message_body

--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -154,7 +154,9 @@ def test_contract_notifications_field_content_mode(client: FlaskClient, user: Us
         _, body = send_email_mock.call_args.args
         assert "Contact Method" in body
         assert "Message" in body
-        assert PGP_SIG in body
+        assert "Signal" in body
+        assert "Contract test message" in body
+        assert PGP_SIG not in body
 
 
 @pytest.mark.usefixtures("_authenticated_user", "_pgp_user")

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -196,7 +196,9 @@ def test_notifications_enabled_yes_content_no_encrypted_body(
     args, _ = mock_do_send_email.call_args
     assert "Contact Method" in args[1]
     assert "Message" in args[1]
-    assert pgp_message_sig in args[1]
+    assert msg_contact_method in args[1]
+    assert msg_content in args[1]
+    assert pgp_message_sig not in args[1]
 
     response = client.get(url_for("message", public_id=message.public_id), follow_redirects=True)
     assert response.status_code == 200
@@ -243,7 +245,9 @@ def test_notifications_enabled_yes_content_no_encrypted_body_delivers_to_all_ena
     assert len(set(bodies)) == 1
     assert "Contact Method" in bodies[0]
     assert "Message" in bodies[0]
-    assert pgp_message_sig in bodies[0]
+    assert msg_contact_method in bodies[0]
+    assert msg_content in bodies[0]
+    assert pgp_message_sig not in bodies[0]
     create_smtp_config.assert_called_once()
 
 


### PR DESCRIPTION
Closed after review. The prior draft was based on an incorrect premise about allowing plaintext notification content. That is not acceptable for Hush Line’s notification model and this PR should not be merged.