### PR TITLE
Embeddable forms: add admin and recipient controls with iframe snippets

### DIFF
--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -2,7 +2,7 @@ import logging
 import math
 from typing import Any, Mapping, Optional, Tuple, Union
 
-from flask import Flask, render_template, request, session, url_for
+from flask import Flask, g, render_template, request, session, url_for
 from jinja2 import StrictUndefined
 from werkzeug.exceptions import HTTPException, InternalServerError
 from werkzeug.wrappers.response import Response
@@ -53,6 +53,7 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
     # Add Content-Security-Policy header to all responses
     @app.after_request
     def add_security_header(response: Response) -> Response:
+        frame_ancestors = getattr(g, "embed_frame_ancestors", "'none'")
         response.headers["Content-Security-Policy"] = ";".join(
             f"{k} {v}"
             for (k, v) in {
@@ -70,13 +71,16 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
                 "img-src": "'self' data: https:",
                 "media-src": "'self' data:",
                 "worker-src": "'self' blob:",
-                "frame-ancestors": "'none'",
+                "frame-ancestors": frame_ancestors,
                 "connect-src": "'self' https://api.stripe.com https://cdn.jsdelivr.net data:",
                 "child-src": "https://js.stripe.com",
                 "frame-src": "https://js.stripe.com",
             }.items()
         )
-        response.headers["X-Frame-Options"] = "DENY"
+        if frame_ancestors == "'none'":
+            response.headers["X-Frame-Options"] = "DENY"
+        else:
+            response.headers.pop("X-Frame-Options", None)
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["Permissions-Policy"] = (
             "geolocation=(), midi=(), notifications=(), push=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=(), vibrate=(), fullscreen=(), payment=(), interest-cohort=();"  # noqa: E501

--- a/hushline/admin.py
+++ b/hushline/admin.py
@@ -5,7 +5,7 @@ from wtforms.validators import ValidationError
 
 from hushline.auth import admin_authentication_required
 from hushline.db import db
-from hushline.model import Tier, User, Username
+from hushline.model import OrganizationSetting, Tier, User, Username
 from hushline.premium import update_price
 from hushline.user_deletion import delete_user_and_related, delete_username_and_related
 from hushline.utils import parse_bool
@@ -131,6 +131,18 @@ def create_blueprint() -> Blueprint:
 
         status_label = "suspended" if desired_suspended else "active"
         flash(f"✅ User suspension status set to {status_label}.", "success")
+        return redirect(url_for("settings.admin"))
+
+    @bp.route("/toggle_embeddable_forms", methods=["POST"])
+    @admin_authentication_required
+    def toggle_embeddable_forms() -> Response:
+        _validate_csrf()
+        desired_enabled = _parse_form_bool("embeddable_forms_enabled")
+        OrganizationSetting.upsert(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED, desired_enabled)
+        db.session.commit()
+
+        status_label = "enabled" if desired_enabled else "disabled"
+        flash(f"✅ Embeddable forms {status_label}.", "success")
         return redirect(url_for("settings.admin"))
 
     @bp.route("/update_tier/<int:tier_id>", methods=["POST"])

--- a/hushline/embeds.py
+++ b/hushline/embeds.py
@@ -1,0 +1,27 @@
+import html
+
+from hushline.external_urls import canonical_external_url
+from hushline.model import Username
+
+EMBED_IFRAME_SANDBOX = "allow-forms allow-scripts"
+EMBED_IFRAME_HEIGHT = 700
+EMBED_IFRAME_MAX_WIDTH = 720
+
+
+def embed_profile_url(username: Username) -> str:
+    return canonical_external_url("embed_profile", username=username.username)
+
+
+def embed_iframe_snippet(username: Username) -> str:
+    src = html.escape(embed_profile_url(username), quote=True)
+    title = html.escape(f"Send a secure message to {username.display_name or username.username}")
+    return (
+        f'<iframe src="{src}" '
+        f'title="{title}" '
+        f'sandbox="{EMBED_IFRAME_SANDBOX}" '
+        'referrerpolicy="no-referrer" '
+        'width="100%" '
+        f'height="{EMBED_IFRAME_HEIGHT}" '
+        f'style="width:100%;max-width:{EMBED_IFRAME_MAX_WIDTH}px;'
+        f'height:{EMBED_IFRAME_HEIGHT}px;border:0;"></iframe>'
+    )

--- a/hushline/routes/forms.py
+++ b/hushline/routes/forms.py
@@ -181,6 +181,7 @@ class DynamicMessageForm:
             )
             owner_guard_nonce = StringField("Owner Guard Nonce", validators=[Optional()])
             owner_guard_signature = StringField("Owner Guard Signature", validators=[Optional()])
+            embed_captcha_token = StringField("Embed CAPTCHA Token", validators=[Optional()])
             captcha_answer = StringField("CAPTCHA", validators=[Optional()])
 
         self.F = F
@@ -275,8 +276,10 @@ class DynamicMessageForm:
                 return field
         return None
 
-    def form(self) -> FlaskForm:
+    def form(self, *, csrf_enabled: bool | None = None) -> FlaskForm:
         """
         Return an instance of the custom form class
         """
-        return self.F()
+        if csrf_enabled is None:
+            return self.F()
+        return self.F(meta={"csrf": csrf_enabled})

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -2,6 +2,7 @@ import hmac
 import re
 import secrets
 from hashlib import sha256
