### PR TITLE
Update runner checkout normalization

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,8 @@ This file provides operating guidance for coding agents working in the Hush Line
   - Exception: when the selected issue is a child of a GitHub parent epic, the runner may allow the long-lived epic PR plus the matching child issue PR, and should stop only for unrelated bot PRs.
 - Required runner behavior:
   - The runner must acquire a local non-blocking lock before touching the repository or Docker; if another Hush Line code-agent run is active, exit without changing local state.
-  - Before any destructive sync, exit without changing files unless the checkout is clean and already on the base branch.
-  - If no issue is available, or a cheap GitHub guard blocks work, exit before `git fetch`, `git checkout`, `git reset`, `git clean`, Docker reset, or dev-data seeding.
+  - After acquiring the runner lock, normalize the agent-only checkout by discarding local worktree changes and switching to the base branch.
+  - If no issue is available, or a cheap GitHub guard blocks work, exit before `git fetch`, Docker reset, or dev-data seeding.
   - After an issue is selected and all cheap GitHub guards pass, sync the local base branch to `origin/main`.
   - Before issue work starts, perform a full local environment reset and seed sequence:
     - `docker compose down -v --remove-orphans`

--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -35,14 +35,14 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 1. Parse arguments (`--issue` optional) and resolve runtime configuration.
 2. Change into the repo (`$HOME/hushline` by default).
 3. Acquire a local runner lock and exit without doing any repository or Docker work if another Hush Line code-agent run is active.
-4. Exit without changing files unless the checkout is clean and already on the base branch.
-5. Check cheap GitHub exit conditions before any new-work queue lookup or destructive repository/Docker work:
+4. Normalize the local agent-only checkout by discarding local worktree changes and switching to the base branch.
+5. Check cheap GitHub exit conditions before any new-work queue lookup or network sync/Docker work:
    - exit if any open human-authored PR exists
    - exit if any open issue is already in project status `In Progress`
-6. Select issue target before any destructive repository or Docker work:
+6. Select issue target before any network sync or Docker work:
    - Use `--issue <n>` when provided (must still be open), otherwise
    - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
-7. Check remaining cheap GitHub exit conditions before any destructive repository or Docker work:
+7. Check remaining cheap GitHub exit conditions before any network sync or Docker work:
    - for non-epic issues, exit if any other open PR exists from `hushline-dev`
    - for child issues with a GitHub parent epic, allow the long-lived epic PR (head branch `codex/epic-<epic>`) and the current child issue PR (head branch `codex/daily-issue-<issue>`)
    - for child issues with a GitHub parent epic, exit only if there are unrelated open bot PRs outside those allowed heads
@@ -104,8 +104,8 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 22. Refresh run log after PR creation (including opened PR URL and post-check steps), commit/push that log update when changed.
 23. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, then resumes polling.
 24. Return to a clean `main` on normal completion or PR closure.
-    - If the run fails after creating branch work, leave the failed worktree on its current branch with its changes intact for human inspection or manual recovery.
-    - A new scheduled pass still exits before any destructive sync if a human or another process has left the checkout off `main` or with local changes.
+    - If the run fails after creating branch work, cleanup resets the checkout back to a clean base branch.
+    - A new scheduled pass discards local worktree changes and switches back to the base branch before evaluating GitHub queue guards.
 
 ## ASCII Workflow (Current)
 
@@ -138,8 +138,8 @@ This runner runs directly in the local repo and performs a narrow local gate bef
       |
       v
 +--------------------------------------------------+
