### PR TITLE
Harden daily runner check execution

### DIFF
--- a/docker-compose.stripe.yaml
+++ b/docker-compose.stripe.yaml
@@ -55,7 +55,7 @@ services:
   dev_data:
     <<: *app_env
     ports: []
-    restart: on-failure
+    restart: "no"
     command: make dev-data
     depends_on:
       postgres:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    restart: on-failure
+    restart: "no"
 
   postgres:
     image: postgres:16.4-alpine3.20

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -60,6 +60,7 @@ MAX_ISSUE_ATTEMPTS="${HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS:-10}"
 MAX_FIX_ATTEMPTS="${HUSHLINE_DAILY_MAX_FIX_ATTEMPTS:-8}"
 RUNTIME_BOOTSTRAP_ATTEMPTS="${HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_ATTEMPTS:-3}"
 RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS="${HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS:-10}"
+CHECK_TIMEOUT_SECONDS="${HUSHLINE_DAILY_CHECK_TIMEOUT_SECONDS:-1800}"
 POST_PR_FEEDBACK_DELAY_SECONDS="${HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS:-60}"
 
 CHECK_LOG_FILE=""
@@ -300,15 +301,70 @@ run_step() {
   "$@"
 }
 
+terminate_process_tree() {
+  local pid="$1"
+  local signal="${2:-TERM}"
+  local child
+
+  while IFS= read -r child; do
+    [[ -n "$child" ]] || continue
+    terminate_process_tree "$child" "$signal"
+  done < <(pgrep -P "$pid" 2>/dev/null || true)
+
+  kill "-$signal" "$pid" >/dev/null 2>&1 || true
+}
+
 run_check_capture() {
   local description="$1"
   shift
   echo "==> ${description}" | tee -a "$CHECK_LOG_FILE"
   local rc=0
+  local output_file=""
+  local command_pid=""
+  local elapsed=0
+  local caller_flags="$-"
+
+  output_file="$(mktemp)"
+  : > "$output_file"
+
   set +e
-  "$@" 2>&1 | tee -a "$CHECK_LOG_FILE"
-  rc=${PIPESTATUS[0]}
-  set -e
+  "$@" > "$output_file" 2>&1 &
+  command_pid=$!
+  while kill -0 "$command_pid" >/dev/null 2>&1; do
+    if (( elapsed >= CHECK_TIMEOUT_SECONDS )); then
+      printf '%s\n' "Timed out after ${CHECK_TIMEOUT_SECONDS}s: ${description}" | tee -a "$CHECK_LOG_FILE"
+      terminate_process_tree "$command_pid" TERM
+      sleep 2
+      terminate_process_tree "$command_pid" KILL
+      wait "$command_pid" >/dev/null 2>&1
+      if [[ -s "$output_file" ]]; then
+        cat "$output_file" | tee -a "$CHECK_LOG_FILE"
+      fi
+      rm -f "$output_file"
+      if [[ "$caller_flags" == *e* ]]; then
+        set -e
+      else
+        set +e
+      fi
+      return 124
+    fi
+    sleep 1
+    elapsed=$((elapsed + 1))
+    if (( elapsed > 0 && elapsed % 60 == 0 )); then
+      printf '%s\n' "Still running after ${elapsed}s: ${description}" | tee -a "$CHECK_LOG_FILE"
+    fi
+  done
+  wait "$command_pid"
+  rc=$?
+  if [[ -s "$output_file" ]]; then
+    cat "$output_file" | tee -a "$CHECK_LOG_FILE"
+  fi
+  rm -f "$output_file"
+  if [[ "$caller_flags" == *e* ]]; then
+    set -e
+  else
+    set +e
+  fi
   return "$rc"
 }
 
