### PR TITLE
Keep assigned runner issues moving to clean PRs

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -30,6 +30,20 @@ Script: `scripts/agent_daily_issue_runner.sh`
 
 This runner runs directly in the local repo and performs a narrow local gate before opening a PR.
 
+## Operational Contract
+
+The issue runner has one job: turn one assigned GitHub issue into one reviewed pull request.
+
+1. Pull the latest base branch after an issue is selected and cheap GitHub guards pass.
+2. Select exactly one assigned issue from the configured project queue, or the issue passed with `--issue`.
+3. Make the smallest safe code, test, or documentation changes needed for that issue.
+4. Before opening or updating a PR, run `make lint` and `make test`; if either fails, repair the failure and rerun the checks.
+5. Open or update the PR only when there are meaningful non-log changes and local validation is clean.
+6. Poll the open PR for actionable comments, review threads, change requests, and failing checks.
+7. Address and resolve actionable feedback, push the PR update, and continue polling until the PR is closed.
+
+Every queued issue is assumed to require a real change. Once the runner claims an issue, the only successful terminal outcome is a clean, usable PR. If an attempt does not complete a validated implementation, the issue stays claimed as `In Progress`; the next runner pass must resume that same assigned issue instead of selecting new work, returning it to the eligible queue, opening a diagnostic PR, or moving it to `Ready for Review`.
+
 ## Execution Flow
 
 1. Parse arguments (`--issue` optional) and resolve runtime configuration.
@@ -40,8 +54,8 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 6. Resume monitoring any open bot-authored issue PR whose head branch matches the daily issue branch pattern before selecting new issue work. This makes PR polling restart-resilient after launchd unloads, crashes, or reboots.
 7. Check cheap GitHub exit conditions before any new-work queue lookup or network sync/Docker work:
    - exit if any open human-authored PR exists
-   - exit if any open issue is already in project status `In Progress`
 8. Select issue target before any network sync or Docker work:
+   - resume the top open issue already in project status `In Progress`, otherwise
    - Use `--issue <n>` when provided (must still be open), otherwise
    - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
 9. Check remaining cheap GitHub exit conditions before any network sync or Docker work:
@@ -107,7 +121,7 @@ This runner runs directly in the local repo and performs a narrow local gate bef
     - `Validation` lists automated checks run by the runner or CI.
     - `Manual Testing` lists human reviewer steps to exercise the changed feature after the PR opens. It is not a log of actions the LLM or runner performed.
 25. Refresh run log after PR creation (including opened PR URL, coverage gap issue URL when created, and post-check steps), commit/push that log update when changed.
-26. Poll the open PR until it closes. When the monitor sees actionable feedback (discussion comments, change-request reviews, unresolved review threads, or failing PR checks), it first waits for all pending PR checks to settle, then invokes Codex on the PR branch, reruns `make lint` and `make test`, commits and pushes any fix, and resumes polling.
+26. Poll the open PR until it closes. When the monitor sees human/reviewer feedback (discussion comments, change-request reviews, or unresolved review threads), it invokes Codex on the PR branch immediately, reruns `make lint` and `make test`, commits and pushes any fix, resolves addressed review threads, and resumes polling. When the only actionable item is a failing check, it waits for pending PR checks to settle before invoking Codex so transient in-progress checks do not trigger unnecessary fixes.
 27. Return to a clean `main` on normal completion or PR closure.
     - If the run fails after creating branch work, cleanup resets the checkout back to a clean base branch.
     - A new scheduled pass discards local worktree changes and switches back to the base branch before evaluating GitHub queue guards.
@@ -153,20 +167,14 @@ This runner runs directly in the local repo and performs a narrow local gate bef
 +------------------------------------------------+
       |
       v
-+-----------------------------------------------+
-| Select issue: forced --issue or project queue |
-+-----------------------------------------------+
++------------------------------------------------+
+| Select issue: forced --issue, In Progress,     |
+| or project queue                               |
++------------------------------------------------+
       |
 +------------------------+
 | Open human PRs > 0 ?   |--yes--> [Skip + Exit]
 +------------------------+
