### PR TITLE
Skip idle runner repository resets

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,7 +97,10 @@ This file provides operating guidance for coding agents working in the Hush Line
   - Exception: when the selected issue is a child of a GitHub parent epic, the runner may allow the long-lived epic PR plus the matching child issue PR, and should stop only for unrelated bot PRs.
 - Required runner behavior:
   - The runner must acquire a local non-blocking lock before touching the repository or Docker; if another Hush Line code-agent run is active, exit without changing local state.
-  - At runner start, perform a full local environment reset and seed sequence:
+  - Before any destructive sync, exit without changing files unless the checkout is clean and already on the base branch.
+  - If no issue is available, or a cheap GitHub guard blocks work, exit before `git fetch`, `git checkout`, `git reset`, `git clean`, Docker reset, or dev-data seeding.
+  - After an issue is selected and all cheap GitHub guards pass, sync the local base branch to `origin/main`.
+  - Before issue work starts, perform a full local environment reset and seed sequence:
     - `docker compose down -v --remove-orphans`
     - Stop/remove all Docker containers (`docker rm -f $(docker ps -aq)`)
     - Kill listener processes on configured runner ports (`HUSHLINE_DAILY_KILL_PORTS`, default `4566 4571 5432 8080`)
@@ -106,8 +109,6 @@ This file provides operating guidance for coding agents working in the Hush Line
   - Run required validation checks locally before opening PRs (`make lint`, `make test`).
   - Persist per-run logs in `docs/agent-logs/` and include the log path in PR context.
   - Use signed commits that verify on GitHub.
-  - Before any destructive sync, exit without changing files unless the checkout is clean and already on the base branch.
-  - After the checkout safety preflight passes, sync the local base branch to `origin/main`.
   - If the selected issue is a child of a GitHub parent epic, create/update the child issue branch as usual, but target its PR at the shared epic branch instead of `main`.
   - The shared epic branch should be the only long-lived PR that targets `main` for that epic.
   - Move the selected issue's project status to `In Progress` while work is underway.

--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -36,20 +36,20 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 2. Change into the repo (`$HOME/hushline` by default).
 3. Acquire a local runner lock and exit without doing any repository or Docker work if another Hush Line code-agent run is active.
 4. Exit without changing files unless the checkout is clean and already on the base branch.
-5. Hard-refresh local state:
-   - `git fetch origin`
-   - `git checkout main`
-   - `git reset --hard origin/main`
-   - `git clean -fd`
-6. Select issue target before bootstrapping runtime:
+5. Select issue target before any destructive repository or Docker work:
    - Use `--issue <n>` when provided (must still be open), otherwise
    - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
-7. Check cheap GitHub exit conditions before bootstrapping runtime:
+6. Check cheap GitHub exit conditions before any destructive repository or Docker work:
    - exit if any open human-authored PR exists
    - exit if any open issue is already in project status `In Progress`
    - for non-epic issues, exit if any other open PR exists from `hushline-dev`
    - for child issues with a GitHub parent epic, allow the long-lived epic PR (head branch `codex/epic-<epic>`) and the current child issue PR (head branch `codex/daily-issue-<issue>`)
    - for child issues with a GitHub parent epic, exit only if there are unrelated open bot PRs outside those allowed heads
+7. Hard-refresh local state only after an issue is selected and skip guards pass:
+   - `git fetch origin`
+   - `git checkout main`
+   - `git reset --hard origin/main`
+   - `git clean -fd`
 8. Move the selected issue into project status `In Progress`.
 9. Configure bot git identity and signed commit settings.
 10. Reset local Docker/runtime state:

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -3101,12 +3101,6 @@ main() {
   cd "$REPO_DIR"
 
   assert_runner_can_take_checkout
-  CLEANUP_REPO_ON_EXIT=1
-
-  run_step "Fetch latest from origin" git fetch origin
-  run_step "Checkout $BASE_BRANCH" git checkout "$BASE_BRANCH"
-  run_step "Reset to origin/$BASE_BRANCH" git reset --hard "origin/$BASE_BRANCH"
-  run_step "Remove untracked files" git clean -fd
 
   ISSUE_NUMBER=""
   if [[ -n "$FORCE_ISSUE_NUMBER" ]]; then
@@ -3184,6 +3178,13 @@ main() {
       exit 0
     fi
   fi
+
+  CLEANUP_REPO_ON_EXIT=1
+
+  run_step "Fetch latest from origin" git fetch origin
+  run_step "Checkout $BASE_BRANCH" git checkout "$BASE_BRANCH"
+  run_step "Reset to origin/$BASE_BRANCH" git reset --hard "origin/$BASE_BRANCH"
+  run_step "Remove untracked files" git clean -fd
 
   run_step \
     "Mark issue #${ISSUE_NUMBER} as ${PROJECT_STATUS_IN_PROGRESS}" \

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -257,6 +257,8 @@ main
     assert "collect-issue-candidates" in calls
     assert "count-open-human-prs" in calls
     assert "count-open-bot-prs-excluding-heads:" in calls
+    assert "Fetch latest from origin" not in calls
+    assert "Reset to origin/main" not in calls
     assert "configure-bot-git" not in calls
     assert "runtime-bootstrap" not in calls
 
@@ -311,6 +313,8 @@ main
     calls = call_log.read_text(encoding="utf-8").splitlines()
     assert "collect-issue-candidates" in calls
     assert "count-open-human-prs" in calls
+    assert "Fetch latest from origin" not in calls
+    assert "Reset to origin/main" not in calls
     assert "count-open-bot-prs" not in calls
     assert "configure-bot-git" not in calls
     assert "runtime-bootstrap" not in calls
@@ -373,6 +377,8 @@ main
     assert "collect-issue-candidates" in calls
     assert "count-open-human-prs" in calls
     assert "count-open-project-issues-in-status:In Progress" in calls
+    assert "Fetch latest from origin" not in calls
+    assert "Reset to origin/main" not in calls
     assert "count-open-bot-prs" not in calls
     assert "configure-bot-git" not in calls
     assert "runtime-bootstrap" not in calls
@@ -427,6 +433,10 @@ main
 
     calls = call_log.read_text(encoding="utf-8").splitlines()
     assert "collect-issue-candidates" in calls
+    assert "Fetch latest from origin" not in calls
+    assert "Checkout main" not in calls
+    assert "Reset to origin/main" not in calls
+    assert "Remove untracked files" not in calls
     assert "count-open-bot-prs" not in calls
     assert "count-open-human-prs" not in calls
     assert "configure-bot-git" not in calls


### PR DESCRIPTION
## What changed
- Move the Hush Line runner fetch checkout reset clean sequence until after an issue is selected and cheap GitHub guards pass.
- Keep the clean-main preflight and overlap lock intact.
- Update runner docs and tests to lock in that no-issue, human-PR, bot-PR, and in-progress-issue skips do not reset the repository.

## Why
The 60-second idle poll was still resetting main before discovering there was no eligible work. Idle and blocked polls should observe GitHub state and exit without touching the checkout.

## Validation
- docker compose run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py -q

## Manual testing
Not applicable beyond the shell harness coverage; this changes runner control flow only.