### PR TITLE
Keep daily issue runner recoverable

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -87,6 +87,8 @@ PR_FEEDBACK_MONITOR_ACTIVE=0
 PR_FEEDBACK_MONITOR_CLOSED=0
 PR_FEEDBACK_MONITOR_PR_NUMBER=""
 PR_FEEDBACK_MONITOR_BRANCH=""
+RUNNER_DIAGNOSTIC_PR=0
+RUNNER_DIAGNOSTIC_REASON=""
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
@@ -145,11 +147,10 @@ cleanup() {
       cleanup_branch="$(git -C "$REPO_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
       cleanup_status="$(git -C "$REPO_DIR" status --short 2>/dev/null || true)"
       if [[ "$cleanup_branch" != "$BASE_BRANCH" || -n "$cleanup_status" ]]; then
-        echo "Leaving failed runner worktree on ${cleanup_branch:-detached HEAD}; exit status was ${exit_code}."
+        echo "Resetting failed runner worktree from ${cleanup_branch:-detached HEAD}; exit status was ${exit_code}."
         if [[ -n "$cleanup_status" ]]; then
           printf '%s\n' "$cleanup_status"
         fi
-        return
       fi
     fi
 
@@ -502,6 +503,61 @@ refresh_runtime_after_schema_changes() {
   reset_runtime_stack_and_seed_dev_data
 }
 
+restore_runtime_generated_static_artifacts() {
+  local generated_status=""
+
+  generated_status="$(git status --short -- hushline/static/js 2>/dev/null || true)"
+  if [[ -z "$generated_status" ]]; then
+    return 0
+  fi
+
+  echo "Restoring generated static JS artifacts dirtied by runtime bootstrap."
+  printf '%s\n' "$generated_status"
+  git restore -- hushline/static/js
+}
+
+restore_non_log_worktree_changes() {
+  local tracked_files=""
+  local untracked_files=""
+  local line
+  local -a tracked_paths=()
+  local -a untracked_paths=()
+
+  tracked_files="$(
+    {
+      git diff --name-only
+      git diff --cached --name-only
+    } | awk 'NF && !/^docs\/agent-logs\/run-.*-issue-[0-9]+\.txt$/ && !seen[$0]++'
+  )"
+  untracked_files="$(
+    git ls-files --others --exclude-standard \
+      | awk 'NF && !/^docs\/agent-logs\/run-.*-issue-[0-9]+\.txt$/'
+  )"
+
+  if [[ -z "$tracked_files" && -z "$untracked_files" ]]; then
+    return 0
+  fi
+
+  echo "Restoring non-log worktree changes before opening diagnostic PR."
+  {
+    printf '%s\n' "$tracked_files"
+    printf '%s\n' "$untracked_files"
+  } | sed '/^$/d'
+
+  if [[ -n "$tracked_files" ]]; then
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && tracked_paths+=("$line")
+    done <<< "$tracked_files"
+    git restore --staged --worktree -- "${tracked_paths[@]}"
+  fi
+  if [[ -n "$untracked_files" ]]; then
+    while IFS= read -r line; do
+      [[ -n "$line" ]] && untracked_paths+=("$line")
+    done <<< "$untracked_files"
+    git clean -f -- "${untracked_paths[@]}"
+  fi
+}
+
 list_changed_files() {
   {
     git diff --name-only "${BASE_BRANCH}...HEAD"
@@ -830,6 +886,11 @@ build_pr_title() {
   local issue_number="$1"
   local issue_title="$2"
   local normalized_title=""
+
+  if [[ "$RUNNER_DIAGNOSTIC_PR" == "1" ]]; then
+    printf '#%s Daily runner diagnostic\n' "$issue_number"
+    return 0
+  fi
 
   normalized_title="$(printf '%s' "$issue_title" | tr '\n' ' ' | tr -s ' ')"
   printf '#%s %s\n' "$issue_number" "$(printf '%s' "$normalized_title" | cut -c1-90)"
@@ -2437,8 +2498,13 @@ write_pr_narrative_lead() {
   review_line=""
 
   if [[ "$non_log_files" == "0" ]]; then
-    scope_line="This run only changes the runner log artifact."
-    plain_line="This run does not change the product itself; it only updates the runner log artifact that records what the daily runner did."
+    if [[ "$RUNNER_DIAGNOSTIC_PR" == "1" ]]; then
+      scope_line="This diagnostic PR only changes the runner log artifact."
+      plain_line="The runner could not produce a product change for \"$issue_title\", so it opened this sanitized log-only PR instead of leaving the local checkout stranded."
+    else
+      scope_line="This run only changes the runner log artifact."
+      plain_line="This run does not change the product itself; it only updates the runner log artifact that records what the daily runner did."
+    fi
   elif [[ -n "$changed_areas" ]]; then
     scope_line="It touches ${non_log_files} non-log file(s) (${total_files} total including runner artifacts), primarily in ${changed_areas}."
   else
@@ -2470,8 +2536,13 @@ $(if [[ -n "$epic_issue_number" ]]; then
   printf 'It is intended to merge into the epic branch first, not directly into `%s`.\n' \
     "$BASE_BRANCH"
 else
-  printf 'This PR implements #%s (`%s`) via the daily runner with a scoped change set focused on the issue requirements.\n' \
-    "$issue_number" "$issue_title"
+  if [[ "$RUNNER_DIAGNOSTIC_PR" == "1" ]]; then
+    printf 'This diagnostic PR records the daily runner outcome for #%s (`%s`).\n' \
+      "$issue_number" "$issue_title"
+  else
+    printf 'This PR implements #%s (`%s`) via the daily runner with a scoped change set focused on the issue requirements.\n' \
+      "$issue_number" "$issue_title"
+  fi
 fi)
 
 ${plain_line}
@@ -2502,6 +2573,10 @@ $(if [[ -n "$epic_issue_number" ]]; then
   printf '%s\n' "- Part of epic #$epic_issue_number: ${epic_issue_title}"
   printf '%s\n' "- This PR targets the epic integration branch \`$base_branch_name\`."
   printf '%s\n' "- The child issue is closed explicitly by workflow after this PR merges into the epic branch."
+elif [[ "$RUNNER_DIAGNOSTIC_PR" == "1" ]]; then
+  printf '%s\n' "- Diagnostic daily runner PR for #$issue_number."
+  printf '%s\n' "- No product code is changed; this PR carries the sanitized runner log so the failure is visible in review."
+  printf '%s\n' "- Runner outcome: ${RUNNER_DIAGNOSTIC_REASON:-implementation did not complete}"
 else
   printf '%s\n' "- Automated daily issue runner implementation for #$issue_number."
   printf '%s\n' "- Implements issue goal: ${issue_title}"
@@ -2528,20 +2603,29 @@ fi)
 EOF2
   write_pr_changed_files_section >> "$PR_BODY_FILE"
 
-  cat >> "$PR_BODY_FILE" <<'EOF2'
+  cat >> "$PR_BODY_FILE" <<EOF2
 
 ## Validation
-- `make lint`
-- `make test` (full suite)
+$(if [[ "$RUNNER_DIAGNOSTIC_PR" == "1" ]]; then
+  printf '%s\n' "- Not run: the runner opened this diagnostic PR because implementation did not complete before validation."
+else
+  printf '%s\n' "- \`make lint\`"
+  printf '%s\n' "- \`make test\` (full suite)"
+fi)
 EOF2
-  cat >> "$PR_BODY_FILE" <<'EOF2'
+  cat >> "$PR_BODY_FILE" <<EOF2
 - Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.
 
 ## Manual Testing
-- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
-- In a local or staging environment, open the feature or workflow changed by this issue.
-- Reproduce the issue scenario or perform the changed workflow end to end as a user.
-- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
+$(if [[ "$RUNNER_DIAGNOSTIC_PR" == "1" ]]; then
+  printf '%s\n' "- Review the sanitized runner log linked above."
+  printf '%s\n' "- Confirm the PR contains only the runner log artifact and no product-code changes."
+else
+  printf '%s\n' "- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took."
+  printf '%s\n' "- In a local or staging environment, open the feature or workflow changed by this issue."
+  printf '%s\n' "- Reproduce the issue scenario or perform the changed workflow end to end as a user."
+  printf '%s\n' "- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions."
+fi)
 EOF2
 }
 
@@ -3231,6 +3315,7 @@ main() {
   run_step "Kill all Docker containers" kill_all_docker_containers
   run_step "Kill processes on runner ports" kill_processes_on_ports
   start_runtime_stack_and_seed_dev_data --build
+  restore_runtime_generated_static_artifacts
 
   ISSUE_TITLE="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO_SLUG" --json title --jq .title)"
   ISSUE_BODY="$(gh issue view "$ISSUE_NUMBER" --repo "$REPO_SLUG" --json body --jq .body)"
@@ -3260,11 +3345,15 @@ main() {
   fi
 
   build_issue_prompt "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY"
-  run_issue_attempt_loop "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY" "$ISSUE_LABELS" "$BRANCH_NAME"
-
-  if ! has_non_log_changes; then
-    echo "Blocked: no usable non-log changes remain for issue #$ISSUE_NUMBER after $MAX_ISSUE_ATTEMPTS attempt(s)." >&2
-    exit 1
+  if ! run_issue_attempt_loop "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY" "$ISSUE_LABELS" "$BRANCH_NAME"; then
+    RUNNER_DIAGNOSTIC_PR=1
+    RUNNER_DIAGNOSTIC_REASON="implementation did not complete"
+    echo "Warning: issue implementation failed; opening a sanitized diagnostic PR instead of leaving the checkout stranded." >&2
+    restore_non_log_worktree_changes
+  elif ! has_non_log_changes; then
+    RUNNER_DIAGNOSTIC_PR=1
+    RUNNER_DIAGNOSTIC_REASON="implementation produced no usable non-log changes"
+    echo "Warning: no usable non-log changes remain; opening a sanitized diagnostic PR instead of leaving the checkout stranded." >&2
   fi
 
   persist_run_log "$ISSUE_NUMBER"

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -187,7 +187,7 @@ git -C "$REPO_DIR" status --short
     assert f"git:-C {tmp_path / 'repo'} clean -fd" in calls
 
 
-def test_cleanup_preserves_failed_runner_worktree_on_issue_branch(tmp_path: Path) -> None:
+def test_cleanup_resets_failed_runner_worktree_on_issue_branch(tmp_path: Path) -> None:
     call_log = tmp_path / "calls.txt"
 
     shell_script = f"""
@@ -218,12 +218,12 @@ set -e
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
-    assert "Leaving failed runner worktree on codex/daily-issue-1978" in result.stdout
+    assert "Resetting failed runner worktree from codex/daily-issue-1978" in result.stdout
     assert " M file.txt" in result.stdout
     calls = call_log.read_text(encoding="utf-8")
-    assert f"git:-C {tmp_path / 'repo'} checkout main" not in calls
-    assert f"git:-C {tmp_path / 'repo'} reset --hard origin/main" not in calls
-    assert f"git:-C {tmp_path / 'repo'} clean -fd" not in calls
+    assert f"git:-C {tmp_path / 'repo'} checkout main" in calls
+    assert f"git:-C {tmp_path / 'repo'} reset --hard origin/main" in calls
+    assert f"git:-C {tmp_path / 'repo'} clean -fd" in calls
 
 
 def test_runner_lock_skips_when_existing_runner_is_active(tmp_path: Path) -> None:
@@ -568,6 +568,19 @@ build_pr_title 1622 $'Normalize geography\\nacross directory listing types'
     assert result.returncode == 0, result.stderr
     assert result.stdout == "#1622 Normalize geography across directory listing types\n"
     assert "Codex Daily:" not in result.stdout
+
+
+def test_build_pr_title_uses_diagnostic_title_for_diagnostic_pr() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+RUNNER_DIAGNOSTIC_PR=1
+build_pr_title 1622 "Normalize geography"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == "#1622 Daily runner diagnostic\n"
 
 
 def test_build_branch_name_uses_issue_prefix() -> None:
@@ -1696,6 +1709,27 @@ write_pr_narrative_lead 1622 "Normalize geography across directory listing types
     assert "This run only changes the runner log artifact." in result.stdout
 
 
+def test_write_pr_narrative_lead_explains_diagnostic_pr() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+RUNNER_DIAGNOSTIC_PR=1
+stream_changed_files() {{
+  printf '%s\\n' 'docs/agent-logs/run-20260308T000000Z-issue-1622.txt'
+}}
+write_pr_narrative_lead 1622 "Normalize geography across directory listing types"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "This diagnostic PR records the daily runner outcome" in result.stdout
+    assert (
+        "it opened this sanitized log-only PR instead of leaving the local checkout stranded"
+        in result.stdout
+    )
+    assert "This diagnostic PR only changes the runner log artifact." in result.stdout
+
+
 def test_audit_failure_environmental_classifier_matches_network_errors() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
@@ -1764,6 +1798,72 @@ fi
 
     assert result.returncode == 0, result.stderr
     assert result.stdout == "schema-changed\n"
+
+
+def test_restore_runtime_generated_static_artifacts_cleans_bootstrap_noise(
+    tmp_path: Path,
+) -> None:
+    call_log = tmp_path / "calls.txt"
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+git() {{
+  printf 'git:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+  case "$*" in
+    "status --short -- hushline/static/js")
+      printf ' M hushline/static/js/directory_verified.js\\n'
+      return 0
+      ;;
+  esac
+  return 0
+}}
+restore_runtime_generated_static_artifacts
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Restoring generated static JS artifacts dirtied by runtime bootstrap." in result.stdout
+    calls = call_log.read_text(encoding="utf-8")
+    assert "git:restore -- hushline/static/js" in calls
+
+
+def test_restore_non_log_worktree_changes_uses_staged_and_worktree_restore(
+    tmp_path: Path,
+) -> None:
+    call_log = tmp_path / "calls.txt"
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+git() {{
+  printf 'git:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+  case "$*" in
+    "diff --name-only")
+      printf 'hushline/static/js/directory_verified.js\\n'
+      return 0
+      ;;
+    "diff --cached --name-only")
+      printf 'tests/test_agent_daily_issue_runner.py\\n'
+      return 0
+      ;;
+    "ls-files --others --exclude-standard")
+      printf 'tmp/new-file.txt\\n'
+      return 0
+      ;;
+  esac
+  return 0
+}}
+restore_non_log_worktree_changes
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Restoring non-log worktree changes before opening diagnostic PR." in result.stdout
+    calls = call_log.read_text(encoding="utf-8")
+    assert (
+        "git:restore --staged --worktree -- hushline/static/js/directory_verified.js "
+        "tests/test_agent_daily_issue_runner.py"
+    ) in calls
+    assert "git:clean -f -- tmp/new-file.txt" in calls
 
 
 def test_run_check_capture_times_out_stuck_check(tmp_path: Path) -> None:
@@ -3437,13 +3537,14 @@ resolve_pr_number_from_ref "https://github.com/scidsg/hushline/pull/2000"
     assert "unexpected gh invocation" not in result.stderr
 
 
-def test_main_blocks_pr_creation_when_only_runner_artifacts_exist(tmp_path: Path) -> None:
+def test_main_opens_diagnostic_pr_when_only_runner_artifacts_exist(tmp_path: Path) -> None:
     call_log = tmp_path / "calls.txt"
     repo_dir = tmp_path / "repo"
 
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
 REPO_DIR={shlex.quote(str(repo_dir))}
+PR_BODY_FILE={shlex.quote(str(tmp_path / "pr-body.md"))}
 mkdir -p "$REPO_DIR/.git"
 parse_args() {{ :; }}
 initialize_run_state() {{ :; }}
@@ -3457,7 +3558,30 @@ run_step() {{
   shift
   "$@"
 }}
-git() {{ return 0; }}
+git() {{
+  case "${{1-}} ${{2-}} ${{3-}} ${{4-}}" in
+    "symbolic-ref --quiet --short HEAD")
+      printf 'codex/daily-issue-1558\\n'
+      return 0
+      ;;
+    "diff --cached --quiet ")
+      return 1
+      ;;
+    "rev-list --count main..codex/daily-issue-1558")
+      printf '1\\n'
+      return 0
+      ;;
+    "commit -m "*)
+      printf 'commit:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+      return 0
+      ;;
+    "push origin codex/daily-issue-1558 ")
+      printf 'push-log-update\\n' >> {shlex.quote(str(call_log))}
+      return 0
+      ;;
+  esac
+  return 0
+}}
 docker() {{ :; }}
 collect_issue_candidates() {{ printf '1558\\n'; }}
 resolve_issue_parent_epic() {{ :; }}
@@ -3471,17 +3595,23 @@ kill_all_docker_containers() {{ :; }}
 kill_processes_on_ports() {{ :; }}
 remote_branch_exists() {{ return 1; }}
 build_issue_prompt() {{ :; }}
-run_issue_attempt_loop() {{ :; }}
+run_issue_attempt_loop() {{ return 1; }}
 has_non_log_changes() {{ return 1; }}
 persist_run_log() {{
+  RUN_LOG_GIT_PATH="docs/agent-logs/run-test-issue-$1.txt"
   printf 'persist:%s\\n' "$1" >> {shlex.quote(str(call_log))}
 }}
 push_branch_for_pr() {{
   printf 'push:%s\\n' "$1" >> {shlex.quote(str(call_log))}
 }}
-write_pr_body() {{ :; }}
-build_pr_title() {{
-  printf '#1558 Title\\n'
+restore_non_log_worktree_changes() {{
+  printf 'restore-non-log\\n' >> {shlex.quote(str(call_log))}
+}}
+write_pr_body() {{
+  printf 'body:diagnostic=%s:%s\\n' \\
+    "$RUNNER_DIAGNOSTIC_PR" \\
+    "$RUNNER_DIAGNOSTIC_REASON" \\
+    >> {shlex.quote(str(call_log))}
 }}
 check_pr_feedback_after_delay() {{ :; }}
 gh() {{
@@ -3496,7 +3626,8 @@ gh() {{
     return 0
   fi
   if [[ "${{1-}} ${{2-}}" == "pr create" ]]; then
-    printf 'pr-create\\n' >> {shlex.quote(str(call_log))}
+    printf 'https://github.com/scidsg/hushline/pull/2000\\n'
+    printf 'pr-create:%s\\n' "$*" >> {shlex.quote(str(call_log))}
     return 0
   fi
   return 0
@@ -3511,11 +3642,16 @@ printf 'rc=%s\\n' "$rc"
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
-    assert "rc=1" in result.stdout
-    assert "Blocked: no usable non-log changes remain for issue #1558 after" in result.stderr
+    assert "rc=0" in result.stdout
+    assert (
+        "opening a sanitized diagnostic PR instead of leaving the checkout stranded"
+        in result.stderr
+    )
     calls = call_log.read_text(encoding="utf-8").splitlines() if call_log.exists() else []
-    assert not any(line == "pr-create" for line in calls)
-    assert not any(line.startswith("persist:") for line in calls)
+    assert any(line == "restore-non-log" for line in calls)
+    assert any(line == "body:diagnostic=1:implementation did not complete" for line in calls)
+    assert any(line.startswith("pr-create:") for line in calls)
+    assert any(line.startswith("persist:1558") for line in calls)
 
 
 def test_main_continues_after_pr_create_when_pr_number_lookup_fails(


### PR DESCRIPTION
## What Changed
- Makes failed daily issue runs recover instead of leaving the checkout stranded on a dirty issue branch.
- Restores runtime-generated static JS artifacts after bootstrap so the runner does not carry local build noise into PRs.
- When implementation fails or produces no usable non-log changes, opens a sanitized diagnostic PR with the runner log instead of exiting before PR creation.
- Updates runner tests for cleanup, diagnostic PR title/body behavior, generated artifact restoration, and log-only diagnostic PR creation.

## Why
The scheduled runner selected issue #1978, bootstrapped the runtime, then failed during implementation and left the local checkout on `codex/daily-issue-1978` with generated static JS changes. That blocked future clean runner attempts. The runner now gets back to a reviewable PR path even when implementation cannot complete.

## Validation
- `bash -n scripts/agent_daily_issue_runner.sh`
- `docker compose run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py -q` (`90 passed`)
- `make lint`
- `make test` (`1735 passed, 1 deselected, 1 xfailed`)
- `make audit-python`
- `make audit-node-runtime`
- `git diff --check`

## Manual Testing
- Review a diagnostic runner PR after a forced or no-op implementation failure and confirm it contains only `docs/agent-logs/...` and no product-code changes.
- Confirm a failed runner interval resets the checkout instead of preserving a dirty issue branch.

## Risks / Follow-ups
- Diagnostic PRs make failed automation visible for review, but they do not hide that implementation failed.
- Branch protection and CI remain the final gate before merge.