### PR TITLE
Fix Stripe receipts and payment method management

### DIFF
--- a/hushline/premium.py
+++ b/hushline/premium.py
@@ -282,6 +282,27 @@ def handle_invoice_created(invoice: stripe.Invoice) -> None:
     db.session.commit()
 
 
+def _receipt_url_from_invoice(invoice: stripe.Invoice) -> str | None:
+    hosted_invoice_url = getattr(invoice, "hosted_invoice_url", None)
+    if isinstance(hosted_invoice_url, str) and hosted_invoice_url:
+        return hosted_invoice_url
+
+    invoice_pdf = getattr(invoice, "invoice_pdf", None)
+    if isinstance(invoice_pdf, str) and invoice_pdf:
+        return invoice_pdf
+
+    return None
+
+
+def _sync_invoice(stripe_invoice: StripeInvoice, invoice: stripe.Invoice) -> None:
+    stripe_invoice.total = invoice.total
+    stripe_invoice.status = StripeInvoiceStatusEnum(invoice.status)
+
+    receipt_url = _receipt_url_from_invoice(invoice)
+    if receipt_url:
+        stripe_invoice.hosted_invoice_url = receipt_url
+
+
 def handle_invoice_updated(invoice: stripe.Invoice) -> None:
     # invoice.updated
 
@@ -289,8 +310,7 @@ def handle_invoice_updated(invoice: stripe.Invoice) -> None:
         db.select(StripeInvoice).filter_by(invoice_id=invoice.id)
     ).one_or_none()
     if stripe_invoice:
-        stripe_invoice.total = invoice.total
-        stripe_invoice.status = StripeInvoiceStatusEnum(invoice.status)
+        _sync_invoice(stripe_invoice, invoice)
         db.session.commit()
     else:
         raise ValueError(f"Could not find invoice with ID {invoice.id}")
@@ -366,7 +386,7 @@ async def worker(app: Flask) -> None:
                     )
                     if event.type == "invoice.created":
                         handle_invoice_created(invoice)
