### PR TITLE
Improve weekly code agent report

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ refresh-newsroom-listings: ## Refresh newsroom directory artifact from public so
 
 .PHONY: weekly-agent-report
 weekly-agent-report: ## Send the weekly local agent runner report with Mail.app
-	./scripts/weekly_agent_report_runner.py
+	./scripts/weekly_hushline_code_agent_report_runner.py
 
 .PHONY: audit-python
 audit-python: ## Run Python dependency audit (CI-equivalent)

--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -4,12 +4,12 @@ This document tracks the current state of the repo-managed agent automation used
 
 ## Repo-Managed Agent State
 
-| Script                                   | Role                           | Current State                                                | PR / Output Surface                                               |
-| ---------------------------------------- | ------------------------------ | ------------------------------------------------------------ | ----------------------------------------------------------------- |
-| `scripts/agent_daily_issue_runner.sh`    | GitHub issue implementation    | Active, branch/PR automation in place                        | issue-specific branches and PRs                                   |
-| `scripts/agent_daily_coverage_runner.sh` | Coverage remediation           | Active, branch/PR automation in place                        | `codex/daily-coverage` style PRs                                  |
-| `scripts/weekly_agent_report_runner.py`  | Weekly local agent reporting   | Active, local Mail.app delivery and local report persistence | email to `glenn@hushline.app`; local `logs/weekly-agent-reports/` |
-| `scripts/agent_issue_bootstrap.sh`       | Local runtime/bootstrap helper | Active, manual helper used by issue and local workflows      | local Docker/bootstrap only                                       |
+| Script                                                | Role                           | Current State                                                | PR / Output Surface                                               |
+| ----------------------------------------------------- | ------------------------------ | ------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `scripts/agent_daily_issue_runner.sh`                 | GitHub issue implementation    | Active, branch/PR automation in place                        | issue-specific branches and PRs                                   |
+| `scripts/agent_daily_coverage_runner.sh`              | Coverage remediation           | Active, branch/PR automation in place                        | `codex/daily-coverage` style PRs                                  |
+| `scripts/weekly_hushline_code_agent_report_runner.py` | Weekly local agent reporting   | Active, local Mail.app delivery and local report persistence | email to `glenn@hushline.app`; local `logs/weekly-agent-reports/` |
+| `scripts/agent_issue_bootstrap.sh`                    | Local runtime/bootstrap helper | Active, manual helper used by issue and local workflows      | local Docker/bootstrap only                                       |
 
 The repository does not currently include runner scripts for the social or docs launch agents listed below. Those host jobs exist outside this repository and should be documented here only as installed host context, not as repo-managed automation.
 
@@ -17,7 +17,7 @@ The repository does not currently include runner scripts for the social or docs 
 
 | Label                                             | Scope                                | Schedule                        | Source                                                  |
 | ------------------------------------------------- | ------------------------------------ | ------------------------------- | ------------------------------------------------------- |
-| org.scidsg.hushline-agent-runner                  | Hush Line issue runner               | Every hour (StartInterval=3600) | org.scidsg.hushline-agent-runner.plist                  |
+| org.scidsg.hushline-code-agent                    | Hush Line issue runner               | Every hour (StartInterval=3600) | org.scidsg.hushline-code-agent.plist                    |
 | com.hushline.coverage.daily                       | Hush Line coverage runner            | Daily at 10:00 AM               | com.hushline.coverage.daily.plist                       |
 | com.hushline.social.daily-planner                 | Social planner                       | Mon-Fri at 6:00 AM              | com.hushline.social.daily-planner.plist                 |
 | com.hushline.social.linkedin.daily                | Social LinkedIn daily                | Mon-Fri at 6:10 AM              | com.hushline.social.linkedin.daily.plist                |
@@ -244,13 +244,13 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 
 ## Weekly Agent Report Runner
 
-Script: `scripts/weekly_agent_report_runner.py`
+Script: `scripts/weekly_hushline_code_agent_report_runner.py`
 
 This runner scans the local runner logs monitored on this machine and builds a plain-text `Weekly Agent Report`. It persists a timestamped local copy before sending through the native macOS Mail app. Mail.app delivery uses a bounded AppleScript timeout and sends asynchronously once the message is handed to Mail, so slow Mail.app network delivery does not fail the LaunchAgent run after the local report has already been written.
 
 Default log files:
 
