### PR TITLE
Throttle idle Codex status checks

### DIFF
--- a/docs/AGENT-RUNNER.md
+++ b/docs/AGENT-RUNNER.md
@@ -154,12 +154,6 @@ Every queued issue is assumed to require a real change. Once the runner claims a
 +-----------------------------------------------+
       |
       v
-+-----------------------------------------------+
-| Check Codex /status rate-limit data           |
-| 5h quota below floor? wait, then re-check     |
-+-----------------------------------------------+
-      |
-      v
 +--------------------------------------------------+
 | Normalize agent-only checkout                 |
 | Discard dirty work + switch to base branch    |
@@ -172,15 +166,17 @@ Every queued issue is assumed to require a real change. Once the runner claims a
       |
       v
 +------------------------------------------------+
-| Select issue: forced --issue, In Progress,     |
-| or project queue                               |
+| Cheap GitHub guards + issue selection:         |
+| human PRs, In Progress, or project queue       |
 +------------------------------------------------+
       |
-+------------------------+
-| Open human PRs > 0 ?   |--yes--> [Skip + Exit]
-+------------------------+
+      +-- no issue / blocked by human PR --> [Hourly idle /status if due, then skip]
       |
-      no
+      v
++-----------------------------------------------+
+| Assigned issue exists: check Codex /status    |
+| 5h quota below floor? wait, then re-check     |
++-----------------------------------------------+
       |
       v
 +----------------------------------------------+
@@ -199,13 +195,7 @@ Every queued issue is assumed to require a real change. Once the runner claims a
 +----------------------------------------------+
       |
       v
-+------------------------+
-| Issue found?           |--no--> [Skip + Exit]
-+------------------------+
-      |
-      yes
-      |
-      v
++----------------------------------------------+
 | Load issue metadata + checkout work branch   |
 | Build initial issue prompt                   |
 +----------------------------------------------+
@@ -377,11 +367,13 @@ The runner now performs an SSH signing preflight immediately after configuring g
 - `HUSHLINE_DAILY_RUN_LOG_RETENTION` (default `10`)
 - `HUSHLINE_DAILY_MAX_ISSUE_ATTEMPTS` (default `10`; positive integer)
 - `HUSHLINE_DAILY_MAX_FIX_ATTEMPTS` (default `8`; positive integer)
-- `HUSHLINE_DAILY_CODEX_STATUS_CHECK_ENABLED` (default `1`; set `0` to skip the pre-work Codex `/status` rate-limit check)
+- `HUSHLINE_DAILY_CODEX_STATUS_CHECK_ENABLED` (default `1`; set `0` to skip Codex `/status` rate-limit checks)
 - `HUSHLINE_DAILY_CODEX_STATUS_CHECK_TIMEOUT_SECONDS` (default `15`; positive integer)
 - `HUSHLINE_DAILY_CODEX_STATUS_RESET_BUFFER_SECONDS` (default `60`; non-negative integer; extra wait after the 5h window reset before rechecking)
 - `HUSHLINE_DAILY_CODEX_STATUS_MIN_REMAINING_PERCENT` (default `25`; integer percentage from `0` to `100`; wait for the 5h window reset when remaining primary quota is below this floor)
 - `HUSHLINE_DAILY_CODEX_STATUS_STALE_RESET_RECHECK_SECONDS` (default `600`; positive integer; backoff before rechecking when Codex reports low remaining 5h quota but the reset timestamp has already passed)
+- `HUSHLINE_DAILY_CODEX_STATUS_IDLE_CHECK_INTERVAL_SECONDS` (default `3600`; non-negative integer; when no issue work is assigned, perform at most one lightweight Codex `/status` check per interval and do not wait on low quota)
+- `HUSHLINE_DAILY_CODEX_STATUS_IDLE_CHECK_STATE_FILE` (default: a hidden sibling file next to `HUSHLINE_DAILY_RUNNER_LOCK_DIR`, for example `/tmp/.hushline-code-agent.lock.codex-status-last-check`; stores the last idle `/status` attempt timestamp without placing files inside the lock directory)
 - `HUSHLINE_DAILY_POST_PR_FEEDBACK_DELAY_SECONDS` (default `600`; non-negative integer; set `0` to skip continuous PR feedback monitoring; when enabled, the issue runner keeps the PR branch checked out and polls until the PR closes)
 - `HUSHLINE_DAILY_RUNNER_LOCK_DIR` (default `${TMPDIR:-/tmp}/hushline-code-agent.lock`)
 - `HUSHLINE_CODEX_MODEL` (default `gpt-5.5`)

