### PR TITLE
Suppress splash screen in docs screenshots

### DIFF
--- a/scripts/capture-doc-screenshots.mjs
+++ b/scripts/capture-doc-screenshots.mjs
@@ -29,6 +29,16 @@ async function sleep(ms) {
   await new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+const GUIDANCE_STORAGE_KEY = "hasFinishedGuidance";
+const FIRST_LOAD_SPLASH_SEEN_KEY = "hushline:first-load-splash-seen";
+const SCREENSHOT_SPLASH_SUPPRESSION_CSS = `
+/* Capture-only: docs screenshots need the target screen, not the first-load splash. */
+#first-load-splash,
+.first-load-splash {
+  display: none !important;
+}
+`;
+
 function resolveTimeoutMs(value, fallbackMs) {
   const parsed = Number(value);
   if (Number.isFinite(parsed) && parsed > 0) {
@@ -37,14 +47,55 @@ function resolveTimeoutMs(value, fallbackMs) {
   return fallbackMs;
 }
 
+async function markCaptureStorage(page) {
+  await page.evaluate(
+    ({ guidanceStorageKey, splashStorageKey }) => {
+      try {
+        localStorage.setItem(guidanceStorageKey, "true");
+      } catch {}
+      try {
+        sessionStorage.setItem(splashStorageKey, "true");
+      } catch {}
+    },
+    {
+      guidanceStorageKey: GUIDANCE_STORAGE_KEY,
+      splashStorageKey: FIRST_LOAD_SPLASH_SEEN_KEY,
+    },
+  );
+}
+
+async function installCaptureGuards(context) {
+  await context.addInitScript(
+    ({ guidanceStorageKey, splashStorageKey }) => {
+      try {
+        localStorage.setItem(guidanceStorageKey, "true");
+      } catch {}
+      try {
+        sessionStorage.setItem(splashStorageKey, "true");
+      } catch {}
+    },
+    {
+      guidanceStorageKey: GUIDANCE_STORAGE_KEY,
+      splashStorageKey: FIRST_LOAD_SPLASH_SEEN_KEY,
+    },
+  );
+
+  await context.route("**/static/css/style.css*", async (route) => {
+    const response = await route.fetch();
+    const body = await response.text();
+    await route.fulfill({
+      response,
+      body: `${body}\n${SCREENSHOT_SPLASH_SUPPRESSION_CSS}`,
+    });
+  });
+}
+
 async function login(baseUrl, context, username, password) {
   await context.clearCookies();
   const page = await context.newPage();
-  // Ensure the guidance modal does not block login interactions in auth sessions.
+  // Ensure capture-only overlays do not block login interactions in auth sessions.
   await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
-  await page.evaluate(() => {
-    localStorage.setItem("hasFinishedGuidance", "true");
-  });
+  await markCaptureStorage(page);
   await page.goto(`${baseUrl}/login`, { waitUntil: "networkidle" });
   await page.fill("#username", username);
   await page.fill("#password", password);
@@ -77,9 +128,9 @@ async function runAction(page, action, defaultWaitTimeoutMs) {
       }
       let dialogPromise = null;
       if (action.acceptDialog === true) {
-        dialogPromise = page.waitForEvent("dialog", { timeout: timeoutMs }).then((dialog) =>
-          dialog.accept(),
-        );
+        dialogPromise = page
+          .waitForEvent("dialog", { timeout: timeoutMs })
+          .then((dialog) => dialog.accept());
       }
       await page.click(action.selector);
       if (dialogPromise) {
@@ -331,13 +382,12 @@ async function main() {
     const ctx = await browser.newContext(
       makeContextOptions(viewport, jsEnabled, theme),
     );
+    await installCaptureGuards(ctx);
     if (jsEnabled) {
-      // Hide guidance modal by default; explicit modal scenes can clear this.
+      // Hide capture-only overlays by default; explicit modal scenes can clear guidance state.
       const page = await ctx.newPage();
       await page.goto(baseUrl, { waitUntil: "domcontentloaded" });
-      await page.evaluate(() => {
-        localStorage.setItem("hasFinishedGuidance", "true");
-      });
+      await markCaptureStorage(page);
       await page.close();
     }
     contexts.set(key, ctx);

--- a/tests/test_docs_screenshots_manifest.py
+++ b/tests/test_docs_screenshots_manifest.py
@@ -97,7 +97,7 @@ def test_docs_screenshot_capture_suppresses_first_load_splash() -> None:
     script = CAPTURE_SCRIPT_PATH.read_text(encoding="utf-8")
 
     assert 'const FIRST_LOAD_SPLASH_SEEN_KEY = "hushline:first-load-splash-seen";' in script
-    assert "sessionStorage.setItem(splashStorageKey, \"true\")" in script
+    assert 'sessionStorage.setItem(splashStorageKey, "true")' in script
     assert "await context.addInitScript(" in script
     assert 'await context.route("**/static/css/style.css*"' in script
     assert "#first-load-splash" in script

--- a/tests/test_docs_screenshots_manifest.py
+++ b/tests/test_docs_screenshots_manifest.py
@@ -4,6 +4,7 @@ from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = REPO_ROOT / "docs" / "screenshots" / "scenes.json"
+CAPTURE_SCRIPT_PATH = REPO_ROOT / "scripts" / "capture-doc-screenshots.mjs"
 INDUSTRY_FIELD_FORM_SELECTOR = (
     ".field-form:not(.field-form-new):has(.field-form-label:has-text('Industry'))"
 )
@@ -90,6 +91,17 @@ def test_docs_screenshots_manifest_disables_full_page_for_heavy_directory_scenes
     assert scenes["auth-admin-directory-all"]["captureModes"] == ["fold", "scroll"]
     assert scenes["guest-directory-newsrooms"]["captureModes"] == ["fold", "scroll"]
     assert scenes["guest-directory-all"]["captureModes"] == ["fold", "scroll"]
+
+
+def test_docs_screenshot_capture_suppresses_first_load_splash() -> None:
+    script = CAPTURE_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert 'const FIRST_LOAD_SPLASH_SEEN_KEY = "hushline:first-load-splash-seen";' in script
+    assert "sessionStorage.setItem(splashStorageKey, \"true\")" in script
+    assert "await context.addInitScript(" in script
+    assert 'await context.route("**/static/css/style.css*"' in script
+    assert "#first-load-splash" in script
+    assert ".first-load-splash" in script
 
 
 def test_docs_screenshots_manifest_artvandelay_notifications_waits_for_third_recipient() -> None:


### PR DESCRIPTION
## What changed

- Updated the docs screenshot capture script to suppress the first-load splash screen during screenshot runs.
- Sets the existing `hushline:first-load-splash-seen` session storage key before app JavaScript runs in Playwright contexts.
- Adds capture-only CSS to the served `style.css` response so JavaScript-disabled screenshot scenes also avoid capturing the splash overlay.
- Added a regression test that locks the screenshot capture script to this splash-suppression behavior.
- Formatted the regression test so CI lint accepts it.

## Why

After adding the first-load splash screen, docs screenshot captures were often recording the splash instead of the actual target page. The screenshot workflow should document the UI state for each scene, not the transient first-load overlay.

This keeps production behavior unchanged. The suppression is only installed inside the Playwright screenshot capture context.

## Validation

- `gh pr list --author app/dependabot --state open --json number,title,url,createdAt,headRefName --limit 20`
  - No open Dependabot PRs.
- `poetry run pytest tests/test_docs_screenshots_manifest.py -q`
  - Passed: `7 passed`
- `node --check scripts/capture-doc-screenshots.mjs`
  - Passed
- `npx prettier --check scripts/capture-doc-screenshots.mjs`
  - Passed
- `git diff --check`
  - Passed
- `make lint`
  - Initial local run from a temporary worktree failed because Docker could not bind already-used local dev-stack ports.
  - Equivalent lint steps were rerun through the existing `hushline` compose project with the clean worktree mounted at `/app`.
  - Passed: ruff format check, ruff check, mypy, and prettier.
- `docker compose -p hushline run --rm --no-deps app poetry run ruff format --check tests/test_docs_screenshots_manifest.py`
  - Passed after the formatting fix.

## Not run

- Full `make test` was not completed before this PR was opened.

## Manual testing

- Not manually exercised with a full docs screenshot capture in this PR. The change is limited to capture-time Playwright setup and is covered by the manifest/script regression test.

## Known risks / follow-up

- The next docs screenshot workflow run should be checked to confirm generated artifacts show each target page rather than the first-load splash.