+from typing import Any
 
 from flask import (
     Flask,
@@ -15,6 +16,7 @@ from flask import (
     session,
     url_for,
 )
+from itsdangerous import BadData, SignatureExpired, URLSafeTimedSerializer
 from sqlalchemy import func
 from sqlalchemy.exc import MultipleResultsFound
 from werkzeug.wrappers.response import Response
@@ -40,12 +42,32 @@ from hushline.routes.common import (
 from hushline.routes.forms import DynamicMessageForm
 from hushline.safe_template import safe_render_template
 
+EMBED_CAPTCHA_MAX_AGE_SECONDS = 60 * 60
+
 
 def register_profile_routes(app: Flask) -> None:
     def _owner_guard_signature(username: str, user_id: int, nonce: str) -> str:
         return hmac.new(
             key=(app.secret_key or "").encode("utf-8"),
             msg=f"{username}:{user_id}:{nonce}".encode(),
+            digestmod=sha256,
+        ).hexdigest()
+
+    def _embed_captcha_serializer() -> URLSafeTimedSerializer:
+        return URLSafeTimedSerializer(app.secret_key or "", salt="embed-profile-captcha")
+
+    def _embed_captcha_answer_signature(
+        username: str,
+        user_id: int,
+        nonce: str,
+        math_problem: str,
+        captcha_answer: str,
+    ) -> str:
+        return hmac.new(
+            key=(app.secret_key or "").encode("utf-8"),
+            msg=(
+                "embed-captcha:v1:" f"{username}:{user_id}:{nonce}:{math_problem}:{captcha_answer}"
+            ).encode(),
             digestmod=sha256,
         ).hexdigest()
 
@@ -60,15 +82,82 @@ def register_profile_routes(app: Flask) -> None:
             )
         )
 
-    def _get_math_problem(force_new: bool = False) -> str:
-        if not force_new and session.get("math_problem") and session.get("math_answer"):
-            return session["math_problem"]
+    def _new_math_problem() -> tuple[str, str]:
         num1 = secrets.randbelow(10) + 1
         num2 = secrets.randbelow(10) + 1
         math_problem = f"{num1} + {num2} ="
-        session["math_answer"] = str(num1 + num2)
+        return math_problem, str(num1 + num2)
+
+    def _get_session_math_problem(force_new: bool = False) -> str:
+        if not force_new and session.get("math_problem") and session.get("math_answer"):
+            return session["math_problem"]
+        math_problem, math_answer = _new_math_problem()
+        session["math_answer"] = math_answer
         session["math_problem"] = math_problem
         return math_problem
+
+    def _new_embed_math_problem(uname: Username) -> tuple[str, str]:
+        math_problem, math_answer = _new_math_problem()
+        nonce = secrets.token_urlsafe(16)
+        answer_signature = _embed_captcha_answer_signature(
+            uname.username,
+            uname.user_id,
+            nonce,
+            math_problem,
+            math_answer,
+        )
+        token = _embed_captcha_serializer().dumps(
+            {
+                "v": 1,
+                "username": uname.username,
+                "user_id": uname.user_id,
+                "nonce": nonce,
+                "math_problem": math_problem,
+                "answer_signature": answer_signature,
+            }
+        )
+        return math_problem, token
+
+    def _validate_embed_captcha(uname: Username, captcha_answer: str, captcha_token: str) -> bool:
+        if not captcha_answer.isdigit():
+            flash("⛔️ Incorrect CAPTCHA. Please enter a valid number.", "error")
+            return False
+
+        try:
+            payload: dict[str, Any] = _embed_captcha_serializer().loads(
+                captcha_token,
+                max_age=EMBED_CAPTCHA_MAX_AGE_SECONDS,
+            )
+        except SignatureExpired:
+            flash("⛔️ CAPTCHA expired. Please try again.", "error")
+            return False
+        except BadData:
+            flash("⛔️ Incorrect CAPTCHA. Please try again.", "error")
+            return False
+
+        if (
+            payload.get("v") != 1
+            or payload.get("username") != uname.username
+            or payload.get("user_id") != uname.user_id
+        ):
+            flash("⛔️ Incorrect CAPTCHA. Please try again.", "error")
+            return False
+
+        nonce = str(payload.get("nonce", ""))
+        math_problem = str(payload.get("math_problem", ""))
+        answer_signature = str(payload.get("answer_signature", ""))
+        expected_signature = _embed_captcha_answer_signature(
+            uname.username,
+            uname.user_id,
+            nonce,
+            math_problem,
+            captcha_answer,
+        )
+        if not hmac.compare_digest(answer_signature, expected_signature):
+            flash("⛔️ Incorrect CAPTCHA. Please try again.", "error")
+            return False
+
+        return True
 
     def _message_submission_block_reason(uname: Username) -> str | None:
         if bool(getattr(uname.user, "is_suspended", False)):
@@ -102,9 +191,14 @@ def register_profile_routes(app: Flask) -> None:
         uname.create_default_field_defs()
 
         dynamic_form = DynamicMessageForm([x for x in uname.message_fields if x.enabled])
-        form = dynamic_form.form()
+        is_embedded = request.endpoint == "embed_profile"
+        form = dynamic_form.form(csrf_enabled=False if is_embedded else None)
 
