### PR TITLE
Check Codex quota before runner work

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -47,43 +47,46 @@ Every queued issue is assumed to require a real change. Once the runner claims a
 ## Execution Flow
 
 1. Parse arguments (`--issue` optional) and resolve runtime configuration.
-2. Change into the repo (`$HOME/hushline` by default).
-3. Acquire a local runner lock and exit without doing any repository or Docker work if another Hush Line code-agent run is active.
-4. Hold the runner lock through all repository cleanup, including exit-time checkout/reset/clean work, so a launchd overlap cannot start a second issue while the prior run is still unwinding.
-5. Normalize the local agent-only checkout by discarding local worktree changes and switching to the base branch.
-6. Resume monitoring any open bot-authored issue PR whose head branch matches the daily issue branch pattern before selecting new issue work. This makes PR polling restart-resilient after launchd unloads, crashes, or reboots.
-7. Check cheap GitHub exit conditions before any new-work queue lookup or network sync/Docker work:
+2. Acquire a local runner lock and exit without doing any repository or Docker work if another Hush Line code-agent run is active.
+3. Check Codex `/status` rate-limit data before repository, GitHub, or Docker work. If the 300-minute primary window has less than the configured minimum remaining quota, wait until after its reset time and re-check before proceeding.
+4. Change into the repo (`$HOME/hushline` by default).
+5. Hold the runner lock through all repository cleanup, including exit-time checkout/reset/clean work, so a launchd overlap cannot start a second issue while the prior run is still unwinding.
+6. Normalize the local agent-only checkout by discarding local worktree changes and switching to the base branch.
+7. Resume monitoring any open bot-authored issue PR whose head branch matches the daily issue branch pattern before selecting new issue work. This makes PR polling restart-resilient after launchd unloads, crashes, or reboots.
+8. Check cheap GitHub exit conditions before any new-work queue lookup or network sync/Docker work:
    - exit if any open human-authored PR exists
-8. Select issue target before any network sync or Docker work:
+9. Select issue target before any network sync or Docker work:
    - resume the top open issue already in project status `In Progress`, otherwise
    - Use `--issue <n>` when provided (must still be open), otherwise
    - select the top open issue from project `Hush Line Roadmap`, column `Agent Eligible`.
-9. Check remaining cheap GitHub exit conditions before any network sync or Docker work:
-   - for non-epic issues, exit if any other open PR exists from `hushline-dev`
-   - for child issues with a GitHub parent epic, allow the long-lived epic PR (head branch `codex/epic-<epic>`) and the current child issue PR (head branch `codex/daily-issue-<issue>`)
-   - for child issues with a GitHub parent epic, exit only if there are unrelated open bot PRs outside those allowed heads
-10. Hard-refresh local state only after an issue is selected and skip guards pass:
+10. Check remaining cheap GitHub exit conditions before any network sync or Docker work:
+
+- for non-epic issues, exit if any other open PR exists from `hushline-dev`
+- for child issues with a GitHub parent epic, allow the long-lived epic PR (head branch `codex/epic-<epic>`) and the current child issue PR (head branch `codex/daily-issue-<issue>`)
+- for child issues with a GitHub parent epic, exit only if there are unrelated open bot PRs outside those allowed heads
+
+11. Hard-refresh local state only after an issue is selected and skip guards pass:
 
 - `git fetch origin`
 - `git checkout main`
 - `git reset --hard origin/main`
 - `git clean -fd`
 
-11. Move the selected issue into project status `In Progress`.
-12. Configure bot git identity and signed commit settings.
-13. Reset local Docker/runtime state:
+12. Move the selected issue into project status `In Progress`.
+13. Configure bot git identity and signed commit settings.
+14. Reset local Docker/runtime state:
 
 - `docker compose down -v --remove-orphans`
 - Remove all Docker containers (`docker rm -f $(docker ps -aq)`, when any exist)
 - Kill processes listening on runner ports (`4566 4571 5432 8080` by default)
 
-14. Start and seed stack:
+15. Start and seed stack:
 
 - `docker compose up -d --build`
 - `docker compose run --rm dev_data`
 - retry the bootstrap sequence when Docker image pulls fail with transient registry/network errors (defaults: `3` attempts, `10`s delay via `HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_ATTEMPTS` and `HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS`)
 
