### PR TITLE
Harden daily issue runner guards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,6 +94,7 @@ This file provides operating guidance for coding agents working in the Hush Line
   - Runner exits early if any issue is already in project status `In Progress`.
 - One-bot-PR guard:
   - Runner exits early if any unrelated open PR exists from bot login (`HUSHLINE_BOT_LOGIN`, default `hushline-dev`).
+  - The dedicated coverage runner PR head (`HUSHLINE_COVERAGE_BRANCH_NAME`, default `codex/daily-coverage`) is treated as an allowed maintenance PR and must not block daily issue selection.
   - Exception: when the selected issue is a child of a GitHub parent epic, the runner may allow the long-lived epic PR plus the matching child issue PR, and should stop only for unrelated bot PRs.
 - Required runner behavior:
   - At runner start, perform a full local environment reset and seed sequence:

--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -45,7 +45,8 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 5. Check cheap GitHub exit conditions before bootstrapping runtime:
    - exit if any open human-authored PR exists
    - exit if any open issue is already in project status `In Progress`
-   - for non-epic issues, exit if any open PR exists from `hushline-dev`
+   - allow the dedicated coverage runner PR head (`codex/daily-coverage` by default)
+   - for non-epic issues, exit if any other open PR exists from `hushline-dev`
    - for child issues with a GitHub parent epic, allow the long-lived epic PR (head branch `codex/epic-<epic>`) and the current child issue PR (head branch `codex/daily-issue-<issue>`)
    - for child issues with a GitHub parent epic, exit only if there are unrelated open bot PRs outside those allowed heads
 6. Move the selected issue into project status `In Progress`.

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -45,6 +45,7 @@ BOT_GIT_SIGNING_KEY="${HUSHLINE_BOT_GIT_SIGNING_KEY:-}"
 DEFAULT_BOT_GIT_SSH_SIGNING_KEY_PATH="${HUSHLINE_BOT_GIT_DEFAULT_SSH_SIGNING_KEY_PATH:-}"
 BRANCH_PREFIX="${HUSHLINE_DAILY_BRANCH_PREFIX:-codex/daily-issue-}"
 EPIC_BRANCH_PREFIX="${HUSHLINE_DAILY_EPIC_BRANCH_PREFIX:-codex/epic-}"
+COVERAGE_BRANCH_NAME="${HUSHLINE_COVERAGE_BRANCH_NAME:-codex/daily-coverage}"
 CODEX_MODEL="${HUSHLINE_CODEX_MODEL:-gpt-5.5}"
 CODEX_REASONING_EFFORT="${HUSHLINE_CODEX_REASONING_EFFORT:-high}"
 PROJECT_OWNER="${HUSHLINE_DAILY_PROJECT_OWNER:-${REPO_SLUG%%/*}}"
@@ -151,6 +152,33 @@ require_cmd() {
     echo "Missing required command: $1" >&2
     exit 1
   fi
+}
+
+is_json_response() {
+  node -e '
+    const fs = require("fs");
+    const input = fs.readFileSync(0, "utf8").trim();
+    if (!input) process.exit(1);
+    try {
+      JSON.parse(input);
+      process.exit(0);
+    } catch {
+      process.exit(1);
+    }
+  '
+}
+
+warn_non_json_response() {
+  local label="$1"
+  local response="$2"
+  local first_line=""
+
+  first_line="$(printf '%s\n' "$response" | sed -n '1p' | cut -c 1-160)"
+  if [[ -z "$first_line" ]]; then
+    first_line="<empty response>"
+  fi
+
+  echo "Warning: ${label} returned a non-JSON response; ignoring it. First line: ${first_line}" >&2
 }
 
 require_positive_integer() {
@@ -1325,23 +1353,32 @@ resolve_issue_parent_epic() {
   local issue_number="$1"
   local owner="${REPO_SLUG%%/*}"
   local repo="${REPO_SLUG##*/}"
+  local response=""
 
-  gh api graphql \
-    -F issueNumber="$issue_number" \
-    -f query='
-      query($issueNumber: Int!) {
-        repository(owner: "'"$owner"'", name: "'"$repo"'") {
-          issue(number: $issueNumber) {
-            parent {
-              number
-              title
-              url
+  response="$({
+    gh api graphql \
+      -F issueNumber="$issue_number" \
+      -f query='
+        query($issueNumber: Int!) {
+          repository(owner: "'"$owner"'", name: "'"$repo"'") {
+            issue(number: $issueNumber) {
+              parent {
+                number
+                title
+                url
+              }
             }
           }
         }
-      }
-    ' 2>/dev/null \
-    | node -e '
+      ' 2>/dev/null
+  } || true)"
+
+  if ! printf '%s' "$response" | is_json_response; then
+    warn_non_json_response "parent epic lookup for issue #${issue_number}" "$response"
+    return 0
+  fi
+
+  printf '%s' "$response" | node -e '
       const fs = require("fs");
       const payload = JSON.parse(fs.readFileSync(0, "utf8"));
       const parent =
@@ -1362,8 +1399,10 @@ resolve_issue_parent_epic() {
 }
 
 resolve_project_number() {
-  local number
-  number="$({
+  local number=""
+  local response=""
+
+  response="$({
     gh api graphql \
       -f owner="$PROJECT_OWNER" \
       -f query='
@@ -1385,8 +1424,16 @@ resolve_project_number() {
             }
           }
         }
-      ' 2>/dev/null \
-      | PROJECT_TITLE="$PROJECT_TITLE" node -e '
+      ' 2>/dev/null
+  } || true)"
+
+  if ! printf '%s' "$response" | is_json_response; then
+    warn_non_json_response "project number lookup for '${PROJECT_TITLE}'" "$response"
+    printf '%s\n' "$number"
+    return 0
+  fi
+
+  number="$(printf '%s' "$response" | PROJECT_TITLE="$PROJECT_TITLE" node -e '
         const fs = require("fs");
         const payload = JSON.parse(fs.readFileSync(0, "utf8"));
         const data = payload && payload.data ? payload.data : {};
