### PR TITLE
Update Runner to Open Issues for Test Gaps

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -97,14 +97,15 @@ This runner runs directly in the local repo and performs a narrow local gate bef
     - child issues under a parent epic open/update a child PR whose base branch is the shared epic branch
     - the long-lived epic PR, when present, remains the only PR that targets `main`
 18. Move the selected issue into project status `Ready for Review` once the PR exists.
-19. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
-20. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
-21. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`, `Manual Testing`).
+19. After the PR exists and before feedback polling starts, parse the latest `make test` coverage snapshot and open a follow-up issue for any files with missed statements. Add that issue to the `Hush Line Roadmap` project in the `Agent Eligible` status.
+20. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
+21. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
+22. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`, `Manual Testing`).
     - `Validation` lists automated checks run by the runner or CI.
     - `Manual Testing` lists human reviewer steps to exercise the changed feature after the PR opens. It is not a log of actions the LLM or runner performed.
-22. Refresh run log after PR creation (including opened PR URL and post-check steps), commit/push that log update when changed.
-23. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, then resumes polling.
-24. Return to a clean `main` on normal completion or PR closure.
+23. Refresh run log after PR creation (including opened PR URL, coverage gap issue URL when created, and post-check steps), commit/push that log update when changed.
+24. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, then resumes polling.
+25. Return to a clean `main` on normal completion or PR closure.
     - If the run fails after creating branch work, cleanup resets the checkout back to a clean base branch.
     - A new scheduled pass discards local worktree changes and switches back to the base branch before evaluating GitHub queue guards.
 

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -1377,6 +1377,24 @@ resolve_pr_number_from_ref() {
   return 1
 }
 
