### PR TITLE
[codex] Fix coverage runner stale branch reuse

### DIFF
--- a/scripts/agent_daily_coverage_runner.sh
+++ b/scripts/agent_daily_coverage_runner.sh
@@ -1273,7 +1273,7 @@ main() {
 
   run_step "Configure bot git identity" configure_bot_git_identity
 
-  if remote_branch_exists "$BRANCH_NAME"; then
+  if [[ -n "$existing_pr_json" ]] && remote_branch_exists "$BRANCH_NAME"; then
     run_step "Create branch $BRANCH_NAME from origin/$BRANCH_NAME" git checkout -B "$BRANCH_NAME" "origin/$BRANCH_NAME"
   else
     run_step "Create branch $BRANCH_NAME" git checkout -B "$BRANCH_NAME" "$BASE_BRANCH"

--- a/tests/test_agent_daily_coverage_runner.py
+++ b/tests/test_agent_daily_coverage_runner.py
@@ -249,3 +249,94 @@ main
     assert "Configure bot git identity" in calls
     assert "runtime-bootstrap" in calls
     assert "coverage-scan" in calls
+
+
+def test_main_starts_from_base_when_stale_remote_coverage_branch_exists(tmp_path: Path) -> None:
+    call_log = tmp_path / "calls.txt"
+    repo_dir = tmp_path / "repo"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(repo_dir))}
+mkdir -p "$REPO_DIR/.git"
+parse_args() {{ :; }}
+initialize_run_state() {{ :; }}
+cleanup() {{ :; }}
+require_cmd() {{ :; }}
+require_positive_integer() {{ :; }}
+run_step() {{
+  printf '%s\\n' "$1" >> {shlex.quote(str(call_log))}
+}}
+count_open_human_prs() {{ printf '0\\n'; }}
+count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
+find_open_pr_for_head_branch() {{ :; }}
+configure_bot_git_identity() {{
+  printf 'configure-bot-git\\n' >> {shlex.quote(str(call_log))}
+}}
+remote_branch_exists() {{ return 0; }}
+start_runtime_stack_and_seed_dev_data() {{
+  printf 'runtime-bootstrap\\n' >> {shlex.quote(str(call_log))}
+}}
+run_coverage_scan() {{
+  printf 'coverage-scan\\n' >> {shlex.quote(str(call_log))}
+  CURRENT_COVERAGE_PERCENT="100.00"
+  CURRENT_COVERAGE_MISSING_LINES="0"
+  CURRENT_COVERAGE_MISSING_FILES="0"
+  CURRENT_COVERAGE_SUMMARY="- No uncovered files remain."
+}}
+main
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert "Create branch codex/daily-coverage" in calls
+    assert "Create branch codex/daily-coverage from origin/codex/daily-coverage" not in calls
+
+
+def test_main_resumes_remote_coverage_branch_when_open_pr_exists(tmp_path: Path) -> None:
+    call_log = tmp_path / "calls.txt"
+    repo_dir = tmp_path / "repo"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(repo_dir))}
+mkdir -p "$REPO_DIR/.git"
+parse_args() {{ :; }}
+initialize_run_state() {{ :; }}
+cleanup() {{ :; }}
+require_cmd() {{ :; }}
+require_positive_integer() {{ :; }}
+run_step() {{
+  printf '%s\\n' "$1" >> {shlex.quote(str(call_log))}
+}}
+count_open_human_prs() {{ printf '0\\n'; }}
+count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
+find_open_pr_for_head_branch() {{
+  printf '%s\\n' '{{"number":123,"url":"https://example.test/pr/123"}}'
+}}
+configure_bot_git_identity() {{
+  printf 'configure-bot-git\\n' >> {shlex.quote(str(call_log))}
+}}
+remote_branch_exists() {{ return 0; }}
+start_runtime_stack_and_seed_dev_data() {{
+  printf 'runtime-bootstrap\\n' >> {shlex.quote(str(call_log))}
+}}
+run_coverage_scan() {{
+  printf 'coverage-scan\\n' >> {shlex.quote(str(call_log))}
+  CURRENT_COVERAGE_PERCENT="100.00"
+  CURRENT_COVERAGE_MISSING_LINES="0"
+  CURRENT_COVERAGE_MISSING_FILES="0"
+  CURRENT_COVERAGE_SUMMARY="- No uncovered files remain."
+}}
+main
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert "Create branch codex/daily-coverage from origin/codex/daily-coverage" in calls


### PR DESCRIPTION
## What Changed

- Updated the daily coverage runner so it only resumes `origin/codex/daily-coverage` when there is an open PR for that head branch.
- Added regression tests for both branch-selection paths:
  - stale remote coverage branch with no open PR starts from fresh `main`
  - active coverage PR still resumes the remote coverage branch

## Why

The coverage LaunchAgent fired today, but the runner checked out a stale `origin/codex/daily-coverage` branch left behind after a merged PR. That stale branch reported 100% coverage, so the runner skipped opening a new coverage PR even though current `main` is at 99% coverage with 11 missed lines.

This change prevents closed or merged coverage PR branches from masking coverage gaps on current `main`.

## Validation

- `docker compose run --rm app poetry run pytest tests/test_agent_daily_coverage_runner.py`
  - Passed: `10 passed`
- `make test`
  - Passed: `1568 passed, 1 deselected, 1 xfailed`
  - Coverage summary from this run: `TOTAL 8294 11 99%`
- `make lint`
  - Ruff format: passed
  - Ruff check: passed
  - mypy: passed
  - Prettier: failed on pre-existing formatting warnings in 21 static JS files not touched by this PR

## Manual Testing

- After merge, confirm the next daily coverage runner starts `codex/daily-coverage` from `main` when there is no open PR for that head.
- Confirm an existing open `codex/daily-coverage` PR is still resumed instead of being overwritten.

## Known Risks / Follow-Up

- The stale remote `codex/daily-coverage` branch can still exist safely; the runner will ignore it unless an open PR for that head exists.
- The repository still has unrelated Prettier warnings in static JS files that block `make lint` locally.