### PR TITLE
Preserve daily runner work and pause host agent

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -4,25 +4,25 @@ This document tracks the current state of the repo-managed agent automation used
 
 ## Repo-Managed Agent State
 
-| Script                                                | Role                           | Current State                                                | PR / Output Surface                                               |
-| ----------------------------------------------------- | ------------------------------ | ------------------------------------------------------------ | ----------------------------------------------------------------- |
-| `scripts/agent_daily_issue_runner.sh`                 | GitHub issue implementation    | Active, branch/PR automation in place                        | issue-specific branches and PRs                                   |
-| `scripts/weekly_hushline_code_agent_report_runner.py` | Weekly local agent reporting   | Active, local Mail.app delivery and local report persistence | email to `glenn@hushline.app`; local `logs/weekly-agent-reports/` |
-| `scripts/agent_issue_bootstrap.sh`                    | Local runtime/bootstrap helper | Active, manual helper used by issue and local workflows      | local Docker/bootstrap only                                       |
+| Script                                                | Role                           | Current State                                                      | PR / Output Surface                                               |
+| ----------------------------------------------------- | ------------------------------ | ------------------------------------------------------------------ | ----------------------------------------------------------------- |
+| `scripts/agent_daily_issue_runner.sh`                 | GitHub issue implementation    | Disabled on this host while runner reliability fixes are validated | issue-specific branches and PRs                                   |
+| `scripts/weekly_hushline_code_agent_report_runner.py` | Weekly local agent reporting   | Active, local Mail.app delivery and local report persistence       | email to `glenn@hushline.app`; local `logs/weekly-agent-reports/` |
+| `scripts/agent_issue_bootstrap.sh`                    | Local runtime/bootstrap helper | Active, manual helper used by issue and local workflows            | local Docker/bootstrap only                                       |
 
 The repository does not currently include runner scripts for the social or docs launch agents listed below. Those host jobs exist outside this repository and should be documented here only as installed host context, not as repo-managed automation.
 
 ## Installed Host Jobs
 
-| Label                                             | Scope                                | Schedule              | Source                                                  |
-| ------------------------------------------------- | ------------------------------------ | --------------------- | ------------------------------------------------------- |
-| org.scidsg.hushline-code-agent                    | Hush Line issue runner               | Every 60 seconds      | org.scidsg.hushline-code-agent.plist                    |
-| com.hushline.social.daily-planner                 | Social planner                       | Mon-Fri at 6:00 AM    | com.hushline.social.daily-planner.plist                 |
-| com.hushline.social.linkedin.daily                | Social LinkedIn daily                | Mon-Fri at 6:10 AM    | com.hushline.social.linkedin.daily.plist                |
-| com.hushline.weekly-agent-report                  | Weekly local agent report            | Sunday at 10:30 PM    | com.hushline.weekly-agent-report.plist                  |
-| com.hushline.social.verified-user.weekly          | Social verified-user weekly          | Monday at 12:00 PM    | com.hushline.social.verified-user.weekly.plist          |
-| com.hushline.social.linkedin.verified-user.weekly | Social verified-user LinkedIn weekly | Monday at 12:10 PM    | com.hushline.social.linkedin.verified-user.weekly.plist |
-| com.hushline.docs.weekly-article                  | Docs weekly article                  | Wednesday at 10:00 AM | com.hushline.docs.weekly-article.plist                  |
+| Label                                             | Scope                                | Schedule                                       | Source                                                  |
+| ------------------------------------------------- | ------------------------------------ | ---------------------------------------------- | ------------------------------------------------------- |
+| org.scidsg.hushline-code-agent                    | Hush Line issue runner               | Disabled pending runner reliability validation | org.scidsg.hushline-code-agent.plist                    |
+| com.hushline.social.daily-planner                 | Social planner                       | Mon-Fri at 6:00 AM                             | com.hushline.social.daily-planner.plist                 |
+| com.hushline.social.linkedin.daily                | Social LinkedIn daily                | Mon-Fri at 6:10 AM                             | com.hushline.social.linkedin.daily.plist                |
+| com.hushline.weekly-agent-report                  | Weekly local agent report            | Sunday at 10:30 PM                             | com.hushline.weekly-agent-report.plist                  |
+| com.hushline.social.verified-user.weekly          | Social verified-user weekly          | Monday at 12:00 PM                             | com.hushline.social.verified-user.weekly.plist          |
+| com.hushline.social.linkedin.verified-user.weekly | Social verified-user LinkedIn weekly | Monday at 12:10 PM                             | com.hushline.social.linkedin.verified-user.weekly.plist |
+| com.hushline.docs.weekly-article                  | Docs weekly article                  | Wednesday at 10:00 AM                          | com.hushline.docs.weekly-article.plist                  |
 
 ## Daily Issue Runner
 
