### PR TITLE
[codex] Fix URL verification DNS rebinding guard

### DIFF
--- a/hushline/settings/common.py
+++ b/hushline/settings/common.py
@@ -2,10 +2,12 @@ import asyncio
 import ipaddress
 import socket
 import urllib.parse
+from dataclasses import dataclass
 from hmac import compare_digest as bytes_are_equal
 from typing import Optional
 
 import aiohttp
+from aiohttp.abc import AbstractResolver, ResolveResult
 from bs4 import BeautifulSoup
 from flask import (
     current_app,
@@ -93,7 +95,34 @@ def _is_blocked_ip(ip: ipaddress.IPv4Address | ipaddress.IPv6Address) -> bool:
     return False
 
 
-async def _is_safe_verification_url(url_to_verify: str) -> bool:
+@dataclass(frozen=True)
+class _SafeVerificationUrl:
+    url: str
+    hostname: str
+    resolved_addresses: tuple[ResolveResult, ...] | None
+
+
+class _StaticVerificationResolver(AbstractResolver):
+    def __init__(self, hostname: str, resolved_addresses: tuple[ResolveResult, ...]) -> None:
+        self._hostname = hostname.lower().rstrip(".")
+        self._resolved_addresses = resolved_addresses
+
+    async def resolve(
+        self,
+        host: str,
+        port: int = 0,
+        family: socket.AddressFamily = socket.AF_INET,
+    ) -> list[ResolveResult]:
+        _ = family
+        if host.lower().rstrip(".") != self._hostname:
+            raise OSError(f"URL verification resolver refused unexpected host: {host!r}")
+        return [ResolveResult(**{**address, "port": port}) for address in self._resolved_addresses]
+
+    async def close(self) -> None:
+        return None
+
+
+async def _resolve_safe_verification_url(url_to_verify: str) -> _SafeVerificationUrl | None:
     parsed_url = urllib.parse.urlparse(url_to_verify)
     hostname = parsed_url.hostname
 
@@ -101,22 +130,22 @@ async def _is_safe_verification_url(url_to_verify: str) -> bool:
         current_app.logger.warning(
             f"URL verification rejected due to non-HTTPS scheme: {url_to_verify!r}"
         )
-        return False
+        return None
 
     if not hostname:
         current_app.logger.warning(
             f"URL verification rejected due to missing hostname: {url_to_verify!r}"
         )
-        return False
+        return None
 
     if current_app.config["TESTING"]:
-        return True
+        return _SafeVerificationUrl(url_to_verify, hostname, None)
 
     if hostname.lower() in {"localhost", "localhost.localdomain"}:
         current_app.logger.warning(
             f"URL verification rejected due to localhost hostname: {url_to_verify!r}"
         )
-        return False
+        return None
 
     try:
         ip = ipaddress.ip_address(hostname)
@@ -128,21 +157,23 @@ async def _is_safe_verification_url(url_to_verify: str) -> bool:
             current_app.logger.warning(
                 f"URL verification rejected due to blocked IP: {url_to_verify!r}"
             )
-            return False
-        return True
+            return None
+        return _SafeVerificationUrl(url_to_verify, hostname, None)
 
     loop = asyncio.get_running_loop()
+    port = parsed_url.port or (443 if parsed_url.scheme == "https" else 80)
     try:
         addrinfo = await asyncio.wait_for(
-            loop.getaddrinfo(hostname, None, type=socket.SOCK_STREAM), timeout=2
+            loop.getaddrinfo(hostname, port, type=socket.SOCK_STREAM), timeout=2
         )
     except (OSError, asyncio.TimeoutError) as exc:
         current_app.logger.warning(
             f"URL verification rejected due to hostname resolution failure for {hostname!r}: {exc}"
         )
-        return False
+        return None
 
-    for _, _, _, _, sockaddr in addrinfo:
+    resolved_addresses: list[ResolveResult] = []
+    for family, _, proto, _, sockaddr in addrinfo:
         ip_str = sockaddr[0]
         try:
             resolved_ip = ipaddress.ip_address(ip_str)
@@ -152,27 +183,69 @@ async def _is_safe_verification_url(url_to_verify: str) -> bool:
             current_app.logger.warning(
                 f"URL verification rejected due to blocked resolved IP {ip_str!r} for {hostname!r}"
             )
-            return False
+            return None
+        resolved_addresses.append(
+            ResolveResult(
+                hostname=hostname,
+                host=ip_str,
+                port=port,
+                family=family,
+                proto=proto,
+                flags=0,
+            )
+        )
 
-    return True
+    if not resolved_addresses:
+        current_app.logger.warning(
+            "URL verification rejected because hostname resolved to no usable addresses: "
+            f"{hostname!r}"
+        )
+        return None
+
+    return _SafeVerificationUrl(url_to_verify, hostname, tuple(resolved_addresses))
+
+
+async def _is_safe_verification_url(url_to_verify: str) -> bool:
+    return await _resolve_safe_verification_url(url_to_verify) is not None
+
+
+async def _fetch_verification_html(safe_url: _SafeVerificationUrl) -> str:
+    timeout = aiohttp.ClientTimeout(total=5)
+
+    if safe_url.resolved_addresses is None:
+        async with (
+            aiohttp.ClientSession() as session,
+            session.get(safe_url.url, timeout=timeout, allow_redirects=False) as response,
+        ):
+            response.raise_for_status()
+            return await response.text()
+
+    connector = aiohttp.TCPConnector(
+        resolver=_StaticVerificationResolver(safe_url.hostname, safe_url.resolved_addresses),
+        use_dns_cache=False,
+        force_close=True,
+    )
+    async with (
+        aiohttp.ClientSession(connector=connector) as session,
+        session.get(safe_url.url, timeout=timeout, allow_redirects=False) as response,
+    ):
+        response.raise_for_status()
+        return await response.text()
 
 
 # Define the async function for URL verification
-async def verify_url(
-    session: aiohttp.ClientSession, username: Username, i: int, url_to_verify: str, profile_url: str
-) -> None:
+async def verify_url(username: Username, i: int, url_to_verify: str, profile_url: str) -> None:
     current_app.logger.debug(
         f"Verifying URL: {url_to_verify!r}. Expecting to find profile URL: {profile_url!r}"
     )
 
     # ensure that regardless of what caller sets this field to, we force it to be false
     setattr(username, f"extra_field_verified{i}", False)
-    if not await _is_safe_verification_url(url_to_verify):
+    safe_url = await _resolve_safe_verification_url(url_to_verify)
+    if safe_url is None:
         return
     try:
-        async with session.get(url_to_verify, timeout=aiohttp.ClientTimeout(total=5)) as response:
-            response.raise_for_status()
-            html_content = await response.text()
+        html_content = await _fetch_verification_html(safe_url)
     except aiohttp.ClientError as e:
         current_app.logger.error(f"Error fetching URL {url_to_verify!r} for field {i}: {e}")
         return
@@ -223,36 +296,35 @@ async def handle_update_bio(username: Username, form: ProfileForm) -> Response:
         username=username._username,
     )
 
