### PR TITLE
Pass actionable failure context to runner self-heal

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -67,6 +67,7 @@ PROMPT_FILE=""
 PR_BODY_FILE=""
 CODEX_OUTPUT_FILE=""
 CODEX_TRANSCRIPT_FILE=""
+CODEX_EXEC_UNAVAILABLE=0
 RUN_LOG_TMP_FILE=""
 RUN_LOG_TIMESTAMP=""
 RUN_LOG_GIT_PATH=""
@@ -3074,6 +3075,7 @@ persist_run_log() {
 
 run_codex_from_prompt() {
   local rc=0
+  CODEX_EXEC_UNAVAILABLE=0
   : > "$CODEX_OUTPUT_FILE"
   : > "$CODEX_TRANSCRIPT_FILE"
 
@@ -3104,6 +3106,13 @@ run_codex_from_prompt() {
 
   if (( rc != 0 )); then
     echo "Codex execution failed (exit ${rc})."
+    if grep -Eq '"has_credits"[[:space:]]*:[[:space:]]*false' "$CODEX_TRANSCRIPT_FILE"; then
+      CODEX_EXEC_UNAVAILABLE=1
+      echo "Codex unavailable: account has no credits; self-heal cannot proceed until credits are restored."
+    elif grep -Eiq 'rate.?limit|quota|credit' "$CODEX_TRANSCRIPT_FILE"; then
+      CODEX_EXEC_UNAVAILABLE=1
+      echo "Codex unavailable: transcript indicates a rate limit, quota, or credit failure; self-heal cannot proceed until access is restored."
+    fi
     log_worktree_snapshot "Post-Codex worktree snapshot:"
     return "$rc"
   fi
@@ -3224,6 +3233,7 @@ recent_failure_block_from_text() {
     /^Coverage HTML written/ { next }
     /^Name[[:space:]]+Stmts[[:space:]]+Miss/ { next }
     /^TOTAL[[:space:]]+/ { next }
+    /^[^[:space:]]+\.py[[:space:]]+[0-9]+[[:space:]]+[0-9]+[[:space:]]+[0-9]+%$/ { next }
     /^={5,}/ { next }
     /^-{5,}/ { next }
     /^tests\/.* (PASSED|XFAIL|XPASS|SKIPPED)([[:space:]]|\[)/ { next }
@@ -3531,7 +3541,12 @@ run_fix_attempt_loop() {
       "$FAILURE_CONTEXT" \
       "$FAILURE_SIGNATURE" \
       "$REPEATED_FAILURE_COUNT"
-    run_codex_from_prompt
+    if ! run_codex_from_prompt; then
+      if [[ "$CODEX_EXEC_UNAVAILABLE" == "1" ]]; then
+        echo "Blocked: Codex self-heal is unavailable for issue #$issue_number; stopping retry loop." >&2
+        return 1
+      fi
+    fi
     fix_attempt=$((fix_attempt + 1))
   done
 
@@ -3553,7 +3568,12 @@ run_issue_attempt_loop() {
 
   while (( issue_attempt <= MAX_ISSUE_ATTEMPTS )); do
     echo "==> Codex issue attempt $issue_attempt"
-    run_codex_from_prompt
+    if ! run_codex_from_prompt; then
+      if [[ "$CODEX_EXEC_UNAVAILABLE" == "1" ]]; then
+        echo "Blocked: Codex issue work is unavailable for issue #$issue_number; stopping retry loop." >&2
+        return 1
+      fi
+    fi
 
     if ! has_non_log_changes; then
       emit_codex_no_change_diagnostic "$issue_number" "$issue_attempt"

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -3073,6 +3073,14 @@ persist_run_log() {
   fi
 }
 
+codex_transcript_has_rate_quota_or_credit_failure() {
+  local transcript_file="$1"
+  local access_failure_pattern
+
+  access_failure_pattern='(^|[^[:alnum:]_])(rate[ -]?limit(ed|ing)?|too many requests|quota[ _-]*(exceeded|exhausted|reached|depleted|unavailable)|exceeded[ _-]+quota|insufficient[ _-]+quota|no[ _-]+credits?|out[ _-]+of[ _-]+credits?|insufficient[ _-]+credits?|credits?[ _-]+(exhausted|depleted|required|unavailable))([^[:alnum:]_]|$)'
+  grep -Eiq "$access_failure_pattern" "$transcript_file"
+}
+
 run_codex_from_prompt() {
   local rc=0
   CODEX_EXEC_UNAVAILABLE=0
@@ -3109,7 +3117,7 @@ run_codex_from_prompt() {
     if grep -Eq '"has_credits"[[:space:]]*:[[:space:]]*false' "$CODEX_TRANSCRIPT_FILE"; then
       CODEX_EXEC_UNAVAILABLE=1
       echo "Codex unavailable: account has no credits; self-heal cannot proceed until credits are restored."
-    elif grep -Eiq 'rate.?limit|quota|credit' "$CODEX_TRANSCRIPT_FILE"; then
+    elif codex_transcript_has_rate_quota_or_credit_failure "$CODEX_TRANSCRIPT_FILE"; then
       CODEX_EXEC_UNAVAILABLE=1
       echo "Codex unavailable: transcript indicates a rate limit, quota, or credit failure; self-heal cannot proceed until access is restored."
     fi

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -2123,6 +2123,52 @@ run_codex_from_prompt > {shlex.quote(str(run_log_file))} 2>&1
     assert "Safe final summary" in run_log_text
 
 
+def test_run_codex_from_prompt_reports_no_credits_without_transcript(
+    tmp_path: Path,
+) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    output_file = tmp_path / "codex-output.txt"
+    transcript_file = tmp_path / "codex-transcript.txt"
+    run_log_file = tmp_path / "run-log.txt"
+    console_file = tmp_path / "console.txt"
+
+    prompt_file.write_text("issue prompt\n", encoding="utf-8")
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(tmp_path))}
+PROMPT_FILE={shlex.quote(str(prompt_file))}
+CODEX_OUTPUT_FILE={shlex.quote(str(output_file))}
+CODEX_TRANSCRIPT_FILE={shlex.quote(str(transcript_file))}
+CODEX_MODEL=test-model
+CODEX_REASONING_EFFORT=high
+VERBOSE_CODEX_OUTPUT=0
+exec 3>{shlex.quote(str(console_file))}
+codex() {{
+  printf '%s\\n' '{{"rate_limits":{{"credits":{{"has_credits":false}}}}}}'
+  printf 'SECRET_TRANSCRIPT_LINE\\n'
+  return 1
+}}
+if run_codex_from_prompt > {shlex.quote(str(run_log_file))} 2>&1; then
+  rc=0
+else
+  rc=$?
+fi
+printf 'rc=%s unavailable=%s\\n' "$rc" "$CODEX_EXEC_UNAVAILABLE"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "rc=1 unavailable=1"
+    run_log_text = run_log_file.read_text(encoding="utf-8")
+    transcript_text = transcript_file.read_text(encoding="utf-8")
+    assert "Codex execution failed (exit 1)." in run_log_text
+    assert "Codex unavailable: account has no credits" in run_log_text
+    assert "SECRET_TRANSCRIPT_LINE" in transcript_text
+    assert "SECRET_TRANSCRIPT_LINE" not in run_log_text
+
+
 def test_write_pr_narrative_lead_adds_plain_language_summary() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
@@ -2733,6 +2779,8 @@ def test_recent_failure_block_from_text_extracts_recent_actionable_context() -> 
         "$'tests/test_setup.py::test_boot PASSED [  1%]\\n'\\\n"
         "$'/Users/scidsg/hushline/tests/test_module.py:12:34: "
         "F821 Undefined name `MissingName`\\n'\\\n"
+        "$'hushline/routes/profile.py                         272     17    94%\\n'\\\n"
+        "$'hushline/settings/common.py                        374      4    99%\\n'\\\n"
         "$'make: *** [fix] Error 1\\nFAILED tests/test_example.py::test_case\\n"
         "/tmp/codex-secret-artifact.txt\\nTraceback\\n'"
     )
@@ -2748,6 +2796,8 @@ recent_failure_block_from_text "$failure_text"
     assert result.returncode == 0, result.stderr
     assert "Container hushline-dev_data-1 Exited" not in result.stdout
     assert "PASSED" not in result.stdout
+    assert "hushline/routes/profile.py" not in result.stdout
+    assert "hushline/settings/common.py" not in result.stdout
     assert "/Users/scidsg/hushline" not in result.stdout
     assert "tests/test_module.py:12:34: F821 Undefined name `MissingName`" in result.stdout
     assert "FAILED tests/test_example.py::test_case" in result.stdout
@@ -2780,6 +2830,30 @@ recent_failure_block_from_text "$failure_text"
     assert "abc/def+ghi~jkl" not in result.stdout
     assert "zyx/wvu+tsr~qpo" not in result.stdout
     assert "hunter2" not in result.stdout
+
+
+def test_recent_failure_block_keeps_traceback_when_coverage_table_follows() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+failure_text=$'FAILED tests/test_embeddable_forms_settings.py::test_origin\\n'\
+$'Traceback (most recent call last):\\n'\
+$'  File "/app/hushline/settings/common.py", line 358, in handle_embed_settings_form\\n'\
+$'    username.set_embed_allowed_origins(form.normalized_origins)\\n'\
+$'AttributeError: EmbedSettingsForm has no attribute normalized_origins\\n'
+for i in $(seq 1 180); do
+  failure_text+=$'hushline/module_'$i$'.py                         100      1    99%\\n'
+done
+failure_text+=$'FAILED tests/test_embeddable_forms_settings.py::test_origin - assert 500 == 400\\n'
+recent_failure_block_from_text "$failure_text"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Traceback (most recent call last):" in result.stdout
+    assert "AttributeError: EmbedSettingsForm has no attribute normalized_origins" in result.stdout
+    assert "hushline/module_180.py" not in result.stdout
+    assert "FAILED tests/test_embeddable_forms_settings.py::test_origin" in result.stdout
 
 
 def test_failure_excerpt_from_text_redacts_sensitive_values() -> None:
@@ -4371,6 +4445,48 @@ printf 'rc=%s\\n' "$rc"
     assert "rc=1" in result.stdout
     assert (
         "Blocked: workflow checks failed after 2 self-heal attempt(s) for issue #1558."
+        in result.stderr
+    )
+
+
+def test_fix_attempt_loop_stops_when_codex_is_unavailable(tmp_path: Path) -> None:
+    check_log_file = tmp_path / "check.log"
+    codex_output_file = tmp_path / "codex-output.txt"
+    call_log = tmp_path / "calls.txt"
+    check_log_file.write_text("persistent failure\n", encoding="utf-8")
+    codex_output_file.write_text("prior summary\n", encoding="utf-8")
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+MAX_FIX_ATTEMPTS=4
+CHECK_LOG_FILE={shlex.quote(str(check_log_file))}
+CODEX_OUTPUT_FILE={shlex.quote(str(codex_output_file))}
+PREVIOUS_FAILURE_SIGNATURE=""
+FAILURE_SIGNATURE=""
+REPEATED_FAILURE_COUNT=0
+run_local_workflow_checks() {{ return 1; }}
+failure_signature_from_text() {{ printf 'same-failure\\n'; }}
+current_change_summary() {{ printf 'summary\\n'; }}
+build_fix_prompt() {{ :; }}
+run_codex_from_prompt() {{
+  printf 'codex\\n' >> {shlex.quote(str(call_log))}
+  CODEX_EXEC_UNAVAILABLE=1
+  return 1
+}}
+set +e
+run_fix_attempt_loop 1558 "Title" "Body" "" "branch"
+rc=$?
+set -e
+printf 'rc=%s\\n' "$rc"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "rc=1" in result.stdout
+    assert call_log.read_text(encoding="utf-8").splitlines() == ["codex"]
+    assert (
+        "Blocked: Codex self-heal is unavailable for issue #1558; stopping retry loop."
         in result.stderr
     )
 

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -2169,6 +2169,52 @@ printf 'rc=%s unavailable=%s\\n' "$rc" "$CODEX_EXEC_UNAVAILABLE"
     assert "SECRET_TRANSCRIPT_LINE" not in run_log_text
 
 
+def test_run_codex_from_prompt_ignores_positive_credit_telemetry(
+    tmp_path: Path,
+) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    output_file = tmp_path / "codex-output.txt"
+    transcript_file = tmp_path / "codex-transcript.txt"
+    run_log_file = tmp_path / "run-log.txt"
+    console_file = tmp_path / "console.txt"
+
+    prompt_file.write_text("issue prompt\n", encoding="utf-8")
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(tmp_path))}
+PROMPT_FILE={shlex.quote(str(prompt_file))}
+CODEX_OUTPUT_FILE={shlex.quote(str(output_file))}
+CODEX_TRANSCRIPT_FILE={shlex.quote(str(transcript_file))}
+CODEX_MODEL=test-model
+CODEX_REASONING_EFFORT=high
+VERBOSE_CODEX_OUTPUT=0
+exec 3>{shlex.quote(str(console_file))}
+codex() {{
+  printf '%s\\n' '{{"rate_limits":{{"credits":{{"has_credits":true}}}}}}'
+  printf 'unrelated execution failure\\n'
+  return 1
+}}
+if run_codex_from_prompt > {shlex.quote(str(run_log_file))} 2>&1; then
+  rc=0
+else
+  rc=$?
+fi
+printf 'rc=%s unavailable=%s\\n' "$rc" "$CODEX_EXEC_UNAVAILABLE"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "rc=1 unavailable=0"
+    run_log_text = run_log_file.read_text(encoding="utf-8")
+    transcript_text = transcript_file.read_text(encoding="utf-8")
+    assert "Codex execution failed (exit 1)." in run_log_text
+    assert "Codex unavailable:" not in run_log_text
+    assert '"has_credits":true' in transcript_text
+    assert "unrelated execution failure" in transcript_text
+
+
 def test_write_pr_narrative_lead_adds_plain_language_summary() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}


### PR DESCRIPTION
## What changed

- Filters coverage table rows out of the runner's sanitized failure excerpts so traceback lines and failing test summaries survive into the Codex self-heal prompt.
- Adds regression coverage for the observed failure shape where a long coverage table crowded out the useful `AttributeError` context.
- Keeps the Codex-unavailable guard from the original patch so no-credit/quota failures fail fast instead of burning retry attempts.

## Why

The runner was technically collecting output, but the excerpt handed back to Codex could be dominated by low-value coverage rows. That meant Codex saw that tests failed without seeing the actionable traceback needed to fix the issue.

## Validation

- `bash -n scripts/agent_daily_issue_runner.sh`
- `docker compose run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py::test_recent_failure_block_from_text_extracts_recent_actionable_context tests/test_agent_daily_issue_runner.py::test_recent_failure_block_keeps_traceback_when_coverage_table_follows tests/test_agent_daily_issue_runner.py::test_run_codex_from_prompt_reports_no_credits_without_transcript tests/test_agent_daily_issue_runner.py::test_fix_attempt_loop_stops_when_codex_is_unavailable -q`
- `docker compose run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py -q`
- `make lint`
- `make test`
- `git diff --check`

## Manual testing

Not applicable; this is runner shell behavior covered by script-level regression tests.

## Risks / follow-ups

- The excerpt is still intentionally sanitized and bounded, so it will not pass raw full logs or sensitive local paths through to Codex.
- The Hush Line launchd runner remains stopped; this PR only updates the branch.