### PR TITLE
Guard Hush Line code runner polling

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,7 @@ This file provides operating guidance for coding agents working in the Hush Line
   - Runner exits early if any unrelated open PR exists from bot login (`HUSHLINE_BOT_LOGIN`, default `hushline-dev`).
   - Exception: when the selected issue is a child of a GitHub parent epic, the runner may allow the long-lived epic PR plus the matching child issue PR, and should stop only for unrelated bot PRs.
 - Required runner behavior:
+  - The runner must acquire a local non-blocking lock before touching the repository or Docker; if another Hush Line code-agent run is active, exit without changing local state.
   - At runner start, perform a full local environment reset and seed sequence:
     - `docker compose down -v --remove-orphans`
     - Stop/remove all Docker containers (`docker rm -f $(docker ps -aq)`)
@@ -105,7 +106,8 @@ This file provides operating guidance for coding agents working in the Hush Line
   - Run required validation checks locally before opening PRs (`make lint`, `make test`).
   - Persist per-run logs in `docs/agent-logs/` and include the log path in PR context.
   - Use signed commits that verify on GitHub.
-  - Force-sync local checkout to `origin/main` at runner start to clear dirty trees.
+  - Before any destructive sync, exit without changing files unless the checkout is clean and already on the base branch.
+  - After the checkout safety preflight passes, sync the local base branch to `origin/main`.
   - If the selected issue is a child of a GitHub parent epic, create/update the child issue branch as usual, but target its PR at the shared epic branch instead of `main`.
   - The shared epic branch should be the only long-lived PR that targets `main` for that epic.
   - Move the selected issue's project status to `In Progress` while work is underway.

--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -16,7 +16,7 @@ The repository does not currently include runner scripts for the social or docs 
 
 | Label                                             | Scope                                | Schedule                        | Source                                                  |
 | ------------------------------------------------- | ------------------------------------ | ------------------------------- | ------------------------------------------------------- |
-| org.scidsg.hushline-code-agent                    | Hush Line issue runner               | Every hour (StartInterval=3600) | org.scidsg.hushline-code-agent.plist                    |
+| org.scidsg.hushline-code-agent                    | Hush Line issue runner               | Every 60 seconds                | org.scidsg.hushline-code-agent.plist                    |
 | com.hushline.social.daily-planner                 | Social planner                       | Mon-Fri at 6:00 AM              | com.hushline.social.daily-planner.plist                 |
 | com.hushline.social.linkedin.daily                | Social LinkedIn daily                | Mon-Fri at 6:10 AM              | com.hushline.social.linkedin.daily.plist                |
 | com.hushline.weekly-agent-report                  | Weekly local agent report            | Sunday at 10:30 PM              | com.hushline.weekly-agent-report.plist                  |
@@ -34,31 +34,33 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 
 1. Parse arguments (`--issue` optional) and resolve runtime configuration.
 2. Change into the repo (`$HOME/hushline` by default).
-3. Hard-refresh local state:
+3. Acquire a local runner lock and exit without doing any repository or Docker work if another Hush Line code-agent run is active.
+4. Exit without changing files unless the checkout is clean and already on the base branch.
+5. Hard-refresh local state:
    - `git fetch origin`
    - `git checkout main`
    - `git reset --hard origin/main`
    - `git clean -fd`
-4. Select issue target before bootstrapping runtime:
+6. Select issue target before bootstrapping runtime:
    - Use `--issue <n>` when provided (must still be open), otherwise
    - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
-5. Check cheap GitHub exit conditions before bootstrapping runtime:
+7. Check cheap GitHub exit conditions before bootstrapping runtime:
    - exit if any open human-authored PR exists
    - exit if any open issue is already in project status `In Progress`
    - for non-epic issues, exit if any other open PR exists from `hushline-dev`
    - for child issues with a GitHub parent epic, allow the long-lived epic PR (head branch `codex/epic-<epic>`) and the current child issue PR (head branch `codex/daily-issue-<issue>`)
    - for child issues with a GitHub parent epic, exit only if there are unrelated open bot PRs outside those allowed heads
-6. Move the selected issue into project status `In Progress`.
-7. Configure bot git identity and signed commit settings.
-8. Reset local Docker/runtime state:
+8. Move the selected issue into project status `In Progress`.
+9. Configure bot git identity and signed commit settings.
+10. Reset local Docker/runtime state:
    - `docker compose down -v --remove-orphans`
    - Remove all Docker containers (`docker rm -f $(docker ps -aq)`, when any exist)
    - Kill processes listening on runner ports (`4566 4571 5432 8080` by default)
