### PR TITLE
Update embeddable profile settings copy and tests

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -5108,3 +5108,11 @@ button .badge {
   margin-top: 1rem;
   margin-bottom: 0.25rem;
 }
+
+.checkbox-group:has(#embed_enabled) {
+  margin: 1rem 0;
+}
+
+.form-group:has(#embed_iframe_snippet) {
+  margin-top: 1rem;
+}

--- a/hushline/templates/settings/embed-settings-form.html
+++ b/hushline/templates/settings/embed-settings-form.html
@@ -1,13 +1,10 @@
-<h4>Embeddable Form</h4>
+<h4>Embeddable Profile</h4>
 <p class="info">
-  Add exact parent origins, one per line, such as https://newsroom.example.
-  The parent page must not wrap the intake area in analytics, heatmaps,
-  session replay, or misleading copy.
+  Add your secure Hush Line profile contact form to your other websites!
 </p>
 <p class="info">
-  Embedding places the Hush Line intake form on another page. The parent
-  website is not the cryptographic trust boundary; message encryption still
-  depends on this Hush Line form and your recipient keys.
+  Enter the domains where you want to embed your profile below. You'll also
+  need to add &quot;tips.hushline.app&quot; to the CSP of those sites.
 </p>
 {% if not embeddable_forms_enabled %}
   <p class="meta">
@@ -70,11 +67,7 @@
 </form>
 {% if embed_iframe_snippet %}
   <div class="form-group">
-    <label for="embed_iframe_snippet">Iframe snippet</label>
+    <label for="embed_iframe_snippet">Code Snippet</label>
     <textarea id="embed_iframe_snippet" rows="5" readonly>{{ embed_iframe_snippet }}</textarea>
-    <p class="meta">
-      Use bounded sizing. The snippet uses a fixed 700px height, 100% width,
-      and a 720px maximum width.
-    </p>
   </div>
 {% endif %}

--- a/hushline/templates/settings/nav.html
+++ b/hushline/templates/settings/nav.html
@@ -5,9 +5,9 @@
     {% with buttons = [
       ('settings.profile', 'Profile', True),
       ('settings.aliases', 'Aliases', aliases_enabled),
-      ('settings.developer', 'Developer', user.is_current_paid_super_user),
       ('settings.auth', 'Authentication', True),
       ('settings.branding', 'Branding', user.is_admin),
+      ('settings.developer', 'Developer', user.is_current_paid_super_user),
       ('settings.encryption', 'Encryption', True),
       ('settings.replies', 'Message Statuses', user.pgp_key is not none),
       ('settings.notifications', 'Notifications', True),

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -850,7 +850,7 @@ def test_profile_settings_do_not_render_embed_settings(client: FlaskClient, user
     response = client.get(url_for("settings.profile"))
 
     assert response.status_code == 200
-    assert "Embeddable Form" not in response.text
+    assert "Embeddable Profile" not in response.text
     assert 'name="embed_enabled"' not in response.text
     assert 'id="embed_iframe_snippet"' not in response.text
 
@@ -912,6 +912,8 @@ def test_settings_nav_shows_developer_only_for_current_paid_super_user(
     assert "Developer" not in nav_text
 
     _make_current_paid_super_user(user)
+    user.is_admin = True
+    db.session.commit()
     response = client.get(url_for("settings.profile"))
     assert response.status_code == 200
     nav = BeautifulSoup(response.text, "html.parser").select_one("nav.settings-tabs")
@@ -920,6 +922,9 @@ def test_settings_nav_shows_developer_only_for_current_paid_super_user(
     assert developer_link is not None
     assert developer_link.get_text(strip=True) == "Developer"
     assert developer_link.get("href") == url_for("settings.developer")
+    labels = [link.get_text(strip=True) for link in nav.find_all("a")]
+    assert labels.index("Developer") > labels.index("Branding")
+    assert labels.index("Developer") < labels.index("Encryption")
 
 
 def test_developer_embed_settings_require_usable_recipient_key(
@@ -1019,6 +1024,9 @@ def test_primary_embed_settings_update_origins_and_render_iframe_snippet(
     )
 
     assert response.status_code == 200
+    assert "Embeddable Profile" in response.text
+    assert "Add your secure Hush Line profile contact form to your other websites!" in response.text
+    assert "tips.hushline.app" in response.text
     db.session.refresh(user.primary_username)
     assert user.primary_username.embed_enabled is True
     assert user.primary_username.embed_allowed_origins == [
@@ -1027,6 +1035,7 @@ def test_primary_embed_settings_update_origins_and_render_iframe_snippet(
     ]
 
     snippet = _iframe_from_snippet(response.text)
+    assert "Code Snippet" in response.text
     iframe = snippet.find("iframe")
     assert iframe is not None
     assert iframe["src"] == url_for(


### PR DESCRIPTION
## What changed

- Renamed the embeddable settings section to "Embeddable Profile" and updated the helper copy and snippet label.
- Moved the Developer tab after Branding in the settings navigation.
- Added/updated tests for the new embeddable profile copy, snippet label, absence from regular profile settings, and the paid/admin nav ordering.
- Added spacing rules for the embeddable profile enablement and snippet controls.

## Why

The tests needed to match the updated HTML/CSS changes and continue covering the security-sensitive embeddable profile settings surface without relying on stale labels.

## Validation

- `make lint`
- `make test`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

Not applicable. The changes are copy/layout/test updates, and the affected settings routes are covered by the updated automated tests.

## Risks and follow-ups

Low risk. The embed behavior and CSP enforcement paths were not changed, and the existing embeddable profile tests plus security header tests passed.