### PR TITLE
Keep runner polling when resumed branch is missing

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -36,24 +36,25 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 2. Change into the repo (`$HOME/hushline` by default).
 3. Acquire a local runner lock and exit without doing any repository or Docker work if another Hush Line code-agent run is active.
 4. Normalize the local agent-only checkout by discarding local worktree changes and switching to the base branch.
-5. Check cheap GitHub exit conditions before any new-work queue lookup or network sync/Docker work:
+5. Resume monitoring any open bot-authored issue PR whose head branch matches the daily issue branch pattern before selecting new issue work. This makes PR polling restart-resilient after launchd unloads, crashes, or reboots.
+6. Check cheap GitHub exit conditions before any new-work queue lookup or network sync/Docker work:
    - exit if any open human-authored PR exists
    - exit if any open issue is already in project status `In Progress`
-6. Select issue target before any network sync or Docker work:
+7. Select issue target before any network sync or Docker work:
    - Use `--issue <n>` when provided (must still be open), otherwise
    - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
-7. Check remaining cheap GitHub exit conditions before any network sync or Docker work:
+8. Check remaining cheap GitHub exit conditions before any network sync or Docker work:
    - for non-epic issues, exit if any other open PR exists from `hushline-dev`
    - for child issues with a GitHub parent epic, allow the long-lived epic PR (head branch `codex/epic-<epic>`) and the current child issue PR (head branch `codex/daily-issue-<issue>`)
    - for child issues with a GitHub parent epic, exit only if there are unrelated open bot PRs outside those allowed heads
-8. Hard-refresh local state only after an issue is selected and skip guards pass:
+9. Hard-refresh local state only after an issue is selected and skip guards pass:
    - `git fetch origin`
    - `git checkout main`
    - `git reset --hard origin/main`
    - `git clean -fd`