-15. Create/update work branch:
+16. Create/update work branch:
 
 - regular issues use `codex/daily-issue-<issue_number>` by default
 - child issues with a parent epic still use `codex/daily-issue-<issue_number>` as the work branch
@@ -91,13 +94,13 @@ Every queued issue is assumed to require a real change. Once the runner claims a
 - if the epic base branch does not exist yet, create and push it from `main` before starting the child branch
 - if the child issue branch already has an open PR, update that child PR instead of opening a duplicate
 
-16. Run a bounded Codex issue loop until repository changes exist (max attempts configurable via `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS`, default `10`).
+17. Run a bounded Codex issue loop until repository changes exist (max attempts configurable via `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS`, default `10`).
     - The issue/fix prompts tell Codex to avoid local container-backed make validation by default, and to defer validation entirely to the runner when schema-affecting files are touched (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`).
     - The fix prompt includes the current branch diff summary, the prior Codex summary, and an extracted failure signature so Codex can repair the current implementation instead of repeating a narrow patch against the same failing symptom.
     - Raw failed check output is intentionally withheld from Codex prompts because local check logs may contain sensitive operational data.
     - Codex transcript output is captured in a temporary file for the duration of the run and is excluded from the persisted runner log; only the final Codex summary is written into the run log.
     - Each Codex attempt logs prompt size and pre/post worktree snapshots so clean-tree no-op runs are visible in the runner log.
-17. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
+18. Run required checks in a bounded self-heal loop (max attempts configurable via `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS`, default `8`):
     - Before lint/test validation, if the working tree includes schema-affecting changes (`hushline/model/`, `migrations/`, `scripts/dev_data.py`, `scripts/dev_migrations.py`), rebuild the local runtime and reseed dev data so the live stack matches the current code.
     - `make lint`
     - `make test` (full suite)
@@ -105,24 +108,24 @@ Every queued issue is assumed to require a real change. Once the runner claims a
     - Lint failures only run deterministic `make fix` self-heal when the failure looks auto-fixable (for example Ruff formatting/check or Prettier); non-auto-fixable lint failures go straight back to Codex.
     - Runtime-dependent tests self-heal by restarting the local stack and reseeding dev data, then retrying once.
     - The broader CI workflow matrix still runs on the PR after branch push; the runner no longer tries to mirror that entire matrix locally.
-18. Persist run log to `docs/agent-logs/run-<timestamp>-issue-<n>.txt`.
+19. Persist run log to `docs/agent-logs/run-<timestamp>-issue-<n>.txt`.
     - After each persist, prune older runner logs and keep only the newest `10` by default.
     - Persisted logs are sanitized before commit to remove developer filesystem paths, emails, and Codex session metadata.
-19. Commit, push branch, and open/update PR:
+20. Commit, push branch, and open/update PR:
     - first push uses a normal push when remote branch is absent
     - existing remote branch uses `--force-with-lease` with one stale-info recovery retry.
     - child issues under a parent epic open/update a child PR whose base branch is the shared epic branch
     - the long-lived epic PR, when present, remains the only PR that targets `main`
-20. Move the selected issue into project status `Ready for Review` once the PR exists.
-21. After the PR exists and before feedback polling starts, parse the latest `make test` coverage snapshot and open a follow-up issue for any files with missed statements. Add that issue to the `Hush Line Roadmap` project in the `Agent Eligible` status.
-22. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
-23. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
-24. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`, `Manual Testing`).
+21. Move the selected issue into project status `Ready for Review` once the PR exists.
+22. After the PR exists and before feedback polling starts, parse the latest `make test` coverage snapshot and open a follow-up issue for any files with missed statements. Add that issue to the `Hush Line Roadmap` project in the `Agent Eligible` status.
+23. For child PRs targeting an epic branch, record `Linked issue: #<n>` in the PR body instead of relying on GitHub's default-branch-only close keywords.
+24. A dedicated workflow closes that linked child issue after the child PR is merged into the epic branch.
+25. Include runner log path in PR context and use a plain-language narrative lead for broad audiences, followed by the structured PR body sections (`Summary`, `Context`, `Changed Files`, `Validation`, `Manual Testing`).
     - `Validation` lists automated checks run by the runner or CI.
     - `Manual Testing` lists human reviewer steps to exercise the changed feature after the PR opens. It is not a log of actions the LLM or runner performed.
