### PR TITLE
Persist weekly agent reports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,6 @@ hushline/static/data/users_directory.json
 /.tmp/
 /playwright-report
 /test-results
+/logs/
 .DS_Store
 hushline/static/js/directory_verified.js

--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -4,12 +4,12 @@ This document tracks the current state of the repo-managed agent automation used
 
 ## Repo-Managed Agent State
 
-| Script                                   | Role                           | Current State                                           | PR / Output Surface              |
-| ---------------------------------------- | ------------------------------ | ------------------------------------------------------- | -------------------------------- |
-| `scripts/agent_daily_issue_runner.sh`    | GitHub issue implementation    | Active, branch/PR automation in place                   | issue-specific branches and PRs  |
-| `scripts/agent_daily_coverage_runner.sh` | Coverage remediation           | Active, branch/PR automation in place                   | `codex/daily-coverage` style PRs |
-| `scripts/weekly_agent_report_runner.py`  | Weekly local agent reporting   | Active, local Mail.app delivery                         | email to `glenn@hushline.app`    |
-| `scripts/agent_issue_bootstrap.sh`       | Local runtime/bootstrap helper | Active, manual helper used by issue and local workflows | local Docker/bootstrap only      |
+| Script                                   | Role                           | Current State                                                | PR / Output Surface                                               |
+| ---------------------------------------- | ------------------------------ | ------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `scripts/agent_daily_issue_runner.sh`    | GitHub issue implementation    | Active, branch/PR automation in place                        | issue-specific branches and PRs                                   |
+| `scripts/agent_daily_coverage_runner.sh` | Coverage remediation           | Active, branch/PR automation in place                        | `codex/daily-coverage` style PRs                                  |
+| `scripts/weekly_agent_report_runner.py`  | Weekly local agent reporting   | Active, local Mail.app delivery and local report persistence | email to `glenn@hushline.app`; local `logs/weekly-agent-reports/` |
+| `scripts/agent_issue_bootstrap.sh`       | Local runtime/bootstrap helper | Active, manual helper used by issue and local workflows      | local Docker/bootstrap only                                       |
 
 The repository does not currently include runner scripts for the social or docs launch agents listed below. Those host jobs exist outside this repository and should be documented here only as installed host context, not as repo-managed automation.
 
@@ -21,6 +21,7 @@ The repository does not currently include runner scripts for the social or docs 
 | com.hushline.coverage.daily                       | Hush Line coverage runner            | Daily at 10:00 AM               | com.hushline.coverage.daily.plist                       |
 | com.hushline.social.daily-planner                 | Social planner                       | Mon-Fri at 6:00 AM              | com.hushline.social.daily-planner.plist                 |
 | com.hushline.social.linkedin.daily                | Social LinkedIn daily                | Mon-Fri at 6:10 AM              | com.hushline.social.linkedin.daily.plist                |
+| com.hushline.weekly-agent-report                  | Weekly local agent report            | Sunday at 9:00 PM               | com.hushline.weekly-agent-report.plist                  |
 | com.hushline.social.verified-user.weekly          | Social verified-user weekly          | Monday at 12:00 PM              | com.hushline.social.verified-user.weekly.plist          |
 | com.hushline.social.linkedin.verified-user.weekly | Social verified-user LinkedIn weekly | Monday at 12:10 PM              | com.hushline.social.linkedin.verified-user.weekly.plist |
 | com.hushline.docs.weekly-article                  | Docs weekly article                  | Wednesday at 10:00 AM           | com.hushline.docs.weekly-article.plist                  |
@@ -245,7 +246,7 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 
 Script: `scripts/weekly_agent_report_runner.py`
 
-This runner scans the local runner logs monitored on this machine and builds a plain-text `Weekly Agent Report`. It sends through the native macOS Mail app.
+This runner scans the local runner logs monitored on this machine and builds a plain-text `Weekly Agent Report`. It persists a timestamped local copy before sending through the native macOS Mail app.
 
 Default log files:
 
@@ -259,6 +260,20 @@ Delivery is fixed in code:
 - To: `glenn@hushline.app`
 
 Additional log files can be supplied with repeated `--log-file` arguments or the colon-separated `HUSHLINE_WEEKLY_AGENT_REPORT_LOG_FILES` environment variable. The runner summarizes completed work, skipped/no-op checks, work/check activity, and attention items without embedding full log transcripts in email.
+
+Persisted report bodies are written to `logs/weekly-agent-reports/weekly-agent-report-<timestamp>.txt` by default. The directory is intentionally ignored by git. The default retention is the newest `12` reports; override it with `--report-retention` or `HUSHLINE_WEEKLY_AGENT_REPORT_RETENTION`. Override the report directory with `--report-output-dir` or `HUSHLINE_WEEKLY_AGENT_REPORT_OUTPUT_DIR`.
+
+Monitor the installed LaunchAgent stdout/stderr logs:
+
+```bash
+tail -F /Users/scidsg/hushline-weekly-report-agent/logs/weekly-agent-report.stdout.log /Users/scidsg/hushline-weekly-report-agent/logs/weekly-agent-report.stderr.log
+```
+
+Check the installed LaunchAgent state:
+
+```bash
+launchctl print gui/$(id -u)/com.hushline.weekly-agent-report
+```
 
 Manual dry run:
 