-| Verify clean base-branch checkout              |
-| Dirty or non-base checkout? skip + exit        |
+| Normalize agent-only checkout                 |
+| Discard dirty work + switch to base branch    |
 +--------------------------------------------------+
       |
       v

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -228,16 +228,20 @@ assert_runner_can_take_checkout() {
   fi
 
   current_branch="$(current_branch_name)"
-  if [[ "$current_branch" != "$BASE_BRANCH" ]]; then
-    runner_status "Skipped: checkout is on '${current_branch:-detached HEAD}', not '$BASE_BRANCH'; leaving local work untouched."
-    exit 0
+  status_output="$(worktree_status_porcelain)"
+
+  if [[ -n "$status_output" ]]; then
+    runner_status "Discarding local checkout changes before runner work."
+    printf '%s\n' "$status_output"
+    git reset --hard
+    git clean -fd
   fi
 
-  status_output="$(worktree_status_porcelain)"
-  if [[ -n "$status_output" ]]; then
-    runner_status "Skipped: checkout has local changes; leaving local work untouched."
-    printf '%s\n' "$status_output"
-    exit 0
+  if [[ "$current_branch" != "$BASE_BRANCH" ]]; then
+    runner_status "Switching checkout from '${current_branch:-detached HEAD}' to '$BASE_BRANCH' before runner work."
+    git checkout "$BASE_BRANCH"
+    git reset --hard
+    git clean -fd
   fi
 }
 

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -87,12 +87,15 @@ printf '%s\\n' "$snapshot_metadata"
     assert snapshot_file.read_text(encoding="utf-8") == RUNNER_SCRIPT.read_text(encoding="utf-8")
 
 
-def test_runner_preflight_skips_when_checkout_is_not_on_base_branch(
+def test_runner_preflight_switches_to_base_branch(
     tmp_path: Path,
 ) -> None:
+    call_log = tmp_path / "calls.txt"
+
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
 git() {{
+  printf 'git:%s\\n' "$*" >> {shlex.quote(str(call_log))}
   case "${{1-}} ${{2-}} ${{3-}}" in
     "rev-parse --is-inside-work-tree ")
       return 0
@@ -108,22 +111,29 @@ git() {{
   return 0
 }}
 assert_runner_can_take_checkout
-printf 'unexpected\\n'
+printf 'continued\\n'
 """
 
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
-    assert "not 'main'; leaving local work untouched" in result.stdout
-    assert "unexpected" not in result.stdout
+    assert "Switching checkout from 'feature' to 'main' before runner work." in result.stdout
+    assert "continued" in result.stdout
+    calls = call_log.read_text(encoding="utf-8")
+    assert "git:checkout main" in calls
+    assert "git:reset --hard" in calls
+    assert "git:clean -fd" in calls
 
 
-def test_runner_preflight_skips_when_checkout_has_local_changes(
+def test_runner_preflight_discards_local_changes(
     tmp_path: Path,
 ) -> None:
+    call_log = tmp_path / "calls.txt"
+
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
 git() {{
+  printf 'git:%s\\n' "$*" >> {shlex.quote(str(call_log))}
   case "${{1-}} ${{2-}} ${{3-}}" in
     "rev-parse --is-inside-work-tree ")
       return 0
@@ -140,15 +150,18 @@ git() {{
   return 0
 }}
 assert_runner_can_take_checkout
-printf 'unexpected\\n'
+printf 'continued\\n'
 """
 
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
-    assert "checkout has local changes; leaving local work untouched" in result.stdout
+    assert "Discarding local checkout changes before runner work." in result.stdout
     assert " M file.txt" in result.stdout
-    assert "unexpected" not in result.stdout
+    assert "continued" in result.stdout
+    calls = call_log.read_text(encoding="utf-8")
+    assert "git:reset --hard" in calls
+    assert "git:clean -fd" in calls
 
 
 def test_cleanup_resets_successful_runner_worktree_to_base_branch(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Change the daily issue runner preflight to discard local worktree changes on the agent-only machine.
- Switch non-base checkouts back to the base branch instead of skipping.
- Update runner tests and documentation to match the destructive checkout-normalization policy.

## Context
This host is dedicated to agent automation, so stale local changes should not block the daily runner. The runner still keeps network sync and Docker reset behind the existing GitHub queue guards.

## Validation
- `docker compose run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py -q` passed: 90 tests.
- `make lint` passed.
- Full `make test` was not run before opening this draft PR.

## Manual Testing
- Not applicable; this change is covered by the focused runner shell tests.

## Known Risks / Follow-ups
- CI should run the full required checks before this PR is marked ready for review.