--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -66,6 +66,7 @@ CODEX_STATUS_CHECK_TIMEOUT_SECONDS="${HUSHLINE_DAILY_CODEX_STATUS_CHECK_TIMEOUT_
 CODEX_STATUS_RESET_BUFFER_SECONDS="${HUSHLINE_DAILY_CODEX_STATUS_RESET_BUFFER_SECONDS:-60}"
 CODEX_STATUS_MIN_REMAINING_PERCENT="${HUSHLINE_DAILY_CODEX_STATUS_MIN_REMAINING_PERCENT:-25}"
 CODEX_STATUS_STALE_RESET_RECHECK_SECONDS="${HUSHLINE_DAILY_CODEX_STATUS_STALE_RESET_RECHECK_SECONDS:-600}"
+CODEX_STATUS_IDLE_CHECK_INTERVAL_SECONDS="${HUSHLINE_DAILY_CODEX_STATUS_IDLE_CHECK_INTERVAL_SECONDS:-3600}"
 
 CHECK_LOG_FILE=""
 PROMPT_FILE=""
@@ -96,6 +97,8 @@ PR_FEEDBACK_MONITOR_BRANCH=""
 RUNNER_DIAGNOSTIC_PR=0
 RUNNER_DIAGNOSTIC_REASON=""
 RUNNER_NO_USABLE_CHANGES=0
