### PR TITLE
Add password reset flow for notification-enabled accounts

### DIFF
--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -73,6 +73,7 @@ The app and public directory support more than individual profiles. Current disc
 | Visitor       | Use an invite code when registrations are gated                                | I can still join approved deployments                                                                    | Registration with invite-code support                 |
 | Visitor       | Complete a CAPTCHA during registration                                         | The platform can reduce low-effort automated abuse                                                       | Registration CAPTCHA                                  |
 | Existing user | Log in and complete a TOTP challenge                                           | I can access my account securely                                                                         | Login and 2FA verification                            |
+| Existing user | Reset my password if I already enabled notification email                      | I can recover account access without making email mandatory for everyone                                 | Password reset flow                                   |
 
 ### Authenticated Recipients: All Users
 

--- a/hushline/model/__init__.py
+++ b/hushline/model/__init__.py
@@ -27,6 +27,8 @@ from hushline.model.newsroom_directory_listing import (
 )
 from hushline.model.notification_recipient import NotificationRecipient
 from hushline.model.organization_setting import OrganizationSetting
+from hushline.model.password_reset_attempt import PasswordResetAttempt
+from hushline.model.password_reset_token import PasswordResetToken
 from hushline.model.public_record_listing import (
     PublicRecordListing,
     get_public_record_listing,

--- a/hushline/model/password_reset_attempt.py
+++ b/hushline/model/password_reset_attempt.py
@@ -1,0 +1,35 @@
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from hushline.db import db
+
+if TYPE_CHECKING:
+    from flask_sqlalchemy.model import Model
+else:
+    Model = db.Model
+
+
+class PasswordResetAttempt(Model):
+    __tablename__ = "password_reset_attempts"
+
+    DIGEST_LENGTH = 64
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    identifier_hash: Mapped[str] = mapped_column(db.String(DIGEST_LENGTH), nullable=False)
+    ip_hash: Mapped[str] = mapped_column(db.String(DIGEST_LENGTH), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now, nullable=False)
+
+    __table_args__ = (
+        Index("idx_password_reset_attempts_identifier_created", "identifier_hash", "created_at"),
+        Index("idx_password_reset_attempts_ip_created", "ip_hash", "created_at"),
+    )
+
+    def __init__(self, identifier_hash: str, ip_hash: str, **kwargs: Any) -> None:
+        super().__init__(
+            identifier_hash=identifier_hash,  # type: ignore[call-arg]
+            ip_hash=ip_hash,  # type: ignore[call-arg]
+            **kwargs,
+        )

--- a/hushline/model/password_reset_token.py
+++ b/hushline/model/password_reset_token.py
@@ -1,0 +1,66 @@
+import secrets
+from datetime import datetime, timedelta
+from hashlib import sha256
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import Index
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from hushline.db import db
+
+if TYPE_CHECKING:
+    from flask_sqlalchemy.model import Model
+
+    from hushline.model.user import User
+else:
+    Model = db.Model
+
+
+def hash_password_reset_token(token: str) -> str:
+    return sha256(token.encode("utf-8")).hexdigest()
+
+
+class PasswordResetToken(Model):
+    __tablename__ = "password_reset_tokens"
+
+    TOKEN_HASH_LENGTH = 64
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(db.ForeignKey("users.id"), nullable=False, index=True)
+    token_hash: Mapped[str] = mapped_column(
+        db.String(TOKEN_HASH_LENGTH),
+        nullable=False,
+        unique=True,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now, nullable=False)
+    expires_at: Mapped[datetime] = mapped_column(nullable=False)
+    used_at: Mapped[datetime | None]
+
+    user: Mapped["User"] = relationship(back_populates="password_reset_tokens")
+
+    __table_args__ = (
+        Index("idx_password_reset_tokens_user_used_expires", "user_id", "used_at", "expires_at"),
+    )
+
+    @staticmethod
+    def hash_password_reset_token(token: str) -> str:
+        return hash_password_reset_token(token)
+
+    def __init__(self, user_id: int, token_hash: str, expires_at: datetime, **kwargs: Any) -> None:
+        super().__init__(
+            user_id=user_id,  # type: ignore[call-arg]
+            token_hash=token_hash,  # type: ignore[call-arg]
+            expires_at=expires_at,  # type: ignore[call-arg]
+            **kwargs,
+        )
+
+    @classmethod
+    def create_for_user(cls, user_id: int, *, ttl: timedelta) -> tuple["PasswordResetToken", str]:
+        raw_token = secrets.token_urlsafe(32)
+        row = cls(
+            user_id=user_id,
+            token_hash=hash_password_reset_token(raw_token),
+            expires_at=datetime.now() + ttl,
+        )
+        return row, raw_token

--- a/hushline/model/user.py
+++ b/hushline/model/user.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
 
     from hushline.model.message import Message
     from hushline.model.notification_recipient import NotificationRecipient
+    from hushline.model.password_reset_token import PasswordResetToken
     from hushline.model.username import Username
 else:
     Model = db.Model
@@ -79,6 +80,11 @@ class User(Model):
         back_populates="user",
         cascade="all, delete-orphan",
         order_by="NotificationRecipient.position.asc(), NotificationRecipient.id.asc()",
+    )
+    password_reset_tokens: Mapped[list["PasswordResetToken"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+        order_by="PasswordResetToken.id.desc()",
     )
     messages: Mapped[list["Message"]] = relationship(
         secondary="usernames",

--- a/hushline/routes/__init__.py
+++ b/hushline/routes/__init__.py
@@ -13,6 +13,8 @@ from hushline.routes.email_headers import register_email_headers_routes
 from hushline.routes.forms import (  # noqa: F401
     DynamicMessageForm,
     LoginForm,
+    PasswordResetForm,
+    PasswordResetRequestForm,
     RegistrationForm,
     TwoFactorForm,
 )

--- a/hushline/routes/auth.py
+++ b/hushline/routes/auth.py
@@ -1,6 +1,7 @@
 import secrets
 from datetime import UTC, datetime, timedelta
 from hashlib import sha256
+from hmac import new as hmac_new
 
 import pyotp
 from flask import (
@@ -29,10 +30,13 @@ from hushline.auth import (
     set_session_user,
 )
 from hushline.db import db
+from hushline.external_urls import canonical_external_url
 from hushline.model import (
     AuthenticationLog,
     InviteCode,
     OrganizationSetting,
+    PasswordResetAttempt,
+    PasswordResetToken,
     User,
     Username,
 )
@@ -41,11 +45,147 @@ from hushline.password_hasher import (
     emit_password_rehash_on_auth_telemetry,
     prepare_password_rehash_on_auth,
 )
-from hushline.routes.forms import LoginForm, RegistrationForm, TwoFactorForm
+from hushline.routes.common import send_email_to_user_recipients
+from hushline.routes.forms import (
+    LoginForm,
+    PasswordResetForm,
+    PasswordResetRequestForm,
+    RegistrationForm,
+    TwoFactorForm,
+)
+
+PASSWORD_RESET_CONFIRMATION_MESSAGE = (
+    "If an eligible account exists, reset instructions will be sent."  # noqa: S105
+)
+PASSWORD_RESET_INVALID_LINK_MESSAGE = (
+    "Password reset links expire quickly and can only be used once. Request a new reset if needed."  # noqa: S105
+)
+
+
+def _now() -> datetime:
+    return datetime.now()
 
 
 def _password_hash_digest(stored_hash: str) -> str:
     return sha256(stored_hash.encode("utf-8")).hexdigest()
+
+
+def _password_reset_hmac(value: str) -> str:
+    secret = (
+        current_app.config.get("SECRET_KEY")
+        or current_app.config.get("SESSION_FERNET_KEY")
+        or current_app.config.get("ENCRYPTION_KEY")
+        or ""
+    )
+    return hmac_new(str(secret).encode("utf-8"), value.encode("utf-8"), sha256).hexdigest()
+
+
+def _password_reset_identifier_hash(identifier: str) -> str:
+    return _password_reset_hmac(identifier.strip().lower())
+
+
+def _password_reset_ip_hash() -> str:
+    return _password_reset_hmac(request.remote_addr or "unknown")
+
+
+def _password_reset_ttl() -> timedelta:
+    minutes = int(current_app.config.get("PASSWORD_RESET_TOKEN_TTL_MINUTES", 30))
+    return timedelta(minutes=minutes)
+
+
+def _password_reset_rate_limited(identifier_hash: str, ip_hash: str) -> bool:
+    now = _now()
+    window_minutes = int(current_app.config.get("PASSWORD_RESET_RATE_LIMIT_WINDOW_MINUTES", 60))
+    identifier_max = int(current_app.config.get("PASSWORD_RESET_RATE_LIMIT_IDENTIFIER_MAX", 5))
+    ip_max = int(current_app.config.get("PASSWORD_RESET_RATE_LIMIT_IP_MAX", 20))
+    window_start = now - timedelta(minutes=window_minutes)
+
+    identifier_count = db.session.scalar(
+        db.select(db.func.count())
+        .select_from(PasswordResetAttempt)
+        .where(
+            PasswordResetAttempt.identifier_hash == identifier_hash,
+            PasswordResetAttempt.created_at >= window_start,
+        )
+    )
+    ip_count = db.session.scalar(
+        db.select(db.func.count())
+        .select_from(PasswordResetAttempt)
+        .where(
+            PasswordResetAttempt.ip_hash == ip_hash,
+            PasswordResetAttempt.created_at >= window_start,
+        )
+    )
+
+    db.session.add(
+        PasswordResetAttempt(
+            identifier_hash=identifier_hash,
+            ip_hash=ip_hash,
+            created_at=now,
+        )
+    )
+    db.session.commit()
+    return bool(
+        identifier_count is not None
+        and identifier_count >= identifier_max
+        or ip_count is not None
+        and ip_count >= ip_max
+    )
+
+
+def _find_primary_username(identifier: str) -> Username | None:
+    try:
+        return db.session.scalars(
+            db.select(Username).where(
+                func.lower(Username._username) == identifier.strip().lower(),
+                Username.is_primary.is_(True),
+            )
+        ).one_or_none()
+    except MultipleResultsFound:
+        current_app.logger.error(
+            "Multiple primary usernames matched case-insensitive password reset lookup",
+            extra={"username_hash": _password_reset_identifier_hash(identifier)},
+        )
+        return None
+
+
+def _invalidate_password_reset_tokens(user: User, *, used_at: datetime) -> None:
+    for token in user.password_reset_tokens:
+        if token.used_at is None:
+            token.used_at = used_at
+            db.session.add(token)
+
+
+def _eligible_password_reset_user(identifier: str) -> User | None:
+    username = _find_primary_username(identifier)
+    if username is None:
+        return None
+
+    user = username.user
+    if not user.enable_email_notifications or not user.enabled_notification_recipients:
+        return None
+    return user
+
+
+def _send_password_reset_email(user: User, raw_token: str) -> None:
+    reset_url = canonical_external_url("reset_password", token=raw_token)
+    body = (
+        "A password reset was requested for your Hush Line account.\n\n"
+        f"Use this link to set a new password: {reset_url}\n\n"
+        "This link expires quickly and can only be used once. "
+        "If you did not request this reset, ignore this email."
+    )
+    send_email_to_user_recipients(user, "Hush Line password reset", body)
+
+
+def _load_active_password_reset_token(raw_token: str) -> PasswordResetToken | None:
+    token_hash = PasswordResetToken.hash_password_reset_token(raw_token)
+    token = db.session.scalars(
+        db.select(PasswordResetToken).where(PasswordResetToken.token_hash == token_hash)
+    ).one_or_none()
+    if token is None or token.used_at is not None or token.expires_at <= _now():
+        return None
+    return token
 
 
 def _stash_pending_password_rehash(*, replacement_hash: str, source_hash: str) -> None:
@@ -312,6 +452,61 @@ def register_auth_routes(app: Flask) -> None:
 
             flash("⛔️ Invalid username or password.")
         return render_template("login.html", form=form)
+
+    @app.route("/password-reset", methods=["GET", "POST"])
+    def request_password_reset() -> Response | str | tuple[str, int]:
+        form = PasswordResetRequestForm()
+        if request.method == "POST" and form.validate():
+            identifier = form.username.data or ""
+            identifier_hash = _password_reset_identifier_hash(identifier)
+            ip_hash = _password_reset_ip_hash()
+            if _password_reset_rate_limited(identifier_hash, ip_hash):
+                flash("⏲️ Please wait before requesting another password reset.")
+                return render_template("password_reset_requested.html"), 429
+
+            if user := _eligible_password_reset_user(identifier):
+                now = _now()
+                _invalidate_password_reset_tokens(user, used_at=now)
+                reset_token, raw_token = PasswordResetToken.create_for_user(
+                    user.id,
+                    ttl=_password_reset_ttl(),
+                )
+                db.session.add(reset_token)
+                db.session.commit()
+                _send_password_reset_email(user, raw_token)
+
+            return render_template("password_reset_requested.html")
+
+        return render_template("password_reset_request.html", form=form)
+
+    @app.route("/password-reset/<token>", methods=["GET", "POST"])
+    def reset_password(token: str) -> Response | str | tuple[str, int]:
+        reset_token = _load_active_password_reset_token(token)
+        if reset_token is None:
+            flash(PASSWORD_RESET_INVALID_LINK_MESSAGE)
+            return redirect(url_for("request_password_reset"))
+
+        form = PasswordResetForm()
+        if request.method == "POST":
+            if form.validate():
+                user = reset_token.user
+                new_password = form.password.data
+                if user.check_password(new_password):
+                    form.password.errors.append("Cannot choose a repeat password.")
+                    return render_template("password_reset.html", form=form), 400
+
+                now = _now()
+                user.password_hash = new_password
+                rotate_user_session_id(user)
+                _invalidate_password_reset_tokens(user, used_at=now)
+                db.session.commit()
+                session.clear()
+                flash("👍 Password successfully reset. Please log in.", "success")
+                return redirect(url_for("login"))
+
+            return render_template("password_reset.html", form=form), 400
+
+        return render_template("password_reset.html", form=form)
 
     @app.route("/verify-2fa-login", methods=["GET", "POST"])
     def verify_2fa_login() -> Response | str | tuple[Response | str, int]:

--- a/hushline/routes/common.py
+++ b/hushline/routes/common.py
@@ -94,7 +94,7 @@ def get_ip_address() -> str:
     return ip_address
 
 
-def do_send_email(user: User, body: str) -> None:
+def send_email_to_user_recipients(user: User, subject: str, body: str) -> None:
     recipients = user.enabled_notification_recipients
     if not recipients or not user.enable_email_notifications:
         return
@@ -141,7 +141,7 @@ def do_send_email(user: User, body: str) -> None:
             try:
                 send_email(
                     recipient_email,
-                    "New Hush Line Message Received",
+                    subject,
                     body,
                     smtp_config,
                     reply_to,
@@ -152,6 +152,10 @@ def do_send_email(user: User, body: str) -> None:
                 )
     except (KeyError, OSError, TypeError, ValueError, smtplib.SMTPException) as e:
         current_app.logger.error(f"Error sending email: {str(e)}", exc_info=True)
+
+
+def do_send_email(user: User, body: str) -> None:
+    send_email_to_user_recipients(user, "New Hush Line Message Received", body)
 
 
 def notification_email_encryption_target(user: User) -> str | list[str] | None:

--- a/hushline/routes/forms.py
+++ b/hushline/routes/forms.py
@@ -89,6 +89,27 @@ class LoginForm(FlaskForm):
     )
 
 
+class PasswordResetRequestForm(FlaskForm):
+    username = StringField(
+        "Username",
+        validators=[
+            DataRequired(),
+            Length(max=Username.USERNAME_MAX_LENGTH),
+        ],
+    )
+
+
+class PasswordResetForm(FlaskForm):
+    password = PasswordField(
+        "New Password",
+        validators=[
+            DataRequired(),
+            Length(min=User.PASSWORD_MIN_LENGTH, max=User.PASSWORD_MAX_LENGTH),
+            ComplexPassword(),
+        ],
+    )
+
+
 class OnboardingProfileForm(FlaskForm):
     display_name = StringField(
         "Display Name",

--- a/hushline/templates/login.html
+++ b/hushline/templates/login.html
@@ -22,6 +22,9 @@
     <button type="submit">Login</button>
   </form>
   <p>
+    <a href="{{ url_for('request_password_reset') }}">Forgot your password?</a>
+  </p>
+  <p>
     Don't have an account? <a href="{{ url_for('register') }}">Register here</a>
   </p>
 {% endblock %}

--- a/hushline/templates/password_reset.html
+++ b/hushline/templates/password_reset.html
@@ -1,0 +1,17 @@
+{% extends "base.html" %}
+{% block title %}Set New Password{% endblock %}
+
+{% block content %}
+  <h2>Set New Password</h2>
+  <form method="POST" data-submit-spinner="true">
+    {{ form.hidden_tag() }}
+    <div>
+      {{ form.password.label(for="password") }}
+      {{ form.password(id="password", required=True, autocomplete="new-password") }}
+      {% for error in form.password.errors %}
+        <span class="error">{{ error }}</span>
+      {% endfor %}
+    </div>
+    <button type="submit">Reset Password</button>
+  </form>
+{% endblock %}

--- a/hushline/templates/password_reset_request.html
+++ b/hushline/templates/password_reset_request.html
@@ -1,0 +1,24 @@
+{% extends "base.html" %}
+{% block title %}Reset Password{% endblock %}
+
+{% block content %}
+  <h2>Reset Password</h2>
+  <p>
+    Password reset only works for accounts that already have email notifications enabled with an
+    email recipient. Hush Line does not require an email address to use an account.
+  </p>
+  <form method="POST" action="{{ url_for('request_password_reset') }}" data-submit-spinner="true">
+    {{ form.hidden_tag() }}
+    <div>
+      {{ form.username.label(for="username") }}
+      {{ form.username(id="username", required=True, autocomplete="username") }}
+      {% for error in form.username.errors %}
+        <span class="error">{{ error }}</span>
+      {% endfor %}
+    </div>
+    <button type="submit">Send Reset Instructions</button>
+  </form>
+  <p>
+    Remembered your password? <a href="{{ url_for('login') }}">Log in</a>
+  </p>
+{% endblock %}

--- a/hushline/templates/password_reset_requested.html
+++ b/hushline/templates/password_reset_requested.html
@@ -1,0 +1,15 @@
+{% extends "base.html" %}
+{% block title %}Reset Requested{% endblock %}
+
+{% block content %}
+  <h2>Reset Requested</h2>
+  <p>
+    If an eligible account exists, reset instructions will be sent.
+  </p>
+  <p>
+    Reset is available only for accounts that already have email notifications enabled.
+  </p>
+  <p>
+    <a href="{{ url_for('login') }}">Return to login</a>
+  </p>
+{% endblock %}

--- a/migrations/versions/2d8a1f7c9b41_add_password_reset_tables.py
+++ b/migrations/versions/2d8a1f7c9b41_add_password_reset_tables.py
@@ -1,0 +1,84 @@
+"""add password reset tables
+
+Revision ID: 2d8a1f7c9b41
+Revises: d1f0e9c2b7aa
+Create Date: 2026-04-24 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "2d8a1f7c9b41"
+down_revision = "d1f0e9c2b7aa"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "password_reset_attempts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("identifier_hash", sa.String(length=64), nullable=False),
+        sa.Column("ip_hash", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_password_reset_attempts_identifier_created",
+        "password_reset_attempts",
+        ["identifier_hash", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_password_reset_attempts_ip_created",
+        "password_reset_attempts",
+        ["ip_hash", "created_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "password_reset_tokens",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("token_hash", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("expires_at", sa.DateTime(), nullable=False),
+        sa.Column("used_at", sa.DateTime(), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        op.f("ix_password_reset_tokens_token_hash"),
+        "password_reset_tokens",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_index(
+        op.f("ix_password_reset_tokens_user_id"),
+        "password_reset_tokens",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_password_reset_tokens_user_used_expires",
+        "password_reset_tokens",
+        ["user_id", "used_at", "expires_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_password_reset_tokens_user_used_expires", table_name="password_reset_tokens")
+    op.drop_index(op.f("ix_password_reset_tokens_user_id"), table_name="password_reset_tokens")
+    op.drop_index(op.f("ix_password_reset_tokens_token_hash"), table_name="password_reset_tokens")
+    op.drop_table("password_reset_tokens")
+
+    op.drop_index("idx_password_reset_attempts_ip_created", table_name="password_reset_attempts")
+    op.drop_index(
+        "idx_password_reset_attempts_identifier_created",
+        table_name="password_reset_attempts",
+    )
+    op.drop_table("password_reset_attempts")

--- a/tests/migrations/revision_2d8a1f7c9b41.py
+++ b/tests/migrations/revision_2d8a1f7c9b41.py
@@ -1,0 +1,133 @@
+from sqlalchemy import text
+
+from hushline.db import db
+
+
+class UpgradeTester:
+    def load_data(self) -> None:
+        db.session.execute(
+            text(
+                """
+                INSERT INTO users (
+                    id,
+                    is_admin,
+                    is_suspended,
+                    password_hash,
+                    session_id,
+                    email,
+                    pgp_key
+                )
+                VALUES (
+                    1,
+                    false,
+                    false,
+                    '$scrypt$',
+                    'session-1',
+                    'primary@example.com',
+                    NULL
+                )
+                """
+            )
+        )
+        db.session.commit()
+
+    def check_upgrade(self) -> None:
+        assert db.session.scalar(text("SELECT count(*) FROM users")) == 1
+        assert db.session.execute(
+            text(
+                """
+                SELECT user_id, enabled, position, email
+                FROM notification_recipients
+                """
+            )
+        ).one() == (1, True, 0, "primary@example.com")
+
+        for table_name in ("password_reset_attempts", "password_reset_tokens"):
+            assert (
+                db.session.scalar(
+                    text(
+                        """
+                        SELECT count(*)
+                        FROM information_schema.tables
+                        WHERE table_schema = 'public'
+                          AND table_name = :table_name
+                        """
+                    ),
+                    {"table_name": table_name},
+                )
+                == 1
+            )
+
+
+class DowngradeTester:
+    def load_data(self) -> None:
+        db.session.execute(
+            text(
+                """
+                INSERT INTO users (
+                    id,
+                    is_admin,
+                    is_suspended,
+                    password_hash,
+                    session_id
+                )
+                VALUES (1, false, false, '$scrypt$', 'session-1')
+                """
+            )
+        )
+        db.session.execute(
+            text(
+                """
+                INSERT INTO password_reset_attempts (
+                    identifier_hash,
+                    ip_hash,
+                    created_at
+                )
+                VALUES (
+                    repeat('a', 64),
+                    repeat('b', 64),
+                    timestamp '2026-04-24 00:00:00'
+                )
+                """
+            )
+        )
+        db.session.execute(
+            text(
+                """
+                INSERT INTO password_reset_tokens (
+                    user_id,
+                    token_hash,
+                    created_at,
+                    expires_at,
+                    used_at
+                )
+                VALUES (
+                    1,
+                    repeat('c', 64),
+                    timestamp '2026-04-24 00:00:00',
+                    timestamp '2026-04-24 01:00:00',
+                    NULL
+                )
+                """
+            )
+        )
+        db.session.commit()
+
+    def check_downgrade(self) -> None:
+        assert db.session.scalar(text("SELECT count(*) FROM users")) == 1
+
+        for table_name in ("password_reset_attempts", "password_reset_tokens"):
+            assert (
+                db.session.scalar(
+                    text(
+                        """
+                        SELECT count(*)
+                        FROM information_schema.tables
+                        WHERE table_schema = 'public'
+                          AND table_name = :table_name
+                        """
+                    ),
+                    {"table_name": table_name},
+                )
+                == 0
+            )

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -19,8 +19,10 @@ from hushline.auth import (
 )
 from hushline.config import PASSWORD_HASH_REHASH_ON_AUTH_ENABLED
 from hushline.db import db
-from hushline.model import InviteCode, OrganizationSetting, User
+from hushline.model import InviteCode, OrganizationSetting, PasswordResetToken, User
 from hushline.routes.auth import (
+    PASSWORD_RESET_CONFIRMATION_MESSAGE,
+    PASSWORD_RESET_INVALID_LINK_MESSAGE,
     _apply_pending_password_rehash,
     _lock_first_user_registration,
     _password_hash_digest,
@@ -287,6 +289,166 @@ def test_login_redirects_to_original_protected_page(
 
     with client.session_transaction() as sess:
         assert POST_AUTH_REDIRECT_SESSION_KEY not in sess
+
+
+def _enable_password_reset_email(user: User) -> None:
+    user.enable_email_notifications = True
+    user.email = "recipient@example.com"
+    db.session.commit()
+
+
+def _extract_reset_token(email_body: str) -> str:
+    marker = "/password-reset/"
+    assert marker in email_body
+    return email_body.split(marker, 1)[1].split()[0]
+
+
+def test_password_reset_request_is_generic_and_sends_only_for_eligible_account(
+    app: Flask, client: FlaskClient, user: User, user2: User
+) -> None:
+    app.config["PUBLIC_BASE_URL"] = "https://safe.example"
+    user2.enable_email_notifications = False
+    user2.email = "ineligible@example.com"
+    _enable_password_reset_email(user)
+
+    response = client.get(url_for("login"))
+    assert response.status_code == 200
+    assert url_for("request_password_reset") in response.text
+
+    with patch("hushline.routes.auth.send_email_to_user_recipients") as send_email_mock:
+        unknown_response = client.post(
+            url_for("request_password_reset"),
+            data={"username": "not-a-real-user"},
+        )
+        ineligible_response = client.post(
+            url_for("request_password_reset"),
+            data={"username": user2.primary_username.username},
+        )
+        eligible_response = client.post(
+            url_for("request_password_reset"),
+            data={"username": user.primary_username.username.upper()},
+        )
+
+    assert unknown_response.status_code == 200
+    assert ineligible_response.status_code == 200
+    assert eligible_response.status_code == 200
+    assert PASSWORD_RESET_CONFIRMATION_MESSAGE in unknown_response.text
+    assert PASSWORD_RESET_CONFIRMATION_MESSAGE in ineligible_response.text
+    assert PASSWORD_RESET_CONFIRMATION_MESSAGE in eligible_response.text
+    send_email_mock.assert_called_once()
+    sent_user, subject, body = send_email_mock.call_args.args
+    assert sent_user == user
+    assert subject == "Hush Line password reset"
+    assert "https://safe.example/password-reset/" in body
+    assert "localhost" not in body
+    raw_token = _extract_reset_token(body)
+    token_hash = PasswordResetToken.hash_password_reset_token(raw_token)
+    token_count = db.session.scalar(
+        db.select(db.func.count())
+        .select_from(PasswordResetToken)
+        .where(
+            PasswordResetToken.user_id == user.id,
+            PasswordResetToken.token_hash == token_hash,
+        )
+    )
+    assert token_count == 1
+
+
+def test_password_reset_sets_new_password_and_consumes_token(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    _enable_password_reset_email(user)
+    original_session_id = user.session_id
+
+    with patch("hushline.routes.auth.send_email_to_user_recipients") as send_email_mock:
+        client.post(
+            url_for("request_password_reset"),
+            data={"username": user.primary_username.username},
+        )
+
+    raw_token = _extract_reset_token(send_email_mock.call_args.args[2])
+
+    invalid_response = client.post(
+        url_for("reset_password", token=raw_token),
+        data={"password": "short"},
+    )
+    assert invalid_response.status_code == 400
+    assert "Field must be between" in invalid_response.text
+
+    repeat_response = client.post(
+        url_for("reset_password", token=raw_token),
+        data={"password": user_password},
+    )
+    assert repeat_response.status_code == 400
+    assert "Cannot choose a repeat password." in repeat_response.text
+
+    new_password = "ResetPassword123!!"
+    response = client.post(
+        url_for("reset_password", token=raw_token),
+        data={"password": new_password},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(url_for("login"))
+    db.session.refresh(user)
+    assert user.session_id != original_session_id
+    assert user.check_password(new_password)
+    assert not user.check_password(user_password)
+    token = db.session.scalars(db.select(PasswordResetToken)).one()
+    assert token.used_at is not None
+
+    reused_response = client.get(url_for("reset_password", token=raw_token), follow_redirects=True)
+    assert reused_response.status_code == 200
+    assert PASSWORD_RESET_INVALID_LINK_MESSAGE in reused_response.text
+    assert "Reset Password" in reused_response.text
+
+
+def test_password_reset_rejects_expired_and_unknown_tokens(client: FlaskClient, user: User) -> None:
+    reset_token, raw_token = PasswordResetToken.create_for_user(
+        user.id,
+        ttl=timedelta(minutes=-1),
+    )
+    db.session.add(reset_token)
+    db.session.commit()
+
+    response = client.get(url_for("reset_password", token=raw_token), follow_redirects=True)
+
+    assert response.status_code == 200
+    assert PASSWORD_RESET_INVALID_LINK_MESSAGE in response.text
+    assert "Reset Password" in response.text
+
+    response = client.get(
+        url_for("reset_password", token="not-a-token"),  # noqa: S106
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert PASSWORD_RESET_INVALID_LINK_MESSAGE in response.text
+    assert "Reset Password" in response.text
+
+
+def test_password_reset_request_rate_limits_repeated_identifier(
+    app: Flask, client: FlaskClient, user: User
+) -> None:
+    app.config["PASSWORD_RESET_RATE_LIMIT_IDENTIFIER_MAX"] = 1
+    app.config["PASSWORD_RESET_RATE_LIMIT_IP_MAX"] = 100
+    _enable_password_reset_email(user)
+
+    with patch("hushline.routes.auth.send_email_to_user_recipients") as send_email_mock:
+        first = client.post(
+            url_for("request_password_reset"),
+            data={"username": user.primary_username.username},
+        )
+        second = client.post(
+            url_for("request_password_reset"),
+            data={"username": user.primary_username.username},
+        )
+
+    assert first.status_code == 200
+    assert second.status_code == 429
+    assert PASSWORD_RESET_CONFIRMATION_MESSAGE in second.text
+    send_email_mock.assert_called_once()
 
 
 def test_stash_post_auth_redirect_skips_logout_and_preserves_session(app: Flask) -> None:

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -31,6 +31,20 @@ def test_profile_page_keeps_csp_enforced(client: FlaskClient, user: User) -> Non
     assert "script-src-elem 'self' 'unsafe-inline'" not in csp
 
 
+def test_password_reset_pages_keep_csp_enforced(client: FlaskClient) -> None:
+    paths = (
+        url_for("request_password_reset"),
+        url_for("reset_password", token="unknown"),  # noqa: S106
+    )
+    for path in paths:
+        response = client.get(path, follow_redirects=True)
+        assert response.status_code == 200
+        csp = (response.headers.get("Content-Security-Policy") or "").strip()
+        assert csp
+        assert "'unsafe-eval'" not in csp
+        assert "script-src-elem 'self' 'unsafe-inline'" not in csp
+
+
 def test_base_template_uses_external_no_js_bootstrap_script(client: FlaskClient) -> None:
     response = client.get(url_for("directory"), follow_redirects=True)
     assert response.status_code == 200


### PR DESCRIPTION
Closes #1893

## What changed
- add a password reset request and completion flow for accounts that already have notification email configured
- add password reset token and attempt models plus the corresponding migration and migration test coverage
- update login and reset templates, route wiring, auth forms, CSP coverage, and auth route tests
- document the workflow in `docs/USE-CASES.md`

## Why
Hush Line did not offer a recovery path for users who had opted into notifications and configured an email address. This change adds that recovery path without making email required for account creation and without exposing whether an account or notification email exists.

## User impact
Users with notification email configured can request a reset and set a new password through a time-limited, single-use token flow. Users without notification email continue to receive generic responses that do not reveal eligibility.

## Root cause
Password recovery by notification email was missing from the authentication flow.

## Validation
Validation was already completed before this request. I did not rerun `make lint` or `make test` in this session because the user explicitly asked to just open the PR.

## Manual testing
Not performed in this session; the branch was handed off as already validated and the request was limited to moving it onto the branch and opening the PR.

## Risks or follow-ups
Review token lifetime, reset-request throttling behavior, and any desired session invalidation semantics during review.