### PR TITLE
Fail fast on repeated coverage runner no-op attempts

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -324,7 +324,7 @@ Current operational state:
 8. Run a machine-readable coverage scan:
    - `docker compose run --rm app poetry run pytest --cov hushline --cov-report json:/app/.coverage-runner/coverage.json --cov-report term-missing -q --skip-local-only`
 9. Exit early when coverage already meets target (`100%` by default).
-10. Build a Codex prompt from the uncovered-line summary and run a bounded implementation loop.
+10. Build a Codex prompt from the uncovered-line summary and run a small bounded implementation loop. The runner stops early when Codex repeatedly fails or leaves no usable non-log changes, rather than repeating the same coverage prompt.
 11. After each Codex attempt, run:
 
 - `make lint`
@@ -356,8 +356,10 @@ If the host reuses the same SSH signing setup as the issue runner, no additional
 
 - `HUSHLINE_COVERAGE_BRANCH_NAME` (default `codex/daily-coverage`)
 - `HUSHLINE_COVERAGE_TARGET_PERCENT` (default `100`)
-- `HUSHLINE_COVERAGE_MAX_ATTEMPTS` (default `10`)
-- `HUSHLINE_COVERAGE_MAX_FIX_ATTEMPTS` (default `8`)
+- `HUSHLINE_COVERAGE_MAX_ATTEMPTS` (default `2`)
+- `HUSHLINE_COVERAGE_MAX_FIX_ATTEMPTS` (default `3`)
+- `HUSHLINE_COVERAGE_MAX_CODEX_FAILURES` (default `2`)
+- `HUSHLINE_COVERAGE_MAX_NO_CHANGE_ATTEMPTS` (default `1`)
 - `HUSHLINE_COVERAGE_SUMMARY_LIMIT` (default `15`)
 - `HUSHLINE_REPO_DIR` (default the repository checkout containing `scripts/agent_daily_coverage_runner.sh`)
 - `HUSHLINE_REPO_SLUG` (default `scidsg/hushline`)

--- a/scripts/agent_daily_coverage_runner.sh
+++ b/scripts/agent_daily_coverage_runner.sh
@@ -46,8 +46,10 @@ BRANCH_NAME="${HUSHLINE_COVERAGE_BRANCH_NAME:-codex/daily-coverage}"
 CODEX_MODEL="${HUSHLINE_CODEX_MODEL:-gpt-5.5}"
 CODEX_REASONING_EFFORT="${HUSHLINE_CODEX_REASONING_EFFORT:-high}"
 HOST_PORTS_TO_CLEAR="${HUSHLINE_DAILY_KILL_PORTS:-4566 4571 5432 8080}"
-MAX_COVERAGE_ATTEMPTS="${HUSHLINE_COVERAGE_MAX_ATTEMPTS:-10}"
-MAX_FIX_ATTEMPTS="${HUSHLINE_COVERAGE_MAX_FIX_ATTEMPTS:-8}"
+MAX_COVERAGE_ATTEMPTS="${HUSHLINE_COVERAGE_MAX_ATTEMPTS:-2}"
+MAX_FIX_ATTEMPTS="${HUSHLINE_COVERAGE_MAX_FIX_ATTEMPTS:-3}"
+MAX_CODEX_FAILURES="${HUSHLINE_COVERAGE_MAX_CODEX_FAILURES:-2}"
+MAX_NO_CHANGE_ATTEMPTS="${HUSHLINE_COVERAGE_MAX_NO_CHANGE_ATTEMPTS:-1}"
 RUNTIME_BOOTSTRAP_ATTEMPTS="${HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_ATTEMPTS:-3}"
 RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS="${HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS:-10}"
 POST_PR_FEEDBACK_DELAY_SECONDS="${HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS:-900}"