+RUNNER_LOCK_STATE_BASENAME="${RUNNER_LOCK_DIR%/}"
+CODEX_STATUS_IDLE_CHECK_STATE_FILE="${HUSHLINE_DAILY_CODEX_STATUS_IDLE_CHECK_STATE_FILE:-$(dirname "$RUNNER_LOCK_STATE_BASENAME")/.$(basename "$RUNNER_LOCK_STATE_BASENAME").codex-status-last-check}"
 
 parse_args() {
   while [[ $# -gt 0 ]]; do
@@ -295,6 +298,74 @@ wait_for_codex_status_credit_window() {
     fi
     return 0
   done
+}
+
+codex_idle_status_check_due() {
+  local now_epoch=""
+  local last_epoch=""
+
+  if [[ "$CODEX_STATUS_CHECK_ENABLED" != "1" ]]; then
+    return 1
+  fi
+
+  if (( CODEX_STATUS_IDLE_CHECK_INTERVAL_SECONDS == 0 )); then
+    return 0
+  fi
+
+  now_epoch="$(date +%s)"
+  if [[ -r "$CODEX_STATUS_IDLE_CHECK_STATE_FILE" ]]; then
+    last_epoch="$(tr -cd '0-9' < "$CODEX_STATUS_IDLE_CHECK_STATE_FILE")"
+    if [[ -n "$last_epoch" ]] && (( now_epoch - last_epoch < CODEX_STATUS_IDLE_CHECK_INTERVAL_SECONDS )); then
+      return 1
+    fi
+  fi
+
+  return 0
+}
+
+record_codex_idle_status_check_attempt() {
+  mkdir -p "$(dirname "$CODEX_STATUS_IDLE_CHECK_STATE_FILE")"
+  date +%s > "$CODEX_STATUS_IDLE_CHECK_STATE_FILE"
+}
+
+check_codex_status_once_for_idle_run() {
+  local status_json=""
+  local parsed_status=""
+  local used_percent=""
+  local window_duration_mins=""
+  local resets_at=""
+  local reached_type=""
+  local reset_label=""
+  local remaining_percent=""
+
+  if ! codex_idle_status_check_due; then
+    return 0
+  fi
+
+  record_codex_idle_status_check_attempt
+  runner_status "Hourly idle Codex /status check due."
+  echo "==> Check Codex /status usage limits"
+  if ! status_json="$(fetch_codex_status_json)"; then
+    echo "Warning: idle Codex /status check failed; continuing idle exit." >&2
+    return 0
+  fi
+
+  if ! parsed_status="$(printf '%s\n' "$status_json" | parse_codex_primary_limit_status)"; then
+    echo "Warning: idle Codex /status check returned unparseable rate limit data; continuing idle exit." >&2
+    return 0
+  fi
+
+  IFS=$'\t' read -r used_percent window_duration_mins resets_at reached_type <<< "$parsed_status"
+  reset_label="$(epoch_to_local_time "$resets_at")"
+  remaining_percent=$((100 - used_percent))
+  if (( remaining_percent < 0 )); then
+    remaining_percent=0
+  fi
+  echo "Codex /status: primary ${window_duration_mins}m window ${used_percent}% used; ${remaining_percent}% remaining; resets at ${reset_label}."
+
+  if [[ -n "$reached_type" && "$reached_type" != "null" ]]; then
+    echo "Codex /status reported reached limit type '${reached_type}' during idle check."
+  fi
 }
 
 initialize_run_state() {
@@ -3849,8 +3920,9 @@ main() {
   require_positive_integer \
     "HUSHLINE_DAILY_CODEX_STATUS_STALE_RESET_RECHECK_SECONDS" \
     "$CODEX_STATUS_STALE_RESET_RECHECK_SECONDS"
-
-  wait_for_codex_status_credit_window
+  require_non_negative_integer \
+    "HUSHLINE_DAILY_CODEX_STATUS_IDLE_CHECK_INTERVAL_SECONDS" \
+    "$CODEX_STATUS_IDLE_CHECK_INTERVAL_SECONDS"
 
   if [[ ! -d "$REPO_DIR/.git" ]]; then
     echo "Repository not found: $REPO_DIR" >&2
@@ -3877,6 +3949,7 @@ main() {
     OPEN_HUMAN_PRS="$(count_open_human_prs)"
     echo "Open human-authored PR count: ${OPEN_HUMAN_PRS}"
     if [[ "$OPEN_HUMAN_PRS" != "0" ]]; then
+      check_codex_status_once_for_idle_run
       runner_status "Skipped: found ${OPEN_HUMAN_PRS} open human-authored PR(s)."
       exit 0
     fi
@@ -3895,9 +3968,12 @@ main() {
   fi
 
   if [[ -z "$ISSUE_NUMBER" ]]; then
+    check_codex_status_once_for_idle_run
     runner_status "Skipped: no open issues found in project '${PROJECT_TITLE}' column '${PROJECT_COLUMN}'."
     exit 0
   fi
+
+  wait_for_codex_status_credit_window
 
   EPIC_ISSUE_NUMBER=""
   EPIC_ISSUE_TITLE=""

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -46,13 +46,33 @@ printf '%s %s\\n' "$CODEX_MODEL" "$CODEX_REASONING_EFFORT"
 def test_runner_defaults_to_ten_minute_idle_polling() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
-printf '%s %s\\n' "$POST_PR_FEEDBACK_DELAY_SECONDS" "$CODEX_STATUS_STALE_RESET_RECHECK_SECONDS"
+printf '%s %s %s\\n' \\
+  "$POST_PR_FEEDBACK_DELAY_SECONDS" \\
+  "$CODEX_STATUS_STALE_RESET_RECHECK_SECONDS" \\
+  "$CODEX_STATUS_IDLE_CHECK_INTERVAL_SECONDS"
 """
 
     result = _run_bash(shell_script)
 
     assert result.returncode == 0, result.stderr
-    assert result.stdout.strip() == "600 600"
+    assert result.stdout.strip() == "600 600 3600"
+
+
+def test_runner_defaults_idle_status_state_file_outside_lock_dir(tmp_path: Path) -> None:
+    lock_dir = tmp_path / "hushline-lock"
+    expected_state_file = tmp_path / ".hushline-lock.codex-status-last-check"
+
+    shell_script = f"""
+HUSHLINE_DAILY_RUNNER_LOCK_DIR={shlex.quote(str(lock_dir))}/
+source {shlex.quote(str(RUNNER_SCRIPT))}
+printf '%s\\n' "$CODEX_STATUS_IDLE_CHECK_STATE_FILE"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == str(expected_state_file)
+    assert expected_state_file.parent == tmp_path
 
 
 def test_wait_for_codex_status_credit_window_proceeds_when_5h_has_capacity() -> None:
@@ -157,6 +177,49 @@ wait_for_codex_status_credit_window
     assert "Codex /status: primary 300m window 7% used; 93% remaining" in result.stdout
     assert call_count_file.read_text(encoding="utf-8").strip() == "2"
     assert sleep_log.read_text(encoding="utf-8").strip() == "sleep:17"
+
+
+def test_idle_codex_status_check_skips_when_recent(tmp_path: Path) -> None:
+    state_file = tmp_path / "last-check"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CODEX_STATUS_CHECK_ENABLED=1
+CODEX_STATUS_IDLE_CHECK_INTERVAL_SECONDS=3600
+CODEX_STATUS_IDLE_CHECK_STATE_FILE={shlex.quote(str(state_file))}
+date +%s > "$CODEX_STATUS_IDLE_CHECK_STATE_FILE"
+fetch_codex_status_json() {{
+  printf 'unexpected-fetch\\n'
+  return 1
+}}
+check_codex_status_once_for_idle_run
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "unexpected-fetch" not in result.stdout
+    assert "Hourly idle Codex /status check due" not in result.stdout
+
+
+def test_idle_codex_status_check_runs_when_due(tmp_path: Path) -> None:
+    state_file = tmp_path / "last-check"
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CODEX_STATUS_CHECK_ENABLED=1
+CODEX_STATUS_IDLE_CHECK_INTERVAL_SECONDS=0
+CODEX_STATUS_IDLE_CHECK_STATE_FILE={shlex.quote(str(state_file))}
+HUSHLINE_DAILY_CODEX_STATUS_JSON='{{"rateLimits":{{"primary":{{"usedPercent":51,"windowDurationMins":300,"resetsAt":1779683479}},"secondary":null,"rateLimitReachedType":null}}}}'
+check_codex_status_once_for_idle_run
+test -s "$CODEX_STATUS_IDLE_CHECK_STATE_FILE"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Hourly idle Codex /status check due" in result.stdout
+    assert "Codex /status: primary 300m window 51% used; 49% remaining" in result.stdout
 
 
 def test_count_open_bot_prs_excluding_heads_fails_closed_when_pr_query_fails() -> None:


### PR DESCRIPTION
## Summary
- Move the full Codex `/status` quota wait until after the runner has selected assigned issue work.
- Add an hourly idle `/status` check for no-work exits, including a state file to avoid polling every scheduled launch.
- Document the new idle status-check settings and update runner tests for no-ticket and assigned-ticket paths.

## Validation
- `docker compose run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py -q` (109 passed)
- `make lint` (passed)
- `make audit-python` (no known vulnerabilities found)
- `make audit-node-runtime` (found 0 vulnerabilities)
- `make test` previously passed on this patch shape: 1798 passed, 1 deselected, 1 xfailed, 100% coverage. A later rerun hit the known local Postgres shared-memory/recovery-mode failure documented in AGENTS.md; Docker volumes were reset before focused validation was rerun.

## Manual Testing
- Not applicable beyond the scripted runner tests; the behavior is exercised by shell-level runner tests for assigned work, no available issue, recent idle check state, and due idle check state.

## Risks / Follow-ups
- Idle quota visibility is now hourly when no ticket work is assigned. Assigned issue work still performs the full `/status` quota wait before doing repo/Docker work.