### PR TITLE
[codex] Fix notifications upsell copy and multi-recipient PGP fallback

### DIFF
--- a/hushline/model/user.py
+++ b/hushline/model/user.py
@@ -365,11 +365,14 @@ class User(Model):
             (recipient for recipient in self.notification_recipients if recipient.position == 0),
             None,
         )
-        if primary_recipient is None:
-            if self.pgp_key:
-                pgp_keys.append(self.pgp_key)
-        elif primary_recipient.enabled and primary_recipient.email and primary_recipient.pgp_key:
+        if primary_recipient is not None and (
+            primary_recipient.enabled and primary_recipient.email and primary_recipient.pgp_key
+        ):
             pgp_keys.append(primary_recipient.pgp_key)
+        elif self.pgp_key:
+            # Preserve legacy key behavior for migrated accounts where the primary recipient
+            # row exists but is incomplete or disabled.
+            pgp_keys.append(self.pgp_key)
 
         non_primary_recipients = (
             self.enabled_notification_recipients

--- a/hushline/templates/settings/notifications.html
+++ b/hushline/templates/settings/notifications.html
@@ -20,7 +20,7 @@
   </form>
 
   {% if user.enable_email_notifications %}
-    {% if not user.pgp_key %}
+    {% if not user.message_encryption_target %}
       <p class="info">
         <a href="{{ url_for('.encryption') }}">Add a public PGP key</a> to keep your tip line message-capable.
       </p>
@@ -55,16 +55,10 @@
         <a href="{{ url_for('.new_notification_recipient') }}" class="btn">Add Recipient</a>
       </div>
     {% elif is_premium_enabled and user.is_free_tier %}
-      <div class="alert">
-        <div>
-          <h4>Need More Destinations?</h4>
-          <p class="info">
-            🚀 Upgrade to Super User for
-            ${{ business_tier_display_price }}/mo to add multiple notification destinations.
-          </p>
-        </div>
-        <a href="{{ url_for('premium.index') }}" class="btn">Upgrade</a>
-      </div>
+      <p class="info">
+        Need more destinations? <a href="{{ url_for('premium.index') }}">Upgrade to Super User</a>
+        for ${{ business_tier_display_price }}/mo to add multiple notification destinations.
+      </p>
     {% else %}
       <p class="meta">Notification destination limit reached for this account.</p>
     {% endif %}

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -297,6 +297,28 @@ def test_profile_allows_submission_with_recipient_key_when_legacy_user_key_missi
 
 
 @pytest.mark.usefixtures("_authenticated_user")
+def test_profile_allows_submission_with_legacy_key_when_primary_recipient_lacks_key(
+    client: FlaskClient, user: User
+) -> None:
+    pgp_key = Path("tests/test_pgp_key.txt").read_text()
+    user.email = "primary@example.com"
+    user.pgp_key = pgp_key
+    primary_recipient = user.primary_notification_recipient
+    assert primary_recipient is not None
+    primary_recipient.pgp_key = None
+    db.session.commit()
+
+    response = client.get(url_for("profile", username=user.primary_username.username))
+    assert response.status_code == 200
+    assert "Sending messages is disabled" not in response.text
+
+    soup = BeautifulSoup(response.data, "html.parser")
+    recipient_keys = soup.find("script", attrs={"id": "recipientPublicKeys"})
+    assert recipient_keys is not None
+    assert "BEGIN PGP PUBLIC KEY BLOCK" in recipient_keys.get_text()
+
+
+@pytest.mark.usefixtures("_authenticated_user")
 def test_profile_submit_message_with_recipient_key_when_legacy_user_key_missing(
     client: FlaskClient, user: User
 ) -> None:

--- a/tests/test_routes_common.py
+++ b/tests/test_routes_common.py
@@ -200,6 +200,18 @@ def test_notification_email_encryption_target_falls_back_to_legacy_user_key(
     assert routes_common.notification_email_encryption_target(user) == "primary-key"
 
 
+def test_notification_email_encryption_target_falls_back_to_legacy_user_key_when_primary_row_lacks_key(
+    user: User,
+) -> None:
+    user.email = "primary@example.com"
+    user.pgp_key = "primary-key"
+    primary_recipient = user.primary_notification_recipient
+    assert primary_recipient is not None
+    primary_recipient.pgp_key = None
+
+    assert routes_common.notification_email_encryption_target(user) == "primary-key"
+
+
 def test_notification_email_encryption_target_uses_non_primary_recipient_without_legacy_key(
     user: User,
 ) -> None:

--- a/tests/test_routes_common.py
+++ b/tests/test_routes_common.py
@@ -200,7 +200,7 @@ def test_notification_email_encryption_target_falls_back_to_legacy_user_key(
     assert routes_common.notification_email_encryption_target(user) == "primary-key"
 
 
-def test_notification_email_encryption_target_falls_back_to_legacy_user_key_when_primary_row_lacks_key(
+def test_notification_email_encryption_target_uses_legacy_key_when_primary_row_lacks_key(
     user: User,
 ) -> None:
     user.email = "primary@example.com"

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1225,6 +1225,31 @@ def test_notifications_page_lists_recipient_drill_ins_for_business_user(
 
 
 @pytest.mark.usefixtures("_authenticated_user")
+def test_notifications_page_uses_any_message_recipient_key_for_message_capable_warning(
+    client: FlaskClient, user: User
+) -> None:
+    with open("tests/test_pgp_key.txt") as file:
+        pgp_key = file.read().strip()
+
+    user.enable_email_notifications = True
+    user.pgp_key = None
+    user.notification_recipients.append(
+        NotificationRecipient(
+            position=1,
+            enabled=True,
+        )
+    )
+    user.notification_recipients[-1].email = "secondary@example.com"
+    user.notification_recipients[-1].pgp_key = pgp_key
+    db.session.commit()
+
+    response = client.get(url_for("settings.notifications"), follow_redirects=True)
+
+    assert response.status_code == 200
+    assert "Add a public PGP key" not in response.text
+
+
+@pytest.mark.usefixtures("_authenticated_user")
 def test_notifications_page_shows_upgrade_when_free_user_reaches_recipient_limit(
     app: Flask, client: FlaskClient, user: User
 ) -> None:
@@ -1240,8 +1265,9 @@ def test_notifications_page_shows_upgrade_when_free_user_reaches_recipient_limit
     response = client.get(url_for("settings.notifications"), follow_redirects=True)
 
     assert response.status_code == 200
-    assert "Need More Destinations?" in response.text
+    assert "Need more destinations?" in response.text
     assert "Upgrade to Super User" in response.text
+    assert url_for("premium.index") in response.text
     assert "Add Recipient" not in response.text
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -18,6 +18,7 @@ from hushline.model import (
     FieldDefinition,
     FieldType,
     Message,
+    NotificationRecipient,
     OrganizationSetting,
     SMTPEncryption,
     Tier,


### PR DESCRIPTION
## What changed
- replaced the notifications-tab premium upsell banner with a simple inline sentence and upgrade link
- fixed `User.message_recipient_keys` so migrated accounts still use the legacy `user.pgp_key` when a primary notification-recipient row exists but is incomplete or disabled
- added regressions covering the migrated multi-recipient fallback path and the updated notifications upsell copy

## Why
- the notifications tab no longer needs the larger upgrade card UI
- accounts affected by the multiple tip recipients migration could have a valid uploaded PGP key but still appear to have no usable recipient key, which disabled message submission incorrectly

## User impact
- the notifications settings page shows a smaller upsell treatment
- migrated accounts with a valid legacy PGP key keep their tip line message-capable until their primary recipient row is fully populated

## Root cause
- `message_recipient_keys` stopped considering the legacy key whenever a position `0` notification-recipient row existed, even if that row had no usable key

## Validation
- `python3 -m py_compile hushline/model/user.py tests/test_routes_common.py tests/test_profile.py tests/test_settings.py`
- targeted `pytest` attempts for the touched settings/profile tests were blocked locally because the test environment could not resolve the expected `postgres` host

## Manual testing
- not run locally because the required test database services were not available in this shell

## Risks / follow-up
- full `make lint` and `make test` still need to run in the normal repo test environment before merge