### PR TITLE
Hold runner lock through cleanup

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -35,38 +35,41 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 1. Parse arguments (`--issue` optional) and resolve runtime configuration.
 2. Change into the repo (`$HOME/hushline` by default).
 3. Acquire a local runner lock and exit without doing any repository or Docker work if another Hush Line code-agent run is active.
-4. Normalize the local agent-only checkout by discarding local worktree changes and switching to the base branch.
-5. Resume monitoring any open bot-authored issue PR whose head branch matches the daily issue branch pattern before selecting new issue work. This makes PR polling restart-resilient after launchd unloads, crashes, or reboots.
-6. Check cheap GitHub exit conditions before any new-work queue lookup or network sync/Docker work:
+4. Hold the runner lock through all repository cleanup, including exit-time checkout/reset/clean work, so a launchd overlap cannot start a second issue while the prior run is still unwinding.
+5. Normalize the local agent-only checkout by discarding local worktree changes and switching to the base branch.
+6. Resume monitoring any open bot-authored issue PR whose head branch matches the daily issue branch pattern before selecting new issue work. This makes PR polling restart-resilient after launchd unloads, crashes, or reboots.
+7. Check cheap GitHub exit conditions before any new-work queue lookup or network sync/Docker work:
    - exit if any open human-authored PR exists
    - exit if any open issue is already in project status `In Progress`
-7. Select issue target before any network sync or Docker work:
+8. Select issue target before any network sync or Docker work:
    - Use `--issue <n>` when provided (must still be open), otherwise
    - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
-8. Check remaining cheap GitHub exit conditions before any network sync or Docker work:
+9. Check remaining cheap GitHub exit conditions before any network sync or Docker work:
    - for non-epic issues, exit if any other open PR exists from `hushline-dev`
    - for child issues with a GitHub parent epic, allow the long-lived epic PR (head branch `codex/epic-<epic>`) and the current child issue PR (head branch `codex/daily-issue-<issue>`)
    - for child issues with a GitHub parent epic, exit only if there are unrelated open bot PRs outside those allowed heads
-9. Hard-refresh local state only after an issue is selected and skip guards pass:
-   - `git fetch origin`
-   - `git checkout main`
-   - `git reset --hard origin/main`
-   - `git clean -fd`
-10. Move the selected issue into project status `In Progress`.
-11. Configure bot git identity and signed commit settings.
-12. Reset local Docker/runtime state:
+10. Hard-refresh local state only after an issue is selected and skip guards pass:
+
+- `git fetch origin`
+- `git checkout main`
+- `git reset --hard origin/main`
+- `git clean -fd`
+
+11. Move the selected issue into project status `In Progress`.
+12. Configure bot git identity and signed commit settings.
+13. Reset local Docker/runtime state:
 
 - `docker compose down -v --remove-orphans`
 - Remove all Docker containers (`docker rm -f $(docker ps -aq)`, when any exist)
 - Kill processes listening on runner ports (`4566 4571 5432 8080` by default)
 
-12. Start and seed stack:
+14. Start and seed stack:
 
 - `docker compose up -d --build`
 - `docker compose run --rm dev_data`
 - retry the bootstrap sequence when Docker image pulls fail with transient registry/network errors (defaults: `3` attempts, `10`s delay via `HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_ATTEMPTS` and `HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS`)
 
-13. Create/update work branch:
+15. Create/update work branch:
 
 - regular issues use `codex/daily-issue-<issue_number>` by default
 - child issues with a parent epic still use `codex/daily-issue-<issue_number>` as the work branch
@@ -74,13 +77,13 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 - if the epic base branch does not exist yet, create and push it from `main` before starting the child branch
 - if the child issue branch already has an open PR, update that child PR instead of opening a duplicate
 