-        math_problem = _get_math_problem(force_new=request.method == "GET")
+        embed_captcha_token = None
+        if is_embedded:
+            math_problem, embed_captcha_token = _new_embed_math_problem(uname)
+        else:
+            math_problem = _get_session_math_problem(force_new=request.method == "GET")
 
         profile_header = safe_render_template(
             OrganizationSetting.fetch_one(OrganizationSetting.BRAND_PROFILE_HEADER_TEMPLATE),
@@ -143,7 +237,8 @@ def register_profile_routes(app: Flask) -> None:
                 message_submission_block_reason=message_submission_block_reason,
                 owner_guard_nonce=owner_guard_nonce,
                 owner_guard_signature=owner_guard_signature,
-                is_embedded=request.endpoint == "embed_profile",
+                is_embedded=is_embedded,
+                embed_captcha_token=embed_captcha_token,
             )
             if status_code is None:
                 return rendered
@@ -183,7 +278,16 @@ def register_profile_routes(app: Flask) -> None:
                     return _render_profile(400)
 
                 captcha_answer = form.captcha_answer.data or ""
-                if not validate_captcha(captcha_answer):
+                captcha_valid = (
+                    _validate_embed_captcha(
+                        uname,
+                        captcha_answer,
+                        form.embed_captcha_token.data or "",
+                    )
+                    if is_embedded
+                    else validate_captcha(captcha_answer)
+                )
+                if not captcha_valid:
                     flash("⛔️ Invalid CAPTCHA answer.", "error")
                     return _render_profile(400)
 
@@ -261,6 +365,14 @@ def register_profile_routes(app: Flask) -> None:
                         current_app.logger.debug("Sending email with generic body")
 
                     do_send_email(uname.user, email_body.strip())
+
+                if is_embedded:
+                    reply_url = canonical_external_url("message_reply", slug=message.reply_slug)
+                    return render_template(
+                        "submission_success.html",
+                        message=message,
+                        reply_url=reply_url,
+                    )
 
                 flash("👍 Message submitted successfully.")
                 session["reply_slug"] = message.reply_slug

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -8,6 +8,7 @@ from flask import (
     abort,
     current_app,
     flash,
+    g,
     redirect,
     render_template,
     request,
@@ -91,6 +92,13 @@ def register_profile_routes(app: Flask) -> None:
         if not uname:
             abort(404)
 
+        if request.endpoint == "embed_profile":
+            if not uname.embed_is_eligible:
+                abort(404)
+            g.embed_frame_ancestors = " ".join(
+                Username.normalize_embed_allowed_origins(uname.embed_allowed_origins or [])
+            )
+
         uname.create_default_field_defs()
 
         dynamic_form = DynamicMessageForm([x for x in uname.message_fields if x.enabled])
@@ -135,6 +143,7 @@ def register_profile_routes(app: Flask) -> None:
                 message_submission_block_reason=message_submission_block_reason,
                 owner_guard_nonce=owner_guard_nonce,
                 owner_guard_signature=owner_guard_signature,
+                is_embedded=request.endpoint == "embed_profile",
             )
             if status_code is None:
                 return rendered
@@ -273,6 +282,13 @@ def register_profile_routes(app: Flask) -> None:
             return _render_profile(400)
 
         return _render_profile()
+
+    app.add_url_rule(
+        "/embed/<username>",
+        endpoint="embed_profile",
+        view_func=profile,
+        methods=["GET", "POST"],
+    )
 
     @app.route("/submit_message/<username>")
     def redirect_submit_message(username: str) -> Response:

--- a/hushline/settings/__init__.py
+++ b/hushline/settings/__init__.py
@@ -20,6 +20,7 @@ from hushline.settings.forms import (
     DirectoryVisibilityForm,
     DisplayNameForm,
     EmailForwardingForm,
+    EmbedSettingsForm,
     NewAliasForm,
     NotificationRecipientForm,
     PGPKeyForm,

--- a/hushline/settings/admin.py
+++ b/hushline/settings/admin.py
@@ -8,7 +8,7 @@ from flask_wtf.csrf import generate_csrf
 
 from hushline.auth import admin_authentication_required
 from hushline.db import db
-from hushline.model import User, Username
+from hushline.model import OrganizationSetting, User, Username
 
 
 def register_admin_routes(bp: Blueprint) -> None:
@@ -38,5 +38,8 @@ def register_admin_routes(bp: Blueprint) -> None:
             two_fa_percentage=(two_fa_count / user_count * 100) if user_count else 0,
             pgp_key_percentage=(pgp_key_count / user_count * 100) if user_count else 0,
             user_verification_enabled=current_app.config.get("USER_VERIFICATION_ENABLED"),
+            embeddable_forms_enabled=bool(
+                OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED)
+            ),
             csrf_token=generate_csrf(),
         )

--- a/hushline/settings/aliases.py
+++ b/hushline/settings/aliases.py
@@ -14,17 +14,21 @@ from werkzeug.wrappers.response import Response
 
 from hushline.auth import authentication_required
 from hushline.db import db
