### PR TITLE
Prevent duplicate notification delivery

### DIFF
--- a/hushline/email.py
+++ b/hushline/email.py
@@ -128,8 +128,10 @@ def send_email(
     retry_delay = float(current_app.config.get("SMTP_SEND_RETRY_DELAY_SEC", 2))
 
     for attempt in range(1, attempts + 1):
+        message_submission_attempted = False
         try:
             with smtp_config.smtp_login(timeout=timeout) as server:
+                message_submission_attempted = True
                 refusals = server.send_message(message)
             if refusals:
                 current_app.logger.error(f"SMTP refused recipients: {refusals}")
@@ -139,6 +141,12 @@ def send_email(
             current_app.logger.error(
                 f"Error sending email (attempt {attempt}/{attempts}): {str(e)}"
             )
+            if message_submission_attempted:
+                current_app.logger.error(
+                    "Not retrying SMTP send after message submission attempt to avoid "
+                    "duplicate delivery."
+                )
+                return False
             if attempt < attempts:
                 time.sleep(retry_delay)
                 continue

--- a/hushline/routes/common.py
+++ b/hushline/routes/common.py
@@ -136,9 +136,16 @@ def send_email_to_user_recipients(user: User, subject: str, body: RecipientEmail
         reply_to = current_app.config.get("NOTIFICATIONS_REPLY_TO") or current_app.config.get(
             "NOTIFICATIONS_ADDRESS"
         )
+        delivered_email_addresses: set[str] = set()
         for recipient in recipients:
             recipient_email = recipient.email
             if recipient_email is None:
+                continue
+            normalized_recipient_email = recipient_email.strip().casefold()
+            if normalized_recipient_email in delivered_email_addresses:
+                current_app.logger.warning(
+                    "Skipping duplicate notification recipient email for user %s", user.id
+                )
                 continue
             recipient_body = body(recipient) if callable(body) else body
             if not recipient_body:
@@ -151,6 +158,7 @@ def send_email_to_user_recipients(user: User, subject: str, body: RecipientEmail
                     smtp_config,
                     reply_to,
                 )
+                delivered_email_addresses.add(normalized_recipient_email)
             except (OSError, TypeError, ValueError, smtplib.SMTPException) as e:
                 current_app.logger.error(
                     "Error sending email to %s: %s", recipient_email, str(e), exc_info=True

--- a/hushline/routes/common.py
+++ b/hushline/routes/common.py
@@ -151,14 +151,14 @@ def send_email_to_user_recipients(user: User, subject: str, body: RecipientEmail
             if not recipient_body:
                 continue
             try:
-                send_email(
+                if send_email(
                     recipient_email,
                     subject,
                     recipient_body,
                     smtp_config,
                     reply_to,
-                )
-                delivered_email_addresses.add(normalized_recipient_email)
+                ):
+                    delivered_email_addresses.add(normalized_recipient_email)
             except (OSError, TypeError, ValueError, smtplib.SMTPException) as e:
                 current_app.logger.error(
                     "Error sending email to %s: %s", recipient_email, str(e), exc_info=True

--- a/tests/test_email.py
+++ b/tests/test_email.py
@@ -112,10 +112,24 @@ class _DummyConfig(email_mod.SMTPConfig):
         yield cast(smtplib.SMTP, self._smtp_server)
 
 
+class _FlakyLoginConfig(_DummyConfig):
+    def __init__(self, *, smtp_server: MagicMock) -> None:
+        super().__init__(smtp_server=smtp_server)
+        self._login_attempts = 0
+
+    @contextmanager
+    def smtp_login(self, timeout: int = 10) -> Generator[smtplib.SMTP, None, None]:
+        _ = timeout
+        self._login_attempts += 1
+        if self._login_attempts == 1:
+            raise smtplib.SMTPServerDisconnected("connect dropped")
+        yield cast(smtplib.SMTP, self._smtp_server)
+
+
 def test_send_email_success_and_retry(app: Flask) -> None:
     smtp_server = MagicMock()
-    smtp_server.send_message.side_effect = [smtplib.SMTPException("transient"), {}]
-    cfg = _DummyConfig(smtp_server=smtp_server)
+    smtp_server.send_message.return_value = {}
+    cfg = _FlakyLoginConfig(smtp_server=smtp_server)
 
     with (
         app.app_context(),
@@ -126,6 +140,24 @@ def test_send_email_success_and_retry(app: Flask) -> None:
         app.config["SMTP_SEND_RETRY_DELAY_SEC"] = 0
         assert email_mod.send_email("to@example.com", "subject", "body", cfg) is True
         sleep_mock.assert_called_once()
+
+
+def test_send_email_does_not_retry_after_message_submission_attempt(app: Flask) -> None:
+    smtp_server = MagicMock()
+    smtp_server.send_message.side_effect = smtplib.SMTPServerDisconnected("after DATA")
+    cfg = _DummyConfig(smtp_server=smtp_server)
+
+    with (
+        app.app_context(),
+        patch("hushline.email.is_safe_smtp_host", return_value=True),
+        patch("hushline.email.time.sleep") as sleep_mock,
+    ):
+        app.config["SMTP_SEND_ATTEMPTS"] = 3
+        app.config["SMTP_SEND_RETRY_DELAY_SEC"] = 0
+        assert email_mod.send_email("to@example.com", "subject", "body", cfg) is False
+
+    smtp_server.send_message.assert_called_once()
+    sleep_mock.assert_not_called()
 
 
 def test_send_email_recipient_refusal_returns_false(app: Flask) -> None:

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -157,6 +157,46 @@ def test_notifications_enabled_no_content_delivers_to_all_enabled_recipients(
 
 @pytest.mark.usefixtures("_authenticated_user")
 @pytest.mark.usefixtures("_pgp_user")
+def test_message_submission_deduplicates_notification_recipient_email_addresses(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _configure_default_smtp(app)
+    user.enable_email_notifications = True
+    user.email_include_message_content = False
+    user.email = "primary@example.com"
+    user.notification_recipients.append(NotificationRecipient(position=1, enabled=True))
+    user.notification_recipients[-1].email = " Primary@Example.com "
+    user.notification_recipients[-1].pgp_key = Path("tests/test_pgp_key.txt").read_text()
+    db.session.commit()
+
+    create_smtp_config = MagicMock(return_value=MagicMock())
+    send_email = MagicMock()
+    monkeypatch.setattr("hushline.routes.common.create_smtp_config", create_smtp_config)
+    monkeypatch.setattr("hushline.routes.common.send_email", send_email)
+
+    response = client.post(
+        url_for("profile", username=user.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            **get_profile_submission_data(client, user.primary_username.username),
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200, response.text
+    assert "Message submitted successfully." in response.text
+    send_email.assert_called_once()
+    assert send_email.call_args.args[0] == "primary@example.com"
+    assert send_email.call_args.args[2] == plaintext_new_message_body
+    create_smtp_config.assert_called_once()
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+@pytest.mark.usefixtures("_pgp_user")
 @patch("hushline.routes.profile.do_send_email")
 def test_notifications_enabled_yes_content_no_encrypted_body(
     mock_do_send_email: MagicMock, client: FlaskClient, user: User

--- a/tests/test_routes_common.py
+++ b/tests/test_routes_common.py
@@ -158,6 +158,39 @@ def test_do_send_email_sends_to_each_enabled_recipient(
     ]
 
 
+def test_do_send_email_deduplicates_recipient_email_addresses(
+    app: Flask,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.enable_email_notifications = True
+    user.email = "primary@example.com"
+    user.notification_recipients.append(NotificationRecipient(position=1, enabled=True))
+    user.notification_recipients[-1].email = " Primary@Example.com "
+    user.notification_recipients[-1].pgp_key = "duplicate-key"
+    user.smtp_server = None
+
+    app.config["SMTP_USERNAME"] = "default-user"
+    app.config["SMTP_SERVER"] = "smtp.default.example"
+    app.config["SMTP_PORT"] = 587
+    app.config["SMTP_PASSWORD"] = "default-pass"
+    app.config["NOTIFICATIONS_ADDRESS"] = "notify@example.com"
+    app.config["NOTIFICATIONS_REPLY_TO"] = "reply@example.com"
+    app.config["SMTP_ENCRYPTION"] = "StartTLS"
+
+    create_smtp_config = MagicMock(return_value=MagicMock())
+    send_email = MagicMock()
+    monkeypatch.setattr("hushline.routes.common.create_smtp_config", create_smtp_config)
+    monkeypatch.setattr("hushline.routes.common.send_email", send_email)
+
+    with app.app_context(), patch.object(app.logger, "warning") as warning_log:
+        routes_common.do_send_email(user, "body")
+
+    send_email.assert_called_once()
+    assert send_email.call_args.args[0] == "primary@example.com"
+    warning_log.assert_called_once()
+
+
 def test_send_email_to_user_recipients_accepts_recipient_body_factory(
     app: Flask,
     user: User,

--- a/tests/test_routes_common.py
+++ b/tests/test_routes_common.py
@@ -191,6 +191,41 @@ def test_do_send_email_deduplicates_recipient_email_addresses(
     warning_log.assert_called_once()
 
 
+def test_do_send_email_retries_duplicate_address_after_false_result(
+    app: Flask,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.enable_email_notifications = True
+    user.email = "primary@example.com"
+    user.notification_recipients.append(NotificationRecipient(position=1, enabled=True))
+    user.notification_recipients[-1].email = " Primary@Example.com "
+    user.notification_recipients[-1].pgp_key = "duplicate-key"
+    user.smtp_server = None
+
+    app.config["SMTP_USERNAME"] = "default-user"
+    app.config["SMTP_SERVER"] = "smtp.default.example"
+    app.config["SMTP_PORT"] = 587
+    app.config["SMTP_PASSWORD"] = "default-pass"
+    app.config["NOTIFICATIONS_ADDRESS"] = "notify@example.com"
+    app.config["NOTIFICATIONS_REPLY_TO"] = "reply@example.com"
+    app.config["SMTP_ENCRYPTION"] = "StartTLS"
+
+    create_smtp_config = MagicMock(return_value=MagicMock())
+    send_email = MagicMock(side_effect=[False, True])
+    monkeypatch.setattr("hushline.routes.common.create_smtp_config", create_smtp_config)
+    monkeypatch.setattr("hushline.routes.common.send_email", send_email)
+
+    with app.app_context(), patch.object(app.logger, "warning") as warning_log:
+        routes_common.do_send_email(user, "body")
+
+    assert [call.args[0] for call in send_email.call_args_list] == [
+        "primary@example.com",
+        " Primary@Example.com ",
+    ]
+    warning_log.assert_not_called()
+
+
 def test_send_email_to_user_recipients_accepts_recipient_body_factory(
     app: Flask,
     user: User,


### PR DESCRIPTION
## What changed

- Deduplicate enabled notification recipients by normalized email address before sending a notification.
- Only mark a normalized recipient address as delivered after `send_email(...)` reports success, so a later duplicate row can still be attempted after a non-raising send failure.
- Stop retrying SMTP delivery after `send_message` has been attempted, because the SMTP server may already have accepted and delivered the message.
- Added regression coverage for duplicate recipient rows on the message submission path, duplicate rows after a non-raising send failure, and SMTP post-submission retry behavior.

## Why

Messages submitted to Hush Line were confirmed to be delivered twice on multiple accounts. The delivery path had two duplicate-delivery risks: duplicate enabled recipient rows for the same mailbox, and SMTP retries after an ambiguous message submission attempt.

The follow-up review also identified that dedupe must not suppress a later duplicate row when the first send attempt returns `False` without raising.

## User impact

A submitted message should now produce at most one notification per mailbox per notification event after a successful send. Distinct notification recipients with distinct email addresses continue to receive individual notifications, and duplicate rows are still attempted if an earlier matching row did not send successfully.

## Security / privacy

- Affected data paths: message submission notifications and resend/password-reset-style calls through the shared recipient email helper.
- Disclosure content handling is unchanged.
- This reduces duplicate disclosure-notification exposure to the same mailbox while preserving existing recipient ordering and avoiding false delivery markers after failed sends.

## Validation

- `docker compose run --rm app poetry run pytest tests/test_routes_common.py::test_do_send_email_deduplicates_recipient_email_addresses tests/test_routes_common.py::test_do_send_email_retries_duplicate_address_after_false_result tests/test_routes_common.py::test_do_send_email_continues_after_single_recipient_failure -q`
- `make lint`
- `make test`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

Not applicable beyond automated regression coverage; the change is in server-side notification delivery behavior and is covered with focused route/helper/SMTP tests.

## Risks / follow-ups

SMTP failures after a message submission attempt now return failure without retrying to avoid duplicate delivery. This may reduce retry-based recovery for ambiguous SMTP errors, but prevents repeated notifications for messages that may already have been accepted by the SMTP server.