--- a/scripts/weekly_agent_report_runner.py
+++ b/scripts/weekly_agent_report_runner.py
@@ -19,6 +19,9 @@ REPORT_FROM = "weekly-report@hushline.app"
 REPORT_TO = "glenn@hushline.app"
 DEFAULT_LOOKBACK_DAYS = 7
 LOG_FILES_ENV = "HUSHLINE_WEEKLY_AGENT_REPORT_LOG_FILES"
+REPORT_OUTPUT_DIR_ENV = "HUSHLINE_WEEKLY_AGENT_REPORT_OUTPUT_DIR"
+REPORT_RETENTION_ENV = "HUSHLINE_WEEKLY_AGENT_REPORT_RETENTION"
+DEFAULT_REPORT_RETENTION = 12
 LOCAL_TZ = ZoneInfo("America/Los_Angeles")
 UTC = timezone.utc
 LOG_TIMEZONES = {
@@ -105,6 +108,28 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         "--output",
         type=Path,
         help="Write the generated report body to this path.",
+    )
+    parser.add_argument(
+        "--report-output-dir",
+        type=Path,
+        help=(
+            "Directory for persisted weekly report bodies. Defaults to "
+            f"{REPORT_OUTPUT_DIR_ENV} or logs/weekly-agent-reports."
+        ),
+    )
+    parser.add_argument(
+        "--report-retention",
+        type=int,
+        default=int(os.environ.get(REPORT_RETENTION_ENV, DEFAULT_REPORT_RETENTION)),
+        help=(
+            "Number of persisted weekly report files to keep. Set to 0 to disable pruning. "
+            f"Default: {DEFAULT_REPORT_RETENTION}."
+        ),
+    )
+    parser.add_argument(
+        "--no-persist",
+        action="store_true",
+        help="Do not write the default persisted report artifact.",
     )
     return parser.parse_args(argv)
 
@@ -363,6 +388,29 @@ def write_output(path: Path, body: str) -> None:
     path.write_text(body, encoding="utf-8")
 
 
+def default_report_output_dir() -> Path:
+    env_value = os.environ.get(REPORT_OUTPUT_DIR_ENV)
+    if env_value:
+        return Path(env_value).expanduser()
+    return repo_root() / "logs" / "weekly-agent-reports"
+
+
+def persisted_report_path(output_dir: Path, until: datetime) -> Path:
+    return output_dir / f"weekly-agent-report-{until.strftime('%Y%m%dT%H%M%SZ')}.txt"
+
+
+def prune_persisted_reports(output_dir: Path, retention_count: int) -> None:
+    if retention_count <= 0 or not output_dir.exists():
+        return
+    reports = sorted(
+        output_dir.glob("weekly-agent-report-*.txt"),
+        key=lambda path: path.name,
+        reverse=True,
+    )
+    for report_path in reports[retention_count:]:
+        report_path.unlink(missing_ok=True)
+
+
 def send_with_mail_app(subject: str, body: str) -> None:
     with tempfile.NamedTemporaryFile("w", encoding="utf-8", suffix=".txt", delete=False) as temp:
         temp.write(body)
@@ -391,6 +439,8 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
     if args.lookback_days < 1:
         raise RunnerError("--lookback-days must be at least 1")
+    if args.report_retention < 0:
+        raise RunnerError("--report-retention must be at least 0")
 
     until = datetime.now(UTC)
     since = until - timedelta(days=args.lookback_days)
@@ -401,11 +451,19 @@ def main(argv: list[str] | None = None) -> int:
 
     if args.output:
         write_output(args.output, body)
+    persisted_path: Path | None = None
+    if not args.no_persist and not args.dry_run:
+        output_dir = (args.report_output_dir or default_report_output_dir()).expanduser().resolve()
+        persisted_path = persisted_report_path(output_dir, until)
+        write_output(persisted_path, body)
+        prune_persisted_reports(output_dir, args.report_retention)
     if args.dry_run:
         print(body, end="")
     else:
         send_with_mail_app(subject, body)
         print(f"Sent {REPORT_TITLE} from {REPORT_FROM} to {REPORT_TO}.")
+        if persisted_path is not None:
+            print(f"Persisted report: {persisted_path}")
     return 0
 
 