+from hushline.embeds import embed_iframe_snippet
 from hushline.model import (
     FieldDefinition,
     FieldValue,
     Message,
+    OrganizationSetting,
     User,
     Username,
 )
 from hushline.settings.common import (
     build_field_forms,
+    create_embed_settings_form,
     create_profile_forms,
     form_error,
+    handle_embed_settings_form,
     handle_field_post,
     handle_new_alias_form,
     handle_profile_post,
@@ -33,6 +37,7 @@ from hushline.settings.forms import (
     DeleteAliasForm,
     DirectoryVisibilityForm,
     DisplayNameForm,
+    EmbedSettingsForm,
     FieldForm,
     NewAliasForm,
     ProfileForm,
@@ -45,12 +50,18 @@ def _render_alias_page(
     alias: Username,
     status_code: int = 200,
     forms: ProfileForms | None = None,
+    embed_settings_form: EmbedSettingsForm | None = None,
     submitted_field_form: FieldForm | None = None,
 ) -> tuple[str, int]:
     if forms is None:
         forms = create_profile_forms(alias)
+    if embed_settings_form is None:
+        embed_settings_form = create_embed_settings_form(alias)
     display_name_form, directory_visibility_form, profile_form = forms
     field_forms, new_field_form = build_field_forms(alias, submitted_form=submitted_field_form)
+    embeddable_forms_enabled = bool(
+        OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED)
+    )
 
     return (
         render_template(
@@ -60,6 +71,9 @@ def _render_alias_page(
             display_name_form=display_name_form,
             directory_visibility_form=directory_visibility_form,
             profile_form=profile_form,
+            embed_settings_form=embed_settings_form,
+            embeddable_forms_enabled=embeddable_forms_enabled,
+            embed_iframe_snippet=(embed_iframe_snippet(alias) if alias.embed_is_eligible else ""),
             field_forms=field_forms,
             new_field_form=new_field_form,
             delete_alias_form=DeleteAliasForm(),
@@ -117,6 +131,17 @@ def register_aliases_routes(bp: Blueprint) -> None:
                 and delete_alias_form.validate_on_submit()
             ):
                 return delete_alias(alias.id)
+            if "update_embed_settings" in request.form:
+                embed_settings_form = create_embed_settings_form(alias, submitted=True)
+                res = handle_embed_settings_form(alias, embed_settings_form)
+                if res:
+                    return res
+                return _render_alias_page(
+                    alias,
+                    status_code=400,
+                    forms=profile_forms,
+                    embed_settings_form=embed_settings_form,
+                )
             res = await handle_profile_post(*profile_forms, alias)
             if res:
                 return res

--- a/hushline/settings/common.py
+++ b/hushline/settings/common.py
@@ -43,6 +43,7 @@ from hushline.settings.forms import (
     ChangeUsernameForm,
     DirectoryVisibilityForm,
     DisplayNameForm,
+    EmbedSettingsForm,
     FieldChoiceForm,
     FieldForm,
     NewAliasForm,
@@ -338,6 +339,22 @@ def handle_update_directory_visibility(user: Username, form: DirectoryVisibility
     return redirect_to_self()
 
 
+def handle_embed_settings_form(username: Username, form: EmbedSettingsForm) -> Response | None:
+    if not username.embed_owner_is_eligible:
+        flash("⛔️ Add a usable recipient PGP key before enabling embeds.")
+        return None
+
+    if not form.validate_on_submit():
+        form_error()
+        return None
+
+    username.embed_enabled = form.embed_enabled.data
+    username.set_embed_allowed_origins(form.normalized_origins)
+    db.session.commit()
+    flash("👍 Embed settings updated successfully.")
+    return redirect_to_self()
+
+
 def handle_display_name_form(username: Username, form: DisplayNameForm) -> Response:
     username.display_name = (form.display_name.data or "").strip() or None
     db.session.commit()
@@ -512,6 +529,16 @@ def create_profile_forms(
     if not profile_form.subdivision.data and not profile_form.city.data:
         set_input_disabled(profile_form.city)
     return display_name_form, directory_visibility_form, profile_form
+
+
+def create_embed_settings_form(username: Username, submitted: bool = False) -> EmbedSettingsForm:
+    if submitted:
+        return EmbedSettingsForm()
+    return EmbedSettingsForm(
+        formdata=None,
+        embed_enabled=username.embed_enabled,
+        embed_allowed_origins="\n".join(username.embed_allowed_origins or []),
+    )
 
 
 async def handle_profile_post(

--- a/hushline/settings/forms.py
+++ b/hushline/settings/forms.py
@@ -218,6 +218,27 @@ class DirectoryVisibilityForm(FlaskForm):
     submit = SubmitField("Update Visibilty", name="update_directory_visibility", widget=Button())
 
 
+class EmbedSettingsForm(FlaskForm):
+    embed_enabled = BooleanField("Allow this tip line to be embedded")
+    embed_allowed_origins = TextAreaField(
+        "Allowed Parent Origins",
+        validators=[OptionalField(), Length(max=5000)],
+    )
+    submit = SubmitField("Update Embed Settings", name="update_embed_settings", widget=Button())
+
+    normalized_origins: list[str]
+
+    def validate_embed_allowed_origins(self, field: TextAreaField) -> None:
+        origins = [line for line in (field.data or "").splitlines() if line.strip()]
+        try:
+            self.normalized_origins = Username.normalize_embed_allowed_origins(origins)
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
+
+        if self.embed_enabled.data and not self.normalized_origins:
+            raise ValidationError("Add at least one exact allowed origin before enabling embeds.")
+
+
 def strip_whitespace(value: Optional[Any]) -> Optional[str]:
     if value is not None and hasattr(value, "strip"):
         return value.strip()

--- a/hushline/settings/profile.py
+++ b/hushline/settings/profile.py
@@ -14,22 +14,27 @@ from werkzeug.wrappers.response import Response
 
 from hushline.auth import authentication_required
 from hushline.db import db
+from hushline.embeds import embed_iframe_snippet
 from hushline.geo import city_options_for_state, state_options
 from hushline.model import (
+    OrganizationSetting,
     Tier,
     User,
     Username,
 )
 from hushline.settings.common import (
     build_field_forms,
+    create_embed_settings_form,
     create_profile_forms,
     form_error,
+    handle_embed_settings_form,
     handle_field_post,
     handle_profile_post,
 )
 from hushline.settings.forms import (
     DirectoryVisibilityForm,
     DisplayNameForm,
+    EmbedSettingsForm,
     FieldForm,
     ProfileForm,
 )
@@ -48,17 +53,23 @@ def _business_tier_display_price() -> str:
     return f"{price_usd:.2f}"
 
 
-def _render_profile_page(
+def _render_profile_page(  # noqa: PLR0913
     user: User,
     username: Username,
     status_code: int = 200,
     forms: ProfileForms | None = None,
+    embed_settings_form: EmbedSettingsForm | None = None,
     submitted_field_form: FieldForm | None = None,
 ) -> tuple[str, int]:
     if forms is None:
         forms = create_profile_forms(username)
+    if embed_settings_form is None:
+        embed_settings_form = create_embed_settings_form(username)
     display_name_form, directory_visibility_form, profile_form = forms
     field_forms, new_field_form = build_field_forms(username, submitted_form=submitted_field_form)
+    embeddable_forms_enabled = bool(
+        OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED)
+    )
 
     return (
         render_template(
@@ -68,6 +79,11 @@ def _render_profile_page(
             display_name_form=display_name_form,
             directory_visibility_form=directory_visibility_form,
             profile_form=profile_form,
+            embed_settings_form=embed_settings_form,
+            embeddable_forms_enabled=embeddable_forms_enabled,
+            embed_iframe_snippet=(
+                embed_iframe_snippet(username) if username.embed_is_eligible else ""
+            ),
             field_forms=field_forms,
             new_field_form=new_field_form,
             business_tier_display_price=_business_tier_display_price(),
@@ -89,6 +105,19 @@ def register_profile_routes(bp: Blueprint) -> None:
         status_code = 200
         if request.method == "POST":
             profile_forms = create_profile_forms(username)
+            if "update_embed_settings" in request.form:
+                embed_settings_form = create_embed_settings_form(username, submitted=True)
+                res = handle_embed_settings_form(username, embed_settings_form)
+                if res:
+                    return res
+                return _render_profile_page(
+                    user,
+                    username,
+                    status_code=400,
+                    forms=profile_forms,
+                    embed_settings_form=embed_settings_form,
+                )
+
             res = await handle_profile_post(*profile_forms, username)
             if res:
                 return res

--- a/hushline/templates/profile.html
+++ b/hushline/templates/profile.html
@@ -112,7 +112,7 @@
 
   <form
     method="POST"
-    action="{{ url_for('profile', username=username.username) }}"
+    action="{% if is_embedded %}{{ url_for('embed_profile', username=username.username) }}{% else %}{{ url_for('profile', username=username.username) }}{% endif %}"
     id="messageForm"
     data-submit-spinner="true"
   >

--- a/hushline/templates/profile.html
+++ b/hushline/templates/profile.html
@@ -119,6 +119,9 @@
     {{ form.hidden_tag() }}
     {{ form.owner_guard_nonce(type="hidden", value=owner_guard_nonce) }}
     {{ form.owner_guard_signature(type="hidden", value=owner_guard_signature) }}
+    {% if is_embedded %}
+      {{ form.embed_captcha_token(type="hidden", value=embed_captcha_token) }}
+    {% endif %}
 
     {% for data in field_data %}
       {% if data['field'].enabled %}

--- a/hushline/templates/settings/admin.html
+++ b/hushline/templates/settings/admin.html
@@ -19,6 +19,27 @@
     </div>
   </div>
 
+  <h4>Embeddable Forms</h4>
+  <p class="info">
+    Enable hosted iframe embeds globally. Recipients still need to opt in each
+    tip line and list exact allowed parent origins.
+  </p>
+  <form
+    action="{{ url_for('admin.toggle_embeddable_forms') }}"
+    method="POST"
+    class="formBody"
+  >
+    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+    <input
+      type="hidden"
+      name="embeddable_forms_enabled"
+      value="{{ 'false' if embeddable_forms_enabled else 'true' }}"
+    />
+    <button type="submit">
+      {{ "Disable Embeds" if embeddable_forms_enabled else "Enable Embeds" }}
+    </button>
+  </form>
+
   <h4>All Usernames</h4>
   <div class="settings-search">
     <div class="search-box">

--- a/hushline/templates/settings/profile-forms.html
+++ b/hushline/templates/settings/profile-forms.html
@@ -53,6 +53,71 @@
   {{ directory_visibility_form.submit }}
 </form>
 
+<h4>Embeddable Form</h4>
+<p class="info">
+  Add exact parent origins, one per line, such as https://newsroom.example.
+  The parent page must not wrap the intake area in analytics, heatmaps,
+  session replay, or misleading copy.
+</p>
+<p class="info">
+  Embedding places the Hush Line intake form on another page. The parent
+  website is not the cryptographic trust boundary; message encryption still
+  depends on this Hush Line form and your recipient keys.
+</p>
+{% if not embeddable_forms_enabled %}
+  <p class="meta">
+    Embeds are disabled globally by an administrator. Saved settings will not
+    make an iframe available until embeds are enabled globally.
+  </p>
+{% endif %}
+{% if not username.embed_owner_is_eligible %}
+  <p class="meta">
+    Add a usable recipient PGP key before enabling embeds.
+  </p>
+{% endif %}
+{% if username.embed_admin_disabled %}
+  <p class="meta">
+    Embeds are disabled for this tip line by an administrator.
+  </p>
+{% endif %}
+<form
+  method="POST"
+  class="formBody"
+  action="{% if is_alias %}{{ url_for('.alias', username_id=alias.id) }}{% else %}{{ url_for('.profile') }}{% endif %}"
+>
+  {{ embed_settings_form.hidden_tag() }}
+  {% for error in embed_settings_form.errors.get('csrf_token', []) %}
+    <span class="error">{{ error }}</span>
+  {% endfor %}
+  <div class="checkbox-group toggle-ui">
+    {{ embed_settings_form.embed_enabled(disabled=(not username.embed_owner_is_eligible or username.embed_admin_disabled)) }}
+    <label for="embed_enabled" class="toggle-label">
+      Allow this tip line to be embedded
+      <div class="toggle">
+        <div class="toggle__ball"></div>
+      </div>
+    </label>
+  </div>
+  <div class="form-group">
+    {{ embed_settings_form.embed_allowed_origins.label }}
+    {{ embed_settings_form.embed_allowed_origins(rows="4", placeholder="https://newsroom.example", disabled=(not username.embed_owner_is_eligible or username.embed_admin_disabled)) }}
+    {% for error in embed_settings_form.embed_allowed_origins.errors %}
+      <span class="error">{{ error }}</span>
+    {% endfor %}
+  </div>
+  {{ embed_settings_form.submit(disabled=(not username.embed_owner_is_eligible or username.embed_admin_disabled)) }}
+</form>
+{% if embed_iframe_snippet %}
+  <div class="form-group">
+    <label for="embed_iframe_snippet">Iframe snippet</label>
+    <textarea id="embed_iframe_snippet" rows="5" readonly>{{ embed_iframe_snippet }}</textarea>
+    <p class="meta">
+      Use bounded sizing. The snippet uses a fixed 700px height, 100% width,
+      and a 720px maximum width.
+    </p>
+  </div>
+{% endif %}
+
 <h4>Profile Information</h4>
 <form
   method="POST"

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1,0 +1,255 @@
+from bs4 import BeautifulSoup
+from flask import url_for
+from flask.testing import FlaskClient
+
+from hushline.db import db
+from hushline.model import OrganizationSetting, User, Username
+
+
+def _make_message_capable(user: User) -> None:
+    with open("tests/test_pgp_key.txt") as file:
+        user.pgp_key = file.read().strip()
+    db.session.commit()
+
+
+def _enable_embeds_globally() -> None:
+    OrganizationSetting.upsert(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED, True)
+    db.session.commit()
+
+
+def _embed_settings_data(enabled: bool, origins: str) -> dict[str, str]:
+    data = {
+        "embed_allowed_origins": origins,
+        "update_embed_settings": "",
+    }
+    if enabled:
+        data["embed_enabled"] = "y"
+    return data
+
+
+def _iframe_from_snippet(response_text: str) -> BeautifulSoup:
+    page = BeautifulSoup(response_text, "html.parser")
+    snippet = page.find("textarea", id="embed_iframe_snippet")
+    assert snippet is not None
+    snippet_text = snippet.get_text()
+    assert "<script" not in snippet_text.lower()
+    return BeautifulSoup(snippet_text, "html.parser")
+
+
+def test_admin_embeddable_forms_default_disabled(client: FlaskClient, admin_user: User) -> None:
+    with client.session_transaction() as session:
+        session["user_id"] = admin_user.id
+        session["session_id"] = admin_user.session_id
+        session["username"] = admin_user.primary_username.username
+        session["is_authenticated"] = True
+
+    response = client.get(url_for("settings.admin"))
+
+    assert response.status_code == 200
+    assert OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED) is False
+    assert "Enable Embeds" in response.text
+    assert "Disable Embeds" not in response.text
+
+
+def test_embed_profile_route_is_disabled_by_default(client: FlaskClient, user: User) -> None:
+    _make_message_capable(user)
+    user.primary_username.embed_enabled = True
+    user.primary_username.set_embed_allowed_origins(["https://tips.example"])
+    db.session.commit()
+
+    response = client.get(url_for("embed_profile", username=user.primary_username.username))
+
+    assert response.status_code == 404
+
+
+def test_profile_embed_settings_do_not_show_snippet_when_globally_disabled(
+    client: FlaskClient, user: User
+) -> None:
+    _make_message_capable(user)
+    user.primary_username.embed_enabled = True
+    user.primary_username.set_embed_allowed_origins(["https://tips.example"])
+    db.session.commit()
+    with client.session_transaction() as session:
+        session["user_id"] = user.id
+        session["session_id"] = user.session_id
+        session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
+
+    response = client.get(url_for("settings.profile"))
+
+    assert response.status_code == 200
+    assert "Embeds are disabled globally by an administrator." in response.text
+    assert 'id="embed_iframe_snippet"' not in response.text
+
+
+def test_admin_can_toggle_embeddable_forms(client: FlaskClient, admin_user: User) -> None:
+    with client.session_transaction() as session:
+        session["user_id"] = admin_user.id
+        session["session_id"] = admin_user.session_id
+        session["username"] = admin_user.primary_username.username
+        session["is_authenticated"] = True
+
+    response = client.post(
+        url_for("admin.toggle_embeddable_forms"),
+        data={"embeddable_forms_enabled": "true"},
+    )
+    assert response.status_code == 302
+    assert OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED) is True
+
+    response = client.post(
+        url_for("admin.toggle_embeddable_forms"),
+        data={"embeddable_forms_enabled": "false"},
+    )
+    assert response.status_code == 302
+    assert OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED) is False
+
+
+def test_non_admin_cannot_toggle_embeddable_forms(client: FlaskClient, user: User) -> None:
+    with client.session_transaction() as session:
+        session["user_id"] = user.id
+        session["session_id"] = user.session_id
+        session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
+
+    response = client.post(
+        url_for("admin.toggle_embeddable_forms"),
+        data={"embeddable_forms_enabled": "true"},
+    )
+
+    assert response.status_code == 403
+    assert OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED) is False
+
+
+def test_primary_embed_settings_update_origins_and_render_iframe_snippet(
+    client: FlaskClient, user: User
+) -> None:
+    _enable_embeds_globally()
+    _make_message_capable(user)
+    with client.session_transaction() as session:
+        session["user_id"] = user.id
+        session["session_id"] = user.session_id
+        session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
+
+    response = client.post(
+        url_for("settings.profile"),
+        data=_embed_settings_data(
+            True,
+            "https://Tips.Example:443\nhttps://other.example:8443",
+        ),
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    db.session.refresh(user.primary_username)
+    assert user.primary_username.embed_enabled is True
+    assert user.primary_username.embed_allowed_origins == [
+        "https://tips.example",
+        "https://other.example:8443",
+    ]
+
+    snippet = _iframe_from_snippet(response.text)
+    iframe = snippet.find("iframe")
+    assert iframe is not None
+    assert iframe["src"] == url_for(
+        "embed_profile",
+        username=user.primary_username.username,
+        _external=True,
+    )
+    assert iframe["sandbox"] == ["allow-forms", "allow-scripts"]
+    assert iframe["referrerpolicy"] == "no-referrer"
+    assert iframe["title"]
+    assert iframe["width"] == "100%"
+    assert iframe["height"] == "700"
+    assert "max-width:720px" in iframe["style"]
+
+
+def test_primary_embed_settings_reject_invalid_origin(client: FlaskClient, user: User) -> None:
+    _make_message_capable(user)
+    with client.session_transaction() as session:
+        session["user_id"] = user.id
+        session["session_id"] = user.session_id
+        session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
+
+    response = client.post(
+        url_for("settings.profile"),
+        data=_embed_settings_data(True, "https://tips.example/path"),
+    )
+
+    assert response.status_code == 400
+    db.session.refresh(user.primary_username)
+    assert user.primary_username.embed_enabled is False
+    assert user.primary_username.embed_allowed_origins == []
+
+
+def test_embed_settings_require_message_capable_owner(client: FlaskClient, user: User) -> None:
+    with client.session_transaction() as session:
+        session["user_id"] = user.id
+        session["session_id"] = user.session_id
+        session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
+
+    response = client.post(
+        url_for("settings.profile"),
+        data=_embed_settings_data(True, "https://tips.example"),
+    )
+
+    assert response.status_code == 400
+    db.session.refresh(user.primary_username)
+    assert user.primary_username.embed_enabled is False
+
+
+def test_alias_embed_settings_are_independent(
+    client: FlaskClient, user: User, user_alias: Username
+) -> None:
+    _enable_embeds_globally()
+    _make_message_capable(user)
+    with client.session_transaction() as session:
+        session["user_id"] = user.id
+        session["session_id"] = user.session_id
+        session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
+
+    response = client.post(
+        url_for("settings.alias", username_id=user_alias.id),
+        data=_embed_settings_data(True, "https://alias.example"),
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    db.session.refresh(user.primary_username)
+    db.session.refresh(user_alias)
+    assert user.primary_username.embed_enabled is False
+    assert user.primary_username.embed_allowed_origins == []
+    assert user_alias.embed_enabled is True
+    assert user_alias.embed_allowed_origins == ["https://alias.example"]
+
+    snippet = _iframe_from_snippet(response.text)
+    iframe = snippet.find("iframe")
+    assert iframe is not None
+    assert iframe["src"] == url_for(
+        "embed_profile",
+        username=user_alias.username,
+        _external=True,
+    )
+
+
+def test_alias_embed_settings_require_alias_owner(
+    client: FlaskClient, user2: User, user_alias: Username
+) -> None:
+    _make_message_capable(user2)
+    with client.session_transaction() as session:
+        session["user_id"] = user2.id
+        session["session_id"] = user2.session_id
+        session["username"] = user2.primary_username.username
+        session["is_authenticated"] = True
+
+    response = client.post(
+        url_for("settings.alias", username_id=user_alias.id),
+        data=_embed_settings_data(True, "https://alias.example"),
+    )
+
+    assert response.status_code == 404
+    db.session.refresh(user_alias)
+    assert user_alias.embed_enabled is False

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1,9 +1,9 @@
 from bs4 import BeautifulSoup
-from flask import url_for
+from flask import Flask, url_for
 from flask.testing import FlaskClient
 
 from hushline.db import db
-from hushline.model import OrganizationSetting, User, Username
+from hushline.model import Message, OrganizationSetting, User, Username
 
 
 def _make_message_capable(user: User) -> None:
@@ -36,6 +36,22 @@ def _iframe_from_snippet(response_text: str) -> BeautifulSoup:
     return BeautifulSoup(snippet_text, "html.parser")
 
 
+def _embed_submission_data(response_text: str) -> dict[str, str]:
+    page = BeautifulSoup(response_text, "html.parser")
+    label = page.find("label", attrs={"for": "captcha_answer"})
+    assert label is not None
+    left, right = label.get_text(strip=True).replace("=", "").split("+")
+
+    data = {"captcha_answer": str(int(left.strip()) + int(right.strip()))}
+    for name in ["owner_guard_nonce", "owner_guard_signature", "embed_captcha_token"]:
+        field = page.find("input", attrs={"name": name})
+        assert field is not None
+        value = field.get("value")
+        assert value
+        data[name] = str(value)
+    return data
+
+
 def test_admin_embeddable_forms_default_disabled(client: FlaskClient, admin_user: User) -> None:
     with client.session_transaction() as session:
         session["user_id"] = admin_user.id
@@ -60,6 +76,50 @@ def test_embed_profile_route_is_disabled_by_default(client: FlaskClient, user: U
     response = client.get(url_for("embed_profile", username=user.primary_username.username))
 
     assert response.status_code == 404
+
+
+def test_embed_profile_submission_does_not_require_session_cookie(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+) -> None:
+    prior_csrf_setting = app.config.get("WTF_CSRF_ENABLED")
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        _enable_embeds_globally()
+        _make_message_capable(user)
+        user.primary_username.embed_enabled = True
+        user.primary_username.set_embed_allowed_origins(["https://tips.example"])
+        db.session.commit()
+
+        response = client.get(url_for("embed_profile", username=user.primary_username.username))
+
+        assert response.status_code == 200
+        assert 'name="csrf_token"' not in response.text
+        with client.session_transaction() as session:
+            assert "math_answer" not in session
+            assert "math_problem" not in session
+
+        submission_data = _embed_submission_data(response.text)
+        with app.test_client() as cross_site_client:
+            post_response = cross_site_client.post(
+                url_for("embed_profile", username=user.primary_username.username),
+                data={
+                    "field_0": "Embedded Signal contact",
+                    "field_1": "Embedded sessionless message",
+                    **submission_data,
+                },
+            )
+
+        assert post_response.status_code == 200, post_response.text
+        assert "Message Submitted!" in post_response.text
+
+        message = db.session.scalars(
+            db.select(Message).filter_by(username_id=user.primary_username.id)
+        ).one()
+        assert len(message.field_values) == 2
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = prior_csrf_setting
 
 
 def test_profile_embed_settings_do_not_show_snippet_when_globally_disabled(

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,6 +1,8 @@
+import pytest
 from flask import Flask, url_for
 from flask.testing import FlaskClient
 
+from hushline.db import db
 from hushline.model import OrganizationSetting, User
 
 
@@ -57,6 +59,32 @@ def test_profile_page_keeps_csp_enforced(client: FlaskClient, user: User) -> Non
     assert csp
     assert "'unsafe-eval'" not in csp
     assert "script-src-elem 'self' 'unsafe-inline'" not in csp
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_settings_profile_keeps_frame_restrictions(client: FlaskClient) -> None:
+    response = client.get(url_for("settings.profile"))
+    assert response.status_code == 200
+
+    csp = (response.headers.get("Content-Security-Policy") or "").strip()
+    assert "frame-ancestors 'none'" in csp
+    assert response.headers["X-Frame-Options"] == "DENY"
+
+
+def test_embed_profile_uses_allowed_origin_frame_ancestors(client: FlaskClient, user: User) -> None:
+    with open("tests/test_pgp_key.txt") as file:
+        user.pgp_key = file.read().strip()
+    user.primary_username.embed_enabled = True
+    user.primary_username.set_embed_allowed_origins(["https://tips.example"])
+    OrganizationSetting.upsert(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED, True)
+    db.session.commit()
+
+    response = client.get(url_for("embed_profile", username=user.primary_username.username))
+    assert response.status_code == 200
+
+    csp = (response.headers.get("Content-Security-Policy") or "").strip()
+    assert "frame-ancestors https://tips.example" in csp
+    assert "X-Frame-Options" not in response.headers
 
 
 def test_password_reset_pages_keep_csp_enforced(client: FlaskClient) -> None:


### PR DESCRIPTION
## What changed

- Added the embeddable form route and iframe snippet generation for eligible profiles.
- Added admin controls to globally enable or disable embeddable forms.
- Added recipient controls for primary and alias profiles, including allowed origins and copied iframe snippets.
- Added CSP coverage so embedded profiles use scoped `frame-ancestors` while normal settings/profile pages remain protected.

## Why

Restores the failed automated work for #1917, building on epic branch `codex/epic-1914` for the embeddable forms epic (#1914).

## Validation

- `make lint`
- `make test TESTS=tests/test_embeddable_forms_settings.py`
- `make test`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

Not applicable; behavior is covered by focused route/settings/security-header tests and the full test suite.

## Risks and follow-up

- Child PR targets the epic branch, so issue #1917 should be closed explicitly when this PR is merged into `codex/epic-1914` rather than relying on GitHub auto-close keywords.
