### PR TITLE
Move embeddable forms controls to Developer settings

### DIFF
--- a/hushline/admin.py
+++ b/hushline/admin.py
@@ -143,7 +143,7 @@ def create_blueprint() -> Blueprint:
 
         status_label = "enabled" if desired_enabled else "disabled"
         flash(f"✅ Embeddable forms {status_label}.", "success")
-        return redirect(url_for("settings.admin"))
+        return redirect(url_for("settings.developer"))
 
     @bp.route("/update_account_category/<int:user_id>", methods=["POST"])
     @admin_authentication_required

--- a/hushline/settings/admin.py
+++ b/hushline/settings/admin.py
@@ -11,7 +11,7 @@ from sqlalchemy.orm import joinedload
 
 from hushline.auth import admin_authentication_required
 from hushline.db import db
-from hushline.model import AccountCategory, OrganizationSetting, User, Username
+from hushline.model import AccountCategory, User, Username
 
 ADMIN_USERNAMES_PER_PAGE = 20
 
@@ -84,9 +84,6 @@ def register_admin_routes(bp: Blueprint) -> None:
             two_fa_percentage=(two_fa_count / user_count * 100) if user_count else 0,
             pgp_key_percentage=(pgp_key_count / user_count * 100) if user_count else 0,
             user_verification_enabled=current_app.config.get("USER_VERIFICATION_ENABLED"),
-            embeddable_forms_enabled=bool(
-                OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED)
-            ),
             account_category_choices=AccountCategory.choices(),
             admin_search_query=search_query,
             admin_current_page=current_page,

--- a/hushline/settings/developer.py
+++ b/hushline/settings/developer.py
@@ -8,6 +8,7 @@ from flask import (
     session,
     url_for,
 )
+from flask_wtf.csrf import generate_csrf
 from werkzeug.wrappers.response import Response
 
 from hushline.auth import authentication_required
@@ -27,7 +28,8 @@ def _render_developer_page(
     status_code: int = 200,
     embed_settings_form: EmbedSettingsForm | None = None,
 ) -> tuple[str, int]:
-    if embed_settings_form is None:
+    can_manage_profile_embeds = user.is_current_paid_super_user
+    if can_manage_profile_embeds and embed_settings_form is None:
         embed_settings_form = create_embed_settings_form(username)
 
     return (
@@ -36,6 +38,9 @@ def _render_developer_page(
             user=user,
             username=username,
             is_alias=False,
+            can_manage_global_embeds=user.is_admin,
+            can_manage_profile_embeds=can_manage_profile_embeds,
+            csrf_token=generate_csrf(),
             embed_settings_action=url_for(".developer"),
             embed_settings_form=embed_settings_form,
             embeddable_forms_enabled=bool(
@@ -54,7 +59,7 @@ def register_developer_routes(bp: Blueprint) -> None:
     @authentication_required
     def developer() -> Response | Tuple[str, int]:
         user = db.session.scalars(db.select(User).filter_by(id=session["user_id"])).one()
-        if not user.is_current_paid_super_user:
+        if not (user.is_admin or user.is_current_paid_super_user):
             return abort(401)
 
         username = user.primary_username
@@ -62,6 +67,8 @@ def register_developer_routes(bp: Blueprint) -> None:
             raise Exception("Username was unexpectedly none")
 
         if request.method == "POST":
+            if not user.is_current_paid_super_user:
+                return abort(401)
             embed_settings_form = create_embed_settings_form(username, submitted=True)
             res = handle_embed_settings_form(username, embed_settings_form)
             if res:

--- a/hushline/templates/premium/business-features.html
+++ b/hushline/templates/premium/business-features.html
@@ -16,7 +16,11 @@
   <p>✅</p>
 </div>
 <div class="feature-meta">
-  <p>🆕 Custom Message Fields</p>
+  <p>Custom Message Fields</p>
+  <p>✅</p>
+</div>
+<div class="feature-meta">
+  <p>🆕 Embeddable Profile Forms</p>
   <p>✅</p>
 </div>
 <div class="feature-meta">

--- a/hushline/templates/settings/admin.html
+++ b/hushline/templates/settings/admin.html
@@ -19,37 +19,6 @@
     </div>
   </div>
 
-  <h4>Embeddable Forms</h4>
-  <p class="info">
-    Enable hosted iframe embeds globally. Recipients still need to opt in each
-    tip line and list exact allowed parent origins.
-  </p>
-  <form
-    action="{{ url_for('admin.toggle_embeddable_forms') }}"
-    method="POST"
-    class="formBody auto-submit"
-  >
-    <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
-    <div class="checkbox-group toggle-ui">
-      <input
-        type="checkbox"
-        id="embeddable_forms_enabled"
-        name="embeddable_forms_enabled"
-        value="true"
-        role="switch"
-        {% if embeddable_forms_enabled %}checked{% endif %}
-      />
-      <input type="hidden" name="embeddable_forms_enabled" value="false" />
-      <label for="embeddable_forms_enabled" class="toggle-label">
-        Enable embeddable forms globally
-        <div class="toggle">
-          <div class="toggle__ball"></div>
-        </div>
-      </label>
-    </div>
-    <button type="submit" class="display-none">Save embeddable forms setting</button>
-  </form>
-
   <h4>All Usernames</h4>
   <form
     action="{{ url_for('settings.admin') }}"

--- a/hushline/templates/settings/developer.html
+++ b/hushline/templates/settings/developer.html
@@ -2,7 +2,42 @@
 
 {% block settings_content %}
   <h3>Developer</h3>
-  {% include "settings/embed-settings-form.html" %}
+  {% if can_manage_global_embeds %}
+    <h4>Embeddable Forms</h4>
+    <p class="info">
+      Enable hosted iframe embeds globally. Recipients still need to opt in each
+      tip line and list exact allowed parent origins.
+    </p>
+    <form
+      action="{{ url_for('admin.toggle_embeddable_forms') }}"
+      method="POST"
+      class="formBody auto-submit"
+    >
+      <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+      <div class="checkbox-group toggle-ui">
+        <input
+          type="checkbox"
+          id="embeddable_forms_enabled"
+          name="embeddable_forms_enabled"
+          value="true"
+          role="switch"
+          {% if embeddable_forms_enabled %}checked{% endif %}
+        />
+        <input type="hidden" name="embeddable_forms_enabled" value="false" />
+        <label for="embeddable_forms_enabled" class="toggle-label">
+          Enable embeddable forms globally
+          <div class="toggle">
+            <div class="toggle__ball"></div>
+          </div>
+        </label>
+      </div>
+      <button type="submit" class="display-none">Save embeddable forms setting</button>
+    </form>
+  {% endif %}
+
+  {% if can_manage_profile_embeds %}
+    {% include "settings/embed-settings-form.html" %}
+  {% endif %}
 {% endblock %}
 
 {% block scripts %}

--- a/hushline/templates/settings/nav.html
+++ b/hushline/templates/settings/nav.html
@@ -7,7 +7,7 @@
       ('settings.aliases', 'Aliases', aliases_enabled),
       ('settings.auth', 'Authentication', True),
       ('settings.branding', 'Branding', user.is_admin),
-      ('settings.developer', 'Developer', user.is_current_paid_super_user),
+      ('settings.developer', 'Developer', user.is_admin or user.is_current_paid_super_user),
       ('settings.encryption', 'Encryption', True),
       ('settings.replies', 'Message Statuses', user.pgp_key is not none),
       ('settings.notifications', 'Notifications', True),

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -139,10 +139,16 @@ def test_admin_embeddable_forms_default_disabled(client: FlaskClient, admin_user
         session["username"] = admin_user.primary_username.username
         session["is_authenticated"] = True
 
-    response = client.get(url_for("settings.admin"))
+    admin_response = client.get(url_for("settings.admin"))
+
+    assert admin_response.status_code == 200
+    assert OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED) is False
+    assert "Enable embeddable forms globally" not in admin_response.text
+    assert 'id="embeddable_forms_enabled"' not in admin_response.text
+
+    response = client.get(url_for("settings.developer"))
 
     assert response.status_code == 200
-    assert OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED) is False
     page = BeautifulSoup(response.text, "html.parser")
     toggle = page.find("input", attrs={"id": "embeddable_forms_enabled"})
     assert toggle is not None
@@ -874,7 +880,9 @@ def test_developer_embed_settings_do_not_show_snippet_when_globally_disabled(
     assert 'id="embed_iframe_snippet"' not in response.text
 
 
-def test_non_super_user_cannot_access_developer_settings(client: FlaskClient, user: User) -> None:
+def test_non_super_non_admin_user_cannot_access_developer_settings(
+    client: FlaskClient, user: User
+) -> None:
     _enable_embeds_globally()
     _add_pgp_key(user)
     with client.session_transaction() as session:
@@ -895,7 +903,7 @@ def test_non_super_user_cannot_access_developer_settings(client: FlaskClient, us
     assert user.primary_username.embed_enabled is False
 
 
-def test_settings_nav_shows_developer_only_for_current_paid_super_user(
+def test_settings_nav_shows_developer_for_admin_or_current_paid_super_user(
     client: FlaskClient, user: User
 ) -> None:
     with client.session_transaction() as session:
@@ -911,9 +919,19 @@ def test_settings_nav_shows_developer_only_for_current_paid_super_user(
     nav_text = nav.get_text(" ", strip=True)
     assert "Developer" not in nav_text
 
-    _make_current_paid_super_user(user)
     user.is_admin = True
     db.session.commit()
+    response = client.get(url_for("settings.profile"))
+    assert response.status_code == 200
+    nav = BeautifulSoup(response.text, "html.parser").select_one("nav.settings-tabs")
+    assert nav is not None
+    admin_developer_link = nav.find("a", href=url_for("settings.developer"))
+    assert admin_developer_link is not None
+    assert admin_developer_link.get_text(strip=True) == "Developer"
+
+    user.is_admin = False
+    db.session.commit()
+    _make_current_paid_super_user(user)
     response = client.get(url_for("settings.profile"))
     assert response.status_code == 200
     nav = BeautifulSoup(response.text, "html.parser").select_one("nav.settings-tabs")
@@ -923,8 +941,36 @@ def test_settings_nav_shows_developer_only_for_current_paid_super_user(
     assert developer_link.get_text(strip=True) == "Developer"
     assert developer_link.get("href") == url_for("settings.developer")
     labels = [link.get_text(strip=True) for link in nav.find_all("a")]
+    assert labels.index("Developer") < labels.index("Encryption")
+
+    user.is_admin = True
+    db.session.commit()
+    response = client.get(url_for("settings.profile"))
+    assert response.status_code == 200
+    nav = BeautifulSoup(response.text, "html.parser").select_one("nav.settings-tabs")
+    assert nav is not None
+    labels = [link.get_text(strip=True) for link in nav.find_all("a")]
     assert labels.index("Developer") > labels.index("Branding")
     assert labels.index("Developer") < labels.index("Encryption")
+
+
+def test_admin_non_super_user_can_access_developer_global_embed_settings_only(
+    client: FlaskClient, user: User
+) -> None:
+    user.is_admin = True
+    db.session.commit()
+    with client.session_transaction() as session:
+        session["user_id"] = user.id
+        session["session_id"] = user.session_id
+        session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
+
+    response = client.get(url_for("settings.developer"))
+
+    assert response.status_code == 200
+    assert "Enable embeddable forms globally" in response.text
+    assert "Embeddable Profile" not in response.text
+    assert 'name="embed_enabled"' not in response.text
 
 
 def test_developer_embed_settings_require_usable_recipient_key(
@@ -974,6 +1020,11 @@ def test_admin_can_toggle_embeddable_forms(client: FlaskClient, admin_user: User
     assert response.status_code == 302
     assert OrganizationSetting.fetch_one(OrganizationSetting.EMBEDDABLE_FORMS_ENABLED) is True
     page_response = client.get(url_for("settings.admin"))
+    page = BeautifulSoup(page_response.text, "html.parser")
+    toggle = page.find("input", attrs={"id": "embeddable_forms_enabled"})
+    assert toggle is None
+
+    page_response = client.get(url_for("settings.developer"))
     page = BeautifulSoup(page_response.text, "html.parser")
     toggle = page.find("input", attrs={"id": "embeddable_forms_enabled"})
     assert toggle is not None


### PR DESCRIPTION
## What changed
- Moved the global embeddable forms toggle out of the Admin settings tab and into the Developer settings tab.
- Made the Developer tab visible to admins and current paid Super Users.
- Kept the global embeddable forms toggle admin-only while keeping profile embed settings limited to current paid Super Users.
- Redirected the global toggle save action back to Developer settings.
- Updated the Super User business features list to include Embeddable Profile Forms separately from Custom Message Fields.
- Updated embeddable forms settings tests for the new admin/Super User visibility rules and tab placement.

## Why
The embeddable form controls are developer-facing configuration. Admins need access to the global enablement toggle, while paid Super Users still manage their own profile embed settings from the same Developer surface.

## Security / privacy notes
- Non-admin, non-Super Users still cannot access Developer settings.
- Admin-only access for the global toggle remains enforced by the existing `admin.toggle_embeddable_forms` route and CSRF validation.
- Admin users who are not current paid Super Users can view and change only the global embeddable forms setting; profile embed opt-in settings remain hidden and POST-protected.
- No CSP directives or external resource permissions were broadened.

## Validation
Passed:
- `docker compose run --rm app poetry run pytest tests/test_embeddable_forms_settings.py -q`
- `docker compose run --rm app poetry run ruff format --check hushline/admin.py hushline/settings/admin.py hushline/settings/developer.py tests/test_embeddable_forms_settings.py`
- `docker compose run --rm app poetry run ruff check hushline/admin.py hushline/settings/admin.py hushline/settings/developer.py tests/test_embeddable_forms_settings.py --output-format full`
- `docker compose run --rm app poetry run pytest tests/test_embeddable_forms_settings.py tests/test_accessibility.py::test_settings_nav_marks_current_page -q`

Not completed locally:
- `make test` was started but interrupted after cascading unrelated database-backed test errors. The focused route/navigation coverage above passed, and the stale local test container was stopped.
- `make lint`, `make audit-python`, and `make audit-node-runtime` have not been completed for this PR yet.

## Manual testing
- As an admin, open Settings and confirm the Admin tab no longer shows the global embeddable forms toggle.
- As an admin, open Developer settings and confirm the global embeddable forms toggle is visible.
- As an admin who is not a current paid Super User, confirm profile embed settings are not visible.
- As a current paid Super User, open Developer settings and confirm profile embed settings are visible.
- As a non-admin, non-Super User, confirm the Developer tab is hidden and direct access returns unauthorized.

## Known risks / follow-up
- Full local validation still needs a clean Docker/database reset and rerun before merge.
- Dependency audits still need to pass before merge.

PR freshness: created May 8, 2026 UTC; not stale.