-9. Start and seed stack:
+11. Start and seed stack:
    - `docker compose up -d --build`
    - `docker compose run --rm dev_data`
    - retry the bootstrap sequence when Docker image pulls fail with transient registry/network errors (defaults: `3` attempts, `10`s delay via `HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_ATTEMPTS` and `HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS`)
-10. Create/update work branch:
+12. Create/update work branch:
 
 - regular issues use `codex/daily-issue-<issue_number>` by default
 - child issues with a parent epic still use `codex/daily-issue-<issue_number>` as the work branch
@@ -66,13 +68,13 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 - if the epic base branch does not exist yet, create and push it from `main` before starting the child branch
 - if the child issue branch already has an open PR, update that child PR instead of opening a duplicate
 
-11. Run a bounded Codex issue loop until repository changes exist (max attempts configurable via `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS`, default `10`).
+13. Run a bounded Codex issue loop until repository changes exist (max attempts configurable via `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS`, default `10`).
     - The issue/fix prompts tell Codex to avoid local container-backed make validation by default, and to defer validation entirely to the runner when schema-affecting files are touched (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`).
     - The fix prompt includes the current branch diff summary, the prior Codex summary, and an extracted failure signature so Codex can repair the current implementation instead of repeating a narrow patch against the same failing symptom.
     - Raw failed check output is intentionally withheld from Codex prompts because local check logs may contain sensitive operational data.
     - Codex transcript output is captured in a temporary file for the duration of the run and is excluded from the persisted runner log; only the final Codex summary is written into the run log.
     - Each Codex attempt logs prompt size and pre/post worktree snapshots so clean-tree no-op runs are visible in the runner log.
-12. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
+14. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
     - Before lint/test validation, if the working tree includes schema-affecting changes (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), rebuild the local runtime and reseed dev data so the live stack matches the current code.
     - `make lint`
     - `make test` (full suite)
@@ -80,24 +82,24 @@ This runner runs directly in the local repo and performs a narrow local gate bef
     - Lint failures only run deterministic `make fix` self-heal when the failure looks auto-fixable (for example Ruff formatting/check or Prettier); non-auto-fixable lint failures go straight back to Codex.
     - Runtime-dependent tests self-heal by restarting the local stack and reseeding dev data, then retrying once.
     - The broader CI workflow matrix still runs on the PR after branch push; the runner no longer tries to mirror that entire matrix locally.
-13. Persist run log to `docs/agent-logs/run-<timestamp>-issue-<n>.txt`.
+15. Persist run log to `docs/agent-logs/run-<timestamp>-issue-<n>.txt`.
     - After each persist, prune older runner logs and keep only the newest `10` by default.
     - Persisted logs are sanitized before commit to remove developer filesystem paths, emails, and Codex session metadata.
-14. Commit, push branch, and open/update PR:
+16. Commit, push branch, and open/update PR:
     - first push uses a normal push when remote branch is absent
     - existing remote branch uses `--force-with-lease` with one stale-info recovery retry.
     - child issues under a parent epic open/update a child PR whose base branch is the shared epic branch
     - the long-lived epic PR, when present, remains the only PR that targets `main`
-15. Move the selected issue into project status `Ready for Review` once the PR exists.
-16. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
-17. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
-18. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`, `Manual Testing`).
+17. Move the selected issue into project status `Ready for Review` once the PR exists.
+18. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
+19. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
+20. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`, `Manual Testing`).
     - `Validation` lists automated checks run by the runner or CI.
     - `Manual Testing` lists human reviewer steps to exercise the changed feature after the PR opens. It is not a log of actions the LLM or runner performed.
-19. Refresh run log after PR creation (including opened PR URL and post-check steps), commit/push that log update when changed.
-20. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, then resumes polling.
-21. Return to `main` on exit (explicit checkout + cleanup trap fallback).
-    - Exit cleanup force-resets the repo to `origin/main` and removes untracked files so interrupted runs do not leave bot work on `main`.
+21. Refresh run log after PR creation (including opened PR URL and post-check steps), commit/push that log update when changed.
+22. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, then resumes polling.
+23. Return to `main` on exit only after successful handoff or PR closure.
+    - If the runner leaves uncommitted work on an issue branch after a failure, cleanup preserves that checkout so the next scheduled pass skips instead of destroying local work.
 
 ## ASCII Workflow (Current)
 
@@ -118,9 +120,21 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 +-----------------------------------------------+
       |
       v
++-----------------------------------------------+
+| Acquire runner lock                           |
+| Already active? skip + exit                   |
++-----------------------------------------------+
+      |
+      v
 +--------------------------------+
 | Require commands + repo exists |
 +--------------------------------+
+      |
+      v
++--------------------------------------------------+
+| Verify clean base-branch checkout              |
+| Dirty or non-base checkout? skip + exit        |
++--------------------------------------------------+
       |
       v
 +------------------------------------------------+
@@ -218,7 +232,8 @@ This runner runs directly in the local repo and performs a narrow local gate bef
       |
       v
 +----------------------------------------------+
-| Checkout base branch + trap cleanup runs      |
+| Cleanup after successful handoff/PR close     |
+| Preserve failed dirty issue branches          |
 +----------------------------------------------+
 ```
 