-    async with aiohttp.ClientSession() as client_session:
-        tasks = []
-        for i in range(1, 5):
-            # always unverify all fields first
-            setattr(username, f"extra_field_verified{i}", False)
+    tasks = []
+    for i in range(1, 5):
+        # always unverify all fields first
+        setattr(username, f"extra_field_verified{i}", False)
 
-            label_field = getattr(form, f"extra_field_label{i}")
-            label = (getattr(label_field, "data") or "").strip() or None
-            setattr(username, f"extra_field_label{i}", label)
+        label_field = getattr(form, f"extra_field_label{i}")
+        label = (getattr(label_field, "data") or "").strip() or None
+        setattr(username, f"extra_field_label{i}", label)
 
-            value_field = getattr(form, f"extra_field_value{i}")
-            value = (getattr(value_field, "data") or "").strip() or None
-            setattr(username, f"extra_field_value{i}", value)
+        value_field = getattr(form, f"extra_field_value{i}")
+        value = (getattr(value_field, "data") or "").strip() or None
+        setattr(username, f"extra_field_value{i}", value)
 
-            # Verify the URL only if it starts with "https://"
-            if value and (
-                value.startswith("https://")
-                or (current_app.config["TESTING"] and value.startswith("http://"))
-            ):
-                task = verify_url(client_session, username, i, value, profile_url)
-                tasks.append(task)
+        # Verify the URL only if it starts with "https://"
+        if value and (
+            value.startswith("https://")
+            or (current_app.config["TESTING"] and value.startswith("http://"))
+        ):
+            task = verify_url(username, i, value, profile_url)
+            tasks.append(task)
 
