### PR TITLE
Resolve runner PR feedback threads after pushed fixes

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -822,6 +822,7 @@ fetch_pr_feedback_json() {
             }
             reviewThreads(first: 50) {
               nodes {
+                id
                 isResolved
                 isOutdated
                 path
@@ -829,6 +830,7 @@ fetch_pr_feedback_json() {
                 originalLine
                 comments(first: 10) {
                   nodes {
+                    databaseId
                     author {
                       login
                     }
@@ -1107,6 +1109,140 @@ pr_feedback_action_key() {
     | sed '/^Feedback pending check /d'
 }
 
+pr_feedback_unresolved_review_thread_targets() {
+  local feedback_json="$1"
+
+  printf '%s\n' "$feedback_json" \
+    | node -e '
+      const fs = require("fs");
+      const payload = JSON.parse(fs.readFileSync(0, "utf8"));
+      const pr =
+        payload &&
+        payload.data &&
+        payload.data.repository &&
+        payload.data.repository.pullRequest
+          ? payload.data.repository.pullRequest
+          : null;
+      const threads =
+        pr && pr.reviewThreads && Array.isArray(pr.reviewThreads.nodes)
+          ? pr.reviewThreads.nodes
+          : [];
+      const seen = new Set();
+      for (const thread of threads) {
+        if (!thread || thread.isResolved || !thread.id || seen.has(thread.id)) {
+          continue;
+        }
+        seen.add(thread.id);
+        const comments =
+          thread.comments && Array.isArray(thread.comments.nodes)
+            ? thread.comments.nodes
+            : [];
+        const firstComment = comments.find(
+          (comment) => comment && Number.isInteger(comment.databaseId),
+        );
+        const commentId = firstComment ? String(firstComment.databaseId) : "";
+        const path = String(thread.path || "").replace(/\t/g, " ");
+        process.stdout.write(`${thread.id}\t${commentId}\t${path}\n`);
+      }
+    '
+}
+
+build_pr_feedback_reply_body() {
+  local short_sha=""
+  local subject=""
+  local changed_files=""
+  local file_count=0
+
+  short_sha="$(git rev-parse --short HEAD 2>/dev/null || true)"
+  subject="$(git log -1 --pretty=%s 2>/dev/null || true)"
+  changed_files="$(git diff-tree --no-commit-id --name-only -r HEAD 2>/dev/null | sed -n '1,8p' || true)"
+
+  printf 'Addressed in'
+  if [[ -n "$short_sha" ]]; then
+    printf ' `%s`' "$short_sha"
+  else
+    printf ' the latest pushed commit'
+  fi
+  printf '.\n\nChanges made:\n'
+
+  if [[ -n "$subject" ]]; then
+    printf -- '- %s\n' "$subject"
+  else
+    printf -- '- Updated the PR branch to address this feedback.\n'
+  fi
+
+  while IFS= read -r changed_file; do
+    [[ -n "$changed_file" ]] || continue
+    printf -- '- Updated `%s`\n' "$changed_file"
+    file_count=$((file_count + 1))
+  done <<<"$changed_files"
+
+  if (( file_count == 8 )); then
+    printf -- '- Additional changed files are included in the pushed commit.\n'
+  fi
+}
+
+acknowledge_pr_feedback_review_threads() {
+  local pr_number="$1"
+  local feedback_json="$2"
+  local reply_body=""
+  local thread_id=""
+  local comment_id=""
+  local thread_path=""
+  local target_count=0
+  local reply_ok=0
+
+  [[ -n "$feedback_json" ]] || return 0
+
+  reply_body="$(build_pr_feedback_reply_body)"
+
+  while IFS=$'\t' read -r thread_id comment_id thread_path; do
+    [[ -n "$thread_id" ]] || continue
+    target_count=$((target_count + 1))
+    reply_ok=0
+
+    if [[ -n "$comment_id" ]]; then
+      if gh api \
+        --method POST \
+        "repos/${REPO_SLUG}/pulls/${pr_number}/comments/${comment_id}/replies" \
+        -f body="$reply_body" >/dev/null; then
+        echo "Replied to PR #${pr_number} review thread ${thread_path:-$thread_id}."
+        reply_ok=1
+      else
+        echo "Warning: failed to reply to PR #${pr_number} review thread ${thread_path:-$thread_id}." >&2
+      fi
+    else
+      echo "Warning: PR #${pr_number} review thread ${thread_path:-$thread_id} had no replyable comment id." >&2
+    fi
+
+    if (( reply_ok == 0 )); then
+      echo "Warning: leaving PR #${pr_number} review thread ${thread_path:-$thread_id} unresolved because no reply was posted." >&2
+      continue
+    fi
+
+    if gh api graphql \
+      -f threadId="$thread_id" \
+      -f query='
+        mutation($threadId: ID!) {
+          resolveReviewThread(input: {threadId: $threadId}) {
+            thread {
+              id
+              isResolved
+            }
+          }
+        }
+      ' >/dev/null; then
+      echo "Resolved PR #${pr_number} review thread ${thread_path:-$thread_id}."
+    else
+      echo "Warning: failed to resolve PR #${pr_number} review thread ${thread_path:-$thread_id}." >&2
+    fi
+  done < <(pr_feedback_unresolved_review_thread_targets "$feedback_json")
+
+  if (( target_count == 0 )); then
+    echo "No unresolved review threads to resolve for PR #${pr_number}."
+  fi
+}
+
 check_pr_feedback_after_delay() {
   local pr_number="$1"
   local issue_number="${2:-}"
@@ -1177,7 +1313,8 @@ check_pr_feedback_after_delay() {
         "$issue_title" \
         "$issue_labels" \
         "${branch_name:-$current_branch}" \
-        "$feedback_summary"
+        "$feedback_summary" \
+        "$feedback_json"
     fi
 
     sleep "$POST_PR_FEEDBACK_DELAY_SECONDS"
@@ -2553,6 +2690,7 @@ address_pr_feedback() {
   local issue_labels="$4"
   local branch_name="$5"
   local feedback_summary="$6"
+  local feedback_json="${7:-}"
 
   if [[ -z "$issue_number" || -z "$branch_name" ]]; then
     echo "Actionable PR feedback detected, but issue or branch context is unavailable; continuing monitor."
@@ -2590,6 +2728,7 @@ address_pr_feedback() {
   git commit -m "fix: address PR feedback for #${issue_number}"
   push_branch_for_pr "$branch_name"
   echo "Pushed PR feedback update for PR #${pr_number}."
+  acknowledge_pr_feedback_review_threads "$pr_number" "$feedback_json"
 }
 
 run_fix_attempt_loop() {

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -2714,6 +2714,167 @@ rm -f "$counter_file"
     assert "PR #2000 is MERGED; returning to main." in result.stdout
 
 
+def test_address_pr_feedback_replies_and_resolves_review_threads(
+    tmp_path: Path,
+) -> None:
+    calls_file = tmp_path / "calls.txt"
+    feedback_json = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 2000,
+                        "state": "OPEN",
+                        "url": "https://github.com/scidsg/hushline/pull/2000",
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "id": "PRRT_kwDOExample",
+                                    "isResolved": False,
+                                    "isOutdated": False,
+                                    "path": "scripts/agent_daily_issue_runner.sh",
+                                    "line": 100,
+                                    "originalLine": 100,
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "databaseId": 123456,
+                                                "author": {"login": "reviewer"},
+                                                "body": "Please resolve after pushing.",
+                                                "createdAt": "2026-05-02T00:00:00Z",
+                                                "url": "https://example.test/thread/1",
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+        }
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_SLUG=scidsg/hushline
+calls_file={shlex.quote(str(calls_file))}
+expected_commit_message="fix: address PR feedback for #1558"
+reply_path="repos/scidsg/hushline/pulls/2000/comments/123456/replies"
+feedback_summary="Post-PR feedback summary: unresolved_review_threads=1 changes_requested_reviews=0"
+feedback_summary="$feedback_summary discussion_comments=0 failing_checks=0 pending_checks=0"
+ensure_worktree_on_branch() {{
+  printf 'ensure:%s\\n' "$1" >> "$calls_file"
+}}
+build_pr_feedback_prompt() {{
+  printf 'prompt:%s\\n' "$1" >> "$calls_file"
+}}
+run_codex_from_prompt() {{
+  printf 'codex\\n' >> "$calls_file"
+}}
+has_non_log_changes() {{
+  return 0
+}}
+run_fix_attempt_loop() {{
+  printf 'fix:%s:%s\\n' "$1" "$5" >> "$calls_file"
+  return 0
+}}
+persist_run_log() {{
+  printf 'log:%s\\n' "$1" >> "$calls_file"
+}}
+push_branch_for_pr() {{
+  printf 'push:%s\\n' "$1" >> "$calls_file"
+}}
+git() {{
+  if [[ "${{1-}}" == "commit" ]] &&
+    [[ "${{2-}}" == "-m" ]] &&
+    [[ "${{3-}}" == "$expected_commit_message" ]]; then
+    printf 'git:commit\\n' >> "$calls_file"
+    return 0
+  fi
+  case "${{1-}} ${{2-}} ${{3-}} ${{4-}}" in
+    "add -A  ")
+      printf 'git:add\\n' >> "$calls_file"
+      return 0
+      ;;
+    "diff --cached --quiet ")
+      return 1
+      ;;
+    "rev-parse --short HEAD ")
+      printf 'abc1234\\n'
+      return 0
+      ;;
+    "log -1 --pretty=%s ")
+      printf 'fix: address PR feedback for #1558\\n'
+      return 0
+      ;;
+    "diff-tree --no-commit-id --name-only -r")
+      printf 'scripts/agent_daily_issue_runner.sh\\n'
+      return 0
+      ;;
+  esac
+  return 0
+}}
+gh() {{
+  if [[ "${{1-}}" == "api" ]] &&
+    [[ "${{2-}}" == "--method" ]] &&
+    [[ "${{3-}}" == "POST" ]] &&
+    [[ "${{4-}}" == "$reply_path" ]]; then
+    local body_arg=""
+    for arg in "$@"; do
+      case "$arg" in
+        body=*) body_arg="${{arg#body=}}" ;;
+      esac
+    done
+    [[ "$body_arg" == *"Changes made:"* ]]
+    [[ "$body_arg" == *"fix: address PR feedback for #1558"* ]]
+    printf 'reply\\n' >> "$calls_file"
+    return 0
+  fi
+  if [[ "${{1-}} ${{2-}}" == "api graphql" ]]; then
+    local thread_arg=""
+    for arg in "$@"; do
+      case "$arg" in
+        threadId=*) thread_arg="${{arg#threadId=}}" ;;
+      esac
+    done
+    [[ "$thread_arg" == "PRRT_kwDOExample" ]]
+    printf 'resolve\\n' >> "$calls_file"
+    return 0
+  fi
+  return 99
+}}
+address_pr_feedback \
+  2000 \
+  1558 \
+  "Title" \
+  "" \
+  "codex/daily-issue-1558" \
+  "$feedback_summary" \
+  {shlex.quote(feedback_json)}
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    calls = calls_file.read_text(encoding="utf-8").splitlines()
+    assert calls == [
+        "ensure:codex/daily-issue-1558",
+        "prompt:2000",
+        "codex",
+        "fix:1558:codex/daily-issue-1558",
+        "ensure:codex/daily-issue-1558",
+        "log:1558",
+        "git:add",
+        "git:commit",
+        "push:codex/daily-issue-1558",
+        "reply",
+        "resolve",
+    ]
+    assert "Replied to PR #2000 review thread scripts/agent_daily_issue_runner.sh." in result.stdout
+    assert "Resolved PR #2000 review thread scripts/agent_daily_issue_runner.sh." in result.stdout
+
+
 def test_resolve_pr_number_from_ref_prefers_pr_url_without_gh_lookup() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}


### PR DESCRIPTION
## Summary

- Add review thread IDs and replyable comment IDs to the runner's PR feedback fetch.
- After the runner commits and pushes a PR feedback fix, reply to each unresolved review thread with the pushed commit summary and changed files.
- Resolve each review thread only after the reply is posted successfully.
- Add runner tests that lock in reply-before-resolve behavior after branch push.

## Why

The post-PR feedback monitor already detects actionable review threads and pushes follow-up fixes, but it left those review threads unresolved and without a clear acknowledgement of what changed. This makes the runner harder to review and leaves maintainers to clean up threads manually.

## Validation

- `bash -n scripts/agent_daily_issue_runner.sh`
- `make test TESTS=tests/test_agent_daily_issue_runner.py PYTEST_ADDOPTS=-q` (75 passed)
- `make lint` partially passed: ruff format, ruff check, and mypy passed; repository-wide Prettier still fails on existing `hushline/static/js/*.js` formatting issues unrelated to this PR.

## Manual Testing

- Review a runner-managed PR with an unresolved inline review thread, let the runner push a feedback fix, and confirm it posts a concise reply before resolving the review thread.

## Known Risks / Follow-ups

- Top-level PR conversation comments are still not resolvable by GitHub, so this only resolves inline review threads.