@@ -357,6 +413,8 @@ refresh_runtime_after_schema_changes() {
 list_changed_files() {
   {
     git diff --name-only "${BASE_BRANCH}...HEAD"
+    git diff --name-only "origin/${BASE_BRANCH}..HEAD" 2>/dev/null || true
+    git diff --name-only "${BASE_BRANCH}..HEAD" 2>/dev/null || true
     git diff --name-only
     git diff --cached --name-only
     git ls-files --others --exclude-standard
@@ -2910,6 +2968,7 @@ main() {
   require_positive_integer \
     "HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS" \
     "$RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS"
+  require_positive_integer "HUSHLINE_DAILY_CHECK_TIMEOUT_SECONDS" "$CHECK_TIMEOUT_SECONDS"
   require_non_negative_integer \
     "HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS" \
     "$POST_PR_FEEDBACK_DELAY_SECONDS"

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -1528,6 +1528,64 @@ fi
     assert result.stdout == "non-environmental\n"
 
 
+def test_runtime_schema_files_changed_detects_branch_schema_diff_from_runtime_base() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+BASE_BRANCH=main
+git() {{
+  case "$*" in
+    "diff --name-only main...HEAD")
+      printf 'hushline/routes/profile.py\\n'
+      return 0
+      ;;
+    "diff --name-only origin/main..HEAD")
+      printf 'migrations/versions/add_embed_fields.py\\n'
+      return 0
+      ;;
+    "diff --name-only main..HEAD"|\
+"diff --name-only"|\
+"diff --cached --name-only"|\
+"ls-files --others --exclude-standard")
+      return 0
+      ;;
+  esac
+  printf 'unexpected git invocation: %s\\n' "$*" >&2
+  return 99
+}}
+if runtime_schema_files_changed; then
+  printf 'schema-changed\\n'
+else
+  printf 'schema-unchanged\\n'
+fi
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "schema-changed\n"
+
+
+def test_run_check_capture_times_out_stuck_check(tmp_path: Path) -> None:
+    check_log_file = tmp_path / "check.log"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CHECK_LOG_FILE={shlex.quote(str(check_log_file))}
+CHECK_TIMEOUT_SECONDS=1
+set +e
+run_check_capture "Slow check" bash -c 'sleep 5'
+rc=$?
+set -e
+printf 'rc=%s\\n' "$rc"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "rc=124" in result.stdout
+    assert "Timed out after 1s: Slow check" in check_log_file.read_text(encoding="utf-8")
+
+
 def test_runtime_bootstrap_retries_retryable_registry_failure(tmp_path: Path) -> None:
     calls_file = tmp_path / "docker-calls.txt"
 

--- a/tests/test_deployment_migrations.py
+++ b/tests/test_deployment_migrations.py
@@ -53,6 +53,15 @@ def test_staging_compose_disables_app_startup_migrations() -> None:
     assert "condition: service_completed_successfully" in app
 
 
+def test_local_dev_data_sidecars_fail_fast_instead_of_restarting() -> None:
+    for compose_name in ("docker-compose.yaml", "docker-compose.stripe.yaml"):
+        blocks = _service_blocks(ROOT / compose_name)
+
+        dev_data = blocks["dev_data"]
+        assert 'restart: "no"' in dev_data
+        assert "restart: on-failure" not in dev_data
+
+
 def test_prod_start_script_supports_disabling_startup_migrations() -> None:
     script = (ROOT / "scripts/prod_start.sh").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## What changed

- Adds a configurable timeout for daily runner validation checks via `HUSHLINE_DAILY_CHECK_TIMEOUT_SECONDS`.
- Emits periodic heartbeat log lines while long-running checks are still active.
- Terminates the full child process tree when a validation check times out, then records captured output in the check log.
- Expands schema-change detection to compare the branch against the runtime base as well as the merge base, so runner-created branches based on an epic or stale branch still refresh local runtime when schema files are present.
- Changes local `dev_data` Compose sidecars to `restart: "no"` so failed seeding is surfaced as a failure instead of endlessly restarting while `app` waits for `service_completed_successfully`.
- Adds regression coverage for the timeout, schema-drift detection, and local Compose fail-fast behavior.

## Why

The autonomous runner stalled because Compose was waiting for `dev_data` to complete successfully while `dev_data` was configured to restart on failure. When a schema mismatch made seeding fail, Compose kept waiting/retrying instead of returning a clear validation failure. A prior source patch also could not affect a runner that had already copied itself to a temporary execution snapshot.

## Validation

- `bash -n scripts/agent_daily_issue_runner.sh`
- `docker compose config --quiet`
- `git diff --check`
- Direct Python assertions for runner timeout/schema-drift guards and local Compose `dev_data` restart policy
- `docker compose -f docker-compose.yaml -f docker-compose.test-no-ports.yaml run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py::test_runtime_schema_files_changed_detects_branch_schema_diff_from_runtime_base tests/test_agent_daily_issue_runner.py::test_run_check_capture_times_out_stuck_check tests/test_deployment_migrations.py -q`

The temporary no-port Compose override was used only to avoid conflicting with the live runner's bound local ports and is not committed.

## Manual testing

Not applicable beyond the targeted runner and Compose validation above; this change affects automation behavior rather than an end-user UI flow.

## Risks and follow-up

- Existing runner processes that already snapshot-copied the old script still need to finish or be restarted before this takes effect.
- Full `make lint` and `make test` should run in CI before merge.