-- `~/.codex/logs/hushline-agent-runner.log`
+- `~/.codex/logs/hushline-code-agent.log`
 - `~/tor-code-agent/logs/tor-agent.err.log`
 - `../hushline-social/logs/social-daily.log`
 
@@ -278,7 +278,7 @@ launchctl print gui/$(id -u)/com.hushline.weekly-agent-report
 Manual dry run:
 
 ```bash
-./scripts/weekly_agent_report_runner.py --dry-run
+./scripts/weekly_hushline_code_agent_report_runner.py --dry-run
 ```
 
 Send report:

--- a/scripts/weekly_hushline_code_agent_report_runner.py
+++ b/scripts/weekly_hushline_code_agent_report_runner.py
@@ -171,7 +171,7 @@ def default_log_sources() -> list[LogSource]:
     return [
         LogSource(
             "Hush Line issue runner",
-            Path.home() / ".codex/logs/hushline-agent-runner.log",
+            Path.home() / ".codex/logs/hushline-code-agent.log",
         ),
         LogSource("Tor code agent", Path.home() / "tor-code-agent/logs/tor-agent.err.log"),
         LogSource("Hush Line social runner", (root / "../hushline-social/logs/social-daily.log")),
@@ -317,6 +317,81 @@ def summarize_repeated(events: list[AgentEvent]) -> list[str]:
     return lines
 
 
+def pluralize(count: int, singular: str, plural: str | None = None) -> str:
+    label = singular if count == 1 else (plural or f"{singular}s")
+    return f"{count} {label}"
+
+
+def unique_in_order(items: list[str]) -> list[str]:
+    unique_items = []
+    seen: set[str] = set()
+    for item in items:
+        if item in seen:
+            continue
+        seen.add(item)
+        unique_items.append(item)
+    return unique_items
+
+
+PAIR_LENGTH = 2
+
+
+def human_join(items: list[str], limit: int = 4, overflow_label: str = "more") -> str:
+    visible_items = items[:limit]
+    remaining = len(items) - len(visible_items)
+    if remaining > 0:
+        visible_items.append(f"{remaining} {overflow_label}")
+    if not visible_items:
+        return ""
+    if len(visible_items) == 1:
+        return visible_items[0]
+    if len(visible_items) == PAIR_LENGTH:
+        return " and ".join(visible_items)
+    return ", ".join(visible_items[:-1]) + f", and {visible_items[-1]}"
+
+
+def sentence(text: str) -> str:
+    text = text.strip()
+    if not text:
+        return ""
+    return text if text.endswith((".", "!", "?")) else f"{text}."
+
+
+def event_description(event: AgentEvent) -> str:
+    summary = event.summary.rstrip(".")
+    detail = f": {event.detail.rstrip('.')}" if event.detail else ""
+    return f"{event.source} - {summary}{detail}"
+
+
+def pr_descriptions(events: list[AgentEvent]) -> list[str]:
+    actions = {
+        "Opened PR": "opened",
+        "Updated PR": "updated",
+        "Referenced pull request": "referenced",
+    }
+    descriptions = []
+    for event in events:
+        action = actions.get(event.summary)
+        if action is None:
+            continue
+        pr_number = ""
+        match = re.search(r"/pull/(\d+)", event.detail)
+        if match:
+            pr_number = f" #{match.group(1)}"
+        descriptions.append(f"{action} PR{pr_number} ({event.detail})")
+    return descriptions
+
+
+def linkedin_post_labels(events: list[AgentEvent]) -> list[str]:
+    labels = []
+    for event in events:
+        if event.summary != "Published LinkedIn post":
+            continue
+        match = re.search(r"Published LinkedIn post for (.+)$", event.detail)
+        labels.append(match.group(1) if match else event.detail)
+    return labels
+
+
 def render_executive_summary(
     completed: list[AgentEvent],
     work: list[AgentEvent],
@@ -326,36 +401,59 @@ def render_executive_summary(
 ) -> list[str]:
     total_events = len(completed) + len(work) + len(skipped) + len(attention)
     if total_events == 0 and not warnings:
-        return [
-            "- No local runner activity or log warnings were detected in this reporting window."
-        ]
+        return ["No local runner activity or log warnings were detected in this reporting window."]
 
-    lines = [
+    paragraphs = [
         (
-            "- Local agent runners recorded "
-            f"{total_events} event(s), including {len(completed)} completed work item(s), "
-            f"{len(work)} work/check item(s), {len(skipped)} no-op item(s), and "
-            f"{len(attention)} attention item(s)."
+            "The monitored local runners recorded "
+            f"{pluralize(total_events, 'notable event')}: "
+            f"{pluralize(len(completed), 'completed work item')}, "
+            f"{pluralize(len(work), 'work/check item')}, "
+            f"{pluralize(len(skipped), 'no-op item')}, and "
+            f"{pluralize(len(attention), 'attention item')}."
         ),
     ]
+
     if completed:
         latest_completed = completed[0]
-        lines.append(
-            "- Most recent completed work: "
-            f"{latest_completed.source} - {latest_completed.summary}."
+        completed_parts = []
+        linkedin_labels = linkedin_post_labels(completed)
+        if linkedin_labels:
+            completed_parts.append(
+                "the social runner published LinkedIn posts for "
+                f"{human_join(unique_in_order(linkedin_labels), overflow_label='more posts')}"
+            )
+        prs = pr_descriptions(completed)
+        if prs:
+            completed_parts.append(f"PR activity included {human_join(prs, limit=3)}")
+        else:
+            completed_parts.append("no pull requests were opened or updated")
+        completed_parts.append(
+            "the most recent completed item was " f"{event_description(latest_completed)}"
         )
+        paragraphs.append(sentence("Completed work: " + "; ".join(completed_parts)))
     else:
-        lines.append("- No completed runner work was detected in this window.")
+        paragraphs.append("No completed runner work was detected in this window.")
 
     if attention:
-        latest_attention = attention[0]
-        lines.append("- Review needed: " f"{latest_attention.source} - {latest_attention.summary}.")
+        attention_items = unique_in_order([event_description(event) for event in attention])
+        paragraphs.append(
+            sentence(
+                "Review is needed for "
+                f"{human_join(attention_items, limit=3, overflow_label='more items')}"
+            )
+        )
     else:
-        lines.append("- No attention items were detected.")
+        paragraphs.append("No attention items were detected.")
 
     if warnings:
-        lines.append(f"- {len(warnings)} log source warning(s) should be checked below.")
-    return lines
+        paragraphs.append(
+            sentence(
+                f"There {'was' if len(warnings) == 1 else 'were'} "
+                f"{pluralize(len(warnings), 'log source warning')} to check below"
+            )
+        )
+    return paragraphs
 
 
 def render_report(

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -1343,7 +1343,7 @@ def test_persisted_runner_log_redacts_developer_metadata(tmp_path: Path) -> None
                 "Runner Codex config: model=gpt-5.5 reasoning_effort=high verbose_codex_output=0",
                 "Configured git identity: hushline-dev <git-dev@scidsg.org>",
                 "Run log file: /Users/scidsg/hushline/docs/agent-logs/run.log",
-                "Global log file: /Users/scidsg/.codex/logs/hushline-agent-runner.log",
+                "Global log file: /Users/scidsg/.codex/logs/hushline-code-agent.log",
                 "workdir: /Users/scidsg/hushline",
                 "model: gpt-5.5",
                 "provider: openai",

--- a/tests/test_weekly_agent_report_runner.py
+++ b/tests/test_weekly_agent_report_runner.py
@@ -9,12 +9,15 @@ from types import ModuleType
 import pytest
 
 ROOT = Path(__file__).resolve().parents[1]
-RUNNER_PATH = ROOT / "scripts" / "weekly_agent_report_runner.py"
+RUNNER_PATH = ROOT / "scripts" / "weekly_hushline_code_agent_report_runner.py"
 UTC = timezone.utc
 
 
 def load_runner() -> ModuleType:
-    spec = importlib.util.spec_from_file_location("weekly_agent_report_runner", RUNNER_PATH)
+    spec = importlib.util.spec_from_file_location(
+        "weekly_hushline_code_agent_report_runner",
+        RUNNER_PATH,
+    )
     assert spec is not None
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
@@ -36,14 +39,14 @@ def test_default_sources_match_monitored_logs() -> None:
 
     paths = [source.path for source in runner.default_log_sources()]
 
-    assert Path.home() / ".codex/logs/hushline-agent-runner.log" in paths
+    assert Path.home() / ".codex/logs/hushline-code-agent.log" in paths
     assert Path.home() / "tor-code-agent/logs/tor-agent.err.log" in paths
     assert (ROOT / "../hushline-social/logs/social-daily.log") in paths
 
 
 def test_collect_events_from_hushline_runner_log(tmp_path: Path) -> None:
     runner = load_runner()
-    log_path = tmp_path / "hushline-agent-runner.log"
+    log_path = tmp_path / "hushline-code-agent.log"
     log_path.write_text(
         "\n".join(
             [
@@ -130,6 +133,13 @@ def test_render_report_groups_completed_attention_and_noop_events(tmp_path: Path
             detail="https://github.com/scidsg/hushline/pull/2001",
         ),
         runner.AgentEvent(
+            timestamp=datetime(2026, 5, 16, 10, 0, tzinfo=UTC),
+            source="Hush Line social runner",
+            category="completed",
+            summary="Published LinkedIn post",
+            detail="Published LinkedIn post for friday",
+        ),
+        runner.AgentEvent(
             timestamp=datetime(2026, 5, 16, 11, 0, tzinfo=UTC),
             source="Tor code agent",
             category="skipped",
@@ -150,15 +160,23 @@ def test_render_report_groups_completed_attention_and_noop_events(tmp_path: Path
     assert "From: weekly-report@hushline.app" in report
     assert "To: glenn@hushline.app" in report
     assert report.index("Executive Summary:") < report.index("Overview:")
-    assert "Local agent runners recorded 3 event(s)" in report
-    assert "Most recent completed work: Hush Line issue runner - Opened PR." in report
+    executive_summary = report.split("Executive Summary:", 1)[1].split("Overview:", 1)[0]
+    assert "\n-" not in executive_summary
+    assert "The monitored local runners recorded 4 notable events" in executive_summary
+    assert "the social runner published LinkedIn posts for friday" in executive_summary
     assert (
-        "Review needed: Hush Line social runner - Error: Post messaging overlaps too heavily."
-        in report
-    )
-    assert "Completed work events: 1" in report
+        "PR activity included opened PR #2001 " "(https://github.com/scidsg/hushline/pull/2001)"
+    ) in executive_summary
+    assert (
+        "Review is needed for Hush Line social runner - "
+        "Error: Post messaging overlaps too heavily"
+    ) in executive_summary
+    assert "Completed work events: 2" in report
     assert (
         "[Hush Line issue runner] Opened PR: " "https://github.com/scidsg/hushline/pull/2001"
+    ) in report
+    assert (
+        "[Hush Line social runner] Published LinkedIn post: " "Published LinkedIn post for friday"
     ) in report
     assert "Needs Attention:" in report
     assert "No-op Summary:" in report


### PR DESCRIPTION
## What changed

- Rename the weekly local agent report runner to `weekly_hushline_code_agent_report_runner.py` and update the Makefile/docs references.
- Point the weekly report at the renamed Hush Line code agent log.
- Render the executive summary as prose with clearer completed work, PR activity, LinkedIn post, attention, and warning context.
- Update runner tests for the renamed script, log path, and revised summary output.

## Why

The local runner naming has moved from the older generic Hush Line agent runner label to the Hush Line code agent label. The weekly report should follow that naming and produce a summary that is easier to scan before reading the detailed sections.

## Impact

This affects local automation/reporting only. It does not change whistleblower message submission, recipient inbox behavior, encryption defaults, disclosure storage, or production request handling.

## Validation

- `make lint`
- `make test`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

Not applicable: this is a local report-rendering and runner-path change covered by automated runner tests.

## Risks and follow-ups

- Risk is limited to local LaunchAgent/Makefile users needing the updated script name.
- No follow-up is currently required.