-9. Move the selected issue into project status `In Progress`.
-10. Configure bot git identity and signed commit settings.
-11. Reset local Docker/runtime state:
+10. Move the selected issue into project status `In Progress`.
+11. Configure bot git identity and signed commit settings.
+12. Reset local Docker/runtime state:
 
 - `docker compose down -v --remove-orphans`
 - Remove all Docker containers (`docker rm -f $(docker ps -aq)`, when any exist)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -16,7 +16,7 @@ prepare_runner_exec_snapshot() {
 
   original_script_dir="$(CDPATH= cd -- "$(dirname -- "$runner_script_path")" && pwd)"
   original_script_path="$original_script_dir/$(basename -- "$runner_script_path")"
-  snapshot_file="$(mktemp "${TMPDIR:-/tmp}/agent_daily_issue_runner.XXXXXX.sh")"
+  snapshot_file="$(mktemp "${TMPDIR:-/tmp}/agent_daily_issue_runner.XXXXXX")"
   cp "$original_script_path" "$snapshot_file"
   chmod 700 "$snapshot_file"
   printf '%s\t%s\n' "$original_script_dir" "$snapshot_file"
@@ -1006,6 +1006,45 @@ find_open_pr_for_head_branch() {
     --jq '.[0] // empty'
 }
 
+find_open_issue_pr_to_resume() {
+  local prs_json=""
+
+  if ! prs_json="$(
+    gh pr list \
+      --repo "$REPO_SLUG" \
+      --state open \
+      --author "$BOT_LOGIN" \
+      --limit 100 \
+      --json number,title,headRefName,updatedAt
+  )"; then
+    echo "Failed to list open PRs by ${BOT_LOGIN}; cannot check for restart-resume PRs." >&2
+    return 1
+  fi
+
+  printf '%s\n' "$prs_json" \
+    | BRANCH_PREFIX="$BRANCH_PREFIX" node -e '
+      const fs = require("fs");
+      const branchPrefix = String(process.env.BRANCH_PREFIX || "");
+      const prs = JSON.parse(fs.readFileSync(0, "utf8"));
+      const match = Array.isArray(prs)
+        ? prs.find((pr) => {
+            const head = String(pr && pr.headRefName ? pr.headRefName : "");
+            const suffix = head.startsWith(branchPrefix)
+              ? head.slice(branchPrefix.length)
+              : "";
+            return /^[0-9]+$/.test(suffix) && Number.isInteger(pr.number);
+          })
+        : null;
+      if (!match) {
+        process.exit(0);
+      }
+      const head = String(match.headRefName);
+      const issueNumber = head.slice(branchPrefix.length);
+      const title = String(match.title || "").replace(/\t/g, " ").replace(/\n/g, " ");
+      process.stdout.write(`${match.number}\t${issueNumber}\t${head}\t${title}\n`);
+    '
+}
+
 count_open_human_prs() {
   gh pr list \
     --repo "$REPO_SLUG" \
@@ -1611,6 +1650,62 @@ check_pr_feedback_after_delay() {
 
     sleep "$POST_PR_FEEDBACK_DELAY_SECONDS"
   done
+}
+
+resume_open_issue_pr_monitor_if_any() {
+  local resume_info=""
+  local pr_number=""
+  local issue_number=""
+  local branch_name=""
+  local pr_title=""
+  local issue_title=""
+  local issue_labels=""
+
+  if [[ -n "$FORCE_ISSUE_NUMBER" ]]; then
+    return 1
+  fi
+
+  if ! resume_info="$(find_open_issue_pr_to_resume)"; then
+    return 1
+  fi
+
+  if [[ -z "$resume_info" ]]; then
+    return 1
+  fi
+
+  IFS=$'\t' read -r pr_number issue_number branch_name pr_title <<< "$resume_info"
+  if [[ -z "$pr_number" || -z "$branch_name" ]]; then
+    return 1
+  fi
+
+  echo "Resuming monitor for open PR #${pr_number} on ${branch_name}; skipping new issue selection until that PR closes."
+  CLEANUP_REPO_ON_EXIT=1
+
+  if remote_branch_exists "$branch_name"; then
+    run_step "Fetch PR branch $branch_name" \
+      git fetch origin "$branch_name:refs/remotes/origin/$branch_name"
+    run_step "Checkout PR branch $branch_name" \
+      git checkout -B "$branch_name" "origin/$branch_name"
+  else
+    ensure_worktree_on_branch "$branch_name"
+  fi
+
+  if [[ -n "$issue_number" ]]; then
+    issue_title="$({
+      gh issue view "$issue_number" --repo "$REPO_SLUG" --json title --jq .title
+    } || true)"
+    issue_labels="$({
+      gh issue view "$issue_number" --repo "$REPO_SLUG" --json labels --jq '.labels[].name // empty'
+    } || true)"
+  fi
+
+  check_pr_feedback_after_delay \
+    "$pr_number" \
+    "$issue_number" \
+    "${issue_title:-$pr_title}" \
+    "$issue_labels" \
+    "$branch_name"
+  return 0
 }
 
 resolve_issue_parent_epic() {
@@ -3206,6 +3301,10 @@ main() {
   cd "$REPO_DIR"
 
   assert_runner_can_take_checkout
+
+  if resume_open_issue_pr_monitor_if_any; then
+    exit 0
+  fi
 
   ISSUE_NUMBER=""
   if [[ -n "$FORCE_ISSUE_NUMBER" ]]; then

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -1643,7 +1643,7 @@ check_pr_feedback_after_delay() {
         "$issue_number" \
         "$issue_title" \
         "$issue_labels" \
-        "${branch_name:-$current_branch}" \
+        "$branch_name" \
         "$feedback_summary" \
         "$feedback_json"
     fi
@@ -1687,7 +1687,10 @@ resume_open_issue_pr_monitor_if_any() {
     run_step "Checkout PR branch $branch_name" \
       git checkout -B "$branch_name" "origin/$branch_name"
   else
-    ensure_worktree_on_branch "$branch_name"
+    if ! ensure_worktree_on_branch "$branch_name"; then
+      echo "Warning: PR branch ${branch_name} is unavailable on origin and local checkout recovery failed; monitoring PR #${pr_number} by number only." >&2
+      branch_name=""
+    fi
   fi
 
   if [[ -n "$issue_number" ]]; then

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -376,6 +376,89 @@ main
     assert "runtime-bootstrap" not in calls
 
 
+def test_main_resumes_open_issue_pr_with_missing_branch_monitors_by_number(
+    tmp_path: Path,
+) -> None:
+    call_log = tmp_path / "calls.txt"
+    repo_dir = tmp_path / "repo"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(repo_dir))}
+mkdir -p "$REPO_DIR/.git"
+parse_args() {{ :; }}
+initialize_run_state() {{ :; }}
+cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{
+  printf 'assert-runner-can-take-checkout\\n' >> {shlex.quote(str(call_log))}
+}}
+require_cmd() {{ :; }}
+require_positive_integer() {{ :; }}
+require_non_negative_integer() {{ :; }}
+find_open_issue_pr_to_resume() {{
+  printf '1991\\t1990\\tcodex/daily-issue-1990\\t#1990 Embedded Hush Line profile updates\\n'
+}}
+remote_branch_exists() {{ return 1; }}
+git() {{
+  case "$*" in
+    "symbolic-ref --quiet --short HEAD")
+      printf 'main\\n'
+      return 0
+      ;;
+    "checkout codex/daily-issue-1990")
+      printf 'git:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+      return 1
+      ;;
+  esac
+  return 0
+}}
+gh() {{
+  if [[ "$1" == "issue" && "$2" == "view" && "$3" == "1990" && "$*" == *"--jq .title"* ]]; then
+    printf 'Embedded Hush Line profile updates\\n'
+    return 0
+  fi
+  if [[ "$1" == "issue" && "$2" == "view" && "$3" == "1990" && "$*" == *".labels[].name"* ]]; then
+    printf 'frontend\\n'
+    return 0
+  fi
+  printf 'unexpected-gh:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+  return 99
+}}
+check_pr_feedback_after_delay() {{
+  printf 'monitor:%s:%s:%s:%s:%s\\n' "$1" "$2" "$3" "$4" "${{5-}}" >> {shlex.quote(str(call_log))}
+}}
+collect_issue_candidates() {{
+  printf 'collect-issue-candidates\\n' >> {shlex.quote(str(call_log))}
+  printf '2001\\n'
+}}
+start_runtime_stack_and_seed_dev_data() {{
+  printf 'runtime-bootstrap\\n' >> {shlex.quote(str(call_log))}
+}}
+main
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Resuming monitor for open PR #1991 on codex/daily-issue-1990; "
+        "skipping new issue selection until that PR closes."
+    ) in result.stdout
+    assert (
+        "Warning: PR branch codex/daily-issue-1990 is unavailable on origin and "
+        "local checkout recovery failed; monitoring PR #1991 by number only."
+    ) in result.stderr
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert calls == [
+        "assert-runner-can-take-checkout",
+        "git:checkout codex/daily-issue-1990",
+        "monitor:1991:1990:Embedded Hush Line profile updates:frontend:",
+    ]
+    assert "collect-issue-candidates" not in calls
+    assert "runtime-bootstrap" not in calls
+
+
 def test_main_exits_before_runtime_bootstrap_when_bot_pr_exists(tmp_path: Path) -> None:
     call_log = tmp_path / "calls.txt"
     repo_dir = tmp_path / "repo"

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -84,6 +84,9 @@ printf '%s\\n' "$snapshot_metadata"
     assert Path(original_dir) == RUNNER_SCRIPT.parent
     assert snapshot_file.exists()
     assert snapshot_file.parent == tmp_path