@@ -964,24 +966,34 @@ run_codex_from_prompt() {
 run_coverage_attempt_loop() {
   local attempt=1
   local failure_context=""
+  local consecutive_codex_failures=0
+  local no_change_attempts=0
 
   while (( attempt <= MAX_COVERAGE_ATTEMPTS )); do
     echo "==> Codex coverage attempt $attempt"
     if ! run_codex_from_prompt; then
+      consecutive_codex_failures=$((consecutive_codex_failures + 1))
+      if (( consecutive_codex_failures >= MAX_CODEX_FAILURES )); then
+        echo "Blocked: Codex failed ${consecutive_codex_failures} consecutive coverage attempt(s); stopping instead of repeating the same coverage prompt." >&2
+        return 1
+      fi
       echo "Warning: Codex coverage attempt $attempt failed; continuing with the next attempt." >&2
       attempt=$((attempt + 1))
       continue
     fi
+    consecutive_codex_failures=0
 
     if ! has_non_log_changes; then
       emit_codex_no_change_diagnostic "$attempt"
-      if (( attempt == MAX_COVERAGE_ATTEMPTS )); then
-        echo "Blocked: Codex produced no usable non-log changes after $MAX_COVERAGE_ATTEMPTS attempt(s)." >&2
+      no_change_attempts=$((no_change_attempts + 1))
+      if (( no_change_attempts >= MAX_NO_CHANGE_ATTEMPTS )); then
+        echo "Blocked: Codex produced no usable non-log changes after ${no_change_attempts} attempt(s); stopping instead of repeating the same coverage prompt." >&2
         return 1
       fi
       attempt=$((attempt + 1))
       continue
     fi
+    no_change_attempts=0
 
     local fix_attempt=1
     while (( fix_attempt <= MAX_FIX_ATTEMPTS )); do
@@ -1005,7 +1017,14 @@ run_coverage_attempt_loop() {
       fi
       build_fix_prompt "$BRANCH_NAME" "$failure_context" "$FAILURE_SIGNATURE" "$REPEATED_FAILURE_COUNT"
       if ! run_codex_from_prompt; then
+        consecutive_codex_failures=$((consecutive_codex_failures + 1))
+        if (( consecutive_codex_failures >= MAX_CODEX_FAILURES )); then
+          echo "Blocked: Codex failed ${consecutive_codex_failures} consecutive validation self-heal attempt(s); stopping instead of repeating failing prompts." >&2
+          return 1
+        fi
         echo "Warning: Codex validation self-heal attempt $fix_attempt failed; continuing." >&2
+      else
+        consecutive_codex_failures=0
       fi
       fix_attempt=$((fix_attempt + 1))
     done
@@ -1228,6 +1247,8 @@ main() {
 
   require_positive_integer "HUSHLINE_COVERAGE_MAX_ATTEMPTS" "$MAX_COVERAGE_ATTEMPTS"
   require_positive_integer "HUSHLINE_COVERAGE_MAX_FIX_ATTEMPTS" "$MAX_FIX_ATTEMPTS"
+  require_positive_integer "HUSHLINE_COVERAGE_MAX_CODEX_FAILURES" "$MAX_CODEX_FAILURES"
+  require_positive_integer "HUSHLINE_COVERAGE_MAX_NO_CHANGE_ATTEMPTS" "$MAX_NO_CHANGE_ATTEMPTS"
   require_positive_integer "HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_ATTEMPTS" "$RUNTIME_BOOTSTRAP_ATTEMPTS"
   require_positive_integer "HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS" "$RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS"
 

--- a/tests/test_agent_daily_coverage_runner.py
+++ b/tests/test_agent_daily_coverage_runner.py
@@ -43,6 +43,22 @@ printf '%s %s\\n' "$CODEX_MODEL" "$CODEX_REASONING_EFFORT"
     assert result.stdout.strip() == "gpt-5.5 high"
 
 
+def test_runner_defaults_to_small_coverage_retry_budget() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+printf '%s %s %s %s\\n' \
+  "$MAX_COVERAGE_ATTEMPTS" \
+  "$MAX_FIX_ATTEMPTS" \
+  "$MAX_CODEX_FAILURES" \
+  "$MAX_NO_CHANGE_ATTEMPTS"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "2 3 2 1"
+
+
 def test_coverage_report_summary_text_sorts_and_compresses_ranges(tmp_path: Path) -> None:
     report_path = tmp_path / "coverage.json"
     report_path.write_text(
@@ -437,6 +453,63 @@ run_coverage_attempt_loop
     assert "Warning: Codex coverage attempt 1 failed" in result.stderr
     calls = call_log.read_text(encoding="utf-8").splitlines()
     assert calls == ["codex-1", "codex-2", "validate"]
+
+
+def test_coverage_attempt_loop_stops_after_consecutive_codex_failures(
+    tmp_path: Path,
+) -> None:
+    call_log = tmp_path / "calls.txt"
+    check_log = tmp_path / "check.log"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CHECK_LOG_FILE={shlex.quote(str(check_log))}
+MAX_COVERAGE_ATTEMPTS=5
+MAX_CODEX_FAILURES=2
+MAX_NO_CHANGE_ATTEMPTS=1
+run_codex_from_prompt() {{
+  printf 'codex\\n' >> {shlex.quote(str(call_log))}
+  set +e
+  return 1
+}}
+run_coverage_attempt_loop
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 1
+    assert "stopping instead of repeating the same coverage prompt" in result.stderr
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert calls == ["codex", "codex"]
+
+
+def test_coverage_attempt_loop_stops_after_no_change_attempt(tmp_path: Path) -> None:
+    call_log = tmp_path / "calls.txt"
+    check_log = tmp_path / "check.log"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CHECK_LOG_FILE={shlex.quote(str(check_log))}
+MAX_COVERAGE_ATTEMPTS=5
+MAX_CODEX_FAILURES=2
+MAX_NO_CHANGE_ATTEMPTS=1
+run_codex_from_prompt() {{
+  printf 'codex\\n' >> {shlex.quote(str(call_log))}
+  return 0
+}}
+has_non_log_changes() {{ return 1; }}
+emit_codex_no_change_diagnostic() {{
+  printf 'no-change-%s\\n' "$1" >> {shlex.quote(str(call_log))}
+}}
+run_coverage_attempt_loop
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 1
+    assert "stopping instead of repeating the same coverage prompt" in result.stderr
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert calls == ["codex", "no-change-1"]
 
 
 def test_local_validation_applies_deterministic_fix_before_retrying_tests(tmp_path: Path) -> None:


### PR DESCRIPTION
## What Changed

- Reduced the daily coverage runner default retry budget from `10` coverage attempts / `8` fix attempts to `2` / `3`.
- Added explicit guards for repeated Codex failures and no-change Codex runs so the runner stops with an actionable error instead of repeating the same prompt.
- Documented the new retry controls and added shell-level tests for the fail-fast behavior.
- Created follow-up coverage ticket: #1961.

## Why

The May 15 coverage runner did fire, but it burned through ten attempts after Codex began failing/no-oping. For a coverage-only maintenance runner, repeated identical attempts hide the real failure mode and waste model/runtime budget.

## Validation

- `docker compose run --rm app poetry run pytest tests/test_agent_daily_coverage_runner.py -q`
- `make lint`
- `make test`
  - First run failed after Postgres reported `No space left on device` while creating per-test databases.
  - Ran `docker compose down -v --remove-orphans` and reran successfully.
- `make audit-python`
- `make audit-node-runtime`

## Manual Testing

- Review a future coverage runner log and confirm repeated Codex failures stop after the configured failure budget.
- Review a future no-change coverage run and confirm it exits after the configured no-change budget rather than repeating the same prompt.

## Risks / Follow-ups

- A truly transient Codex failure now gets fewer retries by default. The budgets remain configurable via environment variables.
- Remaining app coverage gaps are tracked separately in #1961.