### PR TITLE
Restore runner cleanup to clean main

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -98,8 +98,8 @@ This runner runs directly in the local repo and performs a narrow local gate bef
     - `Manual Testing` lists human reviewer steps to exercise the changed feature after the PR opens. It is not a log of actions the LLM or runner performed.
 21. Refresh run log after PR creation (including opened PR URL and post-check steps), commit/push that log update when changed.
 22. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, then resumes polling.
-23. Return to `main` on exit only after successful handoff or PR closure.
-    - If the runner leaves uncommitted work on an issue branch after a failure, cleanup preserves that checkout so the next scheduled pass skips instead of destroying local work.
+23. Return to a clean `main` on exit after a failed run, successful handoff, or PR closure.
+    - A new scheduled pass still exits before any destructive sync if a human or another process has left the checkout off `main` or with local changes.
 
 ## ASCII Workflow (Current)
 
@@ -233,7 +233,7 @@ This runner runs directly in the local repo and performs a narrow local gate bef
       v
 +----------------------------------------------+
 | Cleanup after successful handoff/PR close     |
-| Preserve failed dirty issue branches          |
+| Reset failed runs back to clean main          |
 +----------------------------------------------+
 ```
 

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -74,7 +74,6 @@ RUN_LOG_RETENTION_COUNT="${HUSHLINE_DAILY_RUN_LOG_RETENTION:-10}"
 VERBOSE_CODEX_OUTPUT="${HUSHLINE_DAILY_VERBOSE_CODEX_OUTPUT:-0}"
 AUDIT_STATUS="ok"
 CLEANUP_REPO_ON_EXIT=0
-PRESERVE_WORKTREE_ON_EXIT=0
 RUNNER_LOCK_DIR="${HUSHLINE_DAILY_RUNNER_LOCK_DIR:-${TMPDIR:-/tmp}/hushline-code-agent.lock}"
 RUNNER_LOCK_HELD=0
 AUDIT_NOTE=""
@@ -135,10 +134,6 @@ cleanup() {
   if [[ -d "$REPO_DIR/.git" && "$CLEANUP_REPO_ON_EXIT" == "1" ]]; then
     if [[ "${PR_FEEDBACK_MONITOR_ACTIVE:-0}" == "1" && "${PR_FEEDBACK_MONITOR_CLOSED:-0}" != "1" ]]; then
       echo "Leaving branch ${PR_FEEDBACK_MONITOR_BRANCH:-current branch} checked out because PR #${PR_FEEDBACK_MONITOR_PR_NUMBER:-unknown} is still open."
-      return
-    fi
-    if [[ "$PRESERVE_WORKTREE_ON_EXIT" == "1" ]]; then
-      echo "Leaving current branch checked out because runner work did not complete cleanly."
       return
     fi
     if ! git -C "$REPO_DIR" checkout "$BASE_BRANCH" >/dev/null 2>&1; then
@@ -3229,7 +3224,6 @@ main() {
   else
     run_step "Create branch $BRANCH_NAME" git checkout -B "$BRANCH_NAME" "$BASE_BRANCH"
   fi
-  PRESERVE_WORKTREE_ON_EXIT=1
 
   build_issue_prompt "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY"
   run_issue_attempt_loop "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY" "$ISSUE_LABELS" "$BRANCH_NAME"
@@ -3253,7 +3247,6 @@ main() {
     COMMIT_MESSAGE="${COMMIT_MESSAGE} (epic #${EPIC_ISSUE_NUMBER})"
   fi
   git commit -m "$COMMIT_MESSAGE"
-  PRESERVE_WORKTREE_ON_EXIT=0
 
   ensure_head_commit_on_branch "$BRANCH_NAME" "$BASE_BRANCH"
   require_branch_has_unique_commits "$PR_BASE_REF" "$BRANCH_NAME"

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -151,7 +151,7 @@ printf 'unexpected\\n'
     assert "unexpected" not in result.stdout
 
 
-def test_cleanup_preserves_failed_runner_worktree(tmp_path: Path) -> None:
+def test_cleanup_resets_failed_runner_worktree_to_base_branch(tmp_path: Path) -> None:
     call_log = tmp_path / "calls.txt"
 
     shell_script = f"""
@@ -173,7 +173,6 @@ git() {{
   return 0
 }}
 CLEANUP_REPO_ON_EXIT=1
-PRESERVE_WORKTREE_ON_EXIT=1
 cleanup
 git -C "$REPO_DIR" branch --show-current
 git -C "$REPO_DIR" status --short
@@ -182,10 +181,10 @@ git -C "$REPO_DIR" status --short
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
-    assert "Leaving current branch checked out" in result.stdout
-    assert "codex/daily-issue-1978" in result.stdout
-    assert " M file.txt" in result.stdout
-    assert "git:-C" in call_log.read_text(encoding="utf-8")
+    calls = call_log.read_text(encoding="utf-8")
+    assert f"git:-C {tmp_path / 'repo'} checkout main" in calls
+    assert f"git:-C {tmp_path / 'repo'} reset --hard origin/main" in calls
+    assert f"git:-C {tmp_path / 'repo'} clean -fd" in calls
 
 
 def test_runner_lock_skips_when_existing_runner_is_active(tmp_path: Path) -> None:


### PR DESCRIPTION
## What changed
- Remove the failed-run preserve branch path from the Hush Line code runner cleanup.
- Keep the non-overlap lock and start-of-run clean-main preflight from #1979.
- Update runner docs and tests so failed runs return to clean main.

## Why
The runner should still reset back to main after a completed failed attempt. The guard should prevent overlapping/current-work resets at the start of a new scheduled pass, not leave failed runner branches checked out.

## Validation
- docker compose run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py -q

## Manual testing
Not applicable; this changes runner cleanup behavior covered by the shell harness tests.