-                    elif event.type == "invoice.updated":
+                    elif event.type in ["invoice.updated", "invoice.payment_succeeded"]:
                         handle_invoice_updated(invoice)
 
             except (
@@ -421,6 +441,41 @@ def create_blueprint(app: Flask) -> Blueprint:
         return render_template(
             "premium.html", user=user, invoices=invoices, business_price=get_business_price_string()
         )
+
+    @bp.route("/invoices/<int:invoice_id>/receipt")
+    @authentication_required
+    def receipt(invoice_id: int) -> Response | str:
+        user = db.session.get(User, session.get("user_id"))
+        if not user:
+            session.clear()
+            return redirect(url_for("login"))
+
+        stripe_invoice = db.session.scalars(
+            db.select(StripeInvoice)
+            .filter_by(id=invoice_id)
+            .filter_by(user_id=user.id)
+            .filter_by(status=StripeInvoiceStatusEnum.PAID)
+        ).one_or_none()
+        if not stripe_invoice:
+            abort(404)
+
+        receipt_url = stripe_invoice.hosted_invoice_url
+        try:
+            latest_invoice = stripe.Invoice.retrieve(stripe_invoice.invoice_id)
+        except stripe._error.StripeError as e:
+            current_app.logger.warning(
+                f"Unable to refresh Stripe invoice {stripe_invoice.invoice_id}: {e}"
+            )
+        else:
+            _sync_invoice(stripe_invoice, latest_invoice)
+            db.session.commit()
+            receipt_url = stripe_invoice.hosted_invoice_url
+
+        if not receipt_url:
+            flash("⚠️ Receipt is not available yet. Please try again later.", "warning")
+            return redirect(url_for("premium.index"))
+
+        return redirect(receipt_url)
 
     @bp.route("/select-tier")
     @authentication_required
@@ -508,6 +563,43 @@ def create_blueprint(app: Flask) -> Blueprint:
 
         if checkout_session.url:
             return redirect(checkout_session.url)
+
+        return abort(500)
+
+    @bp.route("/payment-method", methods=["POST"])
+    @authentication_required
+    def update_payment_method() -> Response | str:
+        user = db.session.get(User, session.get("user_id"))
+        if not user:
+            session.clear()
+            return redirect(url_for("login"))
+
+        if not user.is_business_tier or not user.stripe_customer_id:
+            flash("⚠️ No active subscription found.")
+            return redirect(url_for("premium.index"))
+
+        return_url = canonical_external_url("premium.index")
+        try:
+            portal_session = stripe.billing_portal.Session.create(
+                customer=user.stripe_customer_id,
+                return_url=return_url,
+                flow_data={
+                    "type": "payment_method_update",
+                    "after_completion": {
+                        "type": "redirect",
+                        "redirect": {"return_url": return_url},
+                    },
+                },
+            )
+        except stripe._error.StripeError as e:
+            current_app.logger.error(
+                f"Failed to create Stripe billing portal session: {e}", exc_info=True
+            )
+            flash("⚠️ Something went wrong while opening payment settings.")
+            return redirect(url_for("premium.index"))
+
+        if portal_session.url:
+            return redirect(portal_session.url)
 
         return abort(500)
 

--- a/hushline/templates/premium.html
+++ b/hushline/templates/premium.html
@@ -37,6 +37,14 @@
       {% endif %}
 
       {% if user.is_business_tier %}
+        <form
+          id="payment-method-form"
+          action="{{ url_for('premium.update_payment_method') }}"
+          method="post"
+        >
+          <button class="btn" id="update-payment-method">Update Payment Method</button>
+        </form>
+
         {% if user.stripe_subscription_cancel_at_period_end %}
           <p class="meta sub-info">
             ⚠️ Your subscription will expire on {{
@@ -85,10 +93,14 @@
           {% for invoice in invoices %}
             <tr>
               <td>{{ invoice.created_at.strftime('%Y-%m-%d') }}</td>
-              <td>${{ invoice.total / 100 }}</td>
+              <td>{{ "$%d.%02d"|format(invoice.total // 100, invoice.total % 100) }}</td>
               <td>{{ invoice.status.value }}</td>
               <td>
-                <a href="{{ invoice.hosted_invoice_url }}" target="_blank">
+                <a
+                  href="{{ url_for('premium.receipt', invoice_id=invoice.id) }}"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   Receipt
                 </a>
               </td>

--- a/tests/test_premium.py
+++ b/tests/test_premium.py
@@ -392,6 +392,106 @@ def test_handle_invoice_updated(app: Flask, user: User) -> None:
 
     stripe_invoice = db.session.query(StripeInvoice).filter_by(invoice_id="inv_123").one()
     assert stripe_invoice.status == StripeInvoiceStatusEnum.PAID
+    assert stripe_invoice.hosted_invoice_url == "https://example.com"
+
+
+def test_handle_invoice_updated_refreshes_receipt_url(app: Flask, user: User) -> None:
+    user.stripe_customer_id = "cus_123"
+    user.stripe_subscription_id = "sub_123"
+    db.session.commit()
+
+    invoice = MagicMock(
+        id="inv_123",
+        customer="cus_123",
+        hosted_invoice_url="https://stripe.com/invoice/stale",
+        total=2000,
+        status=StripeInvoiceStatusEnum.OPEN.value,
+        lines=MagicMock(data=[MagicMock(plan=MagicMock(product="prod_123"))]),
+        subscription="sub_123",
+    )
+    handle_invoice_created(invoice)
+
+    invoice.status = StripeInvoiceStatusEnum.PAID.value
+    invoice.hosted_invoice_url = "https://stripe.com/invoice/fresh"
+    handle_invoice_updated(invoice)
+
+    stripe_invoice = db.session.query(StripeInvoice).filter_by(invoice_id="inv_123").one()
+    assert stripe_invoice.status == StripeInvoiceStatusEnum.PAID
+    assert stripe_invoice.hosted_invoice_url == "https://stripe.com/invoice/fresh"
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_premium_index_links_receipts_through_authenticated_route(
+    client: FlaskClient, user: User, business_tier: Tier
+) -> None:
+    user.stripe_customer_id = "cus_123"
+    user.set_business_tier()
+    db.session.commit()
+
+    handle_invoice_created(
+        MagicMock(
+            id="inv_123",
+            customer="cus_123",
+            hosted_invoice_url="https://stripe.com/invoice/stale",
+            total=500,
+            status=StripeInvoiceStatusEnum.PAID.value,
+            lines=MagicMock(
+                data=[MagicMock(plan=MagicMock(product=business_tier.stripe_product_id))]
+            ),
+            subscription="sub_123",
+        )
+    )
+    stripe_invoice = db.session.query(StripeInvoice).filter_by(invoice_id="inv_123").one()
+
+    response = client.get(url_for("premium.index"))
+
+    assert response.status_code == 200
+    assert url_for("premium.receipt", invoice_id=stripe_invoice.id) in response.text
+    assert url_for("premium.update_payment_method") in response.text
+    assert "Update Payment Method" in response.text
+    assert "<td>$5.00</td>" in response.text
+    assert "https://stripe.com/invoice/stale" not in response.text
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_receipt_route_refreshes_stale_url_before_redirect(
+    client: FlaskClient, user: User, business_tier: Tier, mocker: MockFixture
+) -> None:
+    user.stripe_customer_id = "cus_123"
+    user.set_business_tier()
+    db.session.commit()
+
+    handle_invoice_created(
+        MagicMock(
+            id="inv_123",
+            customer="cus_123",
+            hosted_invoice_url="https://stripe.com/invoice/stale",
+            total=2000,
+            status=StripeInvoiceStatusEnum.PAID.value,
+            lines=MagicMock(
+                data=[MagicMock(plan=MagicMock(product=business_tier.stripe_product_id))]
+            ),
+            subscription="sub_123",
+        )
+    )
+    stripe_invoice = db.session.query(StripeInvoice).filter_by(invoice_id="inv_123").one()
+    retrieve_invoice = mocker.patch(
+        "hushline.premium.stripe.Invoice.retrieve",
+        return_value=MagicMock(
+            id="inv_123",
+            hosted_invoice_url="https://stripe.com/invoice/fresh",
+            total=2000,
+            status=StripeInvoiceStatusEnum.PAID.value,
+        ),
+    )
+
+    response = client.get(url_for("premium.receipt", invoice_id=stripe_invoice.id))
+
+    assert response.status_code == 302
+    assert response.location == "https://stripe.com/invoice/fresh"
+    retrieve_invoice.assert_called_once_with("inv_123")
+    db.session.refresh(stripe_invoice)
+    assert stripe_invoice.hosted_invoice_url == "https://stripe.com/invoice/fresh"
 
 
 def test_handle_invoice_updated_raises_for_missing_invoice(app: Flask) -> None:
@@ -501,6 +601,80 @@ def test_upgrade_process_uses_public_base_url_for_success_url(
     assert response.status_code == 302
     assert response.location == "https://checkout.stripe.com/session_123"
     assert checkout_create.call_args.kwargs["success_url"] == "https://safe.example/premium/waiting"
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_update_payment_method_creates_billing_portal_session(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    mocker: MockFixture,
+) -> None:
+    user.set_business_tier()
+    user.stripe_customer_id = "cus_123"
+    db.session.commit()
+    app.config["PUBLIC_BASE_URL"] = "https://safe.example"
+    portal_create = mocker.patch(
+        "hushline.premium.stripe.billing_portal.Session.create",
+        return_value=MagicMock(url="https://billing.stripe.com/session_123"),
+    )
+
+    response = client.post(url_for("premium.update_payment_method"))
+
+    assert response.status_code == 302
+    assert response.location == "https://billing.stripe.com/session_123"
+    portal_create.assert_called_once_with(
+        customer="cus_123",
+        return_url="https://safe.example/premium/",
+        flow_data={
+            "type": "payment_method_update",
+            "after_completion": {
+                "type": "redirect",
+                "redirect": {"return_url": "https://safe.example/premium/"},
+            },
+        },
+    )
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_update_payment_method_requires_active_subscription(
+    client: FlaskClient, user: User, mocker: MockFixture
+) -> None:
+    user.set_free_tier()
+    user.stripe_customer_id = "cus_123"
+    db.session.commit()
+    portal_create = mocker.patch("hushline.premium.stripe.billing_portal.Session.create")
+
+    response = client.post(url_for("premium.update_payment_method"))
+
+    assert response.status_code == 302
+    assert response.location == url_for("premium.index")
+    portal_create.assert_not_called()
+    with client.session_transaction():
+        flashed_messages = get_flashed_messages()
+    assert "⚠️ No active subscription found." in flashed_messages
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_update_payment_method_stripe_error(
+    client: FlaskClient, user: User, mocker: MockFixture
+) -> None:
+    user.set_business_tier()
+    user.stripe_customer_id = "cus_123"
+    db.session.commit()
+    portal_create = mocker.patch(
+        "hushline.premium.stripe.billing_portal.Session.create",
+        side_effect=StripeError("An error occurred"),
+    )
+
+    response = client.post(url_for("premium.update_payment_method"))
+
+    assert response.status_code == 302
+    assert response.location == url_for("premium.index")
+    assert portal_create.called
+    with client.session_transaction():
+        flashed_messages = get_flashed_messages()
+    assert "⚠️ Something went wrong while opening payment settings." in flashed_messages
 
 
 def test_disable_autorenew_no_user_in_session(client: FlaskClient) -> None:
@@ -768,6 +942,7 @@ def test_premium_index_warns_on_incomplete_subscription(
         ("premium.select_tier", "get"),
         ("premium.select_free", "post"),
         ("premium.upgrade", "post"),
+        ("premium.update_payment_method", "post"),
         ("premium.disable_autorenew", "post"),
         ("premium.enable_autorenew", "post"),
         ("premium.cancel", "post"),
@@ -799,6 +974,7 @@ def test_premium_routes_redirect_to_login_when_user_missing_after_auth(
         ("premium.select_tier", "get"),
         ("premium.select_free", "post"),
         ("premium.upgrade", "post"),
+        ("premium.update_payment_method", "post"),
         ("premium.disable_autorenew", "post"),
         ("premium.enable_autorenew", "post"),
         ("premium.cancel", "post"),
@@ -1153,3 +1329,44 @@ async def test_worker_processes_invoice_created_event(app: Flask, mocker: MockFi
     db.session.refresh(pending)
     assert pending.status == StripeEventStatusEnum.FINISHED
     handle_invoice_created_mock.assert_called_once_with(invoice_obj)
+
+
+@pytest.mark.asyncio()
+async def test_worker_processes_invoice_payment_succeeded_event(
+    app: Flask, mocker: MockFixture
+) -> None:
+    pending = StripeEvent(
+        MagicMock(id="evt_worker_invoice_paid", created=1, type="invoice.payment_succeeded")
+    )
+    pending.event_data = json.dumps({"id": "evt_worker_invoice_paid"})
+    pending.status = StripeEventStatusEnum.PENDING
+    db.session.add(pending)
+    db.session.commit()
+
+    mocker.patch("hushline.premium.sa.create_engine", return_value=MagicMock())
+    inspect_obj = MagicMock()
+    inspect_obj.has_table.return_value = True
+    mocker.patch("hushline.premium.sa.inspect", return_value=inspect_obj)
+
+    invoice_obj = MagicMock()
+    mocker.patch("hushline.premium.stripe.Invoice.construct_from", return_value=invoice_obj)
+    handle_invoice_updated_mock = mocker.patch("hushline.premium.handle_invoice_updated")
+    mocker.patch(
+        "hushline.premium.stripe.Event.construct_from",
+        return_value=MagicMock(
+            type="invoice.payment_succeeded",
+            data=MagicMock(object={"id": "inv_abc"}),
+        ),
+    )
+
+    async def _stop_sleep(_seconds: int) -> None:
+        raise RuntimeError("stop worker")
+
+    mocker.patch("hushline.premium.asyncio.sleep", side_effect=_stop_sleep)
+
+    with pytest.raises(RuntimeError, match="stop worker"):
+        await worker(app)
+
+    db.session.refresh(pending)
+    assert pending.status == StripeEventStatusEnum.FINISHED
+    handle_invoice_updated_mock.assert_called_once_with(invoice_obj)


### PR DESCRIPTION
## What changed

- Refresh stored Stripe invoice receipt URLs from Stripe invoice updates and `invoice.payment_succeeded` events.
- Route receipt clicks through an authenticated Hush Line endpoint that verifies invoice ownership before redirecting to Stripe.
- Format invoice amounts from integer cents so paid invoices render as `$5.00`/`$20.00` instead of `$5.0`/`$20.0`.
- Add an `Update Payment Method` action for paid users that creates a Stripe Billing Portal `payment_method_update` session.

## Why

Customers reported broken receipt links from Advanced > Manage My Plan. The app stored the receipt URL from early webhook payloads and did not refresh it when Stripe later updated or finalized invoice data. Customers also needed a way to change their payment method without Hush Line handling card details directly.

## Security and privacy

- Payment method changes are handled by Stripe Billing Portal; Hush Line does not receive or process card details.
- Receipt redirects require authentication and only allow access to paid invoices belonging to the current user.
- Stripe-hosted URLs are no longer rendered directly in the invoice table, reducing exposure of stale receipt URLs in page markup.

## Validation

Passed:

- `poetry run ruff check hushline/premium.py tests/test_premium.py`
- `poetry run ruff format --check hushline/premium.py tests/test_premium.py`
- `poetry run mypy hushline/premium.py tests/test_premium.py`
- `git diff --check`
- `docker compose run --rm app poetry run pytest tests/test_premium.py::test_premium_index_links_receipts_through_authenticated_route tests/test_premium.py::test_update_payment_method_creates_billing_portal_session tests/test_premium.py::test_update_payment_method_requires_active_subscription tests/test_premium.py::test_update_payment_method_stripe_error tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route -q` (`22 passed`)
- `docker compose run --rm app poetry run pytest tests/test_premium.py::test_handle_invoice_updated_refreshes_receipt_url tests/test_premium.py::test_premium_index_links_receipts_through_authenticated_route tests/test_premium.py::test_receipt_route_refreshes_stale_url_before_redirect tests/test_premium.py::test_worker_processes_invoice_payment_succeeded_event tests/test_premium.py::test_update_payment_method_creates_billing_portal_session tests/test_premium.py::test_update_payment_method_requires_active_subscription tests/test_premium.py::test_update_payment_method_stripe_error -q` (`7 passed`)
- `make audit-python` (`No known vulnerabilities found`)
- `make audit-node-runtime` (`found 0 vulnerabilities`)

Attempted:

- `make lint`: Ruff format, Ruff check, and mypy completed; the final Prettier check failed on 21 pre-existing static JS files outside this PR scope.
- `make test`: ran through 1185 passing tests before Docker/Postgres exhausted local disk space while creating per-test databases; remaining errors were `psycopg.errors.DiskFull` / `No space left on device`.

## Manual testing

- Paid user opens Advanced > Manage My Plan.
- Invoice rows show two decimal places for amounts, for example `$5.00` and `$20.00`.
- Clicking Receipt opens the authenticated Hush Line receipt route and redirects to the current Stripe receipt URL.
- Clicking Update Payment Method redirects to Stripe Billing Portal and returns to Manage My Plan after completion.

## Risks and follow-ups

- Stripe Billing Portal configuration must allow the `payment_method_update` flow in the connected Stripe account.
- A passing CI run is required before merge because the local full suite was blocked by Docker/Postgres disk exhaustion.