@@ -36,35 +36,36 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 2. Change into the repo (`$HOME/hushline` by default).
 3. Acquire a local runner lock and exit without doing any repository or Docker work if another Hush Line code-agent run is active.
 4. Exit without changing files unless the checkout is clean and already on the base branch.
-5. Select issue target before any destructive repository or Docker work:
-   - Use `--issue <n>` when provided (must still be open), otherwise
-   - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
-6. Check cheap GitHub exit conditions before any destructive repository or Docker work:
+5. Check cheap GitHub exit conditions before any new-work queue lookup or destructive repository/Docker work:
    - exit if any open human-authored PR exists
    - exit if any open issue is already in project status `In Progress`
+6. Select issue target before any destructive repository or Docker work:
+   - Use `--issue <n>` when provided (must still be open), otherwise
+   - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
+7. Check remaining cheap GitHub exit conditions before any destructive repository or Docker work:
    - for non-epic issues, exit if any other open PR exists from `hushline-dev`
    - for child issues with a GitHub parent epic, allow the long-lived epic PR (head branch `codex/epic-<epic>`) and the current child issue PR (head branch `codex/daily-issue-<issue>`)
    - for child issues with a GitHub parent epic, exit only if there are unrelated open bot PRs outside those allowed heads
-7. Hard-refresh local state only after an issue is selected and skip guards pass:
+8. Hard-refresh local state only after an issue is selected and skip guards pass:
    - `git fetch origin`
    - `git checkout main`
    - `git reset --hard origin/main`
    - `git clean -fd`
-8. Move the selected issue into project status `In Progress`.
-9. Configure bot git identity and signed commit settings.
-10. Reset local Docker/runtime state:
+9. Move the selected issue into project status `In Progress`.
+10. Configure bot git identity and signed commit settings.
+11. Reset local Docker/runtime state:
 
 - `docker compose down -v --remove-orphans`
 - Remove all Docker containers (`docker rm -f $(docker ps -aq)`, when any exist)
 - Kill processes listening on runner ports (`4566 4571 5432 8080` by default)
 
-11. Start and seed stack:
+12. Start and seed stack:
 
 - `docker compose up -d --build`
 - `docker compose run --rm dev_data`
 - retry the bootstrap sequence when Docker image pulls fail with transient registry/network errors (defaults: `3` attempts, `10`s delay via `HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_ATTEMPTS` and `HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS`)
 
-12. Create/update work branch:
+13. Create/update work branch:
 
 - regular issues use `codex/daily-issue-<issue_number>` by default
 - child issues with a parent epic still use `codex/daily-issue-<issue_number>` as the work branch
@@ -72,13 +73,13 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 - if the epic base branch does not exist yet, create and push it from `main` before starting the child branch
 - if the child issue branch already has an open PR, update that child PR instead of opening a duplicate
 