--- a/tests/test_weekly_agent_report_runner.py
+++ b/tests/test_weekly_agent_report_runner.py
@@ -186,3 +186,95 @@ def test_send_with_mail_app_uses_native_mail_and_fixed_envelope(
     assert isinstance(script, str)
     assert 'tell application "Mail"' in script
     assert "make new to recipient" in script
+
+
+def test_main_persists_report_body_by_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    output_dir = tmp_path / "reports"
+    sent = []
+
+    def fake_send(subject: str, body: str) -> None:
+        sent.append((subject, body))
+
+    monkeypatch.setenv(runner.REPORT_OUTPUT_DIR_ENV, str(output_dir))
+    monkeypatch.setattr(runner, "send_with_mail_app", fake_send)
+
+    result = runner.main(["--log-file", str(tmp_path / "missing.log")])
+
+    reports = list(output_dir.glob("weekly-agent-report-*.txt"))
+    assert result == 0
+    assert len(reports) == 1
+    assert "Weekly Agent Report" in reports[0].read_text(encoding="utf-8")
+    assert len(sent) == 1
+
+
+def test_main_dry_run_does_not_write_default_persisted_report(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runner = load_runner()
+    output_dir = tmp_path / "reports"
+    monkeypatch.setenv(runner.REPORT_OUTPUT_DIR_ENV, str(output_dir))
+
+    result = runner.main(["--dry-run", "--log-file", str(tmp_path / "missing.log")])
+
+    assert result == 0
+    assert "Weekly Agent Report" in capsys.readouterr().out
+    assert not output_dir.exists()
+
+
+def test_main_prunes_old_persisted_reports(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    output_dir = tmp_path / "reports"
+    output_dir.mkdir()
+    for index in range(3):
+        (output_dir / f"weekly-agent-report-2026050{index + 1}T000000Z.txt").write_text(
+            "old report\n",
+            encoding="utf-8",
+        )
+
+    monkeypatch.setenv(runner.REPORT_OUTPUT_DIR_ENV, str(output_dir))
+    monkeypatch.setattr(runner, "send_with_mail_app", lambda _subject, _body: None)
+
+    result = runner.main(
+        [
+            "--log-file",
+            str(tmp_path / "missing.log"),
+            "--report-retention",
+            "2",
+        ],
+    )
+
+    assert result == 0
+    reports = sorted(path.name for path in output_dir.glob("weekly-agent-report-*.txt"))
+    assert len(reports) == 2
+    assert "weekly-agent-report-20260501T000000Z.txt" not in reports
+
+
+def test_main_no_persist_skips_default_report_artifact(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    output_dir = tmp_path / "reports"
+
+    monkeypatch.setenv(runner.REPORT_OUTPUT_DIR_ENV, str(output_dir))
+    monkeypatch.setattr(runner, "send_with_mail_app", lambda _subject, _body: None)
+
+    result = runner.main(
+        [
+            "--log-file",
+            str(tmp_path / "missing.log"),
+            "--no-persist",
+        ],
+    )
+
+    assert result == 0
+    assert not output_dir.exists()


### PR DESCRIPTION
## Summary

- Persist sent weekly agent report bodies to `logs/weekly-agent-reports/weekly-agent-report-<timestamp>.txt` by default.
- Add report persistence controls: `--report-output-dir`, `--report-retention`, and `--no-persist`.
- Ignore local `logs/` artifacts and document the installed weekly report LaunchAgent monitoring commands.
- Add focused tests for default persistence, dry-run behavior, retention pruning, and disabling persistence.

## Context

The installed weekly report LaunchAgent already writes stdout/stderr logs, but the generated report body was not retained unless an operator supplied `--output` manually. This change makes persistence the default for scheduled sends while keeping Mail.app delivery unchanged.

## Changed Files

- `.gitignore`
- `docs/AGENT-RUNNER.md`
- `scripts/weekly_agent_report_runner.py`
- `tests/test_weekly_agent_report_runner.py`

## Validation

- `docker compose run --rm app poetry run pytest tests/test_weekly_agent_report_runner.py -q` passed: 11 passed.
- `docker compose run --rm app poetry run ruff check scripts/weekly_agent_report_runner.py tests/test_weekly_agent_report_runner.py` passed.
- `docker compose run --rm app poetry run ruff format --check scripts/weekly_agent_report_runner.py tests/test_weekly_agent_report_runner.py` passed.
- `docker compose run --rm app sh -lc 'node_modules/.bin/prettier --check docs/AGENT-RUNNER.md'` passed.
- `make test` passed: 1741 passed, 1 deselected, 1 xfailed; total coverage 99%.
- `make audit-python` passed: no known vulnerabilities found.
- `make audit-node-runtime` passed: found 0 vulnerabilities.
- `make lint` partially passed: Ruff format, Ruff check, and mypy passed; Prettier failed on existing ignored generated files under `hushline/static/js/*.js`. The changed doc was then formatted and verified separately.

## Manual Testing

- Ran `/Users/scidsg/hushline-weekly-report-agent/scripts/weekly_agent_report_runner.py --dry-run --log-file /private/tmp/hushline-missing-weekly.log` from the installed LaunchAgent checkout and confirmed it renders the expected weekly report body without sending mail.
- Synced the updated runner into `/Users/scidsg/hushline-weekly-report-agent`, so the installed `com.hushline.weekly-agent-report` LaunchAgent will use the persistence behavior on its next scheduled run.

## Risks / Follow-ups

- Persisted reports intentionally summarize runner events and do not embed full log transcripts.
- Local report artifacts are ignored by git and retained locally only; default retention keeps the newest 12 reports.