### PR TITLE
Harden embed origin normalization against CSP delimiter bypass

### DIFF
--- a/hushline/model/username.py
+++ b/hushline/model/username.py
@@ -28,10 +28,12 @@ class ExtraField:
 
 def normalize_embed_origin(origin: str) -> str:
     stripped_origin = origin.strip()
+    csp_delimiters = (";", " ", "\t", "\n", "\f", "\r")
     parsed = urlsplit(stripped_origin)
     if (
         not stripped_origin
         or stripped_origin != origin
+        or any(delimiter in stripped_origin for delimiter in csp_delimiters)
         or "*" in stripped_origin
         or parsed.scheme not in {"http", "https"}
         or not parsed.netloc
@@ -55,8 +57,6 @@ def normalize_embed_origin(origin: str) -> str:
     host = parsed.hostname.lower()
     if "*" in host:
         raise ValueError("Embed origins cannot contain wildcards.")
-    if any(delimiter in host for delimiter in (";", " ", "\t", "\r", "\n")):
-        raise ValueError("Embed origins cannot contain CSP delimiter characters.")
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
 

--- a/hushline/model/username.py
+++ b/hushline/model/username.py
@@ -55,6 +55,8 @@ def normalize_embed_origin(origin: str) -> str:
     host = parsed.hostname.lower()
     if "*" in host:
         raise ValueError("Embed origins cannot contain wildcards.")
+    if any(delimiter in host for delimiter in (";", " ", "\t", "\r", "\n")):
+        raise ValueError("Embed origins cannot contain CSP delimiter characters.")
     if ":" in host and not host.startswith("["):
         host = f"[{host}]"
 

--- a/tests/test_embeddable_forms_model.py
+++ b/tests/test_embeddable_forms_model.py
@@ -110,6 +110,10 @@ def test_alias_embed_opt_in_is_independent_from_primary_profile(
         "https://tips.example:",
         "http://tips.example;.onion",
         "http://tips.example .onion",
+        "http://tips.example\t.onion",
+        "http://tips.example\n.onion",
+        "http://tips.example\f.onion",
+        "http://tips.example\r.onion",
     ],
 )
 def test_embed_allowed_origins_reject_invalid_origin_rules(user: User, origin: str) -> None:

--- a/tests/test_embeddable_forms_model.py
+++ b/tests/test_embeddable_forms_model.py
@@ -108,6 +108,8 @@ def test_alias_embed_opt_in_is_independent_from_primary_profile(
         "https://tips.example#fragment",
         "https://user:pass@tips.example",
         "https://tips.example:",
+        "http://tips.example;.onion",
+        "http://tips.example .onion",
     ],
 )
 def test_embed_allowed_origins_reject_invalid_origin_rules(user: User, origin: str) -> None:


### PR DESCRIPTION
### Motivation
- Prevent a bypass of the HTTP-embed restriction where hostnames containing CSP delimiter characters (for example `http://tips.example;.onion`) could satisfy the `.onion` exception and cause unintended CSP `frame-ancestors` parsing.

### Description
- Reject CSP delimiter characters in embed-origin hostnames by adding a check in `normalize_embed_origin` (`hushline/model/username.py`) that raises `ValueError` if the hostname contains any of `;`, ASCII whitespace characters (space, tab, CR, LF); add regression inputs to `tests/test_embeddable_forms_model.py` for `http://tips.example;.onion` and `http://tips.example .onion` to ensure they are rejected.

### Testing
- Ran targeted unit tests with `pytest -q tests/test_embeddable_forms_model.py -k 'normalization_canonicalizes_host_and_ports or rejects_non_exception_http_origins'`, which passed; running the full `pytest -q tests/test_embeddable_forms_model.py` in this environment failed during fixture setup due to an inability to resolve the `postgres` host (DB connection error), so full-suite verification should be performed in CI or a compose-backed environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69ffa1dad948832fa923935aa17111a7)