### PR TITLE
Harden weekly report Mail.app send

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -246,7 +246,7 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 
 Script: `scripts/weekly_agent_report_runner.py`
 
-This runner scans the local runner logs monitored on this machine and builds a plain-text `Weekly Agent Report`. It persists a timestamped local copy before sending through the native macOS Mail app.
+This runner scans the local runner logs monitored on this machine and builds a plain-text `Weekly Agent Report`. It persists a timestamped local copy before sending through the native macOS Mail app. Mail.app delivery uses a bounded AppleScript timeout and sends asynchronously once the message is handed to Mail, so slow Mail.app network delivery does not fail the LaunchAgent run after the local report has already been written.
 
 Default log files:
 

--- a/scripts/weekly_agent_report_runner.py
+++ b/scripts/weekly_agent_report_runner.py
@@ -31,6 +31,8 @@ LOG_TIMEZONES = {
 MIN_PRINTABLE_CODEPOINT = 32
 MAX_COMPLETED_EVENTS = 40
 MAX_ATTENTION_EVENTS = 30
+MAIL_APP_APPLESCRIPT_TIMEOUT_SECONDS = 300
+MAIL_APP_OSASCRIPT_TIMEOUT_SECONDS = MAIL_APP_APPLESCRIPT_TIMEOUT_SECONDS + 30
 
 MAIL_APP_APPLESCRIPT = r"""
 on run argv
@@ -40,28 +42,32 @@ on run argv
   set bodyPath to item 4 of argv
   set messageBody to read POSIX file bodyPath
 
-  tell application "Mail"
-    set matchingAccount to missing value
-    repeat with mailAccount in every account
-      if (email addresses of mailAccount) contains fromAddress then
-        set matchingAccount to mailAccount
-        exit repeat
+  with timeout of 300 seconds
+    tell application "Mail"
+      set matchingAccount to missing value
+      repeat with mailAccount in every account
+        if (email addresses of mailAccount) contains fromAddress then
+          set matchingAccount to mailAccount
+          exit repeat
+        end if
+      end repeat
+      if matchingAccount is missing value then
+        error "Mail account not found for " & fromAddress
       end if
-    end repeat
-    if matchingAccount is missing value then
-      error "Mail account not found for " & fromAddress
-    end if
 
-    set reportMessage to make new outgoing message
-    set subject of reportMessage to messageSubject
-    set content of reportMessage to messageBody
-    set visible of reportMessage to false
-    tell reportMessage
-      set sender to fromAddress
-      make new to recipient at end of to recipients with properties {address:toAddress}
-      send
+      set reportMessage to make new outgoing message
+      set subject of reportMessage to messageSubject
+      set content of reportMessage to messageBody
+      set visible of reportMessage to false
+      tell reportMessage
+        set sender to fromAddress
+        make new to recipient at end of to recipients with properties {address:toAddress}
+        ignoring application responses
+          send
+        end ignoring
+      end tell
     end tell
-  end tell
+  end timeout
 end run
 """
 
@@ -467,13 +473,19 @@ def send_with_mail_app(subject: str, body: str) -> None:
         body_path = temp.name
     try:
         command = ["/usr/bin/osascript", "-", REPORT_FROM, REPORT_TO, subject, body_path]
-        result = subprocess.run(
-            command,  # noqa: S603 - fixed executable; message data is passed by args/file.
-            input=MAIL_APP_APPLESCRIPT,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                command,  # noqa: S603 - fixed executable; message data is passed by args/file.
+                input=MAIL_APP_APPLESCRIPT,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=MAIL_APP_OSASCRIPT_TIMEOUT_SECONDS,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RunnerError(
+                f"Mail.app send timed out after {MAIL_APP_OSASCRIPT_TIMEOUT_SECONDS} seconds",
+            ) from exc
     finally:
         Path(body_path).unlink(missing_ok=True)
     if result.returncode != 0:

--- a/tests/test_weekly_agent_report_runner.py
+++ b/tests/test_weekly_agent_report_runner.py
@@ -192,9 +192,34 @@ def test_send_with_mail_app_uses_native_mail_and_fixed_envelope(
     script = kwargs["input"]
     assert isinstance(script, str)
     assert 'tell application "Mail"' in script
+    assert "with timeout of 300 seconds" in script
+    assert "ignoring application responses" in script
     assert "repeat with mailAccount in every account" in script
     assert "whose email addresses contains" not in script
     assert "make new to recipient" in script
+    assert kwargs["timeout"] == runner.MAIL_APP_OSASCRIPT_TIMEOUT_SECONDS
+
+
+def test_send_with_mail_app_reports_osascript_timeout_and_cleans_tempfile(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    runner = load_runner()
+    body_paths = []
+
+    def fake_run(command: list[str], **kwargs: object) -> object:
+        body_paths.append(Path(command[5]))
+        raise runner.subprocess.TimeoutExpired(
+            command,
+            timeout=runner.MAIL_APP_OSASCRIPT_TIMEOUT_SECONDS,
+        )
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    with pytest.raises(runner.RunnerError, match="Mail.app send timed out"):
+        runner.send_with_mail_app("Subject", "Body")
+
+    assert len(body_paths) == 1
+    assert not body_paths[0].exists()
 
 
 def test_main_persists_report_body_by_default(


### PR DESCRIPTION
## What changed
- Wrap the weekly report Mail.app AppleScript handoff in a 300-second timeout.
- Send the Mail.app message asynchronously after it is handed to Mail, so slow Mail network delivery does not make the runner fail after the local report is already persisted.
- Add focused tests for the Mail.app handoff behavior and timeout cleanup.
- Document the bounded/asynchronous Mail.app delivery behavior.

## Why
The weekly agent mail report failed with:

`Mail got an error: AppleEvent timed out. (-1712)`

The report body had already been generated and persisted locally; the failure was in the Mail.app send AppleEvent waiting on Mail. This keeps the fixed sender/recipient Mail.app path intact while avoiding transient Mail delivery latency failing the LaunchAgent run.

## Validation
- `git diff --check` passed.
- Earlier focused runner validation was run during investigation, but after the user requested stopping the code runner I did not start Docker/test runners again.
- `make lint` was attempted before stopping runners; Ruff format, Ruff check, and mypy passed, then Prettier failed on 21 pre-existing static JS formatting files unrelated to this PR.
- `make test` was attempted before stopping runners; broad fixture setup hit Postgres recovery-mode errors, matching the repo's documented Docker recovery issue. Docker services and LaunchAgent code runners were then stopped per request.

## Manual testing
Not applicable beyond local command validation; this is a scheduled local Mail.app runner. The actionable manual check is the next LaunchAgent run or `make weekly-agent-report` with Mail.app available.

## Risks / follow-up
- This still depends on Mail.app accepting the message and a configured `weekly-report@hushline.app` account.
- If Mail.app accepts the message but later fails SMTP delivery, that remains a Mail.app/account issue rather than a runner process failure.