### PR TITLE
Handle weekly report Mail timeout

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -246,7 +246,7 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 
 Script: `scripts/weekly_hushline_code_agent_report_runner.py`
 
-This runner scans the local runner logs monitored on this machine and builds a plain-text `Weekly Agent Report`. It persists a timestamped local copy before sending through the native macOS Mail app. Mail.app delivery uses a bounded AppleScript timeout and sends asynchronously once the message is handed to Mail, so slow Mail.app network delivery does not fail the LaunchAgent run after the local report has already been written.
+This runner scans the local runner logs monitored on this machine and builds a plain-text `Weekly Agent Report`. It persists a timestamped local copy before sending through the native macOS Mail app. Mail.app delivery uses a bounded AppleScript timeout and sends asynchronously once the message is handed to Mail. If Mail reports its own AppleEvent timeout after that handoff, the runner logs a warning and exits successfully so slow Mail.app network delivery does not fail the LaunchAgent run after the local report has already been written.
 
 Default log files:
 

--- a/scripts/weekly_hushline_code_agent_report_runner.py
+++ b/scripts/weekly_hushline_code_agent_report_runner.py
@@ -33,6 +33,7 @@ MAX_COMPLETED_EVENTS = 40
 MAX_ATTENTION_EVENTS = 30
 MAIL_APP_APPLESCRIPT_TIMEOUT_SECONDS = 300
 MAIL_APP_OSASCRIPT_TIMEOUT_SECONDS = MAIL_APP_APPLESCRIPT_TIMEOUT_SECONDS + 30
+MAIL_APP_APPLE_EVENT_TIMEOUT_CODE = "-1712"
 
 MAIL_APP_APPLESCRIPT = r"""
 on run argv
@@ -588,7 +589,23 @@ def send_with_mail_app(subject: str, body: str) -> None:
         Path(body_path).unlink(missing_ok=True)
     if result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "no Mail.app output"
+        if is_mail_app_apple_event_timeout(detail):
+            print(
+                "Warning: Mail.app reported an AppleEvent timeout after the send handoff; "
+                "the persisted report is available if delivery needs manual confirmation.",
+                file=sys.stderr,
+            )
+            return
         raise RunnerError(f"Mail.app send failed: {detail}")
+
+
+def is_mail_app_apple_event_timeout(detail: str) -> bool:
+    normalized_detail = detail.lower()
+    return (
+        MAIL_APP_APPLE_EVENT_TIMEOUT_CODE in detail
+        and "appleevent timed out" in normalized_detail
+        and "mail got an error" in normalized_detail
+    )
 
 
 def build_subject(since: datetime, until: datetime) -> str:

--- a/tests/test_weekly_agent_report_runner.py
+++ b/tests/test_weekly_agent_report_runner.py
@@ -240,6 +240,31 @@ def test_send_with_mail_app_reports_osascript_timeout_and_cleans_tempfile(
     assert not body_paths[0].exists()
 
 
+def test_send_with_mail_app_treats_mail_apple_event_timeout_as_handoff_warning(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    runner = load_runner()
+    body_paths = []
+
+    class Result:
+        returncode = 1
+        stdout = ""
+        stderr = "273:472: execution error: Mail got an error: " "AppleEvent timed out. (-1712)"
+
+    def fake_run(command: list[str], **kwargs: object) -> Result:
+        body_paths.append(Path(command[5]))
+        return Result()
+
+    monkeypatch.setattr(runner.subprocess, "run", fake_run)
+
+    runner.send_with_mail_app("Subject", "Body")
+
+    assert "AppleEvent timeout after the send handoff" in capsys.readouterr().err
+    assert len(body_paths) == 1
+    assert not body_paths[0].exists()
+
+
 def test_main_persists_report_body_by_default(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Treat Mail.app `AppleEvent timed out (-1712)` after weekly report send handoff as a warning instead of a failed runner exit.
- Keep true `osascript` process timeouts and other Mail.app failures as hard errors.
- Add regression coverage for the observed Mail timeout and document the runner behavior.

## Context

The weekly agent email runner was persisting the report, handing the message to Mail.app, and then failing the LaunchAgent run when Mail returned its own AppleEvent timeout. That left the report artifact available but launchd marked the job failed. This change keeps the runner successful for the known post-handoff timeout while preserving failure behavior for other delivery errors.

## Validation

- `docker compose run --rm app poetry run pytest tests/test_weekly_agent_report_runner.py` - passed, `13 passed`
- `docker compose run --rm app poetry run ruff check scripts/weekly_hushline_code_agent_report_runner.py tests/test_weekly_agent_report_runner.py` - passed
- `./scripts/weekly_hushline_code_agent_report_runner.py --dry-run --log-file /Users/scidsg/hushline-weekly-report-agent/logs/weekly-agent-report.stderr.log` - passed
- `make weekly-agent-report` from `/Users/scidsg/hushline-weekly-report-agent` - passed, sent report and persisted `logs/weekly-agent-reports/weekly-agent-report-20260518T195948Z.txt`
- `make audit-node-runtime` - passed, `found 0 vulnerabilities`
- `make audit-python` - passed, `No known vulnerabilities found`
- `docker compose run --rm app sh -lc 'node_modules/.bin/prettier --ignore-path /dev/null --check docs/AGENT-RUNNER.md'` - passed
- `make test` - passed, `1743 passed, 1 deselected, 1 xfailed`
- `make lint` - blocked after Ruff and mypy passed because Prettier reports existing formatting drift in 21 unchanged `hushline/static/js/*.js` files outside this PR scope.

## Manual Testing

- Confirm the installed weekly report runner still sends from `weekly-report@hushline.app` to `glenn@hushline.app`.
- Confirm launchd no longer marks the weekly report job failed when Mail.app reports `AppleEvent timed out (-1712)` after the send handoff.
- Confirm persisted report artifacts remain available in `logs/weekly-agent-reports/` for manual delivery checks.

## Risks / Follow-ups

- The timeout handling is intentionally narrow: it only downgrades Mail.app AppleEvent timeout `-1712` messages containing the expected Mail error text.
- Full `make lint` still needs the unrelated static JS Prettier drift addressed separately so the local lint target is clean end to end.