-14. Run a bounded Codex issue loop until repository changes exist (max attempts configurable via `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS`, default `10`).
+16. Run a bounded Codex issue loop until repository changes exist (max attempts configurable via `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS`, default `10`).
     - The issue/fix prompts tell Codex to avoid local container-backed make validation by default, and to defer validation entirely to the runner when schema-affecting files are touched (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`).
     - The fix prompt includes the current branch diff summary, the prior Codex summary, and an extracted failure signature so Codex can repair the current implementation instead of repeating a narrow patch against the same failing symptom.
     - Raw failed check output is intentionally withheld from Codex prompts because local check logs may contain sensitive operational data.
     - Codex transcript output is captured in a temporary file for the duration of the run and is excluded from the persisted runner log; only the final Codex summary is written into the run log.
     - Each Codex attempt logs prompt size and pre/post worktree snapshots so clean-tree no-op runs are visible in the runner log.
-15. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
+17. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
     - Before lint/test validation, if the working tree includes schema-affecting changes (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), rebuild the local runtime and reseed dev data so the live stack matches the current code.
     - `make lint`
     - `make test` (full suite)
@@ -88,24 +91,24 @@ This runner runs directly in the local repo and performs a narrow local gate bef
     - Lint failures only run deterministic `make fix` self-heal when the failure looks auto-fixable (for example Ruff formatting/check or Prettier); non-auto-fixable lint failures go straight back to Codex.
     - Runtime-dependent tests self-heal by restarting the local stack and reseeding dev data, then retrying once.
     - The broader CI workflow matrix still runs on the PR after branch push; the runner no longer tries to mirror that entire matrix locally.
-16. Persist run log to `docs/agent-logs/run-<timestamp>-issue-<n>.txt`.
+18. Persist run log to `docs/agent-logs/run-<timestamp>-issue-<n>.txt`.
     - After each persist, prune older runner logs and keep only the newest `10` by default.
     - Persisted logs are sanitized before commit to remove developer filesystem paths, emails, and Codex session metadata.
-17. Commit, push branch, and open/update PR:
+19. Commit, push branch, and open/update PR:
     - first push uses a normal push when remote branch is absent
     - existing remote branch uses `--force-with-lease` with one stale-info recovery retry.
     - child issues under a parent epic open/update a child PR whose base branch is the shared epic branch
     - the long-lived epic PR, when present, remains the only PR that targets `main`
-18. Move the selected issue into project status `Ready for Review` once the PR exists.
-19. After the PR exists and before feedback polling starts, parse the latest `make test` coverage snapshot and open a follow-up issue for any files with missed statements. Add that issue to the `Hush Line Roadmap` project in the `Agent Eligible` status.
-20. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
-21. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
-22. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`, `Manual Testing`).
+20. Move the selected issue into project status `Ready for Review` once the PR exists.
+21. After the PR exists and before feedback polling starts, parse the latest `make test` coverage snapshot and open a follow-up issue for any files with missed statements. Add that issue to the `Hush Line Roadmap` project in the `Agent Eligible` status.
+22. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
+23. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
+24. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`, `Manual Testing`).
     - `Validation` lists automated checks run by the runner or CI.
     - `Manual Testing` lists human reviewer steps to exercise the changed feature after the PR opens. It is not a log of actions the LLM or runner performed.
-23. Refresh run log after PR creation (including opened PR URL, coverage gap issue URL when created, and post-check steps), commit/push that log update when changed.
-24. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it first waits for all pending PR checks to settle, then invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, and resumes polling.
-25. Return to a clean `main` on normal completion or PR closure.
+25. Refresh run log after PR creation (including opened PR URL, coverage gap issue URL when created, and post-check steps), commit/push that log update when changed.
+26. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it first waits for all pending PR checks to settle, then invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, and resumes polling.
+27. Return to a clean `main` on normal completion or PR closure.
     - If the run fails after creating branch work, cleanup resets the checkout back to a clean base branch.
     - A new scheduled pass discards local worktree changes and switches back to the base branch before evaluating GitHub queue guards.
 

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -133,40 +133,42 @@ cleanup() {
   local exit_code=$?
   local cleanup_branch=""
   local cleanup_status=""
+  local checkout_ok=1
 
   rm -f "${CHECK_LOG_FILE:-}" "${PROMPT_FILE:-}" "${PR_BODY_FILE:-}" "${CODEX_OUTPUT_FILE:-}" "${CODEX_TRANSCRIPT_FILE:-}" "${RUN_LOG_TMP_FILE:-}"
   rm -f "${HUSHLINE_DAILY_RUNNER_SNAPSHOT_PATH:-}"
-  release_runner_lock
   if [[ -d "$REPO_DIR/.git" && "$CLEANUP_REPO_ON_EXIT" == "1" ]]; then
     if [[ "${PR_FEEDBACK_MONITOR_ACTIVE:-0}" == "1" && "${PR_FEEDBACK_MONITOR_CLOSED:-0}" != "1" ]]; then
       echo "Leaving branch ${PR_FEEDBACK_MONITOR_BRANCH:-current branch} checked out because PR #${PR_FEEDBACK_MONITOR_PR_NUMBER:-unknown} is still open."
-      return
-    fi
+    else
+      if (( exit_code != 0 )); then
+        cleanup_branch="$(git -C "$REPO_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
+        cleanup_status="$(git -C "$REPO_DIR" status --short 2>/dev/null || true)"
+        if [[ "$cleanup_branch" != "$BASE_BRANCH" || -n "$cleanup_status" ]]; then
+          echo "Resetting failed runner worktree from ${cleanup_branch:-detached HEAD}; exit status was ${exit_code}."
+          if [[ -n "$cleanup_status" ]]; then
+            printf '%s\n' "$cleanup_status"
+          fi
+        fi
+      fi
 
-    if (( exit_code != 0 )); then
-      cleanup_branch="$(git -C "$REPO_DIR" symbolic-ref --quiet --short HEAD 2>/dev/null || true)"
-      cleanup_status="$(git -C "$REPO_DIR" status --short 2>/dev/null || true)"
-      if [[ "$cleanup_branch" != "$BASE_BRANCH" || -n "$cleanup_status" ]]; then
-        echo "Resetting failed runner worktree from ${cleanup_branch:-detached HEAD}; exit status was ${exit_code}."
-        if [[ -n "$cleanup_status" ]]; then
-          printf '%s\n' "$cleanup_status"
+      if ! git -C "$REPO_DIR" checkout "$BASE_BRANCH" >/dev/null 2>&1; then
+        echo "Warning: failed to switch back to $BASE_BRANCH during cleanup." >&2
+        checkout_ok=0
+      fi
+      if [[ "$checkout_ok" == "1" ]]; then
+        if ! git -C "$REPO_DIR" reset --hard "origin/$BASE_BRANCH" >/dev/null 2>&1; then
+          if ! git -C "$REPO_DIR" reset --hard "$BASE_BRANCH" >/dev/null 2>&1; then
+            echo "Warning: failed to reset $BASE_BRANCH during cleanup." >&2
+          fi
+        fi
+        if ! git -C "$REPO_DIR" clean -fd >/dev/null 2>&1; then
+          echo "Warning: failed to remove untracked files during cleanup." >&2
         fi
       fi
     fi
-
-    if ! git -C "$REPO_DIR" checkout "$BASE_BRANCH" >/dev/null 2>&1; then
-      echo "Warning: failed to switch back to $BASE_BRANCH during cleanup." >&2
-      return
-    fi
-    if ! git -C "$REPO_DIR" reset --hard "origin/$BASE_BRANCH" >/dev/null 2>&1; then
-      if ! git -C "$REPO_DIR" reset --hard "$BASE_BRANCH" >/dev/null 2>&1; then
-        echo "Warning: failed to reset $BASE_BRANCH during cleanup." >&2
-      fi
-    fi
-    if ! git -C "$REPO_DIR" clean -fd >/dev/null 2>&1; then
-      echo "Warning: failed to remove untracked files during cleanup." >&2
-    fi
   fi
+  release_runner_lock
 }
 
 release_runner_lock() {

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -242,6 +242,42 @@ set -e
     assert f"git:-C {tmp_path / 'repo'} clean -fd" in calls
 
 
+def test_cleanup_releases_runner_lock_after_worktree_reset(tmp_path: Path) -> None:
+    call_log = tmp_path / "calls.txt"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(tmp_path / "repo"))}
+mkdir -p "$REPO_DIR/.git"
+git() {{
+  printf 'git:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+  return 0
+}}
+release_runner_lock() {{
+  printf 'release_runner_lock\\n' >> {shlex.quote(str(call_log))}
+  RUNNER_LOCK_HELD=0
+}}
+CLEANUP_REPO_ON_EXIT=1
+RUNNER_LOCK_HELD=1
+cleanup
+printf 'lock=%s\\n' "$RUNNER_LOCK_HELD"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "lock=0"
+    calls = call_log.read_text(encoding="utf-8").splitlines()
+    assert calls[-1] == "release_runner_lock"
+    assert calls.index(f"git:-C {tmp_path / 'repo'} checkout main") < calls.index(
+        "release_runner_lock"
+    )
+    assert calls.index(f"git:-C {tmp_path / 'repo'} reset --hard origin/main") < calls.index(
+        "release_runner_lock"
+    )
+    assert calls.index(f"git:-C {tmp_path / 'repo'} clean -fd") < calls.index("release_runner_lock")
+
+
 def test_runner_lock_skips_when_existing_runner_is_active(tmp_path: Path) -> None:
     lock_dir = tmp_path / "runner.lock"
 


### PR DESCRIPTION
## Summary
- Hold the Hush Line code-agent runner lock until exit-time repository cleanup finishes.
- Avoid releasing the lock before checkout/reset/clean operations, which allowed launchd overlap to start another run while the previous process was still unwinding.
- Add a regression test that verifies the runner lock is released after worktree reset operations.
- Document the lock lifetime invariant in the agent runner docs.

## Context
The runner acquired its lock before work began, but `cleanup()` released it before performing repository cleanup. A scheduled launchd invocation could therefore acquire the lock and begin evaluating or selecting issue work while the prior run was still switching, resetting, or cleaning the checkout.

## Validation
- `bash -n scripts/agent_daily_issue_runner.sh`
- `docker compose run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py -q` (`98 passed`)
- `make lint`
- `git diff --check`

## Manual Testing
- Not applicable beyond runner validation: this change affects launchd/runner concurrency control, not an end-user web flow.

## Known Risks / Follow-ups
- Full `make test` was attempted locally before opening the PR, but the command failed at the local command-runner layer before returning test output. The PR should rely on required branch protection checks for the full suite before merge.