-25. Refresh run log after PR creation (including opened PR URL, coverage gap issue URL when created, and post-check steps), commit/push that log update when changed.
-26. Poll the open PR until it closes. When the monitor sees human/reviewer feedback (discussion comments, change-request reviews, or unresolved review threads), it invokes Codex on the PR branch immediately, reruns `make lint` and `make test`, commits and pushes any fix, resolves addressed review threads, and resumes polling. When the only actionable item is a failing check, it waits for pending PR checks to settle before invoking Codex so transient in-progress checks do not trigger unnecessary fixes.
-27. Return to a clean `main` on normal completion or PR closure.
+26. Refresh run log after PR creation (including opened PR URL, coverage gap issue URL when created, and post-check steps), commit/push that log update when changed.
+27. Poll the open PR until it closes. When the monitor sees human/reviewer feedback (discussion comments, change-request reviews, or unresolved review threads), it invokes Codex on the PR branch immediately, reruns `make lint` and `make test`, commits and pushes any fix, resolves addressed review threads, and resumes polling. When the only actionable item is a failing check, it waits for pending PR checks to settle before invoking Codex so transient in-progress checks do not trigger unnecessary fixes.
+28. Return to a clean `main` on normal completion or PR closure.
     - If the run fails after creating branch work, cleanup resets the checkout back to a clean base branch.
     - A new scheduled pass discards local worktree changes and switches back to the base branch before evaluating GitHub queue guards.
 
@@ -151,9 +154,10 @@ Every queued issue is assumed to require a real change. Once the runner claims a
 +-----------------------------------------------+
       |
       v
-+--------------------------------+
-| Require commands + repo exists |
-+--------------------------------+
++-----------------------------------------------+
+| Check Codex /status rate-limit data           |
+| 5h quota below floor? wait, then re-check     |
++-----------------------------------------------+
       |
       v
 +--------------------------------------------------+
@@ -373,6 +377,11 @@ The runner now performs an SSH signing preflight immediately after configuring g
 - `HUSHLINE_DAILY_RUN_LOG_RETENTION` (default `10`)
 - `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS` (default `10`; positive integer)
 - `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS` (default `8`; positive integer)
+- `HUSHLINE_DAILY_CODEX_STATUS_CHECK_ENABLED` (default `1`; set `0` to skip the pre-work Codex `/status` rate-limit check)
+- `HUSHLINE_DAILY_CODEX_STATUS_CHECK_TIMEOUT_SECONDS` (default `15`; positive integer)
+- `HUSHLINE_DAILY_CODEX_STATUS_RESET_BUFFER_SECONDS` (default `60`; non-negative integer; extra wait after the 5h window reset before rechecking)
+- `HUSHLINE_DAILY_CODEX_STATUS_MIN_REMAINING_PERCENT` (default `25`; integer percentage from `0` to `100`; wait for the 5h window reset when remaining primary quota is below this floor)
+- `HUSHLINE_DAILY_CODEX_STATUS_STALE_RESET_RECHECK_SECONDS` (default `60`; positive integer; backoff before rechecking when Codex reports low remaining 5h quota but the reset timestamp has already passed)
 - `HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS` (default `60`; non-negative integer; set `0` to skip continuous PR feedback monitoring; when enabled, the issue runner keeps the PR branch checked out and polls until the PR closes)
 - `HUSHLINE_DAILY_RUNNER_LOCK_DIR` (default `${TMPDIR:-/tmp}/hushline-code-agent.lock`)
 - `HUSHLINE_CODEX_MODEL` (default `gpt-5.5`)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -61,6 +61,11 @@ RUNTIME_BOOTSTRAP_ATTEMPTS="${HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_ATTEMPTS:-3}"
 RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS="${HUSHLINE_DAILY_RUNTIME_BOOTSTRAP_RETRY_DELAY_SECONDS:-10}"
 CHECK_TIMEOUT_SECONDS="${HUSHLINE_DAILY_CHECK_TIMEOUT_SECONDS:-1800}"
 POST_PR_FEEDBACK_DELAY_SECONDS="${HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS:-60}"