-        if tasks:
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            for result in results:
-                if isinstance(result, Exception):
-                    if current_app.config["TESTING"]:
-                        raise result
-                    else:
-                        current_app.logger.warning(f"Exception raised verifying URL: {result}")
+    if tasks:
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception):
+                if current_app.config["TESTING"]:
+                    raise result
+                else:
+                    current_app.logger.warning(f"Exception raised verifying URL: {result}")
 
     db.session.commit()
     flash("👍 Bio and fields updated successfully.")

--- a/tests/test_settings_common.py
+++ b/tests/test_settings_common.py
@@ -1,11 +1,13 @@
 import asyncio
 import ipaddress
+import socket
 from types import SimpleNamespace
 from typing import cast
 from unittest.mock import AsyncMock, patch
 
 import aiohttp
 import pytest
+from aiohttp.abc import ResolveResult
 from flask import Flask, session
 from sqlalchemy.exc import IntegrityError
 from werkzeug.datastructures import MultiDict
@@ -32,8 +34,12 @@ from hushline.model import (
     Username,
 )
 from hushline.settings.common import (
+    _fetch_verification_html,
     _is_blocked_ip,
     _is_safe_verification_url,
+    _resolve_safe_verification_url,
+    _SafeVerificationUrl,
+    _StaticVerificationResolver,
     build_field_forms,
     create_profile_forms,
     handle_change_password_form,
@@ -436,6 +442,99 @@ async def test_is_safe_verification_url_resolved_public_allowed(app: Flask) -> N
 
 
 @pytest.mark.asyncio()
+async def test_resolve_safe_verification_url_returns_pinned_addresses(app: Flask) -> None:
+    with app.app_context():
+        app.config["TESTING"] = False
+        with patch.object(
+            asyncio.get_running_loop(),
+            "getaddrinfo",
+            return_value=[
+                (
+                    socket.AF_INET,
+                    socket.SOCK_STREAM,
+                    socket.IPPROTO_TCP,
+                    "",
+                    ("93.184.216.34", 443),
+                )
+            ],
+        ):
+            safe_url = await _resolve_safe_verification_url("https://example.com/profile")
+
+    assert safe_url is not None
+    assert safe_url.hostname == "example.com"
+    assert safe_url.resolved_addresses is not None
+    assert safe_url.resolved_addresses[0]["host"] == "93.184.216.34"
+
+
+@pytest.mark.asyncio()
+async def test_static_verification_resolver_refuses_unvalidated_hosts() -> None:
+    resolver = _StaticVerificationResolver(
+        "example.com",
+        (
+            ResolveResult(
+                hostname="example.com",
+                host="93.184.216.34",
+                port=443,
+                family=socket.AF_INET,
+                proto=socket.IPPROTO_TCP,
+                flags=0,
+            ),
+        ),
+    )
+
+    resolved = await resolver.resolve("example.com", 443)
+
+    assert resolved[0]["host"] == "93.184.216.34"
+    with pytest.raises(OSError, match="refused unexpected host"):
+        await resolver.resolve("metadata.google.internal", 80)
+
+
+@pytest.mark.asyncio()
+async def test_fetch_verification_html_disables_redirects() -> None:
+    captured: dict[str, object] = {}
+
+    class _Response:
+        def raise_for_status(self) -> None:
+            return None
+
+        async def text(self) -> str:
+            return "<html></html>"
+
+    class _Context:
+        async def __aenter__(self) -> _Response:
+            return _Response()
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            _ = (exc_type, exc, tb)
+
+    class _Session:
+        async def __aenter__(self) -> "_Session":
+            return self
+
+        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+            _ = (exc_type, exc, tb)
+
+        def get(
+            self,
+            url: str,
+            timeout: aiohttp.ClientTimeout,
+            allow_redirects: bool,
+        ) -> _Context:
+            captured["url"] = url
+            captured["timeout"] = timeout
+            captured["allow_redirects"] = allow_redirects
+            return _Context()
+
+    with patch("hushline.settings.common.aiohttp.ClientSession", return_value=_Session()):
+        html = await _fetch_verification_html(
+            _SafeVerificationUrl("https://example.com", "example.com", None)
+        )
+
+    assert html == "<html></html>"
+    assert captured["allow_redirects"] is False
+
+
+@pytest.mark.asyncio()
 async def test_is_safe_verification_url_direct_private_ip_rejected(app: Flask) -> None:
     with app.app_context():
         app.config["TESTING"] = False
@@ -459,27 +558,17 @@ async def test_verify_url_handles_client_error(user: User) -> None:
     username = user.primary_username
     profile_url = "https://example.com/profile"
 
-    class _FailingResponse:
-        def raise_for_status(self) -> None:
-            raise aiohttp.ClientError("boom")
-
-        async def text(self) -> str:
-            return ""
-
-    class _FailingContext:
-        async def __aenter__(self) -> _FailingResponse:
-            return _FailingResponse()
-
-        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
-            _ = (exc_type, exc, tb)
-
-    class _Session:
-        def get(self, url: str, timeout: aiohttp.ClientTimeout) -> _FailingContext:
-            _ = (url, timeout)
-            return _FailingContext()
-
-    with patch("hushline.settings.common._is_safe_verification_url", return_value=True):
-        await verify_url(_Session(), username, 1, "https://example.com", profile_url)  # type: ignore[arg-type]
+    with (
+        patch(
+            "hushline.settings.common._resolve_safe_verification_url",
+            return_value=_SafeVerificationUrl("https://example.com", "example.com", None),
+        ),
+        patch(
+            "hushline.settings.common._fetch_verification_html",
+            side_effect=aiohttp.ClientError("boom"),
+        ),
+    ):
+        await verify_url(username, 1, "https://example.com", profile_url)
 
     db.session.refresh(username)
     assert username.extra_field_verified1 is False
@@ -489,20 +578,54 @@ async def test_verify_url_handles_client_error(user: User) -> None:
 async def test_verify_url_returns_early_when_url_is_not_safe(user: User) -> None:
     username = user.primary_username
 
-    class _Session:
-        def get(self, *_args: object, **_kwargs: object) -> object:
-            raise AssertionError("session.get should not be called for unsafe URLs")
-
-    with patch("hushline.settings.common._is_safe_verification_url", return_value=False):
-        await verify_url(
-            _Session(),  # type: ignore[arg-type]
-            username,
-            1,
-            "https://example.com",
-            "https://example.com/profile",
-        )
+    with (
+        patch("hushline.settings.common._resolve_safe_verification_url", return_value=None),
+        patch(
+            "hushline.settings.common._fetch_verification_html",
+            side_effect=AssertionError("_fetch_verification_html should not be called"),
+        ),
+    ):
+        await verify_url(username, 1, "https://example.com", "https://example.com/profile")
 
     assert username.extra_field_verified1 is False
+
+
+@pytest.mark.asyncio()
+async def test_verify_url_fetches_with_pinned_resolved_addresses(app: Flask, user: User) -> None:
+    username = user.primary_username
+    profile_url = "https://hushline.example/u/alice"
+    captured_safe_url: _SafeVerificationUrl | None = None
+
+    async def _fake_fetch(safe_url: _SafeVerificationUrl) -> str:
+        nonlocal captured_safe_url
+        captured_safe_url = safe_url
+        return f'<html><body><a href="{profile_url}" rel="me">Profile</a></body></html>'
+
+    with app.app_context():
+        app.config["TESTING"] = False
+        with (
+            patch.object(
+                asyncio.get_running_loop(),
+                "getaddrinfo",
+                return_value=[
+                    (
+                        socket.AF_INET,
+                        socket.SOCK_STREAM,
+                        socket.IPPROTO_TCP,
+                        "",
+                        ("93.184.216.34", 443),
+                    )
+                ],
+            ),
+            patch("hushline.settings.common._fetch_verification_html", side_effect=_fake_fetch),
+        ):
+            await verify_url(username, 1, "https://attacker.example/profile", profile_url)
+
+    assert captured_safe_url is not None
+    assert captured_safe_url.hostname == "attacker.example"
+    assert captured_safe_url.resolved_addresses is not None
+    assert captured_safe_url.resolved_addresses[0]["host"] == "93.184.216.34"
+    assert username.extra_field_verified1 is True
 
 
 @pytest.mark.asyncio()
@@ -510,30 +633,18 @@ async def test_verify_url_marks_field_verified_when_profile_link_present(user: U
     username = user.primary_username
     profile_url = "https://example.com/profile"
 
-    class _SuccessResponse:
-        def raise_for_status(self) -> None:
-            return None
+    html_content = (
+        '<html><body><a href="https://example.com/profile" ' 'rel="me">Profile</a></body></html>'
+    )
 
-        async def text(self) -> str:
-            return (
-                '<html><body><a href="https://example.com/profile" '
-                'rel="me">Profile</a></body></html>'
-            )
-
-    class _SuccessContext:
-        async def __aenter__(self) -> _SuccessResponse:
-            return _SuccessResponse()
-
-        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
-            _ = (exc_type, exc, tb)
-
-    class _Session:
-        def get(self, url: str, timeout: aiohttp.ClientTimeout) -> _SuccessContext:
-            _ = (url, timeout)
-            return _SuccessContext()
-
-    with patch("hushline.settings.common._is_safe_verification_url", return_value=True):
-        await verify_url(_Session(), username, 1, "https://example.com", profile_url)  # type: ignore[arg-type]
+    with (
+        patch(
+            "hushline.settings.common._resolve_safe_verification_url",
+            return_value=_SafeVerificationUrl("https://example.com", "example.com", None),
+        ),
+        patch("hushline.settings.common._fetch_verification_html", return_value=html_content),
+    ):
+        await verify_url(username, 1, "https://example.com", profile_url)
 
     assert username.extra_field_verified1 is True
 
@@ -543,30 +654,18 @@ async def test_verify_url_leaves_field_unverified_when_no_matching_profile_link(
     username = user.primary_username
     profile_url = "https://example.com/profile"
 
-    class _SuccessResponse:
-        def raise_for_status(self) -> None:
-            return None
+    html_content = (
+        '<html><body><a href="https://elsewhere.example" ' 'rel="nofollow">Other</a></body></html>'
+    )
 
-        async def text(self) -> str:
-            return (
-                '<html><body><a href="https://elsewhere.example" '
-                'rel="nofollow">Other</a></body></html>'
-            )
-
-    class _SuccessContext:
-        async def __aenter__(self) -> _SuccessResponse:
-            return _SuccessResponse()
-
-        async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
-            _ = (exc_type, exc, tb)
-
-    class _Session:
-        def get(self, url: str, timeout: aiohttp.ClientTimeout) -> _SuccessContext:
-            _ = (url, timeout)
-            return _SuccessContext()
-
-    with patch("hushline.settings.common._is_safe_verification_url", return_value=True):
-        await verify_url(_Session(), username, 1, "https://example.com", profile_url)  # type: ignore[arg-type]
+    with (
+        patch(
+            "hushline.settings.common._resolve_safe_verification_url",
+            return_value=_SafeVerificationUrl("https://example.com", "example.com", None),
+        ),
+        patch("hushline.settings.common._fetch_verification_html", return_value=html_content),
+    ):
+        await verify_url(username, 1, "https://example.com", profile_url)
 
     assert username.extra_field_verified1 is False
 
@@ -651,7 +750,7 @@ async def test_handle_update_bio_uses_public_base_url_for_profile_verification(
     assert response.status_code == 302
     verify_url_mock.assert_awaited_once()
     assert verify_url_mock.await_args is not None
-    assert verify_url_mock.await_args.args[4] == f"https://safe.example/to/{username.username}"
+    assert verify_url_mock.await_args.args[3] == f"https://safe.example/to/{username.username}"
 
 
 def test_handle_new_alias_form_unique_violation_returns_none(

--- a/tests/test_verify_url.py
+++ b/tests/test_verify_url.py
@@ -5,7 +5,6 @@ import traceback
 import urllib.parse
 from typing import Generator
 
-import aiohttp
 import pytest
 import requests
 from flask import Flask, request, url_for
@@ -86,8 +85,7 @@ async def test_verify_url(user: User, verification_server: int) -> None:
     encoded_url = urllib.parse.quote(profile_url)
     url_to_verify = f"http://{HOSTNAME}:{verification_server}/?profile={encoded_url}"
 
-    async with aiohttp.ClientSession() as sess:
-        await verify_url(sess, username, 1, url_to_verify, profile_url)
+    await verify_url(username, 1, url_to_verify, profile_url)
     db.session.commit()
 
     db.session.refresh(username)
@@ -103,8 +101,7 @@ async def test_verify_url_fail(user: User, verification_server: int) -> None:
     profile_url = url_for("profile", username=username.username, _external=True)
     url_to_verify = f"http://{HOSTNAME}:{verification_server}/"
 
-    async with aiohttp.ClientSession() as sess:
-        await verify_url(sess, username, 1, url_to_verify, profile_url)
+    await verify_url(username, 1, url_to_verify, profile_url)
     db.session.commit()
 
     db.session.refresh(username)
@@ -176,8 +173,7 @@ async def test_verify_url_blocks_private_ip_in_production(app: Flask, user: User
     original_testing = app.config["TESTING"]
     app.config["TESTING"] = False
     try:
-        async with aiohttp.ClientSession() as sess:
-            await verify_url(sess, username, 1, url_to_verify, profile_url)
+        await verify_url(username, 1, url_to_verify, profile_url)
     finally:
         app.config["TESTING"] = original_testing
 
@@ -197,8 +193,7 @@ async def test_verify_url_blocks_localhost_in_production(app: Flask, user: User)
     original_testing = app.config["TESTING"]
     app.config["TESTING"] = False
     try:
-        async with aiohttp.ClientSession() as sess:
-            await verify_url(sess, username, 1, url_to_verify, profile_url)
+        await verify_url(username, 1, url_to_verify, profile_url)
     finally:
         app.config["TESTING"] = original_testing
 
@@ -220,8 +215,7 @@ async def test_verify_url_blocks_localhost_localdomain_in_production(
     original_testing = app.config["TESTING"]
     app.config["TESTING"] = False
     try:
-        async with aiohttp.ClientSession() as sess:
-            await verify_url(sess, username, 1, url_to_verify, profile_url)
+        await verify_url(username, 1, url_to_verify, profile_url)
     finally:
         app.config["TESTING"] = original_testing
 
@@ -241,8 +235,7 @@ async def test_verify_url_blocks_unspecified_ip_in_production(app: Flask, user: 
     original_testing = app.config["TESTING"]
     app.config["TESTING"] = False
     try:
-        async with aiohttp.ClientSession() as sess:
-            await verify_url(sess, username, 1, url_to_verify, profile_url)
+        await verify_url(username, 1, url_to_verify, profile_url)
     finally:
         app.config["TESTING"] = original_testing
 


### PR DESCRIPTION
## What changed

This fixes the profile URL verification SSRF guard so the hostname resolution that passes safety validation is the same resolution used for the outbound verification request.

- Added a pinned aiohttp resolver for verified hostnames.
- Changed URL verification to resolve once, reject blocked/private/link-local/etc. addresses, and then connect only to the validated address set.
- Disabled automatic redirects for verification fetches so a safe URL cannot redirect the server to an internal target without revalidation.
- Added regression coverage for pinned resolved addresses, unexpected-host resolver refusal, redirects not being followed, and `verify_url` using the pinned resolution result.

## Why

The previous code validated DNS results in `_is_safe_verification_url()` and then called `aiohttp` with the original hostname. `aiohttp` performed an independent DNS lookup at connection time, leaving a DNS rebinding window where an attacker-controlled hostname could pass validation with a public IP and then resolve to an internal address for the actual request.

## Security impact

Threat: authenticated users can submit profile extra-field URLs for server-side verification. Without this fix, attacker-controlled DNS could potentially turn that verification request into blind SSRF against internal network services.

Affected data path: profile settings extra-field URL verification in `hushline/settings/common.py`.

Mitigation: bind validation and connection to the same resolved address set and refuse automatic redirect following.

## Validation

- `poetry run ruff check hushline/settings/common.py tests/test_settings_common.py tests/test_verify_url.py`
- `docker compose run --rm app poetry run pytest tests/test_settings_common.py tests/test_verify_url.py -q` (`68 passed`)
- `make test` (`1562 passed, 1 deselected, 1 xfailed`, coverage 99%)
- `make audit-python` (`No known vulnerabilities found`)
- `make audit-node-runtime` (`found 0 vulnerabilities`)

`make lint` was also run. Ruff format, Ruff check, and mypy passed in Docker, but the target failed at the Prettier step on pre-existing static JS formatting drift across `hushline/static/js/*.js`. This PR does not include those JS files.

## Manual testing

Not applicable beyond automated coverage: this change affects a server-side URL verification guard and is covered by targeted unit/regression tests plus the full non-external test suite.

## Known risks

Legitimate profile URL verification targets that rely on HTTP redirects may no longer verify, because redirects are intentionally not followed to avoid redirect-based SSRF bypasses. If redirect support is required later, each hop should be resolved and validated with the same pinned-connection strategy.
