### PR TITLE
Scope field setting updates by owner

### DIFF
--- a/hushline/settings/common.py
+++ b/hushline/settings/common.py
@@ -10,6 +10,7 @@ import aiohttp
 from aiohttp.abc import AbstractResolver, ResolveResult
 from bs4 import BeautifulSoup
 from flask import (
+    abort,
     current_app,
     flash,
     redirect,
@@ -603,9 +604,7 @@ def handle_field_post(username: Username, field_form: FieldForm | None = None) -
         # Update an existing field
         if field_form.update.name in request.form:
             current_app.logger.info("Updating field")
-            field_definition = db.session.scalars(
-                db.select(FieldDefinition).filter_by(id=int(field_form.id.data))
-            ).one()
+            field_definition = _field_definition_for_posted_id(username, field_form)
             field_definition.label = field_form.label.data
             field_definition.field_type = FieldType(field_form.field_type.data)
             field_definition.required = field_form.required.data
@@ -619,9 +618,7 @@ def handle_field_post(username: Username, field_form: FieldForm | None = None) -
         # Delete a field
         if field_form.delete.name in request.form:
             current_app.logger.info("Deleting field")
-            field_definition = db.session.scalars(
-                db.select(FieldDefinition).filter_by(id=int(field_form.id.data))
-            ).one()
+            field_definition = _field_definition_for_posted_id(username, field_form)
 
             # Delete all field values that rely on this field definition
             db.session.execute(
@@ -636,9 +633,7 @@ def handle_field_post(username: Username, field_form: FieldForm | None = None) -
         # Move a field up
         if field_form.move_up.name in request.form:
             current_app.logger.info("Moving field up")
-            field_definition = db.session.scalars(
-                db.select(FieldDefinition).filter_by(id=int(field_form.id.data))
-            ).one()
+            field_definition = _field_definition_for_posted_id(username, field_form)
             field_definition.move_up()
             flash("👍 Field moved up.")
             return redirect_to_self()
@@ -646,14 +641,27 @@ def handle_field_post(username: Username, field_form: FieldForm | None = None) -
         # Move a field down
         if field_form.move_down.name in request.form:
             current_app.logger.info("Moving field down")
-            field_definition = db.session.scalars(
-                db.select(FieldDefinition).filter_by(id=int(field_form.id.data))
-            ).one()
+            field_definition = _field_definition_for_posted_id(username, field_form)
             field_definition.move_down()
             flash("👍 Field moved down.")
             return redirect_to_self()
 
     return None
+
+
+def _field_definition_for_posted_id(username: Username, field_form: FieldForm) -> FieldDefinition:
+    try:
+        field_id = int(field_form.id.data)
+    except (TypeError, ValueError):
+        abort(404)
+
+    field_definition = db.session.scalars(
+        db.select(FieldDefinition).filter_by(id=field_id, username_id=username.id)
+    ).one_or_none()
+    if field_definition is None:
+        abort(404)
+
+    return field_definition
 
 
 def _field_form_for_definition(field: FieldDefinition) -> FieldForm:

--- a/tests/test_settings_common.py
+++ b/tests/test_settings_common.py
@@ -11,6 +11,7 @@ from aiohttp.abc import ResolveResult
 from flask import Flask, session
 from sqlalchemy.exc import IntegrityError
 from werkzeug.datastructures import MultiDict
+from werkzeug.exceptions import NotFound
 from wtforms.validators import ValidationError
 
 from hushline.db import db
@@ -1156,6 +1157,60 @@ def test_handle_field_post_move_up_and_down_branches(app: Flask, user: User) -> 
     ):
         response_down = handle_field_post(username)
     assert response_down is not None
+
+
+@pytest.mark.parametrize(
+    "action",
+    ["update", "delete", "move_up", "move_down"],
+)
+def test_handle_field_post_rejects_fields_owned_by_another_user(
+    app: Flask, user: User, user2: User, action: str
+) -> None:
+    attacker_username = user.primary_username
+    victim_username = user2.primary_username
+    victim_field = victim_username.message_fields[0]
+    victim_field.label = "victim field"
+    victim_field.enabled = True
+    victim_field.encrypted = True
+    db.session.add(victim_field)
+    db.session.commit()
+
+    message = Message(username_id=victim_username.id)
+    db.session.add(message)
+    db.session.commit()
+    value = FieldValue(
+        field_definition=victim_field,
+        message=message,
+        value="victim disclosure",
+        encrypted=False,
+    )
+    db.session.add(value)
+    db.session.commit()
+
+    victim_field_id = victim_field.id
+    field_value_id = value.id
+    original_sort_orders = {field.id: field.sort_order for field in victim_username.message_fields}
+    form = cast(FieldForm, _fake_field_form(action, victim_field_id))
+
+    with (
+        app.test_request_context("/settings/fields", method="POST", data={action: ""}),
+        pytest.raises(NotFound),
+    ):
+        handle_field_post(attacker_username, form)
+
+    db.session.expire_all()
+    persisted_field = db.session.get(FieldDefinition, victim_field_id)
+    assert persisted_field is not None
+    assert persisted_field.label == "victim field"
+    assert persisted_field.enabled is True
+    assert persisted_field.encrypted is True
+    assert db.session.get(FieldValue, field_value_id) is not None
+    assert {
+        field.id: field.sort_order
+        for field in db.session.scalars(
+            db.select(FieldDefinition).where(FieldDefinition.username_id == victim_username.id)
+        )
+    } == original_sort_orders
 
 
 def test_build_field_forms_populates_choice_entries(user: User) -> None:


### PR DESCRIPTION
## What changed

- Scope posted `FieldDefinition` lookups in `handle_field_post` by both posted field ID and the active `Username` ID.
- Return 404 for malformed, missing, or cross-owner field IDs before update, delete, or reorder logic can run.
- Add regression coverage for cross-user update, delete, move-up, and move-down attempts, including preserving existing `FieldValue` disclosure content.

## Why

The existing update/delete/reorder branches resolved `FieldDefinition` rows by attacker-supplied ID alone. A registered user could submit a field ID owned by another user and mutate labels/settings, reorder fields, or delete a field and its associated stored field values.

## Security impact

Threat/risk: authenticated cross-tenant IDOR against submission field definitions.

Affected data paths: profile and alias submission field settings, public tip-line field rendering, and stored per-field disclosure values deleted through field deletion.

Mitigation: every non-create field action now resolves the target row through the `Username` object already authorized by the profile or alias route. Cross-owner IDs are treated as not found.

## Validation

Passed:

- `poetry run ruff format --check hushline/settings/common.py tests/test_settings_common.py`
- `poetry run ruff check --output-format full hushline/settings/common.py tests/test_settings_common.py`
- `poetry run mypy hushline/settings/common.py tests/test_settings_common.py`
- `git diff --check`

Attempted but blocked by local environment:

- `poetry run pytest tests/test_settings_common.py -q` did not reach the new assertions because the host process could not resolve the Docker service hostname `postgres`.
- `make lint` could not run because Docker Postgres is unhealthy; logs show `FATAL: could not write lock file "postmaster.pid": No space left on device`.

## Manual testing

Not performed separately; this is a server-side authorization fix covered by the added regression test path once the local Postgres environment is healthy.

## Known risks / follow-ups

- Full `make lint` and `make test` still need to pass in an environment with a healthy Postgres container before merge.
- A CVE request, if desired, should be handled through the project maintainer/security disclosure process.