+    assert snapshot_file.name.startswith("agent_daily_issue_runner.")
+    assert "XXXXXX" not in snapshot_file.name
+    assert not snapshot_file.name.endswith(".sh")
     assert snapshot_file.read_text(encoding="utf-8") == RUNNER_SCRIPT.read_text(encoding="utf-8")
 
 
@@ -256,6 +259,121 @@ printf 'unexpected\\n'
     assert result.returncode == 0, result.stderr
     assert "another Hush Line code agent run is already active" in result.stdout
     assert "unexpected" not in result.stdout
+
+
+def test_find_open_issue_pr_to_resume_selects_issue_branch() -> None:
+    prs_json = json.dumps(
+        [
+            {
+                "number": 1900,
+                "title": "#1900 Epic",
+                "headRefName": "codex/epic-1900",
+                "updatedAt": "2026-05-19T00:00:00Z",
+            },
+            {
+                "number": 1991,
+                "title": "#1990 Embedded Hush Line profile updates",
+                "headRefName": "codex/daily-issue-1990",
+                "updatedAt": "2026-05-19T01:00:00Z",
+            },
+        ]
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+gh() {{
+  if [[ "$1" == "pr" && "$2" == "list" ]]; then
+    printf '%s\\n' {shlex.quote(prs_json)}
+    return 0
+  fi
+  printf 'unexpected gh invocation: %s\\n' "$*" >&2
+  return 99
+}}
+find_open_issue_pr_to_resume
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout == (
+        "1991\t1990\tcodex/daily-issue-1990\t" "#1990 Embedded Hush Line profile updates\n"
+    )
+
+
+def test_main_resumes_open_issue_pr_before_selecting_new_work(tmp_path: Path) -> None:
+    call_log = tmp_path / "calls.txt"
+    repo_dir = tmp_path / "repo"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(repo_dir))}
+mkdir -p "$REPO_DIR/.git"
+parse_args() {{ :; }}
+initialize_run_state() {{ :; }}
+cleanup() {{ :; }}
+acquire_runner_lock() {{ :; }}
+assert_runner_can_take_checkout() {{
+  printf 'assert-runner-can-take-checkout\\n' >> {shlex.quote(str(call_log))}
+}}
+require_cmd() {{ :; }}
+require_positive_integer() {{ :; }}
+require_non_negative_integer() {{ :; }}
+find_open_issue_pr_to_resume() {{
+  printf '1991\\t1990\\tcodex/daily-issue-1990\\t#1990 Embedded Hush Line profile updates\\n'
+}}
+remote_branch_exists() {{ return 0; }}
+run_step() {{
+  printf 'run-step:%s\\n' "$1" >> {shlex.quote(str(call_log))}
+  shift
+  "$@"
+}}
+git() {{
+  printf 'git:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+  return 0
+}}
+gh() {{
+  if [[ "$1" == "issue" && "$2" == "view" && "$3" == "1990" && "$*" == *"--jq .title"* ]]; then
+    printf 'Embedded Hush Line profile updates\\n'
+    return 0
+  fi
+  if [[ "$1" == "issue" && "$2" == "view" && "$3" == "1990" && "$*" == *".labels[].name"* ]]; then
+    printf 'frontend\\n'
+    return 0
+  fi
+  printf 'unexpected-gh:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+  return 99
+}}
+check_pr_feedback_after_delay() {{
+  printf 'monitor:%s:%s:%s:%s:%s\\n' "$1" "$2" "$3" "$4" "$5" >> {shlex.quote(str(call_log))}
+}}
+collect_issue_candidates() {{
+  printf 'collect-issue-candidates\\n' >> {shlex.quote(str(call_log))}
+  printf '2001\\n'
+}}
+start_runtime_stack_and_seed_dev_data() {{
+  printf 'runtime-bootstrap\\n' >> {shlex.quote(str(call_log))}
+}}
+main
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Resuming monitor for open PR #1991 on codex/daily-issue-1990; "
+        "skipping new issue selection until that PR closes."
+    ) in result.stdout
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert calls == [
+        "assert-runner-can-take-checkout",
+        "run-step:Fetch PR branch codex/daily-issue-1990",
+        "git:fetch origin codex/daily-issue-1990:refs/remotes/origin/codex/daily-issue-1990",
+        "run-step:Checkout PR branch codex/daily-issue-1990",
+        "git:checkout -B codex/daily-issue-1990 origin/codex/daily-issue-1990",
+        "monitor:1991:1990:Embedded Hush Line profile updates:frontend:codex/daily-issue-1990",
+    ]
+    assert "collect-issue-candidates" not in calls
+    assert "runtime-bootstrap" not in calls
 
 
 def test_main_exits_before_runtime_bootstrap_when_bot_pr_exists(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Keep restart-resume PR monitoring from hard-failing when an open bot PR head branch is unavailable on `origin` and cannot be recovered locally.
- Continue monitoring the PR by number only when branch context is unavailable, so scheduled runs do not repeatedly abort or accidentally address feedback from the wrong branch.
- Add regression coverage for the missing-branch resume path.

## Why
- The runner can encounter stale or deleted bot PR branches after PR creation. That state should be recoverable for monitoring instead of blocking future scheduled runs.

## Validation
- `make lint`
- `make test` (1745 passed, 1 deselected, 1 xfailed; coverage 99%)

## Manual Testing
- Not applicable; this is runner shell-control behavior covered by automated regression tests.

## Risks / Follow-ups
- In the monitor-only fallback, actionable feedback is reported but not auto-addressed until branch context is available again.

## Freshness
- PR created: 2026-05-20. Reviewed and updated: 2026-05-20.