### PR TITLE
Update approved model README reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ Quick summary:
 - AI-first is allowed for low-risk work such as scoped docs/process edits and isolated low-risk implementation tasks with clear rollback.
 - If scope expands into high-risk areas (for example DB/auth/env/security), ownership immediately escalates to human-first.
 - Ownership mode is tracked (`human-first` vs `ai-first`) with a quarterly operating target of roughly 70/30.
-- Approved coding model policy is defined in [`AGENTS.md`](./AGENTS.md). As of 2026-02-13, the minimum approved coding model is `gpt-5.4 high`.
+- Approved coding model policy is defined in [`AGENTS.md`](./AGENTS.md). As of 2026-05-11, the minimum approved coding model is `gpt-5.5 high`.
 
 ## Contributor Checklist
 


### PR DESCRIPTION
## What changed

- Updated the README contributor checklist to reference the current approved coding model policy: `gpt-5.5 high`.
- Aligned the date in the README note with the current AGENTS.md policy update.

## Why

The active repository policy in `AGENTS.md` now approves `gpt-5.5 high`, but the README still referenced the older `gpt-5.4 high` guidance.

## Validation

- `make fix`
- `make lint`
- `make test` not run per maintainer direction to open this small docs PR immediately.

## Manual testing

Not applicable. This is a documentation-only policy reference update.

## Risks / follow-ups

No known product risk. This changes documentation only.