### PR TITLE
Weekly Agent Report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,10 @@ refresh-globaleaks-listings: ## Refresh GlobaLeaks instance artifact from public
 refresh-newsroom-listings: ## Refresh newsroom directory artifact from public source pages
 	$(CMD) poetry run python ./scripts/refresh_newsroom_directory_listings.py $(REFRESH_NEWSROOM_ARGS)
 
+.PHONY: weekly-agent-report
+weekly-agent-report: ## Send the weekly local agent runner report with Mail.app
+	./scripts/weekly_agent_report_runner.py
+
 .PHONY: audit-python
 audit-python: ## Run Python dependency audit (CI-equivalent)
 	$(CMD) bash -lc 'poetry self add poetry-plugin-export && poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt && python -m pip install --disable-pip-version-check pip-audit==2.10.0 && pip-audit -r /tmp/requirements.txt'

--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -8,6 +8,7 @@ This document tracks the current state of the repo-managed agent automation used
 | ---------------------------------------- | ------------------------------ | ------------------------------------------------------- | -------------------------------- |
 | `scripts/agent_daily_issue_runner.sh`    | GitHub issue implementation    | Active, branch/PR automation in place                   | issue-specific branches and PRs  |
 | `scripts/agent_daily_coverage_runner.sh` | Coverage remediation           | Active, branch/PR automation in place                   | `codex/daily-coverage` style PRs |
+| `scripts/weekly_agent_report_runner.py`  | Weekly local agent reporting   | Active, local Mail.app delivery                         | email to `glenn@hushline.app`    |
 | `scripts/agent_issue_bootstrap.sh`       | Local runtime/bootstrap helper | Active, manual helper used by issue and local workflows | local Docker/bootstrap only      |
 
 The repository does not currently include runner scripts for the social or docs launch agents listed below. Those host jobs exist outside this repository and should be documented here only as installed host context, not as repo-managed automation.
@@ -232,11 +233,43 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 - `make`
 - `node`
 - `lsof` (optional; used for port cleanup)
+- `osascript` and configured macOS Mail.app account `weekly-report@hushline.app` for the weekly agent report runner
 
 ## Manual Run
 
 ```bash
 ./scripts/agent_daily_issue_runner.sh
+```
+
+## Weekly Agent Report Runner
+
+Script: `scripts/weekly_agent_report_runner.py`
+
+This runner scans the local runner logs monitored on this machine and builds a plain-text `Weekly Agent Report`. It sends through the native macOS Mail app.
+
+Default log files:
+
+- `~/.codex/logs/hushline-agent-runner.log`
+- `~/tor-code-agent/logs/tor-agent.err.log`
+- `../hushline-social/logs/social-daily.log`
+
+Delivery is fixed in code:
+
+- From: `weekly-report@hushline.app`
+- To: `glenn@hushline.app`
+
+Additional log files can be supplied with repeated `--log-file` arguments or the colon-separated `HUSHLINE_WEEKLY_AGENT_REPORT_LOG_FILES` environment variable. The runner summarizes completed work, skipped/no-op checks, work/check activity, and attention items without embedding full log transcripts in email.
+
+Manual dry run:
+
+```bash
+./scripts/weekly_agent_report_runner.py --dry-run
+```
+
+Send report:
+
+```bash
+make weekly-agent-report
 ```
 
 Optional forced issue:

