### PR TITLE
Rotate sessions on password change

### DIFF
--- a/hushline/settings/common.py
+++ b/hushline/settings/common.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import IntegrityError
 from werkzeug.wrappers.response import Response
 from wtforms import Field
 
+from hushline.auth import rotate_user_session_id
 from hushline.crypto import can_encrypt_with_pgp_key, is_valid_pgp_key
 from hushline.db import db
 from hushline.external_urls import canonical_external_url
@@ -477,6 +478,7 @@ def handle_change_password_form(
         return None
 
     user.password_hash = change_password_form.new_password.data
+    rotate_user_session_id(user)
     db.session.commit()
     session.clear()
     flash("👍 Password successfully changed. Please log in again.", "success")

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -327,6 +327,7 @@ def test_change_password(app: Flask, client: FlaskClient, user: User, user_passw
     assert len(original_password_hash := user.password_hash) > 32
     assert original_password_hash.startswith("$scrypt$")
     assert user_password not in original_password_hash
+    original_session_id = user.session_id
     original_password = user_password
 
     url = url_for("settings.auth")
@@ -355,7 +356,10 @@ def test_change_password(app: Flask, client: FlaskClient, user: User, user_passw
             assert original_password_hash not in new_password_hash
             assert user_password not in new_password_hash
             assert new_password not in new_password_hash
+            db.session.refresh(user)
+            assert user.session_id != original_session_id
             user_password = new_password
+            original_session_id = user.session_id
         elif user_password == new_password:
             assert "Cannot choose a repeat password." in response.text
             assert original_password_hash == user.password_hash
@@ -395,6 +399,41 @@ def test_change_password(app: Flask, client: FlaskClient, user: User, user_passw
     assert "Empty Inbox" in response.text
     assert "Invalid username or password" not in response.text
     assert "/inbox" in response.request.url
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_change_password_revokes_sibling_session(
+    app: Flask, client: FlaskClient, user: User, user_password: str
+) -> None:
+    stolen_session_id = user.session_id
+    new_password = "ChangedPassword123!!"
+
+    sibling_client = app.test_client()
+    with sibling_client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["session_id"] = stolen_session_id
+        sess["username"] = user.primary_username.username
+        sess["is_authenticated"] = True
+
+    response = sibling_client.get(url_for("inbox"))
+    assert response.status_code == 200
+
+    response = client.post(
+        url_for("settings.auth"),
+        data=form_to_data(
+            ChangePasswordForm(data={"old_password": user_password, "new_password": new_password})
+        ),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert "Password successfully changed. Please log in again." in response.text
+
+    db.session.refresh(user)
+    assert user.session_id != stolen_session_id
+
+    response = sibling_client.get(url_for("inbox"), follow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(url_for("login"))
 
 
 @pytest.mark.usefixtures("_authenticated_user")


### PR DESCRIPTION
## What changed

- Rotate `User.session_id` during in-app password changes before committing the new password hash.
- Extend the existing password-change test to assert the session ID changes on successful password updates.
- Add a regression test that models a cloned sibling session and verifies it is redirected to login after the password change.

## Why

The in-app password change path cleared only the current Flask session cookie. Other browsers or copied cookies with the old `session_id` still matched the unchanged server-side `User.session_id` in `get_session_user`, so they remained authenticated after the password change.

## Security impact

Threat/risk: compromised or copied authenticated sessions survived the password-change recovery action documented by the project.

Affected data paths: all authenticated account and inbox routes reachable with a stale but previously valid session cookie.

Mitigation: the in-app password-change flow now uses the same `rotate_user_session_id(user)` revocation primitive as login, logout, and email password reset. Existing sibling sessions fail the server-side session comparison on their next authenticated request.

## Validation

Passed:

- `poetry run ruff format --check hushline/settings/common.py tests/test_settings.py`
- `poetry run ruff check --output-format full hushline/settings/common.py tests/test_settings.py`
- `poetry run mypy hushline/settings/common.py tests/test_settings.py`
- `git diff --check`

Attempted but blocked by local environment:

- `poetry run pytest tests/test_settings.py -q -k change_password` failed before running assertions because the host process could not resolve the Docker service hostname `postgres`.
- `make lint` could not run because Docker Postgres is unhealthy; Docker reported `dependency failed to start: container hushline-postgres-1 is unhealthy`, and previous Postgres logs showed `FATAL: could not write lock file "postmaster.pid": No space left on device`.

## Manual testing

Not performed separately; this is a server-side session revocation fix covered by the added route-level regression test once the local Postgres environment is healthy.

## Known risks / follow-ups

- Full `make lint` and `make test` still need to pass in an environment with a healthy Postgres container before merge.
- A CVE request, if desired, should be handled through the project maintainer/security disclosure process.