### PR TITLE
Avoid per-recipient server-side encryption fallback for field notifications

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -41,13 +41,11 @@ from hushline.model import (
     OrganizationSetting,
     Username,
 )
-from hushline.model.field_value import add_padding
 from hushline.routes.common import (
     do_send_email,
     format_full_message_email_body,
     format_message_email_fields,
     notification_email_encryption_target,
-    notification_recipient_encryption_target,
     notification_recipient_public_key_entries,
     send_email_to_user_recipients,
     show_directory_caution_badge,

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -513,29 +513,11 @@ def register_profile_routes(app: Flask) -> None:
                                         client_encrypted_value = recipient_fields.get(field_name)
                                         if client_encrypted_value:
                                             value_for_email = client_encrypted_value
-                                        elif raw_value and not _is_armored_pgp_message(raw_value):
-                                            recipient_target = (
-                                                notification_recipient_encryption_target(
-                                                    uname.user, recipient
-                                                )
-                                            )
-                                            if not recipient_target:
-                                                return plaintext_new_message_body
-                                            try:
-                                                value_for_email = encrypt_message(
-                                                    add_padding(raw_value), recipient_target
-                                                )
-                                            except (RuntimeError, TypeError, ValueError) as e:
-                                                current_app.logger.error(
-                                                    (
-                                                        "Failed to encrypt field-level "
-                                                        "notification body: %s"
-                                                    ),
-                                                    str(e),
-                                                    exc_info=True,
-                                                )
-                                                return plaintext_new_message_body
                                         elif raw_value:
+                                            current_app.logger.warning(
+                                                "Missing recipient field ciphertext; "
+                                                "sending generic notification body."
+                                            )
                                             return plaintext_new_message_body
                                     rendered_fields.append((label, value_for_email))
                                 return format_message_email_fields(rendered_fields)

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -286,6 +286,52 @@ def test_notifications_enabled_yes_content_no_encrypted_body_delivers_to_all_ena
 @pytest.mark.usefixtures("_authenticated_user")
 @pytest.mark.usefixtures("_pgp_user")
 @patch("hushline.routes.profile.encrypt_message")
+def test_notifications_multi_recipient_missing_field_ciphertext_uses_generic_body(
+    mock_encrypt_message: MagicMock,
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_default_smtp(app)
+    user.enable_email_notifications = True
+    user.email_include_message_content = True
+    user.email_encrypt_entire_body = False
+    user.email = "primary@example.com"
+    _add_secondary_recipient(user)
+    db.session.commit()
+
+    create_smtp_config = MagicMock(return_value=MagicMock())
+    send_email = MagicMock()
+    monkeypatch.setattr("hushline.routes.common.create_smtp_config", create_smtp_config)
+    monkeypatch.setattr("hushline.routes.common.send_email", send_email)
+
+    response = client.post(
+        url_for("profile", username=user.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            **get_profile_submission_data(client, user.primary_username.username),
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200, response.text
+    assert [call.args[0] for call in send_email.call_args_list] == [
+        "primary@example.com",
+        "secondary@example.com",
+    ]
+    assert [call.args[2] for call in send_email.call_args_list] == [
+        plaintext_new_message_body,
+        plaintext_new_message_body,
+    ]
+    mock_encrypt_message.assert_not_called()
+    create_smtp_config.assert_called_once()
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+@pytest.mark.usefixtures("_pgp_user")
+@patch("hushline.routes.profile.encrypt_message")
 @patch("hushline.routes.profile.do_send_email")
 def test_notifications_enabled_yes_content_yes_encrypted_body(
     mock_do_send_email: MagicMock,


### PR DESCRIPTION
### Motivation
- Close a remotely-triggerable CPU amplification path where omitting optional per-recipient ciphertext caused the server to perform `fields × recipients` synchronous PGP encryptions during a single submission. 
- Preserve confidentiality by keeping server-side fallbacks but avoid expensive per-recipient encryptions in the per-recipient email loop when client-provided ciphertext is missing. 

### Description
- Change in `hushline/routes/profile.py`: when an encrypted field is missing recipient-specific ciphertext the recipient body factory now returns the generic notification body instead of calling `encrypt_message` per recipient, and logs a warning. 
- Added a regression test `test_notifications_multi_recipient_missing_field_ciphertext_uses_generic_body` in `tests/test_notifications.py` that asserts both recipients receive the generic notification body and that `encrypt_message` is not called. 
- No changes to `send_email_to_user_recipients` behavior were made; the fix is localized to the field-level notification body construction. 

### Testing
- Added unit test `test_notifications_multi_recipient_missing_field_ciphertext_uses_generic_body` which was committed and is intended to prevent regressions. 
- Ran `pytest -q tests/test_notifications.py -k "multi_recipient_missing_field_ciphertext or no_encrypted_body_delivers_to_all_enabled_recipients"` which could not complete due to the test environment lacking a reachable Postgres host (error: `Temporary failure in name resolution`). 
- Full test suite and CI-style coverage were not executed here because the local DB/service dependencies were unavailable; the change is minimal and focused, and the new test will validate the behavior when run in CI or a fully provisioned local environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a04c5f94108832f99e866279d333d98)