-13. Run a bounded Codex issue loop until repository changes exist (max attempts configurable via `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS`, default `10`).
+14. Run a bounded Codex issue loop until repository changes exist (max attempts configurable via `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS`, default `10`).
     - The issue/fix prompts tell Codex to avoid local container-backed make validation by default, and to defer validation entirely to the runner when schema-affecting files are touched (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`).
     - The fix prompt includes the current branch diff summary, the prior Codex summary, and an extracted failure signature so Codex can repair the current implementation instead of repeating a narrow patch against the same failing symptom.
     - Raw failed check output is intentionally withheld from Codex prompts because local check logs may contain sensitive operational data.
     - Codex transcript output is captured in a temporary file for the duration of the run and is excluded from the persisted runner log; only the final Codex summary is written into the run log.
     - Each Codex attempt logs prompt size and pre/post worktree snapshots so clean-tree no-op runs are visible in the runner log.
-14. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
+15. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
     - Before lint/test validation, if the working tree includes schema-affecting changes (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), rebuild the local runtime and reseed dev data so the live stack matches the current code.
     - `make lint`
     - `make test` (full suite)
@@ -86,23 +87,24 @@ This runner runs directly in the local repo and performs a narrow local gate bef
     - Lint failures only run deterministic `make fix` self-heal when the failure looks auto-fixable (for example Ruff formatting/check or Prettier); non-auto-fixable lint failures go straight back to Codex.
     - Runtime-dependent tests self-heal by restarting the local stack and reseeding dev data, then retrying once.
     - The broader CI workflow matrix still runs on the PR after branch push; the runner no longer tries to mirror that entire matrix locally.
-15. Persist run log to `docs/agent-logs/run-<timestamp>-issue-<n>.txt`.
+16. Persist run log to `docs/agent-logs/run-<timestamp>-issue-<n>.txt`.
     - After each persist, prune older runner logs and keep only the newest `10` by default.
     - Persisted logs are sanitized before commit to remove developer filesystem paths, emails, and Codex session metadata.
-16. Commit, push branch, and open/update PR:
+17. Commit, push branch, and open/update PR:
     - first push uses a normal push when remote branch is absent
     - existing remote branch uses `--force-with-lease` with one stale-info recovery retry.
     - child issues under a parent epic open/update a child PR whose base branch is the shared epic branch
     - the long-lived epic PR, when present, remains the only PR that targets `main`
-17. Move the selected issue into project status `Ready for Review` once the PR exists.
-18. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
-19. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
-20. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`, `Manual Testing`).
+18. Move the selected issue into project status `Ready for Review` once the PR exists.
+19. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
+20. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
+21. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`, `Manual Testing`).
     - `Validation` lists automated checks run by the runner or CI.
     - `Manual Testing` lists human reviewer steps to exercise the changed feature after the PR opens. It is not a log of actions the LLM or runner performed.
-21. Refresh run log after PR creation (including opened PR URL and post-check steps), commit/push that log update when changed.
-22. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, then resumes polling.
-23. Return to a clean `main` on exit after a failed run, successful handoff, or PR closure.
+22. Refresh run log after PR creation (including opened PR URL and post-check steps), commit/push that log update when changed.
+23. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, then resumes polling.
+24. Return to a clean `main` on normal completion or PR closure.
+    - If the run fails after creating branch work, leave the failed worktree on its current branch with its changes intact for human inspection or manual recovery.
     - A new scheduled pass still exits before any destructive sync if a human or another process has left the checkout off `main` or with local changes.
 
 ## ASCII Workflow (Current)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -128,6 +128,10 @@ initialize_run_state() {
 }
 
 cleanup() {
+  local exit_code=$?
+  local cleanup_branch=""
+  local cleanup_status=""
+
   rm -f "${CHECK_LOG_FILE:-}" "${PROMPT_FILE:-}" "${PR_BODY_FILE:-}" "${CODEX_OUTPUT_FILE:-}" "${CODEX_TRANSCRIPT_FILE:-}" "${RUN_LOG_TMP_FILE:-}"
   rm -f "${HUSHLINE_DAILY_RUNNER_SNAPSHOT_PATH:-}"
   release_runner_lock
@@ -136,6 +140,19 @@ cleanup() {
       echo "Leaving branch ${PR_FEEDBACK_MONITOR_BRANCH:-current branch} checked out because PR #${PR_FEEDBACK_MONITOR_PR_NUMBER:-unknown} is still open."
       return
     fi
+
+    if (( exit_code != 0 )); then
+      cleanup_branch="$(git -C "$REPO_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+      cleanup_status="$(git -C "$REPO_DIR" status --short 2>/dev/null || true)"
+      if [[ "$cleanup_branch" != "$BASE_BRANCH" || -n "$cleanup_status" ]]; then
+        echo "Leaving failed runner worktree on ${cleanup_branch:-detached HEAD}; exit status was ${exit_code}."
+        if [[ -n "$cleanup_status" ]]; then
+          printf '%s\n' "$cleanup_status"
+        fi
+        return
+      fi
+    fi
+
     if ! git -C "$REPO_DIR" checkout "$BASE_BRANCH" >/dev/null 2>&1; then
       echo "Warning: failed to switch back to $BASE_BRANCH during cleanup." >&2
       return
@@ -3111,6 +3128,20 @@ main() {
     ISSUE_NUMBER="$FORCE_ISSUE_NUMBER"
     echo "Selected forced issue #${ISSUE_NUMBER}."
   else
+    OPEN_HUMAN_PRS="$(count_open_human_prs)"
+    echo "Open human-authored PR count: ${OPEN_HUMAN_PRS}"
+    if [[ "$OPEN_HUMAN_PRS" != "0" ]]; then
+      runner_status "Skipped: found ${OPEN_HUMAN_PRS} open human-authored PR(s)."
+      exit 0
+    fi
+
+    OPEN_IN_PROGRESS_ISSUES="$(count_open_project_issues_in_status "$PROJECT_STATUS_IN_PROGRESS")"
+    echo "Open project issues in ${PROJECT_STATUS_IN_PROGRESS}: ${OPEN_IN_PROGRESS_ISSUES}"
+    if [[ "$OPEN_IN_PROGRESS_ISSUES" != "0" ]]; then
+      runner_status "Skipped: found ${OPEN_IN_PROGRESS_ISSUES} open issue(s) in project status '${PROJECT_STATUS_IN_PROGRESS}'."
+      exit 0
+    fi
+
     ISSUE_NUMBER="$(collect_issue_candidates | sed -n '1p')"
     if [[ -n "$ISSUE_NUMBER" ]]; then
       echo "Selected issue #${ISSUE_NUMBER} from project queue."
@@ -3139,11 +3170,13 @@ main() {
   EXISTING_EPIC_PR_JSON=""
   EXISTING_CHILD_PR_JSON=""
 
-  OPEN_HUMAN_PRS="$(count_open_human_prs)"
-  echo "Open human-authored PR count: ${OPEN_HUMAN_PRS}"
-  if [[ "$OPEN_HUMAN_PRS" != "0" ]]; then
-    runner_status "Skipped: found ${OPEN_HUMAN_PRS} open human-authored PR(s)."
-    exit 0
+  if [[ -n "$FORCE_ISSUE_NUMBER" ]]; then
+    OPEN_HUMAN_PRS="$(count_open_human_prs)"
+    echo "Open human-authored PR count: ${OPEN_HUMAN_PRS}"
+    if [[ "$OPEN_HUMAN_PRS" != "0" ]]; then
+      runner_status "Skipped: found ${OPEN_HUMAN_PRS} open human-authored PR(s)."
+      exit 0
+    fi
   fi
 
   OPEN_IN_PROGRESS_ISSUES="$(count_open_project_issues_in_status "$PROJECT_STATUS_IN_PROGRESS")"

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -151,7 +151,7 @@ printf 'unexpected\\n'
     assert "unexpected" not in result.stdout
 
 
-def test_cleanup_resets_failed_runner_worktree_to_base_branch(tmp_path: Path) -> None:
+def test_cleanup_resets_successful_runner_worktree_to_base_branch(tmp_path: Path) -> None:
     call_log = tmp_path / "calls.txt"
 
     shell_script = f"""
@@ -185,6 +185,45 @@ git -C "$REPO_DIR" status --short
     assert f"git:-C {tmp_path / 'repo'} checkout main" in calls
     assert f"git:-C {tmp_path / 'repo'} reset --hard origin/main" in calls
     assert f"git:-C {tmp_path / 'repo'} clean -fd" in calls
+
+
+def test_cleanup_preserves_failed_runner_worktree_on_issue_branch(tmp_path: Path) -> None:
+    call_log = tmp_path / "calls.txt"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(tmp_path / "repo"))}
+mkdir -p "$REPO_DIR/.git"
+git() {{
+  printf 'git:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+  case "$*" in
+    "-C $REPO_DIR symbolic-ref --quiet --short HEAD")
+      printf 'codex/daily-issue-1978\\n'
+      return 0
+      ;;
+    "-C $REPO_DIR status --short")
+      printf ' M file.txt\\n'
+      return 0
+      ;;
+  esac
+  return 0
+}}
+CLEANUP_REPO_ON_EXIT=1
+set +e
+false
+cleanup
+set -e
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Leaving failed runner worktree on codex/daily-issue-1978" in result.stdout
+    assert " M file.txt" in result.stdout
+    calls = call_log.read_text(encoding="utf-8")
+    assert f"git:-C {tmp_path / 'repo'} checkout main" not in calls
+    assert f"git:-C {tmp_path / 'repo'} reset --hard origin/main" not in calls
+    assert f"git:-C {tmp_path / 'repo'} clean -fd" not in calls
 
 
 def test_runner_lock_skips_when_existing_runner_is_active(tmp_path: Path) -> None:
@@ -241,6 +280,10 @@ count_open_human_prs() {{
   printf 'count-open-human-prs\\n' >> {shlex.quote(str(call_log))}
   printf '0\\n'
 }}
+count_open_project_issues_in_status() {{
+  printf 'count-open-project-issues-in-status:%s\\n' "$1" >> {shlex.quote(str(call_log))}
+  printf '0\\n'
+}}
 collect_issue_candidates() {{
   printf 'collect-issue-candidates\\n' >> {shlex.quote(str(call_log))}
   printf '1558\\n'
@@ -256,6 +299,7 @@ main
     calls = call_log.read_text(encoding="utf-8").splitlines()
     assert "collect-issue-candidates" in calls
     assert "count-open-human-prs" in calls
+    assert "count-open-project-issues-in-status:In Progress" in calls
     assert "count-open-bot-prs-excluding-heads:" in calls
     assert "Fetch latest from origin" not in calls
     assert "Reset to origin/main" not in calls
@@ -311,7 +355,7 @@ main
     assert "Skipped: found 2 open human-authored PR(s)." in result.stdout
 
     calls = call_log.read_text(encoding="utf-8").splitlines()
-    assert "collect-issue-candidates" in calls
+    assert "collect-issue-candidates" not in calls
     assert "count-open-human-prs" in calls
     assert "Fetch latest from origin" not in calls
     assert "Reset to origin/main" not in calls
@@ -374,7 +418,7 @@ main
     assert "Skipped: found 1 open issue(s) in project status 'In Progress'." in result.stdout
 
     calls = call_log.read_text(encoding="utf-8").splitlines()
-    assert "collect-issue-candidates" in calls
+    assert "collect-issue-candidates" not in calls
     assert "count-open-human-prs" in calls
     assert "count-open-project-issues-in-status:In Progress" in calls
     assert "Fetch latest from origin" not in calls
@@ -419,6 +463,10 @@ count_open_human_prs() {{
   printf 'count-open-human-prs\\n' >> {shlex.quote(str(call_log))}
   printf '0\\n'
 }}
+count_open_project_issues_in_status() {{
+  printf 'count-open-project-issues-in-status:%s\\n' "$1" >> {shlex.quote(str(call_log))}
+  printf '0\\n'
+}}
 collect_issue_candidates() {{
   printf 'collect-issue-candidates\\n' >> {shlex.quote(str(call_log))}
 }}
@@ -438,7 +486,8 @@ main
     assert "Reset to origin/main" not in calls
     assert "Remove untracked files" not in calls
     assert "count-open-bot-prs" not in calls
-    assert "count-open-human-prs" not in calls
+    assert "count-open-human-prs" in calls
+    assert "count-open-project-issues-in-status:In Progress" in calls
     assert "configure-bot-git" not in calls
     assert "runtime-bootstrap" not in calls
 
@@ -483,6 +532,7 @@ configure_bot_git_identity() {{ :; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 count_open_human_prs() {{ printf '0\\n'; }}
+count_open_project_issues_in_status() {{ printf '0\\n'; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 start_runtime_stack_and_seed_dev_data() {{
   printf 'runtime-bootstrap\\n' >> {shlex.quote(str(call_log))}
@@ -1050,6 +1100,7 @@ resolve_issue_parent_epic() {{
   printf '1735\\tEpic title\\thttps://github.com/scidsg/hushline/issues/1735\\n'
 }}
 count_open_human_prs() {{ printf '0\\n'; }}
+count_open_project_issues_in_status() {{ printf '0\\n'; }}
 count_open_bot_prs_excluding_heads() {{
   printf 'count-open-bot-prs-excluding-heads\\n' >> {shlex.quote(str(call_log))}
   printf '0\\n'
@@ -1105,6 +1156,7 @@ run_step() {{
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
+count_open_project_issues_in_status() {{ printf '0\\n'; }}
 count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 set_issue_project_status() {{
   printf 'status:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(call_log))}
@@ -1185,6 +1237,7 @@ resolve_issue_parent_epic() {{
   printf '1735\\tEpic title\\thttps://github.com/scidsg/hushline/issues/1735\\n'
 }}
 count_open_human_prs() {{ printf '0\\n'; }}
+count_open_project_issues_in_status() {{ printf '0\\n'; }}
 count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 find_open_pr_for_head_branch() {{ :; }}
 set_issue_project_status() {{ :; }}
@@ -1361,6 +1414,7 @@ docker() {{ :; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
+count_open_project_issues_in_status() {{ printf '0\\n'; }}
 count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 set_issue_project_status() {{
   printf 'status:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(call_log))}
@@ -3408,6 +3462,7 @@ docker() {{ :; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
+count_open_project_issues_in_status() {{ printf '0\\n'; }}
 count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 set_issue_project_status() {{ :; }}
 configure_bot_git_identity() {{ :; }}
@@ -3512,6 +3567,7 @@ docker() {{ :; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
+count_open_project_issues_in_status() {{ printf '0\\n'; }}
 count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 set_issue_project_status() {{
   printf 'status:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(call_log))}
@@ -3612,6 +3668,7 @@ docker() {{ :; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
+count_open_project_issues_in_status() {{ printf '0\\n'; }}
 count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
 set_issue_project_status() {{ :; }}
 configure_bot_git_identity() {{ :; }}


### PR DESCRIPTION
## Summary
- Disable the documented host Hush Line code agent state while runner reliability fixes are validated.
- Reorder scheduled runner guards so existing `In Progress` work is checked before looking for new `Agent Eligible` work.
- Preserve failed runner worktrees instead of resetting away uncommitted branch work on nonzero exit.
- Add runner tests for the guard order and failed-work preservation behavior.

## Why
The daily issue runner could start a fresh queue lookup even when another issue was already marked `In Progress`, and failed runs could clean up by returning to `main` and hard-resetting uncommitted branch work. That combination made it possible for useful in-progress work to be lost instead of left for inspection or recovery.

## Validation
- `make test TESTS=tests/test_agent_daily_issue_runner.py PYTEST_ADDOPTS="-q"` - passed, 86 tests.
- `bash -n scripts/agent_daily_issue_runner.sh` - passed.
- `make test` - passed, 1,731 passed, 1 deselected, 1 xfailed.
- `make lint` - Ruff format/check and mypy passed; Prettier still reports pre-existing formatting warnings in 21 `hushline/static/js/*.js` files unrelated to this PR. `docs/AGENT-RUNNER.md` was formatted and passes Prettier directly.
- Dependabot open PR check - no open Dependabot PRs found.

## Manual Testing
- Confirm `launchctl print-disabled gui/$(id -u)` shows `org.scidsg.hushline-code-agent` as disabled on the runner host.
- Run the daily issue runner in a disposable checkout with an `In Progress` project item and verify it exits before selecting from `Agent Eligible`.
- Simulate a failed run on a work branch with local changes and verify the branch and changes remain intact.

## Risks / Follow-ups
- The host agent remains disabled until this patch is reviewed and maintainers explicitly re-enable the LaunchAgent.
- The unrelated static JS Prettier drift should be handled separately to restore a fully green `make lint` gate without mixing unrelated formatting churn into this runner fix.