+resolve_issue_number_from_ref() {
+  local issue_ref="$1"
+  local resolved=""
+
+  if [[ "$issue_ref" =~ /issues/([0-9]+)$ ]]; then
+    printf '%s\n' "${BASH_REMATCH[1]}"
+    return 0
+  fi
+
+  resolved="$(gh issue view "$issue_ref" --repo "$REPO_SLUG" --json number --jq .number 2>/dev/null || true)"
+  if [[ "$resolved" =~ ^[0-9]+$ ]]; then
+    printf '%s\n' "$resolved"
+    return 0
+  fi
+
+  return 1
+}
+
 pr_feedback_state() {
   local feedback_json="$1"
 
@@ -1975,6 +1993,138 @@ resolve_issue_project_item_id() {
     ' || true
 }
 
+resolve_issue_node_id() {
+  local issue_number="$1"
+  local owner="${REPO_SLUG%%/*}"
+  local repo="${REPO_SLUG##*/}"
+  local number="${issue_number}"
+  local response=""
+
+  response="$({
+    gh api graphql \
+      -F issueNumber="$number" \
+      -f query='
+        query($issueNumber: Int!) {
+          repository(owner: "'"$owner"'", name: "'"$repo"'") {
+            issue(number: $issueNumber) {
+              id
+            }
+          }
+        }
+      ' 2>/dev/null
+  } || true)"
+
+  if ! printf '%s' "$response" | is_json_response; then
+    warn_non_json_response "issue node lookup for issue #${issue_number}" "$response"
+    return 0
+  fi
+
+  printf '%s' "$response" | node -e '
+    const fs = require("fs");
+    const payload = JSON.parse(fs.readFileSync(0, "utf8"));
+    const issue =
+      payload &&
+      payload.data &&
+      payload.data.repository &&
+      payload.data.repository.issue
+        ? payload.data.repository.issue
+        : null;
+    process.stdout.write(issue && issue.id ? String(issue.id) : "");
+  ' || true
+}
+
+add_issue_to_project_status() {
+  local issue_number="$1"
+  local target_status_name="$2"
+  local project_number project_id field_id option_id item_id issue_node_id response
+  local edit_args=""
+
+  project_number="$(resolve_project_number)"
+  if [[ -z "$project_number" ]]; then
+    echo "Warning: could not resolve project number for coverage gap issue #${issue_number}." >&2
+    return 0
+  fi
+
+  edit_args="$(resolve_project_status_edit_args "$project_number" "$target_status_name")"
+  if [[ -z "$edit_args" ]]; then
+    echo "Warning: could not resolve project status field/option for coverage gap issue #${issue_number}." >&2
+    return 0
+  fi
+  IFS=$'\t' read -r project_id field_id option_id <<< "$edit_args"
+
+  item_id="$(resolve_issue_project_item_id "$issue_number" "$project_number")"
+  if [[ -z "$item_id" ]]; then
+    issue_node_id="$(resolve_issue_node_id "$issue_number")"
+    if [[ -z "$issue_node_id" ]]; then
+      echo "Warning: could not resolve node id for coverage gap issue #${issue_number}." >&2
+      return 0
+    fi
+
+    response="$({
+      gh api graphql \
+        -f projectId="$project_id" \
+        -f contentId="$issue_node_id" \
+        -f query='
+          mutation($projectId: ID!, $contentId: ID!) {
+            addProjectV2ItemById(input: {projectId: $projectId, contentId: $contentId}) {
+              item {
+                id
+              }
+            }
+          }
+        ' 2>/dev/null
+    } || true)"
+
+    if ! printf '%s' "$response" | is_json_response; then
+      warn_non_json_response "project add for coverage gap issue #${issue_number}" "$response"
+      return 0
+    fi
+
+    item_id="$(printf '%s' "$response" | node -e '
+      const fs = require("fs");
+      const payload = JSON.parse(fs.readFileSync(0, "utf8"));
+      const item =
+        payload &&
+        payload.data &&
+        payload.data.addProjectV2ItemById &&
+        payload.data.addProjectV2ItemById.item
+          ? payload.data.addProjectV2ItemById.item
+          : null;
+      process.stdout.write(item && item.id ? String(item.id) : "");
+    ' || true)"
+  fi
+
+  if [[ -z "$item_id" ]]; then
+    echo "Warning: could not attach coverage gap issue #${issue_number} to project '${PROJECT_TITLE}'." >&2
+    return 0
+  fi
+
+  if ! gh api graphql \
+    -f projectId="$project_id" \
+    -f itemId="$item_id" \
+    -f fieldId="$field_id" \
+    -f optionId="$option_id" \
+    -f query='
+      mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+        updateProjectV2ItemFieldValue(
+          input: {
+            projectId: $projectId
+            itemId: $itemId
+            fieldId: $fieldId
+            value: { singleSelectOptionId: $optionId }
+          }
+        ) {
+          projectV2Item {
+            id
+          }
+        }
+      }
+    ' >/dev/null; then
+    echo "Warning: failed to set coverage gap issue #${issue_number} to project status '${target_status_name}'." >&2
+    return 0
+  fi
+}
+
 set_issue_project_status() {
   local issue_number="$1"
   local target_status_name="$2"
@@ -2365,6 +2515,154 @@ run_local_workflow_checks() {
   fi
 
   run_runtime_check_with_self_heal "Run test (full suite)" make test || return 1
+}
+
+coverage_gap_snapshot_from_log() {
+  local log_file="${1:-$CHECK_LOG_FILE}"
+
+  if [[ -z "$log_file" || ! -s "$log_file" ]]; then
+    return 0
+  fi
+
+  awk '
+    /^Name[[:space:]]+Stmts[[:space:]]+Miss[[:space:]]+Cover$/ {
+      in_table = 1
+      current_header = $0
+      current_count = 0
+      current_total = ""
+      delete current_rows
+      next
+    }
+    in_table && /^-+$/ {
+      next
+    }
+    in_table && /^TOTAL[[:space:]]+/ {
+      current_total = $0
+      if (current_count > 0) {
+        final_header = current_header
+        final_total = current_total
+        final_count = current_count
+        delete final_rows
+        for (i = 1; i <= current_count; i += 1) {
+          final_rows[i] = current_rows[i]
+        }
+      }
+      in_table = 0
+      next
+    }
+    in_table && NF >= 4 {
+      miss = $(NF - 1)
+      gsub(/[^0-9]/, "", miss)
+      if ((miss + 0) > 0) {
+        current_rows[++current_count] = $0
+      }
+      next
+    }
+    END {
+      if (final_count > 0) {
+        print final_header
+        for (i = 1; i <= final_count; i += 1) {
+          print final_rows[i]
+        }
+        if (final_total != "") {
+          print final_total
+        }
+      }
+    }
+  ' "$log_file"
+}
+
+write_coverage_gap_issue_body() {
+  local pr_number="$1"
+  local pr_url="$2"
+  local source_issue_number="$3"
+  local source_issue_title="$4"
+  local branch_name="$5"
+  local coverage_snapshot="$6"
+  local pr_label="the runner PR"
+
+  if [[ -n "$pr_number" ]]; then
+    pr_label="PR #${pr_number}"
+  fi
+
+  cat <<EOF
+## Summary
+The daily runner opened ${pr_label} after local validation passed, then captured the test coverage snapshot below. The files with missed statements should get focused test coverage in a follow-up agent run.
+
+## Source
+- PR: ${pr_url:-unknown}
+- Source issue: #${source_issue_number} ${source_issue_title}
+- Branch: ${branch_name}
+
+## Coverage Snapshot
+
+\`\`\`text
+${coverage_snapshot}
+\`\`\`
+
+## Guidance
+- Add tests for the missed statements shown above.
+- Prefer user-visible behavior and security-critical outcomes over implementation-only assertions.
+- Keep privacy, E2EE, CSP, and operational safety guarantees intact.
+EOF
+}
+
+open_coverage_gap_issue_after_pr() {
+  local pr_number="$1"
+  local pr_url="$2"
+  local source_issue_number="$3"
+  local source_issue_title="$4"
+  local branch_name="$5"
+  local coverage_snapshot=""
+  local issue_body_file=""
+  local issue_title=""
+  local issue_url=""
+  local coverage_issue_number=""
+
+  coverage_snapshot="$(coverage_gap_snapshot_from_log "$CHECK_LOG_FILE")"
+  if [[ -z "$coverage_snapshot" ]]; then
+    echo "Coverage gap issue skipped: no missed statements found in the latest test coverage snapshot."
+    return 0
+  fi
+
+  issue_body_file="$(mktemp)"
+  if [[ -n "$pr_number" ]]; then
+    issue_title="Close test coverage gaps from PR #${pr_number}"
+  else
+    issue_title="Close test coverage gaps from daily runner PR"
+  fi
+
+  write_coverage_gap_issue_body \
+    "$pr_number" \
+    "$pr_url" \
+    "$source_issue_number" \
+    "$source_issue_title" \
+    "$branch_name" \
+    "$coverage_snapshot" > "$issue_body_file"
+
+  if ! issue_url="$(
+    gh issue create \
+      --repo "$REPO_SLUG" \
+      --title "$issue_title" \
+      --body-file "$issue_body_file"
+  )"; then
+    rm -f "$issue_body_file"
+    echo "Warning: failed to open coverage gap issue for ${pr_url:-PR #${pr_number}}." >&2
+    return 0
+  fi
+  rm -f "$issue_body_file"
+
+  if ! coverage_issue_number="$(resolve_issue_number_from_ref "$issue_url")"; then
+    echo "Warning: opened coverage gap issue but failed to resolve its number from '$issue_url'." >&2
+    return 0
+  fi
+
+  echo "Opened coverage gap issue: $issue_url"
+  run_step \
+    "Add coverage gap issue #${coverage_issue_number} to ${PROJECT_COLUMN}" \
+    add_issue_to_project_status \
+    "$coverage_issue_number" \
+    "$PROJECT_COLUMN"
 }
 
 write_pr_changed_files_section() {
@@ -3529,6 +3827,13 @@ main() {
     set_issue_project_status \
     "$ISSUE_NUMBER" \
     "$PROJECT_STATUS_READY_FOR_REVIEW"
+
+  open_coverage_gap_issue_after_pr \
+    "$PR_NUMBER" \
+    "$PR_URL" \
+    "$ISSUE_NUMBER" \
+    "$ISSUE_TITLE" \
+    "$BRANCH_NAME"
 
   persist_run_log "$ISSUE_NUMBER"
 

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -1081,6 +1081,223 @@ set_issue_project_status 1732 "Ready for Review"
     assert result.returncode == 0, result.stderr
 
 
+def test_add_issue_to_project_status_adds_missing_item_and_updates_status(
+    tmp_path: Path,
+) -> None:
+    call_log = tmp_path / "calls.txt"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+resolve_project_number() {{ printf '7\\n'; }}
+resolve_project_status_edit_args() {{ printf 'PVT_project\\tPVTSSF_status\\topt_agent\\n'; }}
+resolve_issue_project_item_id() {{ :; }}
+resolve_issue_node_id() {{ printf 'I_issue\\n'; }}
+gh() {{
+  local query_text=""
+  local project_id=""
+  local content_id=""
+  local item_id=""
+  local field_id=""
+  local option_id=""
+
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f)
+        case "$2" in
+          query=*) query_text="${{2#query=}}" ;;
+          projectId=*) project_id="${{2#projectId=}}" ;;
+          contentId=*) content_id="${{2#contentId=}}" ;;
+          itemId=*) item_id="${{2#itemId=}}" ;;
+          fieldId=*) field_id="${{2#fieldId=}}" ;;
+          optionId=*) option_id="${{2#optionId=}}" ;;
+        esac
+        shift
+        ;;
+    esac
+    shift || break
+  done
+
+  if [[ "$query_text" == *"addProjectV2ItemById"* ]]; then
+    printf 'add:%s:%s\\n' "$project_id" "$content_id" >> {shlex.quote(str(call_log))}
+    printf '{{"data":{{"addProjectV2ItemById":{{"item":{{"id":"PVTI_added"}}}}}}}}\\n'
+    return 0
+  fi
+
+  if [[ "$query_text" == *"updateProjectV2ItemFieldValue"* ]]; then
+    printf 'update:%s:%s:%s:%s\\n' \\
+      "$project_id" \\
+      "$item_id" \\
+      "$field_id" \\
+      "$option_id" \\
+      >> {shlex.quote(str(call_log))}
+    printf '%s\\n' \\
+      '{{"data":{{"updateProjectV2ItemFieldValue":{{"projectV2Item":{{"id":"PVTI_added"}}}}}}}}'
+    return 0
+  fi
+
+  printf 'unexpected gh invocation: %s\\n' "$*" >&2
+  return 99
+}}
+add_issue_to_project_status 2002 "Agent Eligible"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert call_log.read_text(encoding="utf-8").splitlines() == [
+        "add:PVT_project:I_issue",
+        "update:PVT_project:PVTI_added:PVTSSF_status:opt_agent",
+    ]
+
+
+def test_add_issue_to_project_status_warns_when_status_update_fails(
+    tmp_path: Path,
+) -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+resolve_project_number() {{ printf '7\\n'; }}
+resolve_project_status_edit_args() {{ printf 'PVT_project\\tPVTSSF_status\\topt_agent\\n'; }}
+resolve_issue_project_item_id() {{ printf 'PVTI_existing\\n'; }}
+gh() {{
+  local query_text=""
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      -f)
+        case "$2" in
+          query=*) query_text="${{2#query=}}" ;;
+        esac
+        shift
+        ;;
+    esac
+    shift || break
+  done
+
+  if [[ "$query_text" == *"updateProjectV2ItemFieldValue"* ]]; then
+    return 1
+  fi
+
+  printf 'unexpected gh invocation: %s\\n' "$*" >&2
+  return 99
+}}
+add_issue_to_project_status 2002 "Agent Eligible"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "failed to set coverage gap issue #2002" in result.stderr
+
+
+def test_coverage_gap_snapshot_from_log_reports_latest_missed_rows(
+    tmp_path: Path,
+) -> None:
+    check_log = tmp_path / "check.log"
+    check_log.write_text(
+        """
+old run
+Name                                             Stmts   Miss  Cover
+--------------------------------------------------------------------
+hushline/old.py                                    10      1    90%
+TOTAL                                              10      1    90%
+new run
+Name                                             Stmts   Miss  Cover
+--------------------------------------------------------------------
+hushline/__init__.py                              160      0   100%
+hushline/email.py                                 109      1    99%
+hushline/routes/profile.py                        272     17    94%
+TOTAL                                            8881     36    99%
+""",
+        encoding="utf-8",
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+coverage_gap_snapshot_from_log {shlex.quote(str(check_log))}
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "hushline/old.py" not in result.stdout
+    assert "hushline/__init__.py" not in result.stdout
+    assert "hushline/email.py" in result.stdout
+    assert "hushline/routes/profile.py" in result.stdout
+    assert "TOTAL                                            8881     36    99%" in result.stdout
+
+
+def test_open_coverage_gap_issue_after_pr_creates_agent_eligible_issue(
+    tmp_path: Path,
+) -> None:
+    check_log = tmp_path / "check.log"
+    call_log = tmp_path / "calls.txt"
+    body_copy = tmp_path / "body.md"
+    check_log.write_text(
+        """
+Name                                             Stmts   Miss  Cover
+--------------------------------------------------------------------
+hushline/email.py                                 109      1    99%
+hushline/routes/profile.py                        272     17    94%
+TOTAL                                            8881     36    99%
+""",
+        encoding="utf-8",
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CHECK_LOG_FILE={shlex.quote(str(check_log))}
+add_issue_to_project_status() {{
+  printf 'project:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(call_log))}
+}}
+gh() {{
+  if [[ "${{1-}} ${{2-}}" == "issue create" ]]; then
+    local title=""
+    local body_file=""
+    while [[ $# -gt 0 ]]; do
+      case "$1" in
+        --title)
+          title="$2"
+          shift
+          ;;
+        --body-file)
+          body_file="$2"
+          shift
+          ;;
+      esac
+      shift || break
+    done
+    printf 'title:%s\\n' "$title" >> {shlex.quote(str(call_log))}
+    cp "$body_file" {shlex.quote(str(body_copy))}
+    printf 'https://github.com/scidsg/hushline/issues/2002\\n'
+    return 0
+  fi
+  printf 'unexpected gh invocation: %s\\n' "$*" >&2
+  return 99
+}}
+open_coverage_gap_issue_after_pr \\
+  2000 \\
+  "https://github.com/scidsg/hushline/pull/2000" \\
+  1558 \\
+  "Fill coverage gaps" \\
+  "codex/daily-issue-1558"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert (
+        "Opened coverage gap issue: https://github.com/scidsg/hushline/issues/2002" in result.stdout
+    )
+    assert call_log.read_text(encoding="utf-8").splitlines() == [
+        "title:Close test coverage gaps from PR #2000",
+        "project:2002:Agent Eligible",
+    ]
+    body = body_copy.read_text(encoding="utf-8")
+    assert "PR: https://github.com/scidsg/hushline/pull/2000" in body
+    assert "Source issue: #1558 Fill coverage gaps" in body
+    assert "hushline/email.py" in body
+    assert "hushline/routes/profile.py" in body
+
+
 def test_collect_issue_candidates_from_project_filters_open_issues_in_target_status() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
@@ -3946,6 +4163,9 @@ build_pr_title() {{
 check_pr_feedback_after_delay() {{
   printf 'feedback:%s\\n' "${{1-}}" >> {shlex.quote(str(call_log))}
 }}
+open_coverage_gap_issue_after_pr() {{
+  printf 'coverage-issue:%s:%s\\n' "$1" "$3" >> {shlex.quote(str(call_log))}
+}}
 gh() {{
   if [[ "${{1-}} ${{2-}} ${{3-}}" == "issue view 1558" ]]; then
     local last_arg="${{@: -1}}"
@@ -3971,7 +4191,10 @@ main
     assert result.returncode == 0, result.stderr
     calls = call_log.read_text(encoding="utf-8").splitlines()
     assert "status:1558:Ready for Review" in calls
+    assert "coverage-issue:2000:1558" in calls
     assert "feedback:2000" in calls
+    assert calls.index("status:1558:Ready for Review") < calls.index("coverage-issue:2000:1558")
+    assert calls.index("coverage-issue:2000:1558") < calls.index("feedback:2000")
     assert "Warning: opened PR but failed to resolve its number" not in result.stdout
 
 


### PR DESCRIPTION
This PR updates the daily agent runner so it can turn test coverage gaps found after a successful local validation run into follow-up issue work for the project queue.

## Summary
- Parse the latest `make test` coverage table from the runner check log after the runner PR is opened.
- Open a follow-up issue when the latest coverage snapshot contains files with missed statements.
- Add the new coverage-gap issue to the `Hush Line Roadmap` project in the `Agent Eligible` status.
- Include the coverage-gap issue URL in the refreshed runner log when one is created.
- Add runner tests for coverage parsing, issue creation, project attachment/status updates, and main-flow ordering before feedback polling.

## Context
This is runner automation and documentation work. It does not change whistleblower disclosure handling, inbox behavior, authentication, E2EE defaults, directory discovery, CSP policy, or other user-facing privacy/security flows.

The PR was created and merged on May 20, 2026. It had an empty body after merge, so this description was reconstructed from the merged diff and GitHub check metadata.

## Changed Files
- `docs/AGENT-RUNNER.md`: documents the new post-PR coverage-gap issue step and log refresh behavior.
- `scripts/agent_daily_issue_runner.sh`: adds issue number resolution, project attachment/status helpers, coverage table extraction, coverage-gap issue body generation, issue creation, and post-PR invocation.
- `tests/test_agent_daily_issue_runner.py`: covers the new helper behavior and verifies coverage-gap issue creation runs after moving the source issue to `Ready for Review` and before feedback polling.

## Validation
Observed in PR metadata:
- `Workflow Security Checks / actionlint`: success
- `Workflow Security Checks / disallow-unsafe-event-interpolation`: success
- `CodeQL / Analyze (actions)`: success
- `CodeQL / Analyze (javascript)`: success
- `CodeQL / Analyze (python)`: success
- `GitGuardian Security Checks`: success
- `CCPA Compliance / ccpa`: success
- `GDPR Compliance / gdpr`: success
- `E2EE and Privacy Regressions / e2ee-privacy-tests`: success
- `Lighthouse Accessibility / lighthouse`: success
- `Run Linter and Tests / lint`: success

GitHub still reports `Run Linter and Tests / test` and `Run Linter and Tests / test-with-alembic` as `in_progress` on Actions run `26146719118`, so the PR metadata does not show final passing results for those two jobs.

No code or tests were re-run for this metadata-only PR body update.

## Manual Testing
Not applicable for this metadata-only update. For the runner behavior changed by the merged PR, the relevant manual review path is to inspect a runner-created PR after local tests pass and confirm that a coverage-gap issue is opened only when the latest coverage table contains missed statements, then added to `Hush Line Roadmap` as `Agent Eligible`.

## Known Risks / Follow-up
- The coverage-gap issue workflow depends on GitHub issue creation and project GraphQL mutations succeeding after PR creation.
- If GitHub returns non-JSON or project metadata cannot be resolved, the runner warns and continues instead of blocking the already-created PR.
