### PR TITLE
Harden public directory report publishing

### DIFF
--- a/.github/workflows/public-directory-weekly-report.yml
+++ b/.github/workflows/public-directory-weekly-report.yml
@@ -49,6 +49,7 @@ jobs:
           mkdir -p /tmp/public-directory-report
           REPORT_DATE="$(date -u +%F)"
           REPORT_TIMESTAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+          echo "REPORT_TIMESTAMP=${REPORT_TIMESTAMP}" >> "$GITHUB_ENV"
 
           ARGS=(
             --current /tmp/public-directory-current.json
@@ -92,9 +93,16 @@ jobs:
       - name: Commit and open stats PR
         run: |
           set -euo pipefail
-          REPORT_TIMESTAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
           export GH_TOKEN="${{ secrets.HUSHLINE_WEEKLY_REPORT }}"
           cd hushline-stats
+
+          git fetch origin "+refs/heads/${STATS_DEFAULT_BRANCH}:refs/remotes/origin/${STATS_DEFAULT_BRANCH}"
+          stats_branch_exists=false
+          if git ls-remote --exit-code --heads origin "${STATS_BRANCH}" >/dev/null; then
+            stats_branch_exists=true
+            git fetch origin "+refs/heads/${STATS_BRANCH}:refs/remotes/origin/${STATS_BRANCH}"
+          fi
+
           git checkout -B "${STATS_BRANCH}" "origin/${STATS_DEFAULT_BRANCH}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -104,7 +112,29 @@ jobs:
             exit 0
           fi
           git commit -m "Update public directory snapshot report for ${REPORT_TIMESTAMP}"
-          git push --force-with-lease origin "HEAD:${STATS_BRANCH}"
+
+          push_stats_branch() {
+            if [ "$stats_branch_exists" = "true" ] && \
+              git show-ref --verify --quiet "refs/remotes/origin/${STATS_BRANCH}"
+            then
+              git push \
+                --force-with-lease=refs/heads/"${STATS_BRANCH}" \
+                origin "HEAD:${STATS_BRANCH}"
+            else
+              git push origin "HEAD:${STATS_BRANCH}"
+            fi
+          }
+
+          if ! push_stats_branch; then
+            echo "Stats branch push failed; refreshing remote lease and retrying once."
+            if git ls-remote --exit-code --heads origin "${STATS_BRANCH}" >/dev/null; then
+              stats_branch_exists=true
+              git fetch origin "+refs/heads/${STATS_BRANCH}:refs/remotes/origin/${STATS_BRANCH}"
+            else
+              stats_branch_exists=false
+            fi
+            push_stats_branch
+          fi
 
           pr_title="Update public directory snapshot report for ${REPORT_TIMESTAMP}"
           stats_owner="${STATS_REPOSITORY%%/*}"

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -36,6 +36,31 @@ def test_cross_repo_auto_merge_workflows_use_owner_qualified_pr_heads() -> None:
         assert workflow_text.count(head_filter) == expected_count
 
 
+def test_public_directory_weekly_report_refreshes_stats_branch_lease_before_push() -> None:
+    workflow_text = _workflow_text(".github/workflows/public-directory-weekly-report.yml")
+    build_section = workflow_text.split("      - name: Build weekly directory report", 1)[1].split(
+        "      - name: Publish workflow summary", 1
+    )[0]
+    publish_section = workflow_text.split("      - name: Commit and open stats PR", 1)[1]
+
+    assert 'echo "REPORT_TIMESTAMP=${REPORT_TIMESTAMP}" >> "$GITHUB_ENV"' in build_section
+    assert 'REPORT_TIMESTAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"' not in publish_section
+    assert (
+        'git fetch origin "+refs/heads/${STATS_DEFAULT_BRANCH}:'
+        'refs/remotes/origin/${STATS_DEFAULT_BRANCH}"' in publish_section
+    )
+    assert "stats_branch_exists=false" in publish_section
+    assert 'git ls-remote --exit-code --heads origin "${STATS_BRANCH}"' in publish_section
+    assert (
+        'git fetch origin "+refs/heads/${STATS_BRANCH}:'
+        'refs/remotes/origin/${STATS_BRANCH}"' in publish_section
+    )
+    assert "push_stats_branch() {" in publish_section
+    assert '--force-with-lease=refs/heads/"${STATS_BRANCH}"' in publish_section
+    assert 'git push origin "HEAD:${STATS_BRANCH}"' in publish_section
+    assert "Stats branch push failed; refreshing remote lease and retrying once." in publish_section
+
+
 def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> None:
     workflow_text = _workflow_text(".github/workflows/publish-docs-screenshots.yml")
     artifact_section = workflow_text.split("      - name: Download screenshot artifact", 1)[


### PR DESCRIPTION
## Summary
- Refresh the stats repo default branch and existing automation branch before publishing.
- Push the stats automation branch with an explicit force-with-lease and one refresh-and-retry path.
- Reuse the report timestamp from the build step so generated files, commit title, and PR body stay aligned.
- Add a workflow regression test for the lease refresh behavior.

## Root Cause
The latest weekly public directory report run, and the previous scheduled run, generated the report successfully but failed in the stats publish step. The stats checkout only had default-branch refs, so pushing to the pre-existing `automation/public-directory-report` branch with `--force-with-lease` failed with stale lease information.

## Validation
- `poetry run pytest tests/test_workflow_pr_head_qualification.py -q`
- `make lint`
- `make test` was started and then interrupted at the user's request while opening this PR; it reached about 9% before stopping with exit 130.

## Manual Testing
- Not applicable locally; this hardens a GitHub Actions cross-repository publish path that requires repository secrets and the stats repository token.

## Risks / Follow-up
- The next scheduled or manual weekly report run should confirm the stats branch push and auto-merge path now proceed past the stale lease failure.