-      |
-      no
-      |
-      v
-+-------------------------------------+
-| Any issue already In Progress ?     |--yes--> [Skip + Exit]
-+-------------------------------------+
       |
       no
       |

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -90,6 +90,7 @@ PR_FEEDBACK_MONITOR_PR_NUMBER=""
 PR_FEEDBACK_MONITOR_BRANCH=""
 RUNNER_DIAGNOSTIC_PR=0
 RUNNER_DIAGNOSTIC_REASON=""
+RUNNER_NO_USABLE_CHANGES=0
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
@@ -1429,19 +1430,26 @@ pr_feedback_summary_has_actionable_items() {
 pr_feedback_summary_requires_runner_action() {
   local feedback_summary="$1"
   local summary_line=""
+  local review_or_comment_count=0
 
   summary_line="$(printf '%s\n' "$feedback_summary" | sed -n '1p')"
   if [[ ! "$summary_line" =~ unresolved_review_threads=([0-9]+).*changes_requested_reviews=([0-9]+).*discussion_comments=([0-9]+).*failing_checks=([0-9]+).*pending_checks=([0-9]+) ]]; then
     return 1
   fi
 
-  # Wait for the full PR check set to settle before acting so failures from
-  # slower jobs, especially the test jobs, are included in one repair pass.
+  review_or_comment_count=$((BASH_REMATCH[1] + BASH_REMATCH[2] + BASH_REMATCH[3]))
+  if (( review_or_comment_count > 0 )); then
+    return 0
+  fi
+
+  # For check-only feedback, wait for the full PR check set to settle so
+  # failures from slower jobs, especially test jobs, are included in one repair
+  # pass. Human comments and review feedback should not wait behind CI.
   if (( BASH_REMATCH[5] > 0 )); then
     return 1
   fi
 
-  (( BASH_REMATCH[1] + BASH_REMATCH[2] + BASH_REMATCH[3] + BASH_REMATCH[4] > 0 ))
+  (( BASH_REMATCH[4] > 0 ))
 }
 
 pr_feedback_action_key() {
@@ -2468,20 +2476,26 @@ collect_issue_candidates() {
   collect_issue_candidates_from_project "$project_number"
 }
 
-count_open_project_issues_in_status() {
+collect_issue_candidates_in_status() {
   local target_status_name="$1"
-  local project_number issue_number count=0
+  local project_number
 
   project_number="$(resolve_project_number)"
   if [[ -z "$project_number" ]]; then
-    printf '0\n'
     return 0
   fi
+
+  collect_issue_candidates_from_project "$project_number" "$target_status_name"
+}
+
+count_open_project_issues_in_status() {
+  local target_status_name="$1"
+  local issue_number count=0
 
   while IFS= read -r issue_number; do
     [[ -n "$issue_number" ]] || continue
     count=$((count + 1))
-  done < <(collect_issue_candidates_from_project "$project_number" "$target_status_name")
+  done < <(collect_issue_candidates_in_status "$target_status_name")
 
   printf '%s\n' "$count"
 }
@@ -3077,7 +3091,7 @@ codex_transcript_has_rate_quota_or_credit_failure() {
   local transcript_file="$1"
   local access_failure_pattern
 
-  access_failure_pattern='(^|[^[:alnum:]_])(rate[ -]?limit(ed|ing)?|too many requests|quota[ _-]*(exceeded|exhausted|reached|depleted|unavailable)|exceeded[ _-]+quota|insufficient[ _-]+quota|no[ _-]+credits?|out[ _-]+of[ _-]+credits?|insufficient[ _-]+credits?|credits?[ _-]+(exhausted|depleted|required|unavailable))([^[:alnum:]_]|$)'
+  access_failure_pattern='(^|[^[:alnum:]_])((usage|rate)[ -]?limit(ed|ing)?|too many requests|quota[ _-]*(exceeded|exhausted|reached|depleted|unavailable)|exceeded[ _-]+quota|insufficient[ _-]+quota|no[ _-]+credits?|out[ _-]+of[ _-]+credits?|insufficient[ _-]+credits?|credits?[ _-]+(exhausted|depleted|required|unavailable))([^[:alnum:]_]|$)'
   grep -Eiq "$access_failure_pattern" "$transcript_file"
 }
 
@@ -3570,6 +3584,7 @@ run_issue_attempt_loop() {
   local issue_branch="$5"
   local issue_attempt=1
 
+  RUNNER_NO_USABLE_CHANGES=0
   PREVIOUS_FAILURE_SIGNATURE=""
   FAILURE_SIGNATURE=""
   REPEATED_FAILURE_COUNT=0
@@ -3603,6 +3618,7 @@ run_issue_attempt_loop() {
   done
 
   echo "Blocked: Codex produced no usable changes for issue #$issue_number after $MAX_ISSUE_ATTEMPTS attempt(s)." >&2
+  RUNNER_NO_USABLE_CHANGES=1
   return 1
 }
 
@@ -3662,13 +3678,13 @@ main() {
     OPEN_IN_PROGRESS_ISSUES="$(count_open_project_issues_in_status "$PROJECT_STATUS_IN_PROGRESS")"
     echo "Open project issues in ${PROJECT_STATUS_IN_PROGRESS}: ${OPEN_IN_PROGRESS_ISSUES}"
     if [[ "$OPEN_IN_PROGRESS_ISSUES" != "0" ]]; then
-      runner_status "Skipped: found ${OPEN_IN_PROGRESS_ISSUES} open issue(s) in project status '${PROJECT_STATUS_IN_PROGRESS}'."
-      exit 0
-    fi
-
-    ISSUE_NUMBER="$(collect_issue_candidates | sed -n '1p')"
-    if [[ -n "$ISSUE_NUMBER" ]]; then
-      echo "Selected issue #${ISSUE_NUMBER} from project queue."
+      ISSUE_NUMBER="$(collect_issue_candidates_in_status "$PROJECT_STATUS_IN_PROGRESS" | sed -n '1p')"
+      echo "Resuming assigned issue #${ISSUE_NUMBER} from project status '${PROJECT_STATUS_IN_PROGRESS}'."
+    else
+      ISSUE_NUMBER="$(collect_issue_candidates | sed -n '1p')"
+      if [[ -n "$ISSUE_NUMBER" ]]; then
+        echo "Selected issue #${ISSUE_NUMBER} from project queue."
+      fi
     fi
   fi
 
@@ -3701,13 +3717,6 @@ main() {
       runner_status "Skipped: found ${OPEN_HUMAN_PRS} open human-authored PR(s)."
       exit 0
     fi
-  fi
-
-  OPEN_IN_PROGRESS_ISSUES="$(count_open_project_issues_in_status "$PROJECT_STATUS_IN_PROGRESS")"
-  echo "Open project issues in ${PROJECT_STATUS_IN_PROGRESS}: ${OPEN_IN_PROGRESS_ISSUES}"
-  if [[ "$OPEN_IN_PROGRESS_ISSUES" != "0" ]]; then
-    runner_status "Skipped: found ${OPEN_IN_PROGRESS_ISSUES} open issue(s) in project status '${PROJECT_STATUS_IN_PROGRESS}'."
-    exit 0
   fi
 
   if [[ -n "$EPIC_ISSUE_NUMBER" ]]; then
@@ -3786,14 +3795,11 @@ main() {
 
   build_issue_prompt "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY"
   if ! run_issue_attempt_loop "$ISSUE_NUMBER" "$ISSUE_TITLE" "$ISSUE_BODY" "$ISSUE_LABELS" "$BRANCH_NAME"; then
-    RUNNER_DIAGNOSTIC_PR=1
-    RUNNER_DIAGNOSTIC_REASON="implementation did not complete"
-    echo "Warning: issue implementation failed; opening a sanitized diagnostic PR instead of leaving the checkout stranded." >&2
-    restore_non_log_worktree_changes
+    echo "Blocked: assigned issue #${ISSUE_NUMBER} still requires implementation; keeping it in progress and refusing to open a diagnostic PR or mark it ready for review." >&2
+    exit 1
   elif ! has_non_log_changes; then
-    RUNNER_DIAGNOSTIC_PR=1
-    RUNNER_DIAGNOSTIC_REASON="implementation produced no usable non-log changes"
-    echo "Warning: no usable non-log changes remain; opening a sanitized diagnostic PR instead of leaving the checkout stranded." >&2
+    echo "Blocked: assigned issue #${ISSUE_NUMBER} still requires implementation; keeping it in progress and refusing to open a diagnostic PR or mark it ready for review." >&2
+    exit 1
   fi
 
   persist_run_log "$ISSUE_NUMBER"

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -614,7 +614,7 @@ main
     assert "runtime-bootstrap" not in calls
 
 
-def test_main_exits_before_runtime_bootstrap_when_issue_is_already_in_progress(
+def test_main_resumes_in_progress_issue_before_selecting_new_work(
     tmp_path: Path,
 ) -> None:
     call_log = tmp_path / "calls.txt"
@@ -643,10 +643,6 @@ resolve_issue_parent_epic() {{ :; }}
 start_runtime_stack_and_seed_dev_data() {{
   printf 'runtime-bootstrap\\n' >> {shlex.quote(str(call_log))}
 }}
-count_open_bot_prs() {{
-  printf 'count-open-bot-prs\\n' >> {shlex.quote(str(call_log))}
-  printf '0\\n'
-}}
 count_open_human_prs() {{
   printf 'count-open-human-prs\\n' >> {shlex.quote(str(call_log))}
   printf '0\\n'
@@ -655,9 +651,17 @@ count_open_project_issues_in_status() {{
   printf 'count-open-project-issues-in-status:%s\\n' "$1" >> {shlex.quote(str(call_log))}
   printf '1\\n'
 }}
+collect_issue_candidates_in_status() {{
+  printf 'collect-issue-candidates-in-status:%s\\n' "$1" >> {shlex.quote(str(call_log))}
+  printf '1558\\n'
+}}
 collect_issue_candidates() {{
   printf 'collect-issue-candidates\\n' >> {shlex.quote(str(call_log))}
-  printf '1558\\n'
+  printf '9999\\n'
+}}
+count_open_bot_prs_excluding_heads() {{
+  printf 'count-open-bot-prs-excluding-heads:%s\\n' "$*" >> {shlex.quote(str(call_log))}
+  printf '1\\n'
 }}
 main
 """
@@ -665,15 +669,17 @@ main
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
-    assert "Skipped: found 1 open issue(s) in project status 'In Progress'." in result.stdout
+    assert "Resuming assigned issue #1558 from project status 'In Progress'." in result.stdout
+    assert "Skipped: found 1 open PR(s) by hushline-dev." in result.stdout
 
     calls = call_log.read_text(encoding="utf-8").splitlines()
     assert "collect-issue-candidates" not in calls
+    assert "collect-issue-candidates-in-status:In Progress" in calls
     assert "count-open-human-prs" in calls
     assert "count-open-project-issues-in-status:In Progress" in calls
     assert "Fetch latest from origin" not in calls
     assert "Reset to origin/main" not in calls
-    assert "count-open-bot-prs" not in calls
+    assert "count-open-bot-prs-excluding-heads:" in calls
     assert "configure-bot-git" not in calls
     assert "runtime-bootstrap" not in calls
 
@@ -2215,6 +2221,49 @@ printf 'rc=%s unavailable=%s\\n' "$rc" "$CODEX_EXEC_UNAVAILABLE"
     assert "unrelated execution failure" in transcript_text
 
 
+def test_run_codex_from_prompt_reports_usage_limit_without_retries(
+    tmp_path: Path,
+) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    output_file = tmp_path / "codex-output.txt"
+    transcript_file = tmp_path / "codex-transcript.txt"
+    run_log_file = tmp_path / "run-log.txt"
+    console_file = tmp_path / "console.txt"
+
+    prompt_file.write_text("issue prompt\n", encoding="utf-8")
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(tmp_path))}
+PROMPT_FILE={shlex.quote(str(prompt_file))}
+CODEX_OUTPUT_FILE={shlex.quote(str(output_file))}
+CODEX_TRANSCRIPT_FILE={shlex.quote(str(transcript_file))}
+CODEX_MODEL=test-model
+CODEX_REASONING_EFFORT=high
+VERBOSE_CODEX_OUTPUT=0
+exec 3>{shlex.quote(str(console_file))}
+codex() {{
+  printf '%s\\n' "ERROR: You've hit your usage limit. Try again at 7:41 PM."
+  return 1
+}}
+if run_codex_from_prompt > {shlex.quote(str(run_log_file))} 2>&1; then
+  rc=0
+else
+  rc=$?
+fi
+printf 'rc=%s unavailable=%s\\n' "$rc" "$CODEX_EXEC_UNAVAILABLE"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "rc=1 unavailable=1"
+    run_log_text = run_log_file.read_text(encoding="utf-8")
+    transcript_text = transcript_file.read_text(encoding="utf-8")
+    assert "Codex unavailable:" in run_log_text
+    assert "usage limit" in transcript_text
+
+
 def test_write_pr_narrative_lead_adds_plain_language_summary() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
@@ -3683,12 +3732,19 @@ def test_pr_feedback_action_waits_for_pending_checks() -> None:
         "changes_requested_reviews=0 discussion_comments=0 failing_checks=0 pending_checks=0\n"
         "Feedback 1: unresolved review thread by @reviewer on hushline/templates/base.html:100"
     )
+    comment_with_pending_summary = (
+        "Post-PR feedback summary: unresolved_review_threads=0 "
+        "changes_requested_reviews=0 discussion_comments=1 failing_checks=0 pending_checks=2\n"
+        "Feedback comment 1: @maintainer :: This does not address the issue.\n"
+        "Feedback pending check 1: pending PR check Run Linter and Tests / test (IN_PROGRESS)"
+    )
 
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
 pending_only_summary={shlex.quote(pending_only_summary)}
 failing_with_pending_summary={shlex.quote(failing_with_pending_summary)}
 unresolved_summary={shlex.quote(unresolved_summary)}
+comment_with_pending_summary={shlex.quote(comment_with_pending_summary)}
 set +e
 pr_feedback_summary_requires_runner_action "$pending_only_summary"
 pending_rc=$?
@@ -3696,10 +3752,13 @@ pr_feedback_summary_requires_runner_action "$failing_with_pending_summary"
 failing_with_pending_rc=$?
 pr_feedback_summary_requires_runner_action "$unresolved_summary"
 unresolved_rc=$?
+pr_feedback_summary_requires_runner_action "$comment_with_pending_summary"
+comment_with_pending_rc=$?
 set -e
 printf 'pending_rc=%s\\n' "$pending_rc"
 printf 'failing_with_pending_rc=%s\\n' "$failing_with_pending_rc"
 printf 'unresolved_rc=%s\\n' "$unresolved_rc"
+printf 'comment_with_pending_rc=%s\\n' "$comment_with_pending_rc"
 """
 
     result = _run_bash(shell_script)
@@ -3708,6 +3767,7 @@ printf 'unresolved_rc=%s\\n' "$unresolved_rc"
     assert "pending_rc=1" in result.stdout
     assert "failing_with_pending_rc=1" in result.stdout
     assert "unresolved_rc=0" in result.stdout
+    assert "comment_with_pending_rc=0" in result.stdout
 
 
 def test_pr_feedback_action_key_ignores_pending_count_changes() -> None:
@@ -4135,7 +4195,7 @@ resolve_pr_number_from_ref "https://github.com/scidsg/hushline/pull/2000"
     assert "unexpected gh invocation" not in result.stderr
 
 
-def test_main_opens_diagnostic_pr_when_only_runner_artifacts_exist(tmp_path: Path) -> None:
+def test_main_refuses_review_pr_when_issue_loop_fails(tmp_path: Path) -> None:
     call_log = tmp_path / "calls.txt"
     repo_dir = tmp_path / "repo"
 
@@ -4186,15 +4246,20 @@ resolve_issue_parent_epic() {{ :; }}
 count_open_human_prs() {{ printf '0\\n'; }}
 count_open_project_issues_in_status() {{ printf '0\\n'; }}
 count_open_bot_prs_excluding_heads() {{ printf '0\\n'; }}
-set_issue_project_status() {{ :; }}
+set_issue_project_status() {{
+  printf 'status:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(call_log))}
+}}
 configure_bot_git_identity() {{ :; }}
 start_runtime_stack_and_seed_dev_data() {{ :; }}
 kill_all_docker_containers() {{ :; }}
 kill_processes_on_ports() {{ :; }}
 remote_branch_exists() {{ return 1; }}
 build_issue_prompt() {{ :; }}
-run_issue_attempt_loop() {{ return 1; }}
-has_non_log_changes() {{ return 1; }}
+run_issue_attempt_loop() {{
+  RUNNER_NO_USABLE_CHANGES=0
+  return 1
+}}
+has_non_log_changes() {{ return 0; }}
 persist_run_log() {{
   RUN_LOG_GIT_PATH="docs/agent-logs/run-test-issue-$1.txt"
   printf 'persist:%s\\n' "$1" >> {shlex.quote(str(call_log))}
@@ -4240,16 +4305,18 @@ printf 'rc=%s\\n' "$rc"
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
-    assert "rc=0" in result.stdout
-    assert (
-        "opening a sanitized diagnostic PR instead of leaving the checkout stranded"
-        in result.stderr
-    )
+    assert "rc=1" in result.stdout
+    assert "assigned issue #1558 still requires implementation" in result.stderr
+    assert "keeping it in progress" in result.stderr
+    assert "refusing to open a diagnostic PR or mark it ready for review" in result.stderr
     calls = call_log.read_text(encoding="utf-8").splitlines() if call_log.exists() else []
-    assert any(line == "restore-non-log" for line in calls)
-    assert any(line == "body:diagnostic=1:implementation did not complete" for line in calls)
-    assert any(line.startswith("pr-create:") for line in calls)
-    assert any(line.startswith("persist:1558") for line in calls)
+    assert "status:1558:In Progress" in calls
+    assert "status:1558:Agent Eligible" not in calls
+    assert "status:1558:Ready for Review" not in calls
+    assert "restore-non-log" not in calls
+    assert not any(line.startswith("body:") for line in calls)
+    assert not any(line.startswith("pr-create:") for line in calls)
+    assert not any(line.startswith("persist:1558") for line in calls)
 
 
 def test_main_continues_after_pr_create_when_pr_number_lookup_fails(


### PR DESCRIPTION
## What changed
- Runner resumes an assigned issue already in `In Progress` before selecting new Agent Eligible work.
- Assigned issues are not returned to Agent Eligible when an implementation attempt does not produce validated work.
- Runner refuses to open diagnostic/log-only PRs or move an issue to Ready for Review without meaningful non-log changes and clean validation.
- Human/reviewer feedback remains actionable immediately while pending checks continue to poll.

## Why
The runner contract is that every queued issue requires real work. Once claimed, the only successful terminal outcome is a clean, usable PR, and later runner passes must continue that assigned issue until that PR exists and is closed.

## Validation
- `bash -n scripts/agent_daily_issue_runner.sh`
- `make test TESTS=tests/test_agent_daily_issue_runner.py PYTEST_ADDOPTS="-k 'in_progress_issue or issue_loop_fails or run_codex_from_prompt or pr_feedback_action_waits_for_pending_checks or no_work'"`
- `make test TESTS=tests/test_agent_daily_issue_runner.py`
- `make lint`
- `make test` (1755 passed, 1 deselected, 1 xfailed)

## Manual testing
Not applicable; this is runner automation behavior covered by shell harness tests.

## Risks / follow-ups
- The installed LaunchAgent should stay stopped until this PR is merged so main does not keep using the old runner behavior.