+CODEX_STATUS_CHECK_ENABLED="${HUSHLINE_DAILY_CODEX_STATUS_CHECK_ENABLED:-1}"
+CODEX_STATUS_CHECK_TIMEOUT_SECONDS="${HUSHLINE_DAILY_CODEX_STATUS_CHECK_TIMEOUT_SECONDS:-15}"
+CODEX_STATUS_RESET_BUFFER_SECONDS="${HUSHLINE_DAILY_CODEX_STATUS_RESET_BUFFER_SECONDS:-60}"
+CODEX_STATUS_MIN_REMAINING_PERCENT="${HUSHLINE_DAILY_CODEX_STATUS_MIN_REMAINING_PERCENT:-25}"
+CODEX_STATUS_STALE_RESET_RECHECK_SECONDS="${HUSHLINE_DAILY_CODEX_STATUS_STALE_RESET_RECHECK_SECONDS:-60}"
 
 CHECK_LOG_FILE=""
 PROMPT_FILE=""
@@ -113,6 +118,183 @@ parse_args() {
 
 runner_status() {
   printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S %Z')" "$*"
+}
+
+epoch_to_local_time() {
+  local epoch="$1"
+
+  if date -r "$epoch" '+%Y-%m-%d %H:%M:%S %Z' >/dev/null 2>&1; then
+    date -r "$epoch" '+%Y-%m-%d %H:%M:%S %Z'
+  else
+    date -d "@$epoch" '+%Y-%m-%d %H:%M:%S %Z'
+  fi
+}
+
+fetch_codex_status_json() {
+  if [[ -n "${HUSHLINE_DAILY_CODEX_STATUS_JSON:-}" ]]; then
+    printf '%s\n' "$HUSHLINE_DAILY_CODEX_STATUS_JSON"
+    return 0
+  fi
+
+  CODEX_STATUS_CHECK_TIMEOUT_SECONDS="$CODEX_STATUS_CHECK_TIMEOUT_SECONDS" node -e '
+const { spawn } = require("node:child_process");
+
+const timeoutSeconds = Number(process.env.CODEX_STATUS_CHECK_TIMEOUT_SECONDS || "15");
+const timeoutMs = Math.max(1, timeoutSeconds) * 1000;
+const child = spawn("codex", ["app-server", "--listen", "stdio://"], {
+  stdio: ["pipe", "pipe", "pipe"],
+});
+let completed = false;
+let stdoutBuffer = "";
+
+function finish(code) {
+  if (completed) return;
+  completed = true;
+  clearTimeout(timer);
+  child.kill("SIGTERM");
+  process.exit(code);
+}
+
+const timer = setTimeout(() => {
+  console.error("Codex /status rate limit check timed out.");
+  finish(2);
+}, timeoutMs);
+
+child.stdout.setEncoding("utf8");
+child.stdout.on("data", (chunk) => {
+  stdoutBuffer += chunk;
+  const lines = stdoutBuffer.split(/\n/);
+  stdoutBuffer = lines.pop() || "";
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    let message;
+    try {
+      message = JSON.parse(line);
+    } catch {
+      continue;
+    }
+    if (message.id === 2) {
+      if (message.error) {
+        console.error(`Codex /status rate limit check failed: ${message.error.message || "unknown error"}`);
+        finish(2);
+      }
+      process.stdout.write(`${JSON.stringify(message.result || {})}\n`);
+      finish(0);
+    }
+  }
+});
+child.stderr.on("data", () => {});
+child.on("error", (error) => {
+  console.error(`Codex /status rate limit check failed: ${error.message}`);
+  finish(2);
+});
+child.on("exit", (code) => {
+  if (!completed) {
+    console.error(`Codex /status rate limit check exited before returning status: ${code}`);
+    finish(2);
+  }
+});
+
+child.stdin.write(`${JSON.stringify({
+  method: "initialize",
+  id: 1,
+  params: {
+    clientInfo: {
+      name: "hushline_runner",
+      title: "Hush Line Runner",
+      version: "1",
+    },
+  },
+})}\n`);
+child.stdin.write(`${JSON.stringify({ method: "initialized", params: {} })}\n`);
+child.stdin.write(`${JSON.stringify({ method: "account/rateLimits/read", id: 2 })}\n`);
+'
+}
+
+parse_codex_primary_limit_status() {
+  node -e '
+const fs = require("node:fs");
+const input = fs.readFileSync(0, "utf8");
+const root = JSON.parse(input);
+const limits =
+  root.rateLimitsByLimitId?.codex ||
+  root.rateLimits ||
+  root;
+const primary = limits.primary;
+if (!primary) {
+  process.exit(2);
+}
+const usedPercent = Number(primary.usedPercent);
+const windowDurationMins = Number(primary.windowDurationMins);
+const resetsAt = Number(primary.resetsAt);
+const reachedType = limits.rateLimitReachedType || "";
+if (!Number.isFinite(usedPercent) || !Number.isFinite(windowDurationMins) || !Number.isFinite(resetsAt)) {
+  process.exit(2);
+}
+process.stdout.write([
+  Math.trunc(usedPercent),
+  Math.trunc(windowDurationMins),
+  Math.trunc(resetsAt),
+  reachedType,
+].join("\t"));
+'
+}
+
+wait_for_codex_status_credit_window() {
+  local status_json=""
+  local parsed_status=""
+  local used_percent=""
+  local window_duration_mins=""
+  local resets_at=""
+  local reached_type=""
+  local now_epoch=""
+  local sleep_seconds=""
+  local reset_label=""
+  local remaining_percent=""
+
+  if [[ "$CODEX_STATUS_CHECK_ENABLED" != "1" ]]; then
+    echo "Codex /status preflight disabled by HUSHLINE_DAILY_CODEX_STATUS_CHECK_ENABLED."
+    return 0
+  fi
+
+  while :; do
+    echo "==> Check Codex /status usage limits"
+    if ! status_json="$(fetch_codex_status_json)"; then
+      echo "Warning: Codex /status preflight failed; continuing so the runner can still attempt assigned work." >&2
+      return 0
+    fi
+
+    if ! parsed_status="$(printf '%s\n' "$status_json" | parse_codex_primary_limit_status)"; then
+      echo "Warning: Codex /status preflight returned unparseable rate limit data; continuing." >&2
+      return 0
+    fi
+
+    IFS=$'\t' read -r used_percent window_duration_mins resets_at reached_type <<< "$parsed_status"
+    reset_label="$(epoch_to_local_time "$resets_at")"
+    remaining_percent=$((100 - used_percent))
+    if (( remaining_percent < 0 )); then
+      remaining_percent=0
+    fi
+    echo "Codex /status: primary ${window_duration_mins}m window ${used_percent}% used; ${remaining_percent}% remaining; resets at ${reset_label}."
+
+    if (( window_duration_mins == 300 && remaining_percent < CODEX_STATUS_MIN_REMAINING_PERCENT )); then
+      now_epoch="$(date +%s)"
+      if (( resets_at > now_epoch )); then
+        sleep_seconds=$((resets_at - now_epoch + CODEX_STATUS_RESET_BUFFER_SECONDS))
+        runner_status "Codex 5h remaining quota is ${remaining_percent}%, below ${CODEX_STATUS_MIN_REMAINING_PERCENT}%; waiting ${sleep_seconds}s until after reset at ${reset_label}."
+        sleep "$sleep_seconds"
+        continue
+      fi
+      runner_status "Codex 5h remaining quota is below ${CODEX_STATUS_MIN_REMAINING_PERCENT}%, but reset time has passed; waiting ${CODEX_STATUS_STALE_RESET_RECHECK_SECONDS}s before rechecking."
+      sleep "$CODEX_STATUS_STALE_RESET_RECHECK_SECONDS"
+      continue
+    fi
+
+    if [[ -n "$reached_type" && "$reached_type" != "null" ]]; then
+      echo "Codex /status reported reached limit type '${reached_type}', but the 5h window still has capacity; proceeding."
+    fi
+    return 0
+  done
 }
 
 initialize_run_state() {
@@ -299,6 +481,16 @@ require_non_negative_integer() {
 
   if ! [[ "$value" =~ ^[0-9]+$ ]]; then
     echo "${name} must be a non-negative integer (got '${value}')." >&2
+    return 1
+  fi
+}
+
+require_percentage_integer() {
+  local name="$1"
+  local value="$2"
+
+  if ! [[ "$value" =~ ^[0-9]+$ ]] || (( value > 100 )); then
+    echo "${name} must be an integer percentage from 0 to 100 (got '${value}')." >&2
     return 1
   fi
 }
@@ -3645,6 +3837,20 @@ main() {
   require_non_negative_integer \
     "HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS" \
     "$POST_PR_FEEDBACK_DELAY_SECONDS"
+  require_positive_integer \
+    "HUSHLINE_DAILY_CODEX_STATUS_CHECK_TIMEOUT_SECONDS" \
+    "$CODEX_STATUS_CHECK_TIMEOUT_SECONDS"
+  require_non_negative_integer \
+    "HUSHLINE_DAILY_CODEX_STATUS_RESET_BUFFER_SECONDS" \
+    "$CODEX_STATUS_RESET_BUFFER_SECONDS"
+  require_percentage_integer \
+    "HUSHLINE_DAILY_CODEX_STATUS_MIN_REMAINING_PERCENT" \
+    "$CODEX_STATUS_MIN_REMAINING_PERCENT"
+  require_positive_integer \
+    "HUSHLINE_DAILY_CODEX_STATUS_STALE_RESET_RECHECK_SECONDS" \
+    "$CODEX_STATUS_STALE_RESET_RECHECK_SECONDS"
+
+  wait_for_codex_status_credit_window
 
   if [[ ! -d "$REPO_DIR/.git" ]]; then
     echo "Repository not found: $REPO_DIR" >&2

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -43,6 +43,110 @@ printf '%s %s\\n' "$CODEX_MODEL" "$CODEX_REASONING_EFFORT"
     assert result.stdout.strip() == "gpt-5.5 high"
 
 
+def test_wait_for_codex_status_credit_window_proceeds_when_5h_has_capacity() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CODEX_STATUS_CHECK_ENABLED=1
+HUSHLINE_DAILY_CODEX_STATUS_JSON='{{"rateLimits":{{"primary":{{"usedPercent":42,"windowDurationMins":300,"resetsAt":1779683479}},"secondary":null,"rateLimitReachedType":null}}}}'
+sleep() {{
+  printf 'unexpected-sleep:%s\\n' "$1"
+  return 1
+}}
+wait_for_codex_status_credit_window
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Codex /status: primary 300m window 42% used; 58% remaining" in result.stdout
+    assert "unexpected-sleep" not in result.stdout
+
+
+def test_wait_for_codex_status_credit_window_sleeps_until_low_5h_quota_resets(
+    tmp_path: Path,
+) -> None:
+    call_count_file = tmp_path / "status-calls.txt"
+    sleep_log = tmp_path / "sleep-log.txt"
+    call_count_file.write_text("0\n", encoding="utf-8")
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CODEX_STATUS_CHECK_ENABLED=1
+CODEX_STATUS_RESET_BUFFER_SECONDS=11
+fetch_codex_status_json() {{
+  count="$(cat {shlex.quote(str(call_count_file))})"
+  count=$((count + 1))
+  printf '%s\\n' "$count" > {shlex.quote(str(call_count_file))}
+  if [[ "$count" == "1" ]]; then
+    reset_at=$(($(date +%s) + 5))
+    printf '%s' '{{"rateLimits":{{"primary":{{"usedPercent":76,'
+    printf '%s' '"windowDurationMins":300,'
+    printf '"resetsAt":%s}},"secondary":null,' "$reset_at"
+    printf '%s\n' '"rateLimitReachedType":"primary"}}}}'
+  else
+    printf '%s' '{{"rateLimits":{{"primary":{{"usedPercent":7,'
+    printf '%s' '"windowDurationMins":300,"resetsAt":1779683479}},'
+    printf '%s\n' '"secondary":null,"rateLimitReachedType":null}}}}'
+  fi
+}}
+sleep() {{
+  printf 'sleep:%s\\n' "$1" >> {shlex.quote(str(sleep_log))}
+}}
+wait_for_codex_status_credit_window
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Codex 5h remaining quota is 24%, below 25%" in result.stdout
+    assert "Codex /status: primary 300m window 7% used; 93% remaining" in result.stdout
+    assert call_count_file.read_text(encoding="utf-8").strip() == "2"
+    slept_seconds = int(sleep_log.read_text(encoding="utf-8").strip().split(":")[1])
+    assert slept_seconds >= 11
+
+
+def test_wait_for_codex_status_credit_window_backs_off_when_reset_is_stale(
+    tmp_path: Path,
+) -> None:
+    call_count_file = tmp_path / "status-calls.txt"
+    sleep_log = tmp_path / "sleep-log.txt"
+    call_count_file.write_text("0\n", encoding="utf-8")
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CODEX_STATUS_CHECK_ENABLED=1
+CODEX_STATUS_STALE_RESET_RECHECK_SECONDS=17
+fetch_codex_status_json() {{
+  count="$(cat {shlex.quote(str(call_count_file))})"
+  count=$((count + 1))
+  printf '%s\\n' "$count" > {shlex.quote(str(call_count_file))}
+  if [[ "$count" == "1" ]]; then
+    reset_at=$(($(date +%s) - 5))
+    printf '%s' '{{"rateLimits":{{"primary":{{"usedPercent":76,'
+    printf '%s' '"windowDurationMins":300,'
+    printf '"resetsAt":%s}},"secondary":null,' "$reset_at"
+    printf '%s\n' '"rateLimitReachedType":"primary"}}}}'
+  else
+    printf '%s' '{{"rateLimits":{{"primary":{{"usedPercent":7,'
+    printf '%s' '"windowDurationMins":300,"resetsAt":1779683479}},'
+    printf '%s\n' '"secondary":null,"rateLimitReachedType":null}}}}'
+  fi
+}}
+sleep() {{
+  printf 'sleep:%s\\n' "$1" >> {shlex.quote(str(sleep_log))}
+}}
+wait_for_codex_status_credit_window
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "reset time has passed; waiting 17s before rechecking" in result.stdout
+    assert "Codex /status: primary 300m window 7% used; 93% remaining" in result.stdout
+    assert call_count_file.read_text(encoding="utf-8").strip() == "2"
+    assert sleep_log.read_text(encoding="utf-8").strip() == "sleep:17"
+
+
 def test_count_open_bot_prs_excluding_heads_fails_closed_when_pr_query_fails() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}


### PR DESCRIPTION
This updates the daily issue runner so it checks the Codex /status rate-limit data before touching the repository, GitHub queue state, or Docker runtime work. The runner now reads the structured app-server rate-limit status, logs used and remaining primary 300-minute quota, and waits until the reset time plus a buffer when remaining 5h quota is below the configured floor. The default floor is 25%, matching the expected rough cost of a typical ticket.

Summary:
- Add a pre-work Codex status preflight backed by `account/rateLimits/read`.
- Wait/recheck when the primary 300-minute window has less than `HUSHLINE_DAILY_CODEX_STATUS_MIN_REMAINING_PERCENT` remaining.
- Document the new ordering and environment controls in the runner docs.
- Cover both proceed and wait/recheck cases in runner tests.

Validation:
- `bash -n scripts/agent_daily_issue_runner.sh`
- `git diff --check`
- `make test TESTS=tests/test_agent_daily_issue_runner.py PYTEST_ADDOPTS="-k codex_status"`
- `make lint`
- `make test`
- `make audit-python`
- `make audit-node-runtime`
- Real status smoke check with the runner CODEX_HOME: primary 300m window 3% used, 97% remaining.

Manual Testing:
- Review the runner LaunchAgent logs after merge and confirm the first runner action is the Codex /status quota line before checkout, GitHub queue lookup, or Docker reset.
- Temporarily set `HUSHLINE_DAILY_CODEX_STATUS_MIN_REMAINING_PERCENT=100` in a controlled runner shell and confirm it waits until the reported reset instead of starting issue work.

Known Risks:
- The status check uses Codex app-server structured rate-limit data rather than driving the interactive TUI. This avoids prompt side effects while still reading the same account quota state.