@@ -1404,8 +1451,7 @@ resolve_project_number() {
         if (match && Number.isInteger(match.number) && match.number > 0) {
           process.stdout.write(String(match.number));
         }
-      '
-  } || true)"
+      ' || true)"
 
   printf '%s\n' "$number"
 }
@@ -1414,48 +1460,58 @@ resolve_project_status_edit_args() {
   local project_number="$1"
   local target_status_name="$2"
   local number="${project_number}"
+  local response=""
 
-  gh api graphql \
-    -f owner="$PROJECT_OWNER" \
-    -F projectNumber="$number" \
-    -f query='
-      query($owner: String!, $projectNumber: Int!) {
-        user(login: $owner) {
-          projectV2(number: $projectNumber) {
-            id
-            fields(first: 100) {
-              nodes {
-                ... on ProjectV2SingleSelectField {
-                  id
-                  name
-                  options {
+  response="$({
+    gh api graphql \
+      -f owner="$PROJECT_OWNER" \
+      -F projectNumber="$number" \
+      -f query='
+        query($owner: String!, $projectNumber: Int!) {
+          user(login: $owner) {
+            projectV2(number: $projectNumber) {
+              id
+              fields(first: 100) {
+                nodes {
+                  ... on ProjectV2SingleSelectField {
                     id
                     name
+                    options {
+                      id
+                      name
+                    }
+                  }
+                }
+              }
+            }
+          }
+          organization(login: $owner) {
+            projectV2(number: $projectNumber) {
+              id
+              fields(first: 100) {
+                nodes {
+                  ... on ProjectV2SingleSelectField {
+                    id
+                    name
+                    options {
+                      id
+                      name
+                    }
                   }
                 }
               }
             }
           }
         }
-        organization(login: $owner) {
-          projectV2(number: $projectNumber) {
-            id
-            fields(first: 100) {
-              nodes {
-                ... on ProjectV2SingleSelectField {
-                  id
-                  name
-                  options {
-                    id
-                    name
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-    ' 2>/dev/null \
+      ' 2>/dev/null
+  } || true)"
+
+  if ! printf '%s' "$response" | is_json_response; then
+    warn_non_json_response "project status metadata lookup for '${target_status_name}'" "$response"
+    return 0
+  fi
+
+  printf '%s' "$response" \
     | PROJECT_STATUS_FIELD_NAME="$PROJECT_STATUS_FIELD_NAME" \
       TARGET_STATUS_NAME="$target_status_name" \
       node -e '
@@ -1505,26 +1561,35 @@ resolve_issue_project_item_id() {
   local repo="${REPO_SLUG##*/}"
   local number="${issue_number}"
   local project_num="${project_number}"
+  local response=""
 
-  gh api graphql \
-    -F issueNumber="$number" \
-    -f query='
-      query($issueNumber: Int!) {
-        repository(owner: "'"$owner"'", name: "'"$repo"'") {
-          issue(number: $issueNumber) {
-            projectItems(first: 100) {
-              nodes {
-                id
-                project {
-                  number
+  response="$({
+    gh api graphql \
+      -F issueNumber="$number" \
+      -f query='
+        query($issueNumber: Int!) {
+          repository(owner: "'"$owner"'", name: "'"$repo"'") {
+            issue(number: $issueNumber) {
+              projectItems(first: 100) {
+                nodes {
+                  id
+                  project {
+                    number
+                  }
                 }
               }
             }
           }
         }
-      }
-    ' 2>/dev/null \
-    | TARGET_PROJECT_NUMBER="$project_num" node -e '
+      ' 2>/dev/null
+  } || true)"
+
+  if ! printf '%s' "$response" | is_json_response; then
+    warn_non_json_response "project item lookup for issue #${issue_number}" "$response"
+    return 0
+  fi
+
+  printf '%s' "$response" | TARGET_PROJECT_NUMBER="$project_num" node -e '
       const fs = require("fs");
       const payload = JSON.parse(fs.readFileSync(0, "utf8"));
       const items =
@@ -1760,6 +1825,13 @@ collect_issue_candidates_from_project() {
     fi
 
     if [[ -z "$response" ]]; then
+      break
+    fi
+
+    if ! printf '%s' "$response" | is_json_response; then
+      warn_non_json_response \
+        "project item lookup for status '${target_status_name}'" \
+        "$response"
       break
     fi
 
@@ -2903,8 +2975,9 @@ main() {
   if [[ -n "$EPIC_ISSUE_NUMBER" ]]; then
     EXISTING_EPIC_PR_JSON="$(find_open_pr_for_head_branch "$EPIC_BRANCH_NAME")"
     EXISTING_CHILD_PR_JSON="$(find_open_pr_for_head_branch "$BRANCH_NAME")"
-    OPEN_BOT_PRS="$(count_open_bot_prs_excluding_heads "$EPIC_BRANCH_NAME" "$BRANCH_NAME")"
+    OPEN_BOT_PRS="$(count_open_bot_prs_excluding_heads "$COVERAGE_BRANCH_NAME" "$EPIC_BRANCH_NAME" "$BRANCH_NAME")"
     echo "Open unrelated bot PR count: ${OPEN_BOT_PRS}"
+    echo "Allowed bot PR heads: ${COVERAGE_BRANCH_NAME}, ${EPIC_BRANCH_NAME}, ${BRANCH_NAME}"
     if [[ "$OPEN_BOT_PRS" != "0" ]]; then
       runner_status "Skipped: found ${OPEN_BOT_PRS} unrelated open PR(s) by ${BOT_LOGIN}."
       exit 0
@@ -2917,8 +2990,9 @@ main() {
       echo "Child branch ${BRANCH_NAME} already has an open PR; runner will update it."
     fi
   else
-    OPEN_BOT_PRS="$(count_open_bot_prs)"
-    echo "Open bot PR count: ${OPEN_BOT_PRS}"
+    OPEN_BOT_PRS="$(count_open_bot_prs_excluding_heads "$COVERAGE_BRANCH_NAME")"
+    echo "Open unrelated bot PR count: ${OPEN_BOT_PRS}"
+    echo "Allowed bot PR heads: ${COVERAGE_BRANCH_NAME}"
     if [[ "$OPEN_BOT_PRS" != "0" ]]; then
       runner_status "Skipped: found ${OPEN_BOT_PRS} open PR(s) by ${BOT_LOGIN}."
       exit 0

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -748,7 +748,20 @@ count_open_bot_prs() {
 
 count_open_bot_prs_excluding_heads() {
   local allowed_heads=("$@")
-  local head allowed skip count=0
+  local pr_heads head allowed skip count=0
+
+  if ! pr_heads="$(
+    gh pr list \
+      --repo "$REPO_SLUG" \
+      --state open \
+      --author "$BOT_LOGIN" \
+      --limit 100 \
+      --json headRefName \
+      --jq '.[].headRefName // empty'
+  )"; then
+    echo "Failed to list open PRs by ${BOT_LOGIN}; stopping to preserve the one-bot-PR guard." >&2
+    return 1
+  fi
 
   while IFS= read -r head; do
     [[ -z "$head" ]] && continue
@@ -762,15 +775,7 @@ count_open_bot_prs_excluding_heads() {
     if (( skip == 0 )); then
       count=$((count + 1))
     fi
-  done < <(
-    gh pr list \
-      --repo "$REPO_SLUG" \
-      --state open \
-      --author "$BOT_LOGIN" \
-      --limit 100 \
-      --json headRefName \
-      --jq '.[].headRefName // empty'
-  )
+  done <<< "$pr_heads"
 
   printf '%s\n' "$count"
 }

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -43,6 +43,26 @@ printf '%s %s\\n' "$CODEX_MODEL" "$CODEX_REASONING_EFFORT"
     assert result.stdout.strip() == "gpt-5.5 high"
 
 
+def test_count_open_bot_prs_excluding_heads_fails_closed_when_pr_query_fails() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+gh() {{
+  return 42
+}}
+set +e
+count_open_bot_prs_excluding_heads codex/daily-coverage
+rc=$?
+set -e
+printf 'rc=%s\\n' "$rc"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "rc=1"
+    assert "Failed to list open PRs by hushline-dev" in result.stderr
+
+
 def test_prepare_runner_exec_snapshot_copies_script_for_stable_execution(
     tmp_path: Path,
 ) -> None:
@@ -92,8 +112,8 @@ resolve_issue_parent_epic() {{ :; }}
 start_runtime_stack_and_seed_dev_data() {{
   printf 'runtime-bootstrap\\n' >> {shlex.quote(str(call_log))}
 }}
-count_open_bot_prs() {{
-  printf 'count-open-bot-prs\\n' >> {shlex.quote(str(call_log))}
+count_open_bot_prs_excluding_heads() {{
+  printf 'count-open-bot-prs-excluding-heads:%s\\n' "$*" >> {shlex.quote(str(call_log))}
   printf '1\\n'
 }}
 count_open_human_prs() {{
@@ -115,7 +135,7 @@ main
     calls = call_log.read_text(encoding="utf-8").splitlines()
     assert "collect-issue-candidates" in calls
     assert "count-open-human-prs" in calls
-    assert "count-open-bot-prs" in calls
+    assert "count-open-bot-prs-excluding-heads:codex/daily-coverage" in calls
     assert "configure-bot-git" not in calls
     assert "runtime-bootstrap" not in calls
 
@@ -322,7 +342,7 @@ run_step() {{
 }}
 configure_bot_git_identity() {{ :; }}
 resolve_issue_parent_epic() {{ :; }}
-count_open_bot_prs() {{ printf '0\\n'; }}
+count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 count_open_human_prs() {{ printf '0\\n'; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 start_runtime_stack_and_seed_dev_data() {{
@@ -942,7 +962,7 @@ run_step() {{
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
-count_open_bot_prs() {{ printf '0\\n'; }}
+count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 set_issue_project_status() {{
   printf 'status:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(call_log))}
 }}
@@ -1194,7 +1214,7 @@ docker() {{ :; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
-count_open_bot_prs() {{ printf '0\\n'; }}
+count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 set_issue_project_status() {{
   printf 'status:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(call_log))}
 }}
@@ -2915,7 +2935,7 @@ docker() {{ :; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
-count_open_bot_prs() {{ printf '0\\n'; }}
+count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 set_issue_project_status() {{ :; }}
 configure_bot_git_identity() {{ :; }}
 start_runtime_stack_and_seed_dev_data() {{ :; }}
@@ -3017,7 +3037,7 @@ docker() {{ :; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
-count_open_bot_prs() {{ printf '0\\n'; }}
+count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 set_issue_project_status() {{
   printf 'status:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(call_log))}
 }}
@@ -3115,7 +3135,7 @@ docker() {{ :; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
-count_open_bot_prs() {{ printf '0\\n'; }}
+count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 set_issue_project_status() {{ :; }}
 configure_bot_git_identity() {{ :; }}
 start_runtime_stack_and_seed_dev_data() {{ :; }}


### PR DESCRIPTION
## What changed
- Treat non-JSON GitHub/project API responses as warnings instead of piping HTML into JSON.parse.
- Allow the dedicated coverage runner branch (codex/daily-coverage by default) so a coverage maintenance PR does not block daily issue selection.
- Document the coverage branch exception in runner guidance.

## Why
The 2026-05-05 runner hit a GitHub/API response that was HTML, causing a Node SyntaxError, then skipped issue #1919 because the open daily coverage PR was counted as an unrelated bot PR.

## Validation
- bash -n scripts/agent_daily_issue_runner.sh
- sourced runner helper check: HTML is rejected as non-JSON and valid JSON is accepted
- resolved project number through GitHub API: 12
- verified issue #1919 parent epic resolves to #1914
- verified open codex/daily-coverage PR is excluded from bot PR guard count