### PR TITLE
Fix runner guards and feedback polling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,6 +203,7 @@ When behavior changes or features are added/removed, update relevant documentati
 - Include known risks or follow-ups.
 - If PR scope changes after opening, update the PR description so it reflects the final state before merge.
 - Keep title specific and behavior-oriented.
+- Do not prepend `[codex]` or other agent-identifying prefixes to PR titles.
 - Check when the PR was created and explicitly flag if it appears stale or no longer relevant before proceeding.
 - Never interpolate untrusted GitHub event text fields (issue/PR/comment title or body) directly in shell `run:` steps in workflows.
 - Enforce branch protection required checks before merge: `Workflow Security Checks`, CodeQL scanning, and `Run Linter and Tests`.

--- a/scripts/agent_daily_coverage_runner.sh
+++ b/scripts/agent_daily_coverage_runner.sh
@@ -1265,11 +1265,7 @@ main() {
   fi
 
   open_bot_prs="$(count_open_bot_prs_excluding_heads "$BRANCH_NAME")"
-  echo "Open unrelated bot PR count: ${open_bot_prs}"
-  if [[ "$open_bot_prs" != "0" ]]; then
-    runner_status "Skipped: found ${open_bot_prs} unrelated open PR(s) by ${BOT_LOGIN}."
-    exit 0
-  fi
+  echo "Open unrelated bot PR count: ${open_bot_prs}; continuing coverage runner."
 
   run_step "Configure bot git identity" configure_bot_git_identity
 

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -824,13 +824,15 @@ fetch_pr_feedback_json() {
               nodes {
                 isResolved
                 isOutdated
+                path
+                line
+                originalLine
                 comments(first: 10) {
                   nodes {
                     author {
                       login
                     }
                     body
-                    path
                     createdAt
                     url
                   }
@@ -939,9 +941,7 @@ summarize_pr_feedback() {
           ? pr.reviewThreads.nodes
           : [];
 
-      const unresolvedThreads = reviewThreads.filter(
-        (thread) => thread && !thread.isResolved && !thread.isOutdated,
-      );
+      const unresolvedThreads = reviewThreads.filter((thread) => thread && !thread.isResolved);
       const failingChecks = checks.filter(
         (check) => String(check && check.bucket ? check.bucket : "") === "fail",
       );
@@ -973,10 +973,20 @@ summarize_pr_feedback() {
           comment && comment.author && comment.author.login
             ? String(comment.author.login)
             : "unknown";
-        const path = comment && comment.path ? String(comment.path) : "general";
+        const path =
+          thread && thread.path
+            ? String(thread.path)
+            : comment && comment.path
+              ? String(comment.path)
+              : "general";
+        const location =
+          thread && (thread.line || thread.originalLine)
+            ? `:${thread.line || thread.originalLine}`
+            : "";
+        const outdated = thread && thread.isOutdated ? " (outdated)" : "";
         const body = clip(cleanText(comment && comment.body ? comment.body : ""));
         lines.push(
-          `Feedback ${index + 1}: unresolved review thread by @${login} on ${path}${body ? ` :: ${body}` : ""}`,
+          `Feedback ${index + 1}: unresolved review thread by @${login} on ${path}${location}${outdated}${body ? ` :: ${body}` : ""}`,
         );
       });
 

--- a/tests/test_agent_daily_coverage_runner.py
+++ b/tests/test_agent_daily_coverage_runner.py
@@ -221,7 +221,7 @@ run_step() {{
   printf '%s\\n' "$1" >> {shlex.quote(str(call_log))}
 }}
 count_open_human_prs() {{ printf '0\\n'; }}
-count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
+count_open_bot_prs_excluding_heads() {{ printf '2\\n'; }}
 find_open_pr_for_head_branch() {{ :; }}
 configure_bot_git_identity() {{
   printf 'configure-bot-git\\n' >> {shlex.quote(str(call_log))}
@@ -243,6 +243,7 @@ main
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
+    assert "Open unrelated bot PR count: 2; continuing coverage runner." in result.stdout
     assert "Skipped: coverage already meets target at 100.00%." in result.stdout
 
     calls = call_log.read_text(encoding="utf-8").splitlines()

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -2162,6 +2162,61 @@ summarize_pr_feedback "$feedback_json"
     )
 
 
+def test_summarize_pr_feedback_reports_unresolved_outdated_threads() -> None:
+    feedback_json = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 2000,
+                        "url": "https://github.com/scidsg/hushline/pull/2000",
+                        "reviewDecision": "REVIEW_REQUIRED",
+                        "comments": {"nodes": []},
+                        "latestReviews": {"nodes": []},
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "isResolved": False,
+                                    "isOutdated": True,
+                                    "path": "hushline/templates/base.html",
+                                    "line": None,
+                                    "originalLine": 170,
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "author": {"login": "chatgpt-codex-connector"},
+                                                "body": ("Serve splash logo from local assets."),
+                                                "createdAt": "2026-05-01T05:27:30Z",
+                                                "url": "https://example.test/thread/1",
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+        }
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+BOT_LOGIN=hushline-dev
+feedback_json={shlex.quote(feedback_json)}
+summarize_pr_feedback "$feedback_json"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Post-PR feedback summary: unresolved_review_threads=1" in result.stdout
+    assert (
+        "unresolved review thread by @chatgpt-codex-connector "
+        "on hushline/templates/base.html:170 (outdated)"
+    ) in result.stdout
+
+
 def test_summarize_pr_feedback_reports_failing_and_pending_checks() -> None:
     feedback_json = json.dumps(
         {


### PR DESCRIPTION
## What Changed

- Let the daily coverage runner continue when unrelated bot-authored PRs are open instead of exiting before the coverage scan.
- Keep the issue runner's PR feedback monitor from hiding unresolved inline review threads just because GitHub marks them outdated after later commits.
- Include review-thread path and line metadata in feedback summaries.
- Document that Codex-created PR titles should not use `[codex]` or other agent-identifying prefixes.
- Added regression coverage for both runner behaviors.

## Why

On May 1, the coverage LaunchAgent did fire at 10:00 PDT, but it skipped after detecting one unrelated open bot PR. That prevented the coverage runner from doing the work it was scheduled to do.

The issue runner also polled PR #1901 repeatedly, but summarized `unresolved_review_threads=0` because it filtered out `isOutdated` threads. That can hide still-unresolved review feedback after subsequent commits move the diff.

PR titles should stay specific and behavior-oriented without agent-identifying prefixes, including for Codex-created PRs.

## Validation

- `make lint`
  - Passed
- `docker compose run --rm app poetry run pytest tests/test_agent_daily_coverage_runner.py tests/test_agent_daily_issue_runner.py -q`
  - Passed: `81 passed`
- `make test`
  - Passed: `1573 passed, 1 deselected, 1 xfailed`
  - Coverage summary: `TOTAL 8298 11 99%`
- No additional tests run for the `AGENTS.md` title-prefix guidance update because it is documentation-only.

## Manual Testing

- Confirm a daily coverage run logs unrelated bot PRs but continues into runtime setup and coverage scanning.
- Confirm a PR feedback summary reports unresolved outdated inline review threads with file and line context.
- Confirm PR titles created by agents do not include `[codex]` or other agent-identifying prefixes.

## Known Risks / Follow-Up

- Coverage PR creation can still be blocked later by branch/PR uniqueness checks if a coverage PR already exists, but unrelated bot PRs no longer prevent the runner from measuring coverage.
- Outdated unresolved review threads may include stale suggestions; surfacing them is intentional because unresolved security/privacy feedback should not disappear silently.