@@ -340,6 +355,7 @@ The runner now performs an SSH signing preflight immediately after configuring g
 - `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS` (default `10`; positive integer)
 - `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS` (default `8`; positive integer)
 - `HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS` (default `60`; non-negative integer; set `0` to skip continuous PR feedback monitoring; when enabled, the issue runner keeps the PR branch checked out and polls until the PR closes)
+- `HUSHLINE_DAILY_RUNNER_LOCK_DIR` (default `${TMPDIR:-/tmp}/hushline-code-agent.lock`)
 - `HUSHLINE_CODEX_MODEL` (default `gpt-5.5`)
 - `HUSHLINE_CODEX_REASONING_EFFORT` (default `high`)
 - `HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT` (default `0`; set `1` to print full Codex transcript output to the live console only, without writing it into persisted runner logs)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -73,6 +73,10 @@ RUN_LOG_GIT_PATH=""
 RUN_LOG_RETENTION_COUNT="${HUSHLINE_DAILY_RUN_LOG_RETENTION:-10}"
 VERBOSE_CODEX_OUTPUT="${HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT:-0}"
 AUDIT_STATUS="ok"
+CLEANUP_REPO_ON_EXIT=0
+PRESERVE_WORKTREE_ON_EXIT=0
+RUNNER_LOCK_DIR="${HUSHLINE_DAILY_RUNNER_LOCK_DIR:-${TMPDIR:-/tmp}/hushline-code-agent.lock}"
+RUNNER_LOCK_HELD=0
 AUDIT_NOTE=""
 NODE_FULL_AUDIT_REQUIRED=0
 MIGRATION_SMOKE_REQUIRED=0
