### PR TITLE
Harden full-body notification encryption for multi-recipient profiles

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -401,7 +401,10 @@ def register_profile_routes(app: Flask) -> None:
                         if uname.user.email_encrypt_entire_body:
                             encrypted_email_body = (form.encrypted_email_body.data or "").strip()
                             client_body_is_armored = _is_armored_pgp_message(encrypted_email_body)
-                            if client_body_is_armored:
+                            can_trust_client_encrypted_body = client_body_is_armored and isinstance(
+                                notification_encryption_target, str
+                            )
+                            if can_trust_client_encrypted_body:
                                 email_body = encrypted_email_body
                                 current_app.logger.debug("Sending email with encrypted body")
                             else:

--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -205,7 +205,7 @@ def test_contract_notifications_full_body_mode_falls_back_to_server_encrypt(
 
 
 @pytest.mark.usefixtures("_authenticated_user", "_pgp_user")
-def test_contract_notifications_full_body_mode_encrypts_for_all_enabled_recipients(
+def test_contract_notifications_full_body_mode_server_encrypts_for_all_enabled_recipients(
     client: FlaskClient, user: User
 ) -> None:
     user.enable_email_notifications = True
@@ -219,15 +219,18 @@ def test_contract_notifications_full_body_mode_encrypts_for_all_enabled_recipien
     client_body = (
         "-----BEGIN PGP MESSAGE-----\n\nclient encrypted body\n\n-----END PGP MESSAGE-----"
     )
-    field_body = "-----BEGIN PGP MESSAGE-----\n\nfield encrypted body\n\n-----END PGP MESSAGE-----"
+    server_body = "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
     with (
         patch("hushline.routes.profile.do_send_email", new=MagicMock()) as send_email_mock,
-        patch("hushline.model.field_value.encrypt_message", new=MagicMock(return_value=field_body)),
-        patch("hushline.routes.profile.encrypt_message", new=MagicMock()) as encrypt_mock,
+        patch("hushline.routes.profile.encrypt_message", new=MagicMock(return_value=server_body))
+        as encrypt_mock,
     ):
         _submit_message(client, user, encrypted_email_body=client_body)
-        encrypt_mock.assert_not_called()
-        send_email_mock.assert_called_once_with(user, client_body)
+        expected_plaintext_body = format_full_message_email_body(
+            [("Contact Method", "Signal"), ("Message", "Contract test message")]
+        )
+        encrypt_mock.assert_called_once_with(expected_plaintext_body, [user.pgp_key, "secondary-key"])
+        send_email_mock.assert_called_once_with(user, server_body)
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -213,23 +213,29 @@ def test_contract_notifications_full_body_mode_server_encrypts_for_all_enabled_r
     user.email_encrypt_entire_body = True
     user.notification_recipients.append(NotificationRecipient(position=1, enabled=True))
     user.notification_recipients[-1].email = "secondary@example.com"
-    user.notification_recipients[-1].pgp_key = "secondary-key"
+    secondary_pgp_key = f"{user.pgp_key}\n"
+    user.notification_recipients[-1].pgp_key = secondary_pgp_key
     db.session.commit()
 
     client_body = (
         "-----BEGIN PGP MESSAGE-----\n\nclient encrypted body\n\n-----END PGP MESSAGE-----"
     )
-    server_body = "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
+    server_body = (
+        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
+    )
     with (
         patch("hushline.routes.profile.do_send_email", new=MagicMock()) as send_email_mock,
-        patch("hushline.routes.profile.encrypt_message", new=MagicMock(return_value=server_body))
-        as encrypt_mock,
+        patch(
+            "hushline.routes.profile.encrypt_message", new=MagicMock(return_value=server_body)
+        ) as encrypt_mock,
     ):
         _submit_message(client, user, encrypted_email_body=client_body)
         expected_plaintext_body = format_full_message_email_body(
             [("Contact Method", "Signal"), ("Message", "Contract test message")]
         )
-        encrypt_mock.assert_called_once_with(expected_plaintext_body, [user.pgp_key, "secondary-key"])
+        encrypt_mock.assert_called_once_with(
+            expected_plaintext_body, [user.pgp_key, secondary_pgp_key]
+        )
         send_email_mock.assert_called_once_with(user, server_body)
 
 

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -348,14 +348,13 @@ def test_notifications_full_body_encryption_embedded_markers_use_server_fallback
 @pytest.mark.usefixtures("_authenticated_user")
 @pytest.mark.usefixtures("_pgp_user")
 @patch("hushline.routes.profile.encrypt_message")
-def test_notifications_full_body_encryption_prefers_client_body_for_all_enabled_recipients(
+def test_notifications_full_body_encryption_prefers_server_encryption_for_all_enabled_recipients(
     mock_encrypt_message: MagicMock,
-    app: Flask,
+    _app: Flask,
     client: FlaskClient,
     user: User,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _configure_default_smtp(app)
+    _configure_default_smtp(_app)
     user.enable_email_notifications = True
     user.email_include_message_content = True
     user.email_encrypt_entire_body = True
@@ -366,10 +365,10 @@ def test_notifications_full_body_encryption_prefers_client_body_for_all_enabled_
     client_encrypted_email_body = (
         "-----BEGIN PGP MESSAGE-----\n\nclient encrypted body\n\n-----END PGP MESSAGE-----"
     )
-    create_smtp_config = MagicMock(return_value=MagicMock())
-    send_email = MagicMock()
-    monkeypatch.setattr("hushline.routes.common.create_smtp_config", create_smtp_config)
-    monkeypatch.setattr("hushline.routes.common.send_email", send_email)
+    server_encrypted_email_body = (
+        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
+    )
+    mock_encrypt_message.return_value = server_encrypted_email_body
 
     response = client.post(
         url_for("profile", username=user.primary_username.username),
@@ -383,16 +382,13 @@ def test_notifications_full_body_encryption_prefers_client_body_for_all_enabled_
     )
 
     assert response.status_code == 200, response.text
-    mock_encrypt_message.assert_not_called()
-    assert [call.args[0] for call in send_email.call_args_list] == [
-        "primary@example.com",
-        "secondary@example.com",
-    ]
-    assert [call.args[2] for call in send_email.call_args_list] == [
-        client_encrypted_email_body,
-        client_encrypted_email_body,
-    ]
-    create_smtp_config.assert_called_once()
+    expected_fallback_body = format_full_message_email_body(
+        [("Contact Method", msg_contact_method), ("Message", msg_content)]
+    )
+    mock_encrypt_message.assert_called_once_with(
+        expected_fallback_body, [user.pgp_key, "secondary-key"]
+    )
+    mock_do_send_email.assert_called_once_with(user, server_encrypted_email_body)
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -459,13 +455,11 @@ def test_notifications_full_body_encryption_server_fallback(
 
 @pytest.mark.usefixtures("_authenticated_user")
 @pytest.mark.usefixtures("_pgp_user")
-@patch("hushline.model.field_value.encrypt_message")
 @patch("hushline.routes.profile.encrypt_message")
 @patch("hushline.routes.profile.do_send_email")
 def test_notifications_full_body_encryption_uses_all_enabled_recipient_keys(
     mock_do_send_email: MagicMock,
     mock_encrypt_message: MagicMock,
-    mock_field_value_encrypt_message: MagicMock,
     client: FlaskClient,
     user: User,
 ) -> None:
@@ -480,9 +474,10 @@ def test_notifications_full_body_encryption_uses_all_enabled_recipient_keys(
     client_encrypted_email_body = (
         "-----BEGIN PGP MESSAGE-----\n\nclient encrypted body\n\n-----END PGP MESSAGE-----"
     )
-    mock_field_value_encrypt_message.return_value = (
-        "-----BEGIN PGP MESSAGE-----\n\nfield encrypted body\n\n-----END PGP MESSAGE-----"
+    server_encrypted_email_body = (
+        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
     )
+    mock_encrypt_message.return_value = server_encrypted_email_body
 
     response = client.post(
         url_for("profile", username=user.primary_username.username),
@@ -496,5 +491,10 @@ def test_notifications_full_body_encryption_uses_all_enabled_recipient_keys(
     )
 
     assert response.status_code == 200, response.text
-    mock_encrypt_message.assert_not_called()
-    mock_do_send_email.assert_called_once_with(user, client_encrypted_email_body)
+    expected_fallback_body = format_full_message_email_body(
+        [("Contact Method", msg_contact_method), ("Message", msg_content)]
+    )
+    mock_encrypt_message.assert_called_once_with(
+        expected_fallback_body, [user.pgp_key, "secondary-key"]
+    )
+    mock_do_send_email.assert_called_once_with(user, server_encrypted_email_body)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -471,7 +471,8 @@ def test_notifications_full_body_encryption_uses_all_enabled_recipient_keys(
     user.email_encrypt_entire_body = True
     user.notification_recipients.append(NotificationRecipient(position=1, enabled=True))
     user.notification_recipients[-1].email = "secondary@example.com"
-    user.notification_recipients[-1].pgp_key = "secondary-key"
+    secondary_pgp_key = f"{user.pgp_key}\n"
+    user.notification_recipients[-1].pgp_key = secondary_pgp_key
     db.session.commit()
 
     client_encrypted_email_body = (
@@ -498,6 +499,6 @@ def test_notifications_full_body_encryption_uses_all_enabled_recipient_keys(
         [("Contact Method", msg_contact_method), ("Message", msg_content)]
     )
     mock_encrypt_message.assert_called_once_with(
-        expected_fallback_body, [user.pgp_key, "secondary-key"]
+        expected_fallback_body, [user.pgp_key, secondary_pgp_key]
     )
     mock_do_send_email.assert_called_once_with(user, server_encrypted_email_body)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -348,18 +348,21 @@ def test_notifications_full_body_encryption_embedded_markers_use_server_fallback
 @pytest.mark.usefixtures("_authenticated_user")
 @pytest.mark.usefixtures("_pgp_user")
 @patch("hushline.routes.profile.encrypt_message")
+@patch("hushline.routes.profile.do_send_email")
 def test_notifications_full_body_encryption_prefers_server_encryption_for_all_enabled_recipients(
+    mock_do_send_email: MagicMock,
     mock_encrypt_message: MagicMock,
-    _app: Flask,
+    app: Flask,
     client: FlaskClient,
     user: User,
 ) -> None:
-    _configure_default_smtp(_app)
+    _configure_default_smtp(app)
     user.enable_email_notifications = True
     user.email_include_message_content = True
     user.email_encrypt_entire_body = True
     user.email = "primary@example.com"
-    _add_secondary_recipient(user)
+    secondary_pgp_key = f"{user.pgp_key}\n"
+    _add_secondary_recipient(user, secondary_pgp_key)
     db.session.commit()
 
     client_encrypted_email_body = (
@@ -386,7 +389,7 @@ def test_notifications_full_body_encryption_prefers_server_encryption_for_all_en
         [("Contact Method", msg_contact_method), ("Message", msg_content)]
     )
     mock_encrypt_message.assert_called_once_with(
-        expected_fallback_body, [user.pgp_key, "secondary-key"]
+        expected_fallback_body, [user.pgp_key, secondary_pgp_key]
     )
     mock_do_send_email.assert_called_once_with(user, server_encrypted_email_body)
 


### PR DESCRIPTION
### Motivation
- Prevent clients from bypassing server-side encryption for notification emails in multi-recipient profiles by submitting arbitrary PGP-armored blobs that are not actually encrypted for all recipients.
- Preserve the existing behavior that allows trusting a client-provided encrypted body when there is a single, verified recipient key.

### Description
- Require that client-provided `encrypted_email_body` is trusted only when the `notification_encryption_target` is a single recipient key (`str`) by adding a `can_trust_client_encrypted_body` guard around that code path in `hushline/routes/profile.py`.
- For multi-recipient notification configurations (list of keys) force the server to use the server-side encryption fallback (`encrypt_message`) with the list of recipient keys instead of accepting client-supplied armored blocks.
- Update tests in `tests/test_notifications.py` and `tests/test_behavior_contracts.py` to assert that server-side encryption is used when multiple notification recipients are enabled and to reflect the adjusted expected behavior and function names.

### Testing
- Ran `make lint` locally but it failed in this environment due to missing Docker (`docker: not found`).
- Ran targeted pytest for the modified notification/contract tests with `pytest -q <tests>` but runs failed because the test environment could not resolve the configured Postgres host (`postgres`), so DB-backed tests did not complete.
- Unit/test changes were added to lock in the intended behavior (server-side encryption for multi-recipient full-body notifications) and should pass in CI where Docker and the test DB are available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ffa0538cac832f8374082a07a29c1d)