### PR TITLE
[codex] Preserve client-encrypted notification bodies for multiple recipients

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -215,9 +215,7 @@ def register_profile_routes(app: Flask) -> None:
                         if uname.user.email_encrypt_entire_body:
                             encrypted_email_body = (form.encrypted_email_body.data or "").strip()
                             client_body_is_armored = _is_armored_pgp_message(encrypted_email_body)
-                            if client_body_is_armored and isinstance(
-                                notification_encryption_target, str
-                            ):
+                            if client_body_is_armored:
                                 email_body = encrypted_email_body
                                 current_app.logger.debug("Sending email with encrypted body")
                             else:
@@ -227,17 +225,10 @@ def register_profile_routes(app: Flask) -> None:
                                         email_body = encrypt_message(
                                             fallback_body, notification_encryption_target
                                         )
-                                        if client_body_is_armored:
-                                            current_app.logger.warning(
-                                                "Received single-recipient encrypted email body; "
-                                                "used server-side full-body encryption for "
-                                                "enabled notification recipients."
-                                            )
-                                        else:
-                                            current_app.logger.warning(
-                                                "Missing/invalid client encrypted email body; "
-                                                "used server-side full-body encryption fallback."
-                                            )
+                                        current_app.logger.warning(
+                                            "Missing/invalid client encrypted email body; "
+                                            "used server-side full-body encryption fallback."
+                                        )
                                     else:
                                         email_body = plaintext_new_message_body
                                         current_app.logger.debug(

--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -216,9 +216,6 @@ def test_contract_notifications_full_body_mode_encrypts_for_all_enabled_recipien
     user.notification_recipients[-1].pgp_key = "secondary-key"
     db.session.commit()
 
-    server_body = (
-        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
-    )
     client_body = (
         "-----BEGIN PGP MESSAGE-----\n\nclient encrypted body\n\n-----END PGP MESSAGE-----"
     )
@@ -226,19 +223,11 @@ def test_contract_notifications_full_body_mode_encrypts_for_all_enabled_recipien
     with (
         patch("hushline.routes.profile.do_send_email", new=MagicMock()) as send_email_mock,
         patch("hushline.model.field_value.encrypt_message", new=MagicMock(return_value=field_body)),
-        patch(
-            "hushline.routes.profile.encrypt_message", new=MagicMock(return_value=server_body)
-        ) as encrypt_mock,
+        patch("hushline.routes.profile.encrypt_message", new=MagicMock()) as encrypt_mock,
     ):
         _submit_message(client, user, encrypted_email_body=client_body)
-        expected_plaintext_body = format_full_message_email_body(
-            [("Contact Method", "Signal"), ("Message", "Contract test message")]
-        )
-        encrypt_mock.assert_called_once_with(
-            expected_plaintext_body,
-            [user.pgp_key, "secondary-key"],
-        )
-        send_email_mock.assert_called_once_with(user, server_body)
+        encrypt_mock.assert_not_called()
+        send_email_mock.assert_called_once_with(user, client_body)
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -348,7 +348,7 @@ def test_notifications_full_body_encryption_embedded_markers_use_server_fallback
 @pytest.mark.usefixtures("_authenticated_user")
 @pytest.mark.usefixtures("_pgp_user")
 @patch("hushline.routes.profile.encrypt_message")
-def test_notifications_full_body_encryption_server_fallback_delivers_to_all_enabled_recipients(
+def test_notifications_full_body_encryption_prefers_client_body_for_all_enabled_recipients(
     mock_encrypt_message: MagicMock,
     app: Flask,
     client: FlaskClient,
@@ -366,17 +366,8 @@ def test_notifications_full_body_encryption_server_fallback_delivers_to_all_enab
     client_encrypted_email_body = (
         "-----BEGIN PGP MESSAGE-----\n\nclient encrypted body\n\n-----END PGP MESSAGE-----"
     )
-    server_encrypted_email_body = (
-        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
-    )
-    mock_encrypt_message.return_value = server_encrypted_email_body
-
     create_smtp_config = MagicMock(return_value=MagicMock())
     send_email = MagicMock()
-    monkeypatch.setattr(
-        "hushline.routes.profile.notification_email_encryption_target",
-        MagicMock(return_value=[user.pgp_key, user.notification_recipients[-1].pgp_key]),
-    )
     monkeypatch.setattr("hushline.routes.common.create_smtp_config", create_smtp_config)
     monkeypatch.setattr("hushline.routes.common.send_email", send_email)
 
@@ -392,20 +383,14 @@ def test_notifications_full_body_encryption_server_fallback_delivers_to_all_enab
     )
 
     assert response.status_code == 200, response.text
-    expected_fallback_body = format_full_message_email_body(
-        [("Contact Method", msg_contact_method), ("Message", msg_content)]
-    )
-    mock_encrypt_message.assert_called_once_with(
-        expected_fallback_body,
-        [user.pgp_key, user.notification_recipients[-1].pgp_key],
-    )
+    mock_encrypt_message.assert_not_called()
     assert [call.args[0] for call in send_email.call_args_list] == [
         "primary@example.com",
         "secondary@example.com",
     ]
     assert [call.args[2] for call in send_email.call_args_list] == [
-        server_encrypted_email_body,
-        server_encrypted_email_body,
+        client_encrypted_email_body,
+        client_encrypted_email_body,
     ]
     create_smtp_config.assert_called_once()
 
@@ -495,13 +480,9 @@ def test_notifications_full_body_encryption_uses_all_enabled_recipient_keys(
     client_encrypted_email_body = (
         "-----BEGIN PGP MESSAGE-----\n\nclient encrypted body\n\n-----END PGP MESSAGE-----"
     )
-    server_encrypted_email_body = (
-        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
-    )
     mock_field_value_encrypt_message.return_value = (
         "-----BEGIN PGP MESSAGE-----\n\nfield encrypted body\n\n-----END PGP MESSAGE-----"
     )
-    mock_encrypt_message.return_value = server_encrypted_email_body
 
     response = client.post(
         url_for("profile", username=user.primary_username.username),
@@ -515,11 +496,5 @@ def test_notifications_full_body_encryption_uses_all_enabled_recipient_keys(
     )
 
     assert response.status_code == 200, response.text
-    expected_fallback_body = format_full_message_email_body(
-        [("Contact Method", msg_contact_method), ("Message", msg_content)]
-    )
-    mock_encrypt_message.assert_called_once_with(
-        expected_fallback_body,
-        [user.pgp_key, "secondary-key"],
-    )
-    mock_do_send_email.assert_called_once_with(user, server_encrypted_email_body)
+    mock_encrypt_message.assert_not_called()
+    mock_do_send_email.assert_called_once_with(user, client_encrypted_email_body)


### PR DESCRIPTION
## What Changed
- fixed the initial tip-submission notification path so full-body notification emails keep using the browser-generated encrypted body when it is valid armored PGP
- removed the multi-recipient special case that discarded the client-encrypted body and forced a server-side fallback
- updated notification regression tests and behavior-contract coverage to require the client-encrypted body for multi-recipient delivery

## Why It Changed
Single-recipient forwarded notifications were arriving correctly, but adding a second notification recipient changed the delivery path. The server stopped trusting the already-encrypted client body and replaced it with a fallback path during initial tip submission.

## Root Cause
`hushline/routes/profile.py` only accepted `encrypted_email_body` as-is when the notification encryption target was a single key. When multiple recipient keys were enabled, the route rejected the valid armored client body and re-encrypted instead. The browser was already encrypting `encrypted_email_body` to all configured recipient public keys.

## User and Developer Impact
Full-body forwarded notifications now behave consistently for one or many recipients: the encrypted body generated in the browser is sent to every enabled notification recipient, preserving the existing E2EE model.

## Validation
- `docker compose run --rm app poetry run pytest tests/test_notifications.py tests/test_behavior_contracts.py -q`
- `make lint`
- `make test`

## Manual Testing
- configure two enabled notification recipients with valid PGP keys
- submit a tip with notification content enabled
- confirm the forwarded emails use the same encrypted full-body payload instead of a server-generated fallback

## Known Risks or Follow-ups
- this PR only changes the initial forwarded notification path on tip submission
- resend-to-email behavior remains unchanged