### PR TITLE
Harden docs screenshots workflow against token exfiltration

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,6 @@
+paths:
+  .github/workflows/docs-screenshots.yml:
+    ignore:
+      # GitHub documents these reusable-workflow identity properties, but
+      # actionlint 1.7.x does not include them in its job context schema yet.
+      - 'property "workflow_(repository|sha)" is not defined in object type .+'

--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -52,6 +52,15 @@ jobs:
             echo "Skipping docs screenshots: docs/screenshots/scenes.json not found."
           fi
 
+      - name: Check out trusted workflow scripts
+        if: steps.manifest.outputs.enabled == 'true'
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          ref: ${{ github.workflow_sha }}
+          path: .trusted-workflow
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Set up Docker Buildx
         if: ${{ github.event_name == 'release' && steps.manifest.outputs.enabled == 'true' }}
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
@@ -165,7 +174,7 @@ jobs:
             "$CLONE_URL" \
             "$WEBSITE_DIR"
 
-          python3 scripts/resolve-doc-screenshot-allowlist.py \
+          python3 .trusted-workflow/scripts/resolve-doc-screenshot-allowlist.py \
             --hushline-dir "$GITHUB_WORKSPACE" \
             --website-dir "$WEBSITE_DIR" \
             --screenshot-root src/assets/img/screenshots \

--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -56,7 +56,8 @@ jobs:
         if: steps.manifest.outputs.enabled == 'true'
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
-          ref: ${{ github.workflow_sha }}
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
           path: .trusted-workflow
           fetch-depth: 1
           persist-credentials: false

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -108,12 +108,18 @@ def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> 
     checkout_section = capture_workflow_text.split(
         "      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5", 1
     )[1].split("      - name: Check screenshot manifest", 1)[0]
+    trusted_checkout_section = capture_workflow_text.split(
+        "      - name: Check out trusted workflow scripts", 1
+    )[1].split("      - name: Set up Docker Buildx", 1)[0]
     website_section = publish_workflow_text.split(
         "      - name: Publish current screenshots to hushline-website", 1
     )[1]
 
     assert "fetch-depth: 1" in checkout_section
     assert "fetch-depth: 0" not in checkout_section
+    assert "repository: ${{ job.workflow_repository }}" in trusted_checkout_section
+    assert "ref: ${{ job.workflow_sha }}" in trusted_checkout_section
+    assert "ref: ${{ github.workflow_sha }}" not in trusted_checkout_section
     assert "Resolve screenshot capture manifest" in capture_workflow_text
     assert '--manifest-out "$CAPTURE_MANIFEST"' in capture_workflow_text
     assert '--output "$CAPTURE_FILES"' in capture_workflow_text


### PR DESCRIPTION
### Motivation
- Prevent a secret-exposure vulnerability where the allowlist resolver was executed from a caller-selected `release_ref` (an untrusted checkout) while `WEBSITE_READ_TOKEN` was present, which could allow a malicious ref to read and exfiltrate the token.

### Description
- Checkout a trusted copy of workflow scripts at `github.workflow_sha` into `.trusted-workflow` and invoke the allowlist resolver as `.trusted-workflow/scripts/resolve-doc-screenshot-allowlist.py` instead of running the script from the caller-controlled release checkout, preserving the existing manifest/capture flow.

### Testing
- Ran `pytest -q tests/test_workflow_pr_head_qualification.py -k screenshots_workflow_publishes_current_folder_to_website_directly` which completed successfully (`1 passed, 6 deselected`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a08e5b45c70832fb9776f5f4dedbbfb)