@@ -127,9 +131,14 @@ initialize_run_state() {
 cleanup() {
   rm -f "${CHECK_LOG_FILE:-}" "${PROMPT_FILE:-}" "${PR_BODY_FILE:-}" "${CODEX_OUTPUT_FILE:-}" "${CODEX_TRANSCRIPT_FILE:-}" "${RUN_LOG_TMP_FILE:-}"
   rm -f "${HUSHLINE_DAILY_RUNNER_SNAPSHOT_PATH:-}"
-  if [[ -d "$REPO_DIR/.git" ]]; then
+  release_runner_lock
+  if [[ -d "$REPO_DIR/.git" && "$CLEANUP_REPO_ON_EXIT" == "1" ]]; then
     if [[ "${PR_FEEDBACK_MONITOR_ACTIVE:-0}" == "1" && "${PR_FEEDBACK_MONITOR_CLOSED:-0}" != "1" ]]; then
       echo "Leaving branch ${PR_FEEDBACK_MONITOR_BRANCH:-current branch} checked out because PR #${PR_FEEDBACK_MONITOR_PR_NUMBER:-unknown} is still open."
+      return
+    fi
+    if [[ "$PRESERVE_WORKTREE_ON_EXIT" == "1" ]]; then
+      echo "Leaving current branch checked out because runner work did not complete cleanly."
       return
     fi
     if ! git -C "$REPO_DIR" checkout "$BASE_BRANCH" >/dev/null 2>&1; then
@@ -144,6 +153,78 @@ cleanup() {
     if ! git -C "$REPO_DIR" clean -fd >/dev/null 2>&1; then
       echo "Warning: failed to remove untracked files during cleanup." >&2
     fi
+  fi
+}
+
+release_runner_lock() {
+  if [[ "$RUNNER_LOCK_HELD" != "1" ]]; then
+    return 0
+  fi
+  rm -f "$RUNNER_LOCK_DIR/pid"
+  rmdir "$RUNNER_LOCK_DIR" 2>/dev/null || true
+  RUNNER_LOCK_HELD=0
+}
+
+acquire_runner_lock() {
+  local existing_pid=""
+
+  if mkdir "$RUNNER_LOCK_DIR" 2>/dev/null; then
+    RUNNER_LOCK_HELD=1
+    printf '%s\n' "$$" > "$RUNNER_LOCK_DIR/pid"
+    return 0
+  fi
+
+  if [[ -L "$RUNNER_LOCK_DIR" ]]; then
+    runner_status "Skipped: runner lock path is a symlink; refusing to modify it."
+    exit 0
+  fi
+
+  if [[ -f "$RUNNER_LOCK_DIR/pid" ]]; then
+    existing_pid="$(sed -n '1p' "$RUNNER_LOCK_DIR/pid" 2>/dev/null || true)"
+    if [[ "$existing_pid" =~ ^[0-9]+$ ]] && kill -0 "$existing_pid" 2>/dev/null; then
+      runner_status "Skipped: another Hush Line code agent run is already active as PID $existing_pid."
+      exit 0
+    fi
+  fi
+
+  rm -f "$RUNNER_LOCK_DIR/pid" 2>/dev/null || true
+  if rmdir "$RUNNER_LOCK_DIR" 2>/dev/null && mkdir "$RUNNER_LOCK_DIR" 2>/dev/null; then
+    RUNNER_LOCK_HELD=1
+    printf '%s\n' "$$" > "$RUNNER_LOCK_DIR/pid"
+    return 0
+  fi
+
+  runner_status "Skipped: another Hush Line code agent run is already active."
+  exit 0
+}
+
+current_branch_name() {
+  git symbolic-ref --quiet --short HEAD 2>/dev/null || true
+}
+
+worktree_status_porcelain() {
+  git status --porcelain 2>/dev/null || true
+}
+
+assert_runner_can_take_checkout() {
+  local current_branch=""
+  local status_output=""
+
+  if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    return 0
+  fi
+
+  current_branch="$(current_branch_name)"
+  if [[ "$current_branch" != "$BASE_BRANCH" ]]; then
+    runner_status "Skipped: checkout is on '${current_branch:-detached HEAD}', not '$BASE_BRANCH'; leaving local work untouched."
+    exit 0
+  fi
+
+  status_output="$(worktree_status_porcelain)"
+  if [[ -n "$status_output" ]]; then
+    runner_status "Skipped: checkout has local changes; leaving local work untouched."
+    printf '%s\n' "$status_output"
+    exit 0
   fi
 }
 
@@ -2997,6 +3078,7 @@ main() {
   parse_args "$@"
   initialize_run_state
   trap cleanup EXIT
+  acquire_runner_lock
 
   require_cmd git
   require_cmd gh
@@ -3022,6 +3104,9 @@ main() {
   fi
 
   cd "$REPO_DIR"
+
+  assert_runner_can_take_checkout
+  CLEANUP_REPO_ON_EXIT=1
 
   run_step "Fetch latest from origin" git fetch origin
   run_step "Checkout $BASE_BRANCH" git checkout "$BASE_BRANCH"
@@ -3144,6 +3229,7 @@ main() {
   else
     run_step "Create branch $BRANCH_NAME" git checkout -B "$BRANCH_NAME" "$BASE_BRANCH"
   fi
+  PRESERVE_WORKTREE_ON_EXIT=1
 
   build_issue_prompt "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY"
   run_issue_attempt_loop "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY" "$ISSUE_LABELS" "$BRANCH_NAME"
@@ -3167,6 +3253,7 @@ main() {
     COMMIT_MESSAGE="${COMMIT_MESSAGE} (epic #${EPIC_ISSUE_NUMBER})"
   fi
   git commit -m "$COMMIT_MESSAGE"
+  PRESERVE_WORKTREE_ON_EXIT=0
 
   ensure_head_commit_on_branch "$BRANCH_NAME" "$BASE_BRANCH"
   require_branch_has_unique_commits "$PR_BASE_REF" "$BRANCH_NAME"

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -87,6 +87,126 @@ printf '%s\\n' "$snapshot_metadata"
     assert snapshot_file.read_text(encoding="utf-8") == RUNNER_SCRIPT.read_text(encoding="utf-8")
 
 
+def test_runner_preflight_skips_when_checkout_is_not_on_base_branch(
+    tmp_path: Path,
+) -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+git() {{
+  case "${{1-}} ${{2-}} ${{3-}}" in
+    "rev-parse --is-inside-work-tree ")
+      return 0
+      ;;
+    "symbolic-ref --quiet --short")
+      printf 'feature\\n'
+      return 0
+      ;;
+    "status --porcelain ")
+      return 0
+      ;;
+  esac
+  return 0
+}}
+assert_runner_can_take_checkout
+printf 'unexpected\\n'
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "not 'main'; leaving local work untouched" in result.stdout
+    assert "unexpected" not in result.stdout
+
+
+def test_runner_preflight_skips_when_checkout_has_local_changes(
+    tmp_path: Path,
+) -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+git() {{
+  case "${{1-}} ${{2-}} ${{3-}}" in
+    "rev-parse --is-inside-work-tree ")
+      return 0
+      ;;
+    "symbolic-ref --quiet --short")
+      printf 'main\\n'
+      return 0
+      ;;
+    "status --porcelain ")
+      printf ' M file.txt\\n'
+      return 0
+      ;;
+  esac
+  return 0
+}}
+assert_runner_can_take_checkout
+printf 'unexpected\\n'
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "checkout has local changes; leaving local work untouched" in result.stdout
+    assert " M file.txt" in result.stdout
+    assert "unexpected" not in result.stdout
+
+
+def test_cleanup_preserves_failed_runner_worktree(tmp_path: Path) -> None:
+    call_log = tmp_path / "calls.txt"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(tmp_path / "repo"))}
+mkdir -p "$REPO_DIR/.git"
+git() {{
+  printf 'git:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+  case "${{1-}} ${{2-}} ${{3-}}" in
+    "-C $REPO_DIR branch")
+      printf 'codex/daily-issue-1978\\n'
+      return 0
+      ;;
+    "-C $REPO_DIR status")
+      printf ' M file.txt\\n'
+      return 0
+      ;;
+  esac
+  return 0
+}}
+CLEANUP_REPO_ON_EXIT=1
+PRESERVE_WORKTREE_ON_EXIT=1
+cleanup
+git -C "$REPO_DIR" branch --show-current
+git -C "$REPO_DIR" status --short
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Leaving current branch checked out" in result.stdout
+    assert "codex/daily-issue-1978" in result.stdout
+    assert " M file.txt" in result.stdout
+    assert "git:-C" in call_log.read_text(encoding="utf-8")
+
+
+def test_runner_lock_skips_when_existing_runner_is_active(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "runner.lock"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+RUNNER_LOCK_DIR={shlex.quote(str(lock_dir))}
+mkdir -p "$RUNNER_LOCK_DIR"
+printf '%s\\n' "$$" > "$RUNNER_LOCK_DIR/pid"
+acquire_runner_lock
+printf 'unexpected\\n'
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "another Hush Line code agent run is already active" in result.stdout
+    assert "unexpected" not in result.stdout
+
+
 def test_main_exits_before_runtime_bootstrap_when_bot_pr_exists(tmp_path: Path) -> None:
     call_log = tmp_path / "calls.txt"
     repo_dir = tmp_path / "repo"
@@ -99,6 +219,8 @@ mkdir -p "$REPO_DIR/.git"
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -152,6 +274,8 @@ mkdir -p "$REPO_DIR/.git"
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -207,6 +331,8 @@ mkdir -p "$REPO_DIR/.git"
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -265,6 +391,8 @@ mkdir -p "$REPO_DIR/.git"
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -330,6 +458,8 @@ mkdir -p "$REPO_DIR/.git"
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -894,6 +1024,8 @@ mkdir -p "$REPO_DIR/.git"
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -949,6 +1081,8 @@ mkdir -p "$REPO_DIR/.git"
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -1001,6 +1135,8 @@ PR_BODY_FILE={shlex.quote(str(tmp_path / "pr-body.md"))}
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -1183,6 +1319,8 @@ PR_BODY_FILE={shlex.quote(str(tmp_path / "pr-body.md"))}
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -3247,6 +3385,8 @@ mkdir -p "$REPO_DIR/.git"
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -3330,6 +3470,8 @@ PR_BODY_FILE={shlex.quote(str(tmp_path / "pr-body.md"))}
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}
@@ -3431,6 +3573,8 @@ mkdir -p "$REPO_DIR/.git"
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
 cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{ :; }}
 require_cmd() {{ :; }}
 require_positive_integer() {{ :; }}
 require_non_negative_integer() {{ :; }}


### PR DESCRIPTION
## What changed
- Add a non-blocking local runner lock before the Hush Line code agent touches Docker or the repository.
- Skip scheduled runs unless the checkout is on the base branch and has no local changes.
- Preserve failed runner branches/worktrees so the next 60-second poll does not reset active work.
- Document the new runner behavior and lock env var.

## Why
The 60-second LaunchAgent could start a new pass while a previous run or human/Codex work was still active. That new pass force-synced main and removed local changes.

## Validation
- docker compose run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py -q
- Full make test was started, then stopped when requested to open the PR immediately.

## Manual testing
Not applicable beyond the focused runner tests; this changes runner control flow and docs only.

## Notes
The installed Hush Line LaunchAgent remains disabled locally pending this fix. The plist interval is still 60 seconds.