### PR TITLE
Use base Hush Line styles for embedded profiles

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1356,6 +1356,12 @@ body.directory-page {
   scroll-behavior: smooth;
 }
 
+body.embed-page {
+  align-items: stretch;
+  display: block;
+  padding: 0;
+}
+
 main {
   --container-padding: 2rem;
   max-width: 640px;
@@ -3454,6 +3460,101 @@ p.bio+.extra-fields {
   padding-left: 1.5rem;
 }
 
+body.embed-page *,
+body.embed-page *::before,
+body.embed-page *::after {
+  box-sizing: border-box;
+}
+
+.embed-shell {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  margin: 0 auto;
+  max-width: 44rem;
+  min-width: 0;
+  padding: 1rem;
+}
+
+.embed-profile-summary,
+.embed-actions {
+  border-bottom: 1px solid #d8d8d8;
+  padding-bottom: 1rem;
+}
+
+.embed-meta {
+  margin: 0.25rem 0 0;
+}
+
+.embed-page .badgeContainer {
+  flex-wrap: wrap;
+}
+
+.embed-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.embed-actions a {
+  align-items: center;
+  display: inline-flex;
+  min-height: 2rem;
+}
+
+.embed-error-summary,
+.embed-noscript {
+  border: 2px solid var(--color-error);
+  border-radius: 0.25rem;
+  color: var(--color-error);
+  padding: 0.75rem;
+}
+
+.embed-error-summary {
+  margin: 0;
+}
+
+.embed-error-summary ul {
+  margin: 0.5rem 0 0;
+  padding-left: 1.25rem;
+}
+
+.embed-noscript {
+  background: #fff4f4;
+}
+
+.embed-page input,
+.embed-page textarea,
+.embed-page select,
+.embed-page button {
+  max-width: 100%;
+}
+
+.embed-page textarea,
+.embed-page input:not([type="hidden"]),
+.embed-page select {
+  width: 100%;
+}
+
+.embed-page .captcha_container {
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.embed-page input#captcha_answer {
+  max-width: 8rem;
+  width: 8rem;
+}
+
+.embed-page a:focus-visible,
+.embed-page button:focus-visible,
+.embed-page input:focus-visible,
+.embed-page textarea:focus-visible,
+.embed-page select:focus-visible {
+  outline: 3px solid var(--theme-color-dark);
+  outline-offset: 3px;
+}
+
 .pgp-disabled-overlay {
   position: absolute;
   top: 0;
@@ -3477,6 +3578,31 @@ p.bio+.extra-fields {
   position: relative;
   padding-top: 1.5rem;
   margin-top: 0.5rem;
+}
+
+@media (max-width: 28rem) {
+  .embed-shell {
+    padding: 0.75rem;
+  }
+
+  .embed-actions {
+    flex-direction: column;
+  }
+
+  .embed-page button[type="submit"] {
+    width: 100%;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  body.embed-page *,
+  body.embed-page *::before,
+  body.embed-page *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
 }
 
 #plan-wrapper {

--- a/hushline/templates/embed_profile.html
+++ b/hushline/templates/embed_profile.html
@@ -10,140 +10,6 @@
       href="{{ url_for('static', filename='css/style.css') }}"
     />
     <script src="{{ url_for('static', filename='no-js.js') }}"></script>
-    <style>
-      :root {
-        --color-brand: oklch(from {{ brand_primary_color }} l c h);
-        --theme-color-dark: {{ brand_primary_color_dark }};
-      }
-
-      body.embed-page {
-        background: #fff;
-        color: #111;
-        display: block;
-        margin: 0;
-        padding: 0;
-      }
-
-      body.embed-page *,
-      body.embed-page *::before,
-      body.embed-page *::after {
-        box-sizing: border-box;
-      }
-
-      .embed-shell {
-        display: flex;
-        flex-direction: column;
-        gap: 1rem;
-        margin: 0 auto;
-        max-width: 44rem;
-        min-width: 0;
-        padding: 1rem;
-      }
-
-      .embed-profile-summary,
-      .embed-actions {
-        border-bottom: 1px solid #d8d8d8;
-        padding-bottom: 1rem;
-      }
-
-      .embed-meta {
-        margin: 0.25rem 0 0;
-      }
-
-      .embed-page .badgeContainer {
-        flex-wrap: wrap;
-      }
-
-      .embed-actions {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.75rem;
-      }
-
-      .embed-actions a {
-        align-items: center;
-        display: inline-flex;
-        min-height: 2rem;
-      }
-
-      .embed-error-summary,
-      .embed-noscript {
-        border: 2px solid #842029;
-        border-radius: 0.25rem;
-        color: #842029;
-        padding: 0.75rem;
-      }
-
-      .embed-error-summary {
-        margin: 0;
-      }
-
-      .embed-error-summary ul {
-        margin: 0.5rem 0 0;
-        padding-left: 1.25rem;
-      }
-
-      .embed-noscript {
-        background: #fff4f4;
-      }
-
-      .embed-page input,
-      .embed-page textarea,
-      .embed-page select,
-      .embed-page button {
-        max-width: 100%;
-      }
-
-      .embed-page textarea,
-      .embed-page input:not([type="hidden"]),
-      .embed-page select {
-        width: 100%;
-      }
-
-      .embed-page .captcha_container {
-        align-items: flex-start;
-        flex-wrap: wrap;
-      }
-
-      .embed-page input#captcha_answer {
-        max-width: 8rem;
-        width: 8rem;
-      }
-
-      .embed-page a:focus-visible,
-      .embed-page button:focus-visible,
-      .embed-page input:focus-visible,
-      .embed-page textarea:focus-visible,
-      .embed-page select:focus-visible {
-        outline: 3px solid var(--theme-color-dark);
-        outline-offset: 3px;
-      }
-
-      @media (max-width: 28rem) {
-        .embed-shell {
-          padding: 0.75rem;
-        }
-
-        .embed-actions {
-          flex-direction: column;
-        }
-
-        .embed-page button[type="submit"] {
-          width: 100%;
-        }
-      }
-
-      @media (prefers-reduced-motion: reduce) {
-        *,
-        *::before,
-        *::after {
-          animation-duration: 0.01ms !important;
-          animation-iteration-count: 1 !important;
-          scroll-behavior: auto !important;
-          transition-duration: 0.01ms !important;
-        }
-      }
-    </style>
     {% if not message_submission_block_reason %}
       <script defer src="{{ url_for('static', filename='js/diceware-words.js') }}"></script>
       <script defer src="{{ url_for('static', filename='js/client-side-encryption.js') }}"></script>
@@ -184,6 +50,15 @@
           role="group"
           aria-label="Recipient trust and encryption state"
         >
+          {% if recipient_public_keys %}
+            <span class="badge" role="img" aria-label="End-to-end encrypted">
+              🔒&nbsp;End-to-End Encrypted
+            </span>
+          {% else %}
+            <span class="badge" role="img" aria-label="Encryption unavailable">
+              🔒&nbsp;Encryption unavailable
+            </span>
+          {% endif %}
           {% if user.is_admin %}
             <span class="badge" role="img" aria-label="Admin">
               ⚙️&nbsp;Admin
@@ -227,15 +102,6 @@
             </span>
           {% endif %}
 
-          {% if recipient_public_keys %}
-            <span class="badge" role="img" aria-label="End-to-end encrypted">
-              🔒&nbsp;End-to-End Encrypted
-            </span>
-          {% else %}
-            <span class="badge" role="img" aria-label="Encryption unavailable">
-              🔒&nbsp;Encryption unavailable
-            </span>
-          {% endif %}
         </div>
 
         {% if username.bio %}

--- a/hushline/templates/embed_profile.html
+++ b/hushline/templates/embed_profile.html
@@ -10,6 +10,12 @@
       href="{{ url_for('static', filename='css/style.css') }}"
     />
     <script src="{{ url_for('static', filename='no-js.js') }}"></script>
+    <style>
+      :root {
+        --color-brand: oklch(from {{ brand_primary_color }} l c h);
+        --theme-color-dark: {{ brand_primary_color_dark }};
+      }
+    </style>
     {% if not message_submission_block_reason %}
       <script defer src="{{ url_for('static', filename='js/diceware-words.js') }}"></script>
       <script defer src="{{ url_for('static', filename='js/client-side-encryption.js') }}"></script>

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1073,6 +1073,13 @@ def test_embed_profile_template_has_compact_trust_chrome_and_form(
     assert response.status_code == 200
     page = BeautifulSoup(response.text, "html.parser")
     assert page.select_one("body.embed-page") is not None
+    stylesheet = page.find("link", attrs={"rel": "stylesheet"})
+    assert stylesheet is not None
+    assert stylesheet.get("href") == url_for("static", filename="css/style.css")
+    runtime_style = page.find("style")
+    assert runtime_style is not None
+    assert "--color-brand: oklch(from" in runtime_style.get_text()
+    assert "--theme-color-dark:" in runtime_style.get_text()
     assert page.find(string="Secure Hush Line form") is None
     assert "Hosted by" not in response.text
     assert "Powered by Hush Line" not in response.text
@@ -1109,6 +1116,19 @@ def test_embed_profile_template_has_compact_trust_chrome_and_form(
     assert not any("submit-message.js" in source for source in script_sources)
     assert page.find("iframe") is None
     assert "script-widget" not in response.text
+
+
+def test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source() -> None:
+    stylesheet_source = Path("assets/scss/style.scss").read_text()
+
+    assert "body.embed-page" in stylesheet_source
+    assert ".embed-shell" in stylesheet_source
+    assert ".embed-profile-summary" in stylesheet_source
+    assert ".embed-actions" in stylesheet_source
+    assert ".embed-error-summary" in stylesheet_source
+    assert ".embed-noscript" in stylesheet_source
+    assert ".embed-page a:focus-visible" in stylesheet_source
+    assert "outline: 3px solid var(--theme-color-dark)" in stylesheet_source
 
 
 def test_embed_profile_renders_additional_profile_fields_like_full_profile(
@@ -1180,13 +1200,11 @@ def test_embed_profile_keyboard_flow_and_mobile_accessibility_chrome(
     assert focusable_labels.index("Open on Hush Line") < focusable_labels.index("field_0")
     assert focusable_labels.index("Leave") < focusable_labels.index("field_0")
     assert focusable_labels.index("captcha_answer") < focusable_labels.index("Send Message")
-    style = page.find("style")
-    assert style is not None
-    style_text = style.get_text()
-    assert "@media (max-width: 28rem)" in style_text
-    assert "@media (prefers-reduced-motion: reduce)" in style_text
-    assert ":focus-visible" in style_text
-    assert "flex-wrap: wrap" in style_text
+    stylesheet_source = Path("assets/scss/style.scss").read_text()
+    assert "@media (max-width: 28rem)" in stylesheet_source
+    assert "@media (prefers-reduced-motion: reduce)" in stylesheet_source
+    assert ":focus-visible" in stylesheet_source
+    assert "flex-wrap: wrap" in stylesheet_source
 
 
 def test_embed_profile_required_chrome_survives_recipient_branding_settings(
@@ -1207,6 +1225,9 @@ def test_embed_profile_required_chrome_survives_recipient_branding_settings(
     assert response.status_code == 200
     page = BeautifulSoup(response.text, "html.parser")
     assert page.find(string="Secure Hush Line form") is None
+    runtime_style = page.find("style")
+    assert runtime_style is not None
+    assert "--color-brand: oklch(from #005f73 l c h);" in runtime_style.get_text()
     assert not page.find(string=lambda value: value and "Hosted by Recipient Brand" in value)
     assert "Powered by Hush Line" not in response.text
     assert "Recipient Newsroom" in response.text


### PR DESCRIPTION
## What changed

- Removed the large inline embed-specific CSS block from `embed_profile.html`.
- Restored the runtime embed brand variables in the embed page head so configured brand colors still apply to embedded profiles.
- Moved the embed layout, mobile, reduced-motion, error, noscript, field sizing, and focus-visible rules into `assets/scss/style.scss` under embed-specific selectors.
- Moved the encryption state badge to the front of the badge group so the security state is the first visible trust signal.
- Added tests that lock in the embed stylesheet link, runtime brand variables, and embed layout/focus style coverage.

## Why

The embedded profile should look and behave like Hush Line without carrying a large one-off inline style block. The review also correctly flagged that the iframe still needs scoped layout/accessibility CSS and runtime brand variables, so those are preserved in the appropriate places.

## Validation

- `make test` - 1688 passed, 1 deselected, 1 xfailed
- `docker compose run --rm app poetry run pytest tests/test_embeddable_forms_settings.py -q` - 43 passed
- `docker compose run --rm app poetry run ruff format --check tests/test_embeddable_forms_settings.py`
- `docker compose run --rm app poetry run ruff check tests/test_embeddable_forms_settings.py --output-format full`
- `make lint` partially ran: Ruff format, Ruff check, and mypy passed; the final Prettier stage failed on existing generated `hushline/static/js/*.js` formatting.

## Manual testing

- Open a locally enabled embedded profile URL such as `/embed/to/<username>`.
- Compare the embedded profile against the normal Hush Line profile styling.
- Confirm the form remains usable in an iframe, including field layout, captcha, submit button, keyboard focus visibility, and the open-profile / emergency-exit links.

## Security and privacy notes

- The frame-ancestor/CSP logic is unchanged.
- The iframe sandbox snippet is unchanged.
- Client-side encryption script loading is unchanged.
- The embed page keeps recipient/admin-configured brand color variables for focus and brand styling.