--- a/scripts/weekly_agent_report_runner.py
+++ b/scripts/weekly_agent_report_runner.py
@@ -1,0 +1,411 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from zoneinfo import ZoneInfo
+
+REPORT_TITLE = "Weekly Agent Report"
+REPORT_FROM = "weekly-report@hushline.app"
+REPORT_TO = "glenn@hushline.app"
+DEFAULT_LOOKBACK_DAYS = 7
+LOG_FILES_ENV = "HUSHLINE_WEEKLY_AGENT_REPORT_LOG_FILES"
+LOCAL_TZ = ZoneInfo("America/Los_Angeles")
+UTC = timezone.utc
+MIN_PRINTABLE_CODEPOINT = 32
+MAX_COMPLETED_EVENTS = 40
+MAX_ATTENTION_EVENTS = 30
+
+MAIL_APP_APPLESCRIPT = r"""
+on run argv
+  set fromAddress to item 1 of argv
+  set toAddress to item 2 of argv
+  set messageSubject to item 3 of argv
+  set bodyPath to item 4 of argv
+  set messageBody to read POSIX file bodyPath
+
+  tell application "Mail"
+    set matchingAccounts to every account whose email addresses contains fromAddress
+    if (count of matchingAccounts) is 0 then
+      error "Mail account not found for " & fromAddress
+    end if
+
+    set reportMessage to make new outgoing message
+    set subject of reportMessage to messageSubject
+    set content of reportMessage to messageBody
+    set visible of reportMessage to false
+    tell reportMessage
+      set sender to fromAddress
+      make new to recipient at end of to recipients with properties {address:toAddress}
+      send
+    end tell
+  end tell
+end run
+"""
+
+
+@dataclass(frozen=True)
+class LogSource:
+    name: str
+    path: Path
+
+
+@dataclass(frozen=True)
+class AgentEvent:
+    timestamp: datetime
+    source: str
+    category: str
+    summary: str
+    detail: str = ""
+
+
+class RunnerError(Exception):
+    """Raised when the report runner cannot complete safely."""
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Send a weekly summary of local agent runner work through Mail.app.",
+    )
+    parser.add_argument(
+        "--lookback-days",
+        type=int,
+        default=DEFAULT_LOOKBACK_DAYS,
+        help=f"Number of days to include in the report. Default: {DEFAULT_LOOKBACK_DAYS}.",
+    )
+    parser.add_argument(
+        "--log-file",
+        action="append",
+        type=Path,
+        default=[],
+        help=(
+            "Log file to scan. Can be repeated. Defaults to the local Hush Line, "
+            f"Tor code agent, and social runner logs, or paths from {LOG_FILES_ENV}."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the report instead of sending it through Mail.app.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Write the generated report body to this path.",
+    )
+    return parser.parse_args(argv)
+
+
+def normalize_text(value: object, max_length: int = 260) -> str:
+    text = str(value or "").replace("\r", " ").replace("\n", " ")
+    text = "".join(ch for ch in text if ch == "\t" or ord(ch) >= MIN_PRINTABLE_CODEPOINT)
+    text = " ".join(text.split())
+    if len(text) <= max_length:
+        return text
+    return text[: max_length - 3].rstrip() + "..."
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def default_log_sources() -> list[LogSource]:
+    env_value = os.environ.get(LOG_FILES_ENV, "")
+    if env_value:
+        return [
+            LogSource(path.name, path)
+            for path in (Path(item).expanduser() for item in env_value.split(os.pathsep) if item)
+        ]
+
+    root = repo_root()
+    return [
+        LogSource(
+            "Hush Line issue runner",
+            Path.home() / ".codex/logs/hushline-agent-runner.log",
+        ),
+        LogSource("Tor code agent", Path.home() / "tor-code-agent/logs/tor-agent.err.log"),
+        LogSource("Hush Line social runner", (root / "../hushline-social/logs/social-daily.log")),
+    ]
+
+
+def resolved_log_sources(cli_paths: list[Path]) -> list[LogSource]:
+    sources = (
+        [LogSource(path.name, path.expanduser()) for path in cli_paths]
+        if cli_paths
+        else default_log_sources()
+    )
+    resolved: list[LogSource] = []
+    seen: set[Path] = set()
+    for source in sources:
+        path = source.path.expanduser().resolve()
+        if path in seen:
+            continue
+        seen.add(path)
+        resolved.append(LogSource(source.name, path))
+    return resolved
+
+
+def parse_log_timestamp(line: str) -> tuple[datetime | None, str]:
+    match = re.match(
+        r"^\[(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}) (PDT|PST)\]\s*(.*)$",
+        line,
+    )
+    if not match:
+        return None, line
+    timestamp = datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S").replace(tzinfo=LOCAL_TZ)
+    return timestamp.astimezone(UTC), match.group(3)
+
+
+def read_source_lines(source: LogSource) -> list[tuple[datetime | None, str]]:
+    if not source.path.exists():
+        return []
+    events: list[tuple[datetime | None, str]] = []
+    current_timestamp: datetime | None = None
+    for line in source.path.read_text(encoding="utf-8", errors="replace").splitlines():
+        timestamp, message = parse_log_timestamp(line)
+        if timestamp is not None:
+            current_timestamp = timestamp
+        events.append((current_timestamp, normalize_text(message)))
+    return events
+
+
+def pr_event(source: str, timestamp: datetime, line: str) -> AgentEvent | None:
+    match = re.search(r"(Opened|Updated) PR:\s*(https://github\.com/\S+)", line)
+    if match:
+        return AgentEvent(timestamp, source, "completed", f"{match.group(1)} PR", match.group(2))
+    match = re.search(r"https://github\.com/[^ ]+/pull/\d+", line)
+    if match and "/pull/new/" not in match.group(0):
+        return AgentEvent(timestamp, source, "completed", "Referenced pull request", match.group(0))
+    return None
+
+
+def commit_event(source: str, timestamp: datetime, line: str) -> AgentEvent | None:
+    match = re.match(r"^\[[^\]]+\s+[0-9a-f]{7,40}\]\s+(.+)$", line)
+    if match:
+        return AgentEvent(timestamp, source, "completed", "Created commit", match.group(1))
+    return None
+
+
+def classify_line(source: str, timestamp: datetime, line: str) -> AgentEvent | None:
+    if not line:
+        return None
+
+    event = pr_event(source, timestamp, line) or commit_event(source, timestamp, line)
+    if event is not None:
+        return event
+
+    if "Published LinkedIn post" in line:
+        return AgentEvent(timestamp, source, "completed", "Published LinkedIn post", line)
+    if line.startswith("Validated daily plan for "):
+        return AgentEvent(timestamp, source, "completed", "Validated social plan", line)
+    if line.startswith("Prepared daily planning context for "):
+        return AgentEvent(timestamp, source, "work", "Prepared social planning context", line)
+    if line.startswith("Synced latest screenshots into "):
+        return AgentEvent(timestamp, source, "work", "Synced screenshots", line)
+    if line.startswith("Archive push skipped."):
+        return AgentEvent(timestamp, source, "skipped", "Archive push skipped", "")
+    if line.startswith("Skipped:"):
+        return AgentEvent(timestamp, source, "skipped", line, "")
+    if "No open issues assigned to " in line:
+        return AgentEvent(timestamp, source, "skipped", "No assigned issues", line)
+    if line.startswith("No open issues assigned to "):
+        return AgentEvent(timestamp, source, "skipped", "No assigned issues", line)
+    if line.startswith("No open issues found "):
+        return AgentEvent(timestamp, source, "skipped", "No eligible issues", line)
+    if line.startswith("Reconciling "):
+        return AgentEvent(timestamp, source, "work", "Checked project queue", line)
+    if line.startswith("Starting "):
+        return AgentEvent(timestamp, source, "work", line, "")
+    if line.startswith("Retrying "):
+        return AgentEvent(timestamp, source, "work", line, "")
+    if line.startswith("Blocked:"):
+        return AgentEvent(timestamp, source, "attention", line, "")
+    if line.startswith(("Error:", "fatal:")) or "Traceback (most recent call last)" in line:
+        return AgentEvent(timestamp, source, "attention", line, "")
+    return None
+
+
+def collect_events(sources: list[LogSource], since: datetime) -> tuple[list[AgentEvent], list[str]]:
+    events: list[AgentEvent] = []
+    warnings: list[str] = []
+    for source in sources:
+        if not source.path.exists():
+            warnings.append(f"{source.name}: missing log file at {source.path}")
+            continue
+        for timestamp, line in read_source_lines(source):
+            if timestamp is None or timestamp < since:
+                continue
+            event = classify_line(source.name, timestamp, line)
+            if event is not None:
+                events.append(event)
+    return sorted(events, key=event_sort_key), warnings
+
+
+def event_sort_key(event: AgentEvent) -> tuple[float, int]:
+    category_priority = {
+        "attention": 0,
+        "completed": 1,
+        "work": 2,
+        "skipped": 3,
+    }
+    return (-event.timestamp.timestamp(), category_priority.get(event.category, 9))
+
+
+def event_line(event: AgentEvent) -> str:
+    detail = f": {event.detail}" if event.detail else ""
+    timestamp = event.timestamp.strftime("%Y-%m-%d %H:%M UTC")
+    return f"- {timestamp} [{event.source}] {event.summary}{detail}"
+
+
+def summarize_repeated(events: list[AgentEvent]) -> list[str]:
+    counts: Counter[tuple[str, str]] = Counter((event.source, event.summary) for event in events)
+    lines = []
+    for (source, summary), count in sorted(counts.items()):
+        lines.append(f"- {source}: {summary} ({count})")
+    return lines
+
+
+def render_report(
+    events: list[AgentEvent],
+    warnings: list[str],
+    sources: list[LogSource],
+    since: datetime,
+    until: datetime,
+) -> str:
+    grouped: dict[str, list[AgentEvent]] = defaultdict(list)
+    for event in events:
+        grouped[event.category].append(event)
+
+    completed = grouped["completed"]
+    work = grouped["work"]
+    skipped = grouped["skipped"]
+    attention = grouped["attention"]
+
+    lines = [
+        REPORT_TITLE,
+        "",
+        f"Window: {since.strftime('%Y-%m-%d %H:%M UTC')} to {until.strftime('%Y-%m-%d %H:%M UTC')}",
+        f"From: {REPORT_FROM}",
+        f"To: {REPORT_TO}",
+        "",
+        "Overview:",
+        f"- Log files configured: {len(sources)}",
+        f"- Events found: {len(events)}",
+        f"- Completed work events: {len(completed)}",
+        f"- Work/check events: {len(work)}",
+        f"- Skipped/no-op events: {len(skipped)}",
+        f"- Attention events: {len(attention)}",
+    ]
+
+    if warnings:
+        lines.extend(["", "Log Warnings:"])
+        lines.extend(f"- {warning}" for warning in warnings)
+
+    lines.extend(["", "Completed Work:"])
+    if completed:
+        lines.extend(event_line(event) for event in completed[:MAX_COMPLETED_EVENTS])
+        if len(completed) > MAX_COMPLETED_EVENTS:
+            lines.append(
+                f"- ... {len(completed) - MAX_COMPLETED_EVENTS} more completed work event(s)",
+            )
+    else:
+        lines.append("- No completed runner work was detected in this window.")
+
+    if attention:
+        lines.extend(["", "Needs Attention:"])
+        lines.extend(event_line(event) for event in attention[:MAX_ATTENTION_EVENTS])
+        if len(attention) > MAX_ATTENTION_EVENTS:
+            lines.append(
+                f"- ... {len(attention) - MAX_ATTENTION_EVENTS} more attention event(s)",
+            )
+
+    if skipped:
+        lines.extend(["", "No-op Summary:"])
+        lines.extend(summarize_repeated(skipped))
+
+    if work:
+        lines.extend(["", "Work/Check Summary:"])
+        lines.extend(summarize_repeated(work))
+
+    lines.extend(["", "Log Sources:"])
+    for source in sources:
+        lines.append(f"- {source.name}: {source.path}")
+
+    lines.extend(
+        [
+            "",
+            "Notes:",
+            "- This report summarizes the local runner logs you monitor on this machine.",
+            "- Full log transcripts are not included in the email.",
+            "- Delivery is restricted to Mail.app using the fixed sender and recipient above.",
+        ],
+    )
+    return "\n".join(lines) + "\n"
+
+
+def write_output(path: Path, body: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def send_with_mail_app(subject: str, body: str) -> None:
+    with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".txt", delete=False) as temp:
+        temp.write(body)
+        body_path = temp.name
+    try:
+        command = ["/usr/bin/osascript", "-", REPORT_FROM, REPORT_TO, subject, body_path]
+        result = subprocess.run(
+            command,  # noqa: S603 - fixed executable; message data is passed by args/file.
+            input=MAIL_APP_APPLESCRIPT,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+    finally:
+        Path(body_path).unlink(missing_ok=True)
+    if result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no Mail.app output"
+        raise RunnerError(f"Mail.app send failed: {detail}")
+
+
+def build_subject(since: datetime, until: datetime) -> str:
+    return f"{REPORT_TITLE}: {since.strftime('%Y-%m-%d')} to {until.strftime('%Y-%m-%d')}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.lookback_days < 1:
+        raise RunnerError("--lookback-days must be at least 1")
+
+    until = datetime.now(UTC)
+    since = until - timedelta(days=args.lookback_days)
+    sources = resolved_log_sources(args.log_file)
+    events, warnings = collect_events(sources, since)
+    body = render_report(events, warnings, sources, since, until)
+    subject = build_subject(since, until)
+
+    if args.output:
+        write_output(args.output, body)
+    if args.dry_run:
+        print(body, end="")
+    else:
+        send_with_mail_app(subject, body)
+        print(f"Sent {REPORT_TITLE} from {REPORT_FROM} to {REPORT_TO}.")
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except RunnerError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/weekly_agent_report_runner.py
+++ b/scripts/weekly_agent_report_runner.py
@@ -21,6 +21,10 @@ DEFAULT_LOOKBACK_DAYS = 7
 LOG_FILES_ENV = "HUSHLINE_WEEKLY_AGENT_REPORT_LOG_FILES"
 LOCAL_TZ = ZoneInfo("America/Los_Angeles")
 UTC = timezone.utc
+LOG_TIMEZONES = {
+    "PDT": timezone(timedelta(hours=-7), "PDT"),
+    "PST": timezone(timedelta(hours=-8), "PST"),
+}
 MIN_PRINTABLE_CODEPOINT = 32
 MAX_COMPLETED_EVENTS = 40
 MAX_ATTENTION_EVENTS = 30
@@ -161,7 +165,9 @@ def parse_log_timestamp(line: str) -> tuple[datetime | None, str]:
     )
     if not match:
         return None, line
-    timestamp = datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S").replace(tzinfo=LOCAL_TZ)
+    timestamp = datetime.strptime(match.group(1), "%Y-%m-%d %H:%M:%S").replace(
+        tzinfo=LOG_TIMEZONES[match.group(2)],
+    )
     return timestamp.astimezone(UTC), match.group(3)
 
 

--- a/tests/test_weekly_agent_report_runner.py
+++ b/tests/test_weekly_agent_report_runner.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+RUNNER_PATH = ROOT / "scripts" / "weekly_agent_report_runner.py"
+UTC = timezone.utc
+
+
+def load_runner() -> ModuleType:
+    spec = importlib.util.spec_from_file_location("weekly_agent_report_runner", RUNNER_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_report_addresses_and_title_are_fixed() -> None:
+    runner = load_runner()
+
+    assert runner.REPORT_TITLE == "Weekly Agent Report"
+    assert runner.REPORT_FROM == "weekly-report@hushline.app"
+    assert runner.REPORT_TO == "glenn@hushline.app"
+
+
+def test_default_sources_match_monitored_logs() -> None:
+    runner = load_runner()
+
+    paths = [source.path for source in runner.default_log_sources()]
+
+    assert Path.home() / ".codex/logs/hushline-agent-runner.log" in paths
+    assert Path.home() / "tor-code-agent/logs/tor-agent.err.log" in paths
+    assert (ROOT / "../hushline-social/logs/social-daily.log") in paths
+
+
+def test_collect_events_from_hushline_runner_log(tmp_path: Path) -> None:
+    runner = load_runner()
+    log_path = tmp_path / "hushline-agent-runner.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "[2026-05-17 10:00:00 PDT] Starting daily issue runner check.",
+                (
+                    "[2026-05-17 10:00:06 PDT] Skipped: no open issues found in "
+                    "project 'Hush Line Roadmap' column 'Agent Eligible'."
+                ),
+                "[2026-05-17 11:00:00 PDT] Starting daily issue runner check.",
+                "Opened PR: https://github.com/scidsg/hushline/pull/2001",
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    events, warnings = runner.collect_events(
+        [runner.LogSource("Hush Line issue runner", log_path)],
+        datetime(2026, 5, 17, 16, 0, tzinfo=UTC),
+    )
+
+    assert warnings == []
+    assert [event.category for event in events] == ["completed", "work", "skipped", "work"]
+    assert events[0].summary == "Opened PR"
+    assert events[0].detail == "https://github.com/scidsg/hushline/pull/2001"
+
+
+def test_collect_events_from_social_runner_log(tmp_path: Path) -> None:
+    runner = load_runner()
+    log_path = tmp_path / "social-daily.log"
+    log_path.write_text(
+        "\n".join(
+            [
+                "[2026-05-15 06:10:04 PDT] Starting daily LinkedIn publisher wrapper.",
+                "Published LinkedIn post for friday",
+                "- post id: urn:li:share:7461040224387801089",
+                "[main 713c565] Archive social post for 2026-05-15",
+                (
+                    "Error: Post messaging for 2026-05-15 overlaps too heavily "
+                    "with recent archive 2026-05-05."
+                ),
+            ],
+        ),
+        encoding="utf-8",
+    )
+
+    events, warnings = runner.collect_events(
+        [runner.LogSource("Hush Line social runner", log_path)],
+        datetime(2026, 5, 15, 13, 0, tzinfo=UTC),
+    )
+
+    assert warnings == []
+    assert any(event.summary == "Published LinkedIn post" for event in events)
+    assert any(event.summary == "Created commit" for event in events)
+    assert any(event.category == "attention" for event in events)
+
+
+def test_render_report_groups_completed_attention_and_noop_events(tmp_path: Path) -> None:
+    runner = load_runner()
+    source = runner.LogSource("Hush Line issue runner", tmp_path / "runner.log")
+    since = datetime(2026, 5, 10, 0, 0, tzinfo=UTC)
+    until = datetime(2026, 5, 17, 0, 0, tzinfo=UTC)
+    events = [
+        runner.AgentEvent(
+            timestamp=datetime(2026, 5, 16, 12, 0, tzinfo=UTC),
+            source="Hush Line issue runner",
+            category="completed",
+            summary="Opened PR",
+            detail="https://github.com/scidsg/hushline/pull/2001",
+        ),
+        runner.AgentEvent(
+            timestamp=datetime(2026, 5, 16, 11, 0, tzinfo=UTC),
+            source="Tor code agent",
+            category="skipped",
+            summary="No assigned issues",
+            detail="No open issues assigned to glenns.",
+        ),
+        runner.AgentEvent(
+            timestamp=datetime(2026, 5, 15, 12, 0, tzinfo=UTC),
+            source="Hush Line social runner",
+            category="attention",
+            summary="Error: Post messaging overlaps too heavily.",
+        ),
+    ]
+
+    report = runner.render_report(events, [], [source], since, until)
+
+    assert "Weekly Agent Report" in report
+    assert "From: weekly-report@hushline.app" in report
+    assert "To: glenn@hushline.app" in report
+    assert "Completed work events: 1" in report
+    assert (
+        "[Hush Line issue runner] Opened PR: " "https://github.com/scidsg/hushline/pull/2001"
+    ) in report
+    assert "Needs Attention:" in report
+    assert "No-op Summary:" in report
+    assert "Tor code agent: No assigned issues (1)" in report
+    assert "Full log transcripts are not included in the email." in report
+
+
+def test_send_with_mail_app_uses_native_mail_and_fixed_envelope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    calls = []
+
+    class Result:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def fake_run(command: list[str], **kwargs: object) -> Result:
+        calls.append((command, kwargs))
+        return Result()
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    runner.send_with_mail_app("Subject", "Body")
+
+    assert len(calls) == 1
+    command, kwargs = calls[0]
+    assert command[:2] == ["/usr/bin/osascript", "-"]
+    assert command[2:5] == ["weekly-report@hushline.app", "glenn@hushline.app", "Subject"]
+    script = kwargs["input"]
+    assert isinstance(script, str)
+    assert 'tell application "Mail"' in script
+    assert "make new to recipient" in script

--- a/tests/test_weekly_agent_report_runner.py
+++ b/tests/test_weekly_agent_report_runner.py
@@ -70,6 +70,22 @@ def test_collect_events_from_hushline_runner_log(tmp_path: Path) -> None:
     assert events[0].detail == "https://github.com/scidsg/hushline/pull/2001"
 
 
+def test_parse_log_timestamp_uses_timezone_abbreviation_during_fallback() -> None:
+    runner = load_runner()
+
+    pdt_timestamp, pdt_message = runner.parse_log_timestamp(
+        "[2026-11-01 01:30:00 PDT] before fallback",
+    )
+    pst_timestamp, pst_message = runner.parse_log_timestamp(
+        "[2026-11-01 01:30:00 PST] after fallback",
+    )
+
+    assert pdt_message == "before fallback"
+    assert pst_message == "after fallback"
+    assert pdt_timestamp == datetime(2026, 11, 1, 8, 30, tzinfo=UTC)
+    assert pst_timestamp == datetime(2026, 11, 1, 9, 30, tzinfo=UTC)
+
+
 def test_collect_events_from_social_runner_log(tmp_path: Path) -> None:
     runner = load_runner()
     log_path = tmp_path / "social-daily.log"


### PR DESCRIPTION
## What changed
- Added a local Weekly Agent Report runner that summarizes monitored agent logs and sends a fixed plain-text report through native macOS Mail.app.
- Added `make weekly-agent-report` as the local entrypoint.
- Documented runner prerequisites, default log files, dry-run usage, and send usage in `docs/AGENT-RUNNER.md`.
- Added focused unit coverage for fixed delivery metadata, default log sources, event collection, report rendering, and Mail.app invocation.

## Why
- Provides a repeatable local weekly summary of Hush Line, Tor code agent, and Hush Line social runner activity without embedding full log transcripts in email.

## Validation
- `docker compose run --rm app poetry run pytest tests/test_weekly_agent_report_runner.py -q`
- `docker compose run --rm app poetry run ruff check scripts/weekly_agent_report_runner.py tests/test_weekly_agent_report_runner.py`
- `docker compose run --rm app poetry run mypy scripts/weekly_agent_report_runner.py tests/test_weekly_agent_report_runner.py`
- `./scripts/weekly_agent_report_runner.py --dry-run --lookback-days 1`

## Manual testing
- Ran the weekly report runner in dry-run mode for a one-day lookback and confirmed it generated the local report body without sending email.

## Known risks / follow-ups
- `make lint` reached Prettier and failed on pre-existing unrelated formatting warnings in `hushline/static/js/*.js`; those files were left untouched.
- Actual email delivery requires the local macOS Mail.app account `weekly-report@hushline.app` to be configured on the runner host.