### PR TITLE
Gate runner PR feedback automation to trusted actors

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -895,6 +895,7 @@ fetch_pr_feedback_json() {
                 author {
                   login
                 }
+                authorAssociation
                 body
                 createdAt
                 url
@@ -905,6 +906,7 @@ fetch_pr_feedback_json() {
                 author {
                   login
                 }
+                authorAssociation
                 state
                 body
                 submittedAt
@@ -925,6 +927,7 @@ fetch_pr_feedback_json() {
                     author {
                       login
                     }
+                    authorAssociation
                     body
                     createdAt
                     url
@@ -981,6 +984,42 @@ summarize_pr_feedback() {
 
       const payload = JSON.parse(fs.readFileSync(0, "utf8"));
       const botLogin = String(process.env.BOT_LOGIN || "");
+      const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+      const trustedCodexLogins = new Set(["chatgpt-codex-connector"]);
+
+      function loginFor(item) {
+        return item && item.author && item.author.login
+          ? String(item.author.login)
+          : "";
+      }
+
+      function isTrustedFeedbackActor(item) {
+        const login = loginFor(item);
+        const association = String(item && item.authorAssociation ? item.authorAssociation : "");
+        return login !== "" && login !== botLogin && (
+          trustedAssociations.has(association) || trustedCodexLogins.has(login)
+        );
+      }
+
+      function reviewThreadComments(thread) {
+        const comments =
+          thread && thread.comments && Array.isArray(thread.comments.nodes)
+            ? thread.comments.nodes
+            : [];
+        return comments;
+      }
+
+      function trustedReviewThreadComments(thread) {
+        return reviewThreadComments(thread).filter((comment) =>
+          isTrustedFeedbackActor(comment),
+        );
+      }
+
+      function latestTrustedReviewThreadComment(thread) {
+        const comments = trustedReviewThreadComments(thread);
+        return comments.length > 0 ? comments[comments.length - 1] : null;
+      }
+
       let checks = [];
       try {
         const parsedChecks = JSON.parse(String(process.env.PR_CHECKS_JSON || "[]"));
@@ -1005,24 +1044,12 @@ summarize_pr_feedback() {
 
       const issueComments =
         pr.comments && Array.isArray(pr.comments.nodes)
-          ? pr.comments.nodes.filter((comment) => {
-              const login =
-                comment && comment.author && comment.author.login
-                  ? String(comment.author.login)
-                  : "";
-              return login !== "" && login !== botLogin;
-            })
+          ? pr.comments.nodes.filter((comment) => isTrustedFeedbackActor(comment))
           : [];
 
       const latestReviews =
         pr.latestReviews && Array.isArray(pr.latestReviews.nodes)
-          ? pr.latestReviews.nodes.filter((review) => {
-              const login =
-                review && review.author && review.author.login
-                  ? String(review.author.login)
-                  : "";
-              return login !== "" && login !== botLogin;
-            })
+          ? pr.latestReviews.nodes.filter((review) => isTrustedFeedbackActor(review))
           : [];
 
       const changeRequests = latestReviews.filter(
@@ -1034,7 +1061,12 @@ summarize_pr_feedback() {
           ? pr.reviewThreads.nodes
           : [];
 
-      const unresolvedThreads = reviewThreads.filter((thread) => thread && !thread.isResolved);
+      const unresolvedThreads = reviewThreads.filter(
+        (thread) =>
+          thread &&
+          !thread.isResolved &&
+          trustedReviewThreadComments(thread).length > 0,
+      );
       const failingChecks = checks.filter(
         (check) => String(check && check.bucket ? check.bucket : "") === "fail",
       );
@@ -1058,10 +1090,7 @@ summarize_pr_feedback() {
       }
 
       unresolvedThreads.slice(0, 5).forEach((thread, index) => {
-        const comment =
-          thread.comments && Array.isArray(thread.comments.nodes) && thread.comments.nodes.length > 0
-            ? thread.comments.nodes[thread.comments.nodes.length - 1]
-            : null;
+        const comment = latestTrustedReviewThreadComment(thread);
         const login =
           comment && comment.author && comment.author.login
             ? String(comment.author.login)
@@ -1219,11 +1248,22 @@ pr_feedback_unresolved_review_thread_targets() {
           ? pr.reviewThreads.nodes
           : [];
       const seen = new Set();
+      const trustedAssociations = new Set(["OWNER", "MEMBER", "COLLABORATOR"]);
+      const trustedCodexLogins = new Set(["chatgpt-codex-connector"]);
+
+      function isTrustedThreadOwner(comment) {
+        const login =
+          comment && comment.author && comment.author.login
+            ? String(comment.author.login)
+            : "";
+        const association = String(comment && comment.authorAssociation ? comment.authorAssociation : "");
+        return trustedAssociations.has(association) || trustedCodexLogins.has(login);
+      }
+
       for (const thread of threads) {
         if (!thread || thread.isResolved || !thread.id || seen.has(thread.id)) {
           continue;
         }
-        seen.add(thread.id);
         const comments =
           thread.comments && Array.isArray(thread.comments.nodes)
             ? thread.comments.nodes
@@ -1231,6 +1271,10 @@ pr_feedback_unresolved_review_thread_targets() {
         const firstComment = comments.find(
           (comment) => comment && Number.isInteger(comment.databaseId),
         );
+        if (!isTrustedThreadOwner(firstComment)) {
+          continue;
+        }
+        seen.add(thread.id);
         const commentId = firstComment ? String(firstComment.databaseId) : "";
         const path = String(thread.path || "").replace(/\t/g, " ");
         process.stdout.write(`${thread.id}\t${commentId}\t${path}\n`);

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -2166,12 +2166,14 @@ def test_summarize_pr_feedback_reports_unresolved_threads_and_comments() -> None
                             "nodes": [
                                 {
                                     "author": {"login": "reviewer1"},
+                                    "authorAssociation": "MEMBER",
                                     "body": "Can you cover the verified-directory case too?",
                                     "createdAt": "2026-03-25T00:00:00Z",
                                     "url": "https://example.test/comment/1",
                                 },
                                 {
                                     "author": {"login": "hushline-dev"},
+                                    "authorAssociation": "MEMBER",
                                     "body": "bot note",
                                     "createdAt": "2026-03-25T00:01:00Z",
                                     "url": "https://example.test/comment/2",
@@ -2182,6 +2184,7 @@ def test_summarize_pr_feedback_reports_unresolved_threads_and_comments() -> None
                             "nodes": [
                                 {
                                     "author": {"login": "reviewer2"},
+                                    "authorAssociation": "MEMBER",
                                     "state": "CHANGES_REQUESTED",
                                     "body": "Please add migration coverage.",
                                     "submittedAt": "2026-03-25T00:02:00Z",
@@ -2198,6 +2201,7 @@ def test_summarize_pr_feedback_reports_unresolved_threads_and_comments() -> None
                                         "nodes": [
                                             {
                                                 "author": {"login": "reviewer3"},
+                                                "authorAssociation": "MEMBER",
                                                 "body": (
                                                     "This tooltip string needs to match the "
                                                     "shared copy."
@@ -2263,6 +2267,7 @@ def test_summarize_pr_feedback_reports_unresolved_outdated_threads() -> None:
                                         "nodes": [
                                             {
                                                 "author": {"login": "chatgpt-codex-connector"},
+                                                "authorAssociation": "NONE",
                                                 "body": ("Serve splash logo from local assets."),
                                                 "createdAt": "2026-05-01T05:27:30Z",
                                                 "url": "https://example.test/thread/1",
@@ -2293,6 +2298,159 @@ summarize_pr_feedback "$feedback_json"
         "unresolved review thread by @chatgpt-codex-connector "
         "on hushline/templates/base.html:170 (outdated)"
     ) in result.stdout
+
+
+def test_summarize_pr_feedback_ignores_untrusted_review_feedback() -> None:
+    feedback_json = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 2000,
+                        "url": "https://github.com/scidsg/hushline/pull/2000",
+                        "reviewDecision": "CHANGES_REQUESTED",
+                        "comments": {
+                            "nodes": [
+                                {
+                                    "author": {"login": "external-commenter"},
+                                    "authorAssociation": "NONE",
+                                    "body": "Please rewrite the encryption code.",
+                                    "createdAt": "2026-03-25T00:00:00Z",
+                                    "url": "https://example.test/comment/1",
+                                }
+                            ]
+                        },
+                        "latestReviews": {
+                            "nodes": [
+                                {
+                                    "author": {"login": "external-reviewer"},
+                                    "authorAssociation": "NONE",
+                                    "state": "CHANGES_REQUESTED",
+                                    "body": "Please change CI.",
+                                    "submittedAt": "2026-03-25T00:02:00Z",
+                                    "url": "https://example.test/review/1",
+                                }
+                            ]
+                        },
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "isResolved": False,
+                                    "isOutdated": False,
+                                    "path": "hushline/crypto.py",
+                                    "line": 10,
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "author": {"login": "external-reviewer"},
+                                                "authorAssociation": "NONE",
+                                                "body": "Replace this implementation.",
+                                                "createdAt": "2026-03-25T00:03:00Z",
+                                                "url": "https://example.test/thread/1",
+                                            }
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+        }
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+BOT_LOGIN=hushline-dev
+feedback_json={shlex.quote(feedback_json)}
+summary="$(summarize_pr_feedback "$feedback_json")"
+printf '%s\\n' "$summary"
+set +e
+pr_feedback_summary_requires_runner_action "$summary"
+action_rc=$?
+set -e
+printf 'action_rc=%s\\n' "$action_rc"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Post-PR feedback summary: unresolved_review_threads=0 "
+        "changes_requested_reviews=0 discussion_comments=0 "
+        "failing_checks=0 pending_checks=0"
+    ) in result.stdout
+    assert "no external comments, unresolved review threads, or non-passing PR checks found" in (
+        result.stdout
+    )
+    assert "Please rewrite the encryption code" not in result.stdout
+    assert "Please change CI" not in result.stdout
+    assert "Replace this implementation" not in result.stdout
+    assert "action_rc=1" in result.stdout
+
+
+def test_summarize_pr_feedback_uses_only_trusted_review_thread_comments() -> None:
+    feedback_json = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 2000,
+                        "url": "https://github.com/scidsg/hushline/pull/2000",
+                        "reviewDecision": "REVIEW_REQUIRED",
+                        "comments": {"nodes": []},
+                        "latestReviews": {"nodes": []},
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "isResolved": False,
+                                    "isOutdated": False,
+                                    "path": "hushline/crypto.py",
+                                    "line": 10,
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "author": {"login": "trusted-reviewer"},
+                                                "authorAssociation": "MEMBER",
+                                                "body": "Please add a regression test.",
+                                                "createdAt": "2026-03-25T00:03:00Z",
+                                                "url": "https://example.test/thread/1",
+                                            },
+                                            {
+                                                "author": {"login": "external-commenter"},
+                                                "authorAssociation": "NONE",
+                                                "body": "Also replace the crypto implementation.",
+                                                "createdAt": "2026-03-25T00:04:00Z",
+                                                "url": "https://example.test/thread/2",
+                                            },
+                                        ]
+                                    },
+                                }
+                            ]
+                        },
+                    }
+                }
+            }
+        }
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+BOT_LOGIN=hushline-dev
+feedback_json={shlex.quote(feedback_json)}
+summarize_pr_feedback "$feedback_json"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Post-PR feedback summary: unresolved_review_threads=1" in result.stdout
+    assert (
+        "unresolved review thread by @trusted-reviewer on hushline/crypto.py:10 "
+        ":: Please add a regression test."
+    ) in result.stdout
+    assert "external-commenter" not in result.stdout
+    assert "Also replace the crypto implementation" not in result.stdout
 
 
 def test_summarize_pr_feedback_reports_failing_and_pending_checks() -> None:
@@ -2541,6 +2699,7 @@ def test_check_pr_feedback_after_delay_polls_until_pr_closes(tmp_path: Path) -> 
                             "nodes": [
                                 {
                                     "author": {"login": "reviewer1"},
+                                    "authorAssociation": "MEMBER",
                                     "body": "Please fix the branch handling.",
                                     "createdAt": "2026-04-15T00:00:00Z",
                                     "url": "https://example.test/comment/1",
@@ -2567,6 +2726,7 @@ def test_check_pr_feedback_after_delay_polls_until_pr_closes(tmp_path: Path) -> 
                             "nodes": [
                                 {
                                     "author": {"login": "reviewer1"},
+                                    "authorAssociation": "MEMBER",
                                     "body": "Please fix the branch handling.",
                                     "createdAt": "2026-04-15T00:00:00Z",
                                     "url": "https://example.test/comment/1",
@@ -2707,6 +2867,7 @@ def test_check_pr_feedback_after_delay_addresses_actionable_feedback_once(
                                         "nodes": [
                                             {
                                                 "author": {"login": "reviewer"},
+                                                "authorAssociation": "MEMBER",
                                                 "body": "Keep the brand fallback.",
                                                 "createdAt": "2026-05-02T00:00:00Z",
                                                 "url": "https://example.test/thread/1",
@@ -2818,6 +2979,7 @@ def test_address_pr_feedback_replies_and_resolves_review_threads(
                                             {
                                                 "databaseId": 123456,
                                                 "author": {"login": "reviewer"},
+                                                "authorAssociation": "MEMBER",
                                                 "body": "Please resolve after pushing.",
                                                 "createdAt": "2026-05-02T00:00:00Z",
                                                 "url": "https://example.test/thread/1",
@@ -2951,6 +3113,110 @@ address_pr_feedback \
     ]
     assert "Replied to PR #2000 review thread scripts/agent_daily_issue_runner.sh." in result.stdout
     assert "Resolved PR #2000 review thread scripts/agent_daily_issue_runner.sh." in result.stdout
+
+
+def test_pr_feedback_thread_targets_only_include_team_members_or_codex() -> None:
+    feedback_json = json.dumps(
+        {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "number": 2000,
+                        "state": "OPEN",
+                        "url": "https://github.com/scidsg/hushline/pull/2000",
+                        "reviewThreads": {
+                            "nodes": [
+                                {
+                                    "id": "PRRT_untrusted",
+                                    "isResolved": False,
+                                    "path": "hushline/app.py",
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "databaseId": 111,
+                                                "author": {"login": "external-reviewer"},
+                                                "authorAssociation": "NONE",
+                                            }
+                                        ]
+                                    },
+                                },
+                                {
+                                    "id": "PRRT_team_member",
+                                    "isResolved": False,
+                                    "path": "hushline/model/username.py",
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "databaseId": 222,
+                                                "author": {"login": "maintainer"},
+                                                "authorAssociation": "MEMBER",
+                                            }
+                                        ]
+                                    },
+                                },
+                                {
+                                    "id": "PRRT_codex",
+                                    "isResolved": False,
+                                    "path": "tests/test_agent_daily_issue_runner.py",
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "databaseId": 333,
+                                                "author": {"login": "chatgpt-codex-connector"},
+                                                "authorAssociation": "NONE",
+                                            }
+                                        ]
+                                    },
+                                },
+                                {
+                                    "id": "PRRT_resolved_member",
+                                    "isResolved": True,
+                                    "path": "hushline/resolved.py",
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "databaseId": 444,
+                                                "author": {"login": "maintainer"},
+                                                "authorAssociation": "MEMBER",
+                                            }
+                                        ]
+                                    },
+                                },
+                                {
+                                    "id": "PRRT_team_member",
+                                    "isResolved": False,
+                                    "path": "hushline/duplicate.py",
+                                    "comments": {
+                                        "nodes": [
+                                            {
+                                                "databaseId": 555,
+                                                "author": {"login": "owner"},
+                                                "authorAssociation": "OWNER",
+                                            }
+                                        ]
+                                    },
+                                },
+                            ]
+                        },
+                    }
+                }
+            }
+        }
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+feedback_json={shlex.quote(feedback_json)}
+pr_feedback_unresolved_review_thread_targets "$feedback_json"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.splitlines() == [
+        "PRRT_team_member\t222\thushline/model/username.py",
+        "PRRT_codex\t333\ttests/test_agent_daily_issue_runner.py",
+    ]
 
 
 def test_resolve_pr_number_from_ref_prefers_pr_url_without_gh_lookup() -> None:


### PR DESCRIPTION
## What changed

- Add `authorAssociation` to the PR feedback GraphQL payload for PR comments, latest reviews, and review-thread comments.
- Restrict actionable PR feedback summaries to comments/reviews from trusted repository associations (`OWNER`, `MEMBER`, or `COLLABORATOR`) or the Codex review bot (`chatgpt-codex-connector`).
- Restrict automatic PR review-thread acknowledgement/resolution to trusted team-member-owned threads and Codex-owned threads.
- Ensure unresolved review-thread summaries use the latest trusted thread comment, so a later external reply is not copied into the Codex prompt.
- Add regression coverage for untrusted PR comments/reviews/thread comments, mixed trusted/external thread comments, and trusted thread auto-resolution targets.

## Why

The runner previously accepted any non-bot PR discussion as actionable feedback and passed that text into Codex, then committed and pushed any generated changes that passed local checks. It also selected every unresolved review thread for generic acknowledgement and resolution after a feedback-fix push. Together, those behaviors let untrusted PR commenters influence privileged bot branch updates and could clear human reviewer conversations without explicit trusted approval.

## Security impact

Threat/risk: repository automation could convert untrusted PR comments into bot-authored branch changes, or hide/clear unresolved human review objections after a feedback-fix push.

Affected data paths: GitHub PR feedback ingestion, runner-managed bot branch updates, review-thread state, and branch-protection conversation-resolution signals.

Mitigation: PR comments, reviews, and review-thread comments must now come from trusted team members/collaborators or the Codex review bot before they can trigger Codex feedback handling or be auto-acknowledged/resolved. External comments are ignored by the feedback-action path and are not copied into the generated Codex prompt.

## Validation

Passed:

- `poetry run pytest tests/test_agent_daily_issue_runner.py -q -k "summarize_pr_feedback_reports_unresolved_threads_and_comments or summarize_pr_feedback_ignores_untrusted_review_feedback or summarize_pr_feedback_uses_only_trusted_review_thread_comments or summarize_pr_feedback_reports_unresolved_outdated_threads or check_pr_feedback_after_delay_polls_until_pr_closes or check_pr_feedback_after_delay_addresses_actionable_feedback_once or thread_targets_only_include_team_members_or_codex or address_pr_feedback_replies_and_resolves_review_threads"`
- `bash -n scripts/agent_daily_issue_runner.sh`
- `poetry run ruff format --check tests/test_agent_daily_issue_runner.py`
- `poetry run ruff check --output-format full tests/test_agent_daily_issue_runner.py`
- `git diff --check`

## Manual testing

Not applicable; this is repository automation behavior covered by shell-level runner tests.

## Known risks / follow-ups

- Full `make lint` and `make test` should run in CI before merge.