### PR TITLE
Restore issue 2014 runner log

### DIFF
--- a/docs/agent-logs/run-20260526T042438Z-issue-2014.txt
+++ b/docs/agent-logs/run-20260526T042438Z-issue-2014.txt
@@ -1,0 +1,2531 @@
+Daily runner log
+Timestamp (UTC): 20260526T042438Z
+Issue: #2014
+Repository: scidsg/hushline
+
+[2026-05-25 21:24:38 PDT] Starting daily issue runner check.
+Runner Codex config: [redacted]
+Open human-authored PR count: 0
+Open project issues in In Progress: 0
+Selected issue #2014 from project queue.
+==> Check Codex /status usage limits
+Codex /status: primary 300m window 1% used; 99% remaining; resets at 2026-05-26 02:24:49 PDT.
+Issue #2014 is a child of epic #2013.
+Open unrelated bot PR count: 0
+Allowed bot PR heads: codex/epic-2013, codex/daily-issue-2014
+==> Fetch latest from origin
+==> Checkout main
+Already on 'main'
+Your branch is up to date with 'origin/main'.
+==> Reset to origin/main
+HEAD is now at d893290f Document issue 411 crypto feasibility (#2012)
+==> Remove untracked files
+==> Mark issue #2014 as In Progress
+==> Configure bot git identity
+==> Stop and remove Docker resources
+ Container hushline-webpack-1 Stopping 
+ Container hushline-app-1 Stopping 
+ Container hushline-webpack-1 Stopped 
+ Container hushline-webpack-1 Removing 
+ Container hushline-webpack-1 Removed 
+ Container hushline-app-1 Stopped 
+ Container hushline-app-1 Removing 
+ Container hushline-app-1 Removed 
+ Container hushline-dev_data-1 Stopping 
+ Container hushline-blob-storage-1 Stopping 
+ Container hushline-dev_data-1 Stopped 
+ Container hushline-dev_data-1 Removing 
+ Container hushline-dev_data-1 Removed 
+ Container hushline-postgres-1 Stopping 
+ Container hushline-postgres-1 Stopped 
+ Container hushline-postgres-1 Removing 
+ Container hushline-postgres-1 Removed 
+ Container hushline-blob-storage-1 Stopped 
+ Container hushline-blob-storage-1 Removing 
+ Container hushline-blob-storage-1 Removed 
+ Network hushline_default Removing 
+ Volume hushline_hushline-node-modules Removing 
+ Volume hushline_hushline-node-modules Removed 
+ Network hushline_default Removed 
+==> Kill all Docker containers
+==> Kill processes on runner ports
+==> Start Docker stack
+ Image hushline-app Building 
+ Image hushline-dev_data Building 
+#1 [internal] load local bake definitions
+#1 reading from stdin 913B done
+#1 DONE 0.0s
+
+#2 [app internal] load build definition from Dockerfile.dev
+#2 transferring dockerfile: 1.15kB done
+#2 DONE 0.0s
+
+#3 [app internal] load metadata for docker.io/library/python:3.13-slim-bookworm
+#3 DONE 0.8s
+
+#4 [dev_data internal] load .dockerignore
+#4 transferring context: 144B done
+#4 DONE 0.0s
+
+#5 [app 1/8] FROM docker.io/library/python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2
+#5 resolve docker.io/library/python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2 done
+#5 DONE 0.0s
+
+#6 [dev_data internal] load build context
+#6 transferring context: 68B done
+#6 DONE 0.0s
+
+#7 [app 3/8] RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+#7 CACHED
+
+#8 [app 6/8] WORKDIR /app
+#8 CACHED
+
+#9 [app 7/8] COPY pyproject.toml poetry.lock ./
+#9 CACHED
+
+#10 [app 5/8] RUN npm install --global prettier@3.3.3
+#10 CACHED
+
+#11 [app 2/8] RUN apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update &&     apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y --fix-missing --no-install-recommends     curl     build-essential     clang     pkg-config     libffi-dev     libpq-dev     libpcsclite-dev     nettle-dev     nodejs     npm &&     rm -rf /var/lib/apt/lists/*
+#11 CACHED
+
+#12 [app 4/8] RUN python -m pip install --no-cache-dir --upgrade "pip>=26,<27" &&     python -m pip install --no-cache-dir poetry
+#12 CACHED
+
+#13 [app 8/8] RUN poetry install --no-root
+#13 CACHED
+
+#14 [dev_data] exporting to image
+#14 exporting layers done
+#14 exporting manifest sha256:d4d633a72f43512c563be3aa798001aec4bc9772275dea375596d56fb485e3b3 done
+#14 exporting config sha256:8ee7dc3a1036e4843c6345fca685e34af0c98f80f49352995b79d3dceec9d7e6 done
+#14 exporting attestation manifest sha256:6ac3b4c71df7173b4fa5f9441e9b25872b8ce039fd21592a510abe3e186fe460 0.0s done
+#14 exporting manifest list sha256:46795cd1a7951e961d7d6478e5789cf5b758df67d244978917c70b0f0a79ab8d 0.0s done
+#14 naming to docker.io/library/hushline-dev_data:latest
+#14 naming to docker.io/library/hushline-dev_data:latest done
+#14 unpacking to docker.io/library/hushline-dev_data:latest done
+#14 DONE 0.1s
+
+#15 [app] exporting to image
+#15 exporting layers done
+#15 exporting manifest sha256:20e1330ead784b3b4a37a3acea3db4aa98e346dca655290d3a5942674c6064c7 done
+#15 exporting config sha256:b50f065c3f5a68cada72c89c9cc6d8669785b7c34a53088afcf5934f85c82199 done
+#15 exporting attestation manifest sha256:a28bd97828a698521ffbc6a52fb97282bf8207f036d4e7ae6849899e98a11ed4 0.0s done
+#15 exporting manifest list sha256:7728e0a21b23a197778d8eab66b837306feaad4e52a463eef678bdf4751c4158 0.0s done
+#15 naming to docker.io/library/hushline-app:latest done
+#15 unpacking to docker.io/library/hushline-app:latest done
+#15 DONE 0.1s
+
+#16 [app] resolving provenance for metadata file
+#16 DONE 0.0s
+
+#17 [dev_data] resolving provenance for metadata file
+#17 DONE 0.0s
+ Image hushline-dev_data Built 
+ Image hushline-app Built 
+ Network hushline_default Creating 
+ Network hushline_default Created 
+ Volume hushline_hushline-node-modules Creating 
+ Volume hushline_hushline-node-modules Created 
+ Container hushline-blob-storage-1 Creating 
+ Container hushline-postgres-1 Creating 
+ Container hushline-webpack-1 Creating 
+ Container hushline-webpack-1 Created 
+ Container hushline-blob-storage-1 Created 
+ Container hushline-postgres-1 Created 
+ Container hushline-dev_data-1 Creating 
+ Container hushline-dev_data-1 Created 
+ Container hushline-app-1 Creating 
+ Container hushline-app-1 Created 
+ Container hushline-postgres-1 Starting 
+ Container hushline-blob-storage-1 Starting 
+ Container hushline-webpack-1 Starting 
+ Container hushline-blob-storage-1 Started 
+ Container hushline-webpack-1 Started 
+ Container hushline-postgres-1 Started 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-1 Starting 
+ Container hushline-app-1 Started 
+==> Seed development data
+ Container hushline-postgres-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-run-d4c93b5ad61e Creating 
+ Container hushline-dev_data-run-d4c93b5ad61e Created 
+poetry run ./scripts/dev_migrations.py
+Creating database tables
+Database tables created
+poetry run ./scripts/dev_data.py
+2026-05-26 04:25:31,500:INFO:Password hash counter
+2026-05-26 04:25:31,684:INFO:Password hash counter
+2026-05-26 04:25:31,864:INFO:Password hash counter
+2026-05-26 04:25:32,040:INFO:Password hash counter
+2026-05-26 04:25:32,239:INFO:Password hash counter
+2026-05-26 04:25:32,418:INFO:Password hash counter
+2026-05-26 04:25:32,594:INFO:Password hash counter
+2026-05-26 04:25:32,770:INFO:Password hash counter
+2026-05-26 04:25:32,946:INFO:Password hash counter
+2026-05-26 04:25:33,123:INFO:Password hash counter
+2026-05-26 04:25:33,309:INFO:Password hash counter
+2026-05-26 04:25:33,497:INFO:Password hash counter
+2026-05-26 04:25:33,673:INFO:Password hash counter
+2026-05-26 04:25:33,847:INFO:Password hash counter
+2026-05-26 04:25:34,024:INFO:Password hash counter
+2026-05-26 04:25:34,201:INFO:Password hash counter
+2026-05-26 04:25:34,376:INFO:Password hash counter
+2026-05-26 04:25:34,576:INFO:Password hash counter
+2026-05-26 04:25:34,752:INFO:Password hash counter
+Adding dev data
+Tier:
+  name = Free
+  monthly_amount = 0
+Tier:
+  name = Super User
+  monthly_amount = 500
+Dev data added
+User updated:
+  username = admin
+User updated:
+  username = artvandelay
+User updated:
+  username = jerryseinfeld
+User updated:
+  username = georgecostanza
+User updated:
+  username = elainebenes
+User updated:
+  username = cosmokramer
+User updated:
+  username = newman
+User updated:
+  username = frankcostanza
+User updated:
+  username = michaelbluth
+User updated:
+  username = gobbluth
+User updated:
+  username = busterbluth
+User updated:
+  username = lucillebluth
+User updated:
+  username = tobiasfunke
+User updated:
+  username = larrydavid
+User updated:
+  username = jeffgreene
+User updated:
+  username = leonblack
+User updated:
+  username = dwightschrute
+User updated:
+  username = martymcfly
+User updated:
+  username = georgecostanzakr
+Public storage bucket: public
+Restoring generated static JS artifacts dirtied by runtime bootstrap.
+ M hushline/static/js/directory_verified.js
+ M hushline/static/js/settings-location.js
+==> Fetch epic base branch codex/epic-2013
+==> Create branch codex/daily-issue-2014 from origin/codex/epic-2013
+Switched to a new branch 'codex/daily-issue-2014'
+branch 'codex/daily-issue-2014' set up to track 'origin/codex/epic-2013'.
+==> Codex issue attempt 1
+Codex execution started; transcript output is excluded from persisted run logs.
+Prompt stats: bytes=3282 lines=56 words=487
+Pre-Codex worktree snapshot:
+git status --short:
+(clean)
+Non-log changed files:
+(none)
+Codex execution completed.
+Post-Codex worktree snapshot:
+git status --short:
+ M docs/ENCRYPTED-FIELD-MODERNIZATION-ADR.md
+ M hushline/crypto.py
+ M tests/test_crypto.py
+ M tests/test_encrypted_field_inventory.py
+Non-log changed files:
+docs/ENCRYPTED-FIELD-MODERNIZATION-ADR.md
+hushline/crypto.py
+tests/test_crypto.py
+tests/test_encrypted_field_inventory.py
+Codex final message:
+Implemented issue #2014.
+
+Changed:
+- Added stable encrypted-field domain/AAD contracts in [crypto.py]([redacted-path]
+- Added a prototype AES-256-GCM v2 envelope path that authenticates domain + AAD, without wiring it into production model writes.
+- Added tests for canonical AAD, mutable-context rejection, wrong-domain failure, wrong-AAD failure, and inventory coverage.
+- Documented the domain/AAD stability contract in [ENCRYPTED-FIELD-MODERNIZATION-ADR.md]([redacted-path]
+
+Validation not run locally; the runner should execute `make lint` and `make test`.
+==> Refresh local runtime after schema changes
+Skipped: no schema-affecting files changed.
+==> Run lint
+docker compose run --rm app poetry run ruff format --check && \
+	docker compose run --rm app poetry run ruff check --output-format full && \
+	docker compose run --rm app poetry run mypy . && \
+	docker compose run --rm app sh -lc 'if [ -x node_modules/.bin/prettier ] && node_modules/.bin/prettier --version >/dev/null 2>&1; then node_modules/.bin/prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; elif command -v prettier >/dev/null 2>&1 && prettier --version >/dev/null 2>&1; then prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; else echo "Error: prettier/node is unavailable in this environment." >&2; exit 1; fi'
+ Container hushline-postgres-1 Running 
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-ce021eb4e5ef Creating 
+ Container hushline-app-run-ce021eb4e5ef Created 
+Would reformat: hushline/crypto.py
+Would reformat: tests/test_crypto.py
+2 files would be reformatted, 226 files already formatted
+
+make: *** [lint] Error 1
+Self-heal: applying deterministic lint fix via make fix.
+==> Auto-fix lint issues (make fix)
+docker compose run --rm app sh -lc 'set -e; \
+		poetry run ruff check --fix || true; \
+		poetry run ruff format; \
+		if [ -x node_modules/.bin/prettier ] && node_modules/.bin/prettier --version >/dev/null 2>&1; then node_modules/.bin/prettier --ignore-path /dev/null --write ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; elif command -v prettier >/dev/null 2>&1 && prettier --version >/dev/null 2>&1; then prettier --ignore-path /dev/null --write ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; else echo "Error: prettier/node is unavailable in this environment." >&2; exit 1; fi'
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-3bf748fb503f Creating 
+ Container hushline-app-run-3bf748fb503f Created 
+All checks passed!
+2 files reformatted, 226 files left unchanged
+AGENTS.md 90ms (unchanged)
+README.md 30ms (unchanged)
+SECURITY.md 13ms (unchanged)
+docs/AGENT-RUNNER.md 47ms (unchanged)
+docs/AGENTIC-CODE-POLICY.md 2ms (unchanged)
+docs/ARCHITECTURE.md 3ms (unchanged)
+docs/DEV.md 3ms (unchanged)
+docs/EMBEDDABLE-E2EE-PROFILE-FORMS-FEASIBILITY.md 44ms (unchanged)
+docs/EMBEDDABLE-FORMS-ADMIN.md 5ms (unchanged)
+docs/ENCRYPTED-FIELD-MODERNIZATION-ADR.md 23ms
+docs/FLASK-WTF-WTFORMS-MODERNIZATION-STRATEGY.md 28ms (unchanged)
+docs/GLOBALEAKS-DIRECTORY-SYNC.md 3ms (unchanged)
+docs/ISO-37002.md 148ms (unchanged)
+docs/ISSUE-411-SYMMETRIC-CRYPTO-FEASIBILITY.md 42ms (unchanged)
+docs/library/getting-started/new-user-onboarding.md 4ms (unchanged)
+docs/library/getting-started/prep-your-account.md 5ms (unchanged)
+docs/library/getting-started/README.md 2ms (unchanged)
+docs/library/getting-started/secure-your-account.md 3ms (unchanged)
+docs/library/getting-started/share-your-tip-line.md 3ms (unchanged)
+docs/library/getting-started/start-here.md 3ms (unchanged)
+docs/library/personal-server/README.md 1ms (unchanged)
+docs/library/personal-server/specs.md 3ms (unchanged)
+docs/library/personal-server/the-hush-line-personal-server.md 2ms (unchanged)
+docs/library/README.md 1ms (unchanged)
+docs/library/using-your-tip-line/account-verification.md 3ms (unchanged)
+docs/library/using-your-tip-line/dark-mode.md 2ms (unchanged)
+docs/library/using-your-tip-line/download-your-data.md 3ms (unchanged)
+docs/library/using-your-tip-line/email-validation.md 3ms (unchanged)
+docs/library/using-your-tip-line/embeddable-forms.md 3ms (unchanged)
+docs/library/using-your-tip-line/message-statuses.md 3ms (unchanged)
+docs/library/using-your-tip-line/reading-messages.md 3ms (unchanged)
+docs/library/using-your-tip-line/README.md 2ms (unchanged)
+docs/library/using-your-tip-line/tools.md 2ms (unchanged)
+docs/library/using-your-tip-line/vision-assistant.md 3ms (unchanged)
+docs/library/using-your-tip-line/your-inbox.md 2ms (unchanged)
+docs/library/welcome/README.md 1ms (unchanged)
+docs/library/welcome/welcome-to-hush-line.md 3ms (unchanged)
+docs/LOCAL-CONTRIBUTOR-ONBOARDING-PROMPT.md 2ms (unchanged)
+docs/NEWSROOM-DIRECTORY-DATA.md 1ms (unchanged)
+docs/PRIVACY.md 12ms (unchanged)
+docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md 74ms (unchanged)
+docs/PYTHON-3.13-UPGRADE-READINESS.md 12ms (unchanged)
+docs/README.md 3ms (unchanged)
+docs/screenshots/README.md 3ms (unchanged)
+docs/screenshots/releases/dark-debug/manifest.json 29ms (unchanged)
+docs/screenshots/releases/dark-target-check/manifest.json 3ms (unchanged)
+docs/screenshots/releases/latest/manifest.json 2ms (unchanged)
+docs/screenshots/releases/latest/README.md 1ms (unchanged)
+docs/screenshots/releases/one-off-directory/manifest.json 2ms (unchanged)
+docs/screenshots/releases/one-off-directory/README.md 2ms (unchanged)
+docs/screenshots/releases/recipient-qa/manifest.json 5ms (unchanged)
+docs/screenshots/releases/recipient-qa/README.md 4ms (unchanged)
+docs/screenshots/scenes.first-user.json 1ms (unchanged)
+docs/screenshots/scenes.json 31ms (unchanged)
+docs/SECUREDROP-DIRECTORY-SYNC.md 2ms (unchanged)
+docs/SECURITY-AUDIT-HITLIST.md 62ms (unchanged)
+docs/TERMS.md 4ms (unchanged)
+docs/THREAT-MODEL.md 19ms (unchanged)
+docs/UI-TEXT-AUDIT.md 12ms (unchanged)
+docs/USE-CASES.md 33ms (unchanged)
+docs/WHISTLEBLOWER-PROTECTION-ACCOUNTABILITY-WALL-FEASIBILITY.md 32ms (unchanged)
+.github/workflows/build-latest.yml 21ms (unchanged)
+.github/workflows/build-release.yml 5ms (unchanged)
+.github/workflows/bump-personal-server-after-release.yml 12ms (unchanged)
+.github/workflows/bump-staging-after-release.yml 10ms (unchanged)
+.github/workflows/ccpa-compliance.yml 3ms (unchanged)
+.github/workflows/close-epic-child-issue-on-merge.yml 3ms (unchanged)
+.github/workflows/dependency-security-audit.yml 6ms (unchanged)
+.github/workflows/dev_deploy.yml 9ms (unchanged)
+.github/workflows/docs-screenshots.yml 14ms (unchanged)
+.github/workflows/e2ee-privacy-regressions.yml 3ms (unchanged)
+.github/workflows/gdpr-compliance.yml 2ms (unchanged)
+.github/workflows/globaleaks-directory-refresh.yml 3ms (unchanged)
+.github/workflows/lighthouse-performance.yml 2ms (unchanged)
+.github/workflows/lighthouse.yml 3ms (unchanged)
+.github/workflows/migration-smoke.yml 2ms (unchanged)
+.github/workflows/public-directory-weekly-report.yml 5ms (unchanged)
+.github/workflows/public-record-link-check.yml 1ms (unchanged)
+.github/workflows/public-record-quarterly-refresh.yml 4ms (unchanged)
+.github/workflows/publish-docs-screenshots.yml 4ms (unchanged)
+.github/workflows/securedrop-directory-refresh.yml 3ms (unchanged)
+.github/workflows/tests.yml 3ms (unchanged)
+.github/workflows/w3c-validators.yml 3ms (unchanged)
+.github/workflows/workflow-security.yml 2ms (unchanged)
+hushline/data/globaleaks_instances.json 4ms (unchanged)
+hushline/data/newsroom_directory_listings.json 297ms (unchanged)
+hushline/data/public_record_law_firms.json 33ms (unchanged)
+hushline/data/public_record_law_firms_legacy.json 5ms (unchanged)
+hushline/data/securedrop_directory_instances.json 5ms (unchanged)
+hushline/static/manifest.json 0ms (unchanged)
+hushline/static/no-js.js 8ms (unchanged)
+hushline/static/js/directory_verified.js 110ms (unchanged)
+hushline/static/js/settings-location.js 14ms (unchanged)
+/Library/Developer/CommandLineTools/usr/bin/make lint
+docker compose run --rm app poetry run ruff format --check && \
+	docker compose run --rm app poetry run ruff check --output-format full && \
+	docker compose run --rm app poetry run mypy . && \
+	docker compose run --rm app sh -lc 'if [ -x node_modules/.bin/prettier ] && node_modules/.bin/prettier --version >/dev/null 2>&1; then node_modules/.bin/prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; elif command -v prettier >/dev/null 2>&1 && prettier --version >/dev/null 2>&1; then prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; else echo "Error: prettier/node is unavailable in this environment." >&2; exit 1; fi'
+ Container hushline-postgres-1 Running 
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-a7ee9cc69643 Creating 
+ Container hushline-app-run-a7ee9cc69643 Created 
+228 files already formatted
+ Container hushline-postgres-1 Running 
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-8c8f8c5c8d49 Creating 
+ Container hushline-app-run-8c8f8c5c8d49 Created 
+All checks passed!
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-8683dbf4647d Creating 
+ Container hushline-app-run-8683dbf4647d Created 
+Success: no issues found in 227 source files
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-351c5d9801b6 Creating 
+ Container hushline-app-run-351c5d9801b6 Created 
+Checking formatting...
+All matched files use Prettier code style!
+==> Re-run lint after deterministic auto-fix
+docker compose run --rm app poetry run ruff format --check && \
+	docker compose run --rm app poetry run ruff check --output-format full && \
+	docker compose run --rm app poetry run mypy . && \
+	docker compose run --rm app sh -lc 'if [ -x node_modules/.bin/prettier ] && node_modules/.bin/prettier --version >/dev/null 2>&1; then node_modules/.bin/prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; elif command -v prettier >/dev/null 2>&1 && prettier --version >/dev/null 2>&1; then prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; else echo "Error: prettier/node is unavailable in this environment." >&2; exit 1; fi'
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-5734218da129 Creating 
+ Container hushline-app-run-5734218da129 Created 
+228 files already formatted
+ Container hushline-postgres-1 Running 
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-b82870bcb6f1 Creating 
+ Container hushline-app-run-b82870bcb6f1 Created 
+All checks passed!
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-78018e4b358e Creating 
+ Container hushline-app-run-78018e4b358e Created 
+Success: no issues found in 227 source files
+ Container hushline-postgres-1 Running 
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-74acf0780bea Creating 
+ Container hushline-app-run-74acf0780bea Created 
+Checking formatting...
+All matched files use Prettier code style!
+==> Run test (full suite)
+Still running after 60s: Run test (full suite)
+Still running after 120s: Run test (full suite)
+Still running after 180s: Run test (full suite)
+Still running after 240s: Run test (full suite)
+Still running after 300s: Run test (full suite)
+Still running after 360s: Run test (full suite)
+docker compose run --rm app poetry run pytest --cov hushline --cov-report term --cov-report html:/tmp/hushline-htmlcov -vv -m "not external_network"  ./tests/
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-40d0b072720e Creating 
+ Container hushline-app-run-40d0b072720e Created 
+============================= test session starts ==============================
+platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.5.0 -- /root/.cache/pypoetry/virtualenvs/hushline-9TtSrW0h-py3.13/bin/python
+cachedir: .pytest_cache
+rootdir: /app
+configfile: pyproject.toml
+plugins: cov-5.0.0, asyncio-1.3.0, mock-3.14.0
+asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
+collecting ... collected 1845 items / 1 deselected / 1844 selected
+
+tests/test_2fa.py::test_enable_2fa PASSED                                [  0%]
+tests/test_2fa.py::test_valid_2fa_should_login PASSED                    [  0%]
+tests/test_2fa.py::test_valid_2fa_should_login_with_native_werkzeug_scrypt_first_factor PASSED [  0%]
+tests/test_2fa.py::test_invalid_2fa_should_not_login PASSED              [  0%]
+tests/test_2fa.py::test_legacy_password_rehash_waits_for_successful_2fa PASSED [  0%]
+tests/test_2fa.py::test_reuse_of_2fa_code_should_fail PASSED             [  0%]
+tests/test_2fa.py::test_limit_invalid_2fa_guesses PASSED                 [  0%]
+tests/test_accessibility.py::test_directory_tab_aria_and_controls PASSED [  0%]
+tests/test_accessibility.py::test_settings_nav_marks_current_page PASSED [  0%]
+tests/test_accessibility.py::test_inbox_filter_nav_marks_current_page PASSED [  0%]
+tests/test_accessibility.py::test_guidance_modal_has_accessible_attributes PASSED [  0%]
+tests/test_admin.py::test_admin_settings_shows_verified_on_managed_service PASSED [  0%]
+tests/test_admin.py::test_admin_settings_includes_user_search PASSED     [  0%]
+tests/test_admin.py::test_admin_settings_paginates_usernames PASSED      [  0%]
+tests/test_admin.py::test_admin_settings_clamps_invalid_page_requests PASSED [  0%]
+tests/test_admin.py::test_admin_settings_searches_all_usernames_before_paginating PASSED [  0%]
+tests/test_admin.py::test_admin_settings_hides_verified_on_nonmanaged_service PASSED [  0%]
+tests/test_admin.py::test_toggle_verified_on_managed_service PASSED      [  0%]
+tests/test_admin.py::test_toggle_verified_on_nonmanaged_service PASSED   [  1%]
+tests/test_admin.py::test_toggle_admin_only_admin PASSED                 [  1%]
+tests/test_admin.py::test_toggle_admin_multiple_admins PASSED            [  1%]
+tests/test_admin.py::test_toggle_verified_alias_on_managed_service PASSED [  1%]
+tests/test_admin.py::test_delete_user_removes_user PASSED                [  1%]
+tests/test_admin.py::test_delete_only_admin_blocked PASSED               [  1%]
+tests/test_admin.py::test_delete_self_blocked PASSED                     [  1%]
+tests/test_admin.py::test_delete_alias_does_not_delete_user PASSED       [  1%]
+tests/test_admin.py::test_delete_primary_deletes_aliases PASSED          [  1%]
+tests/test_admin.py::test_admin_actions_require_csrf_token PASSED        [  1%]
+tests/test_admin.py::test_toggle_verified_user_not_found PASSED          [  1%]
+tests/test_admin.py::test_toggle_verified_username_nonmanaged_forbidden PASSED [  1%]
+tests/test_admin.py::test_toggle_verified_username_not_found PASSED      [  1%]
+tests/test_admin.py::test_toggle_admin_missing_bool_field_returns_bad_request PASSED [  1%]
+tests/test_admin.py::test_toggle_admin_invalid_bool_field_returns_bad_request PASSED [  1%]
+tests/test_admin.py::test_toggle_cautious_updates_user PASSED            [  1%]
+tests/test_admin.py::test_toggle_suspended_updates_user PASSED           [  1%]
+tests/test_admin.py::test_toggle_suspended_clears_user_state PASSED      [  1%]
+tests/test_admin.py::test_update_account_category_validates_and_updates_user PASSED [  2%]
+tests/test_admin.py::test_update_account_category_rejects_missing_field_and_unknown_user PASSED [  2%]
+tests/test_admin.py::test_toggle_cautious_user_not_found PASSED          [  2%]
+tests/test_admin.py::test_toggle_suspended_forbidden_for_non_admin PASSED [  2%]
+tests/test_admin.py::test_toggle_suspended_user_not_found PASSED         [  2%]
+tests/test_admin.py::test_toggle_admin_user_not_found PASSED             [  2%]
+tests/test_admin.py::test_update_tier_missing_tier_returns_not_found PASSED [  2%]
+tests/test_admin.py::test_update_tier_missing_monthly_price PASSED       [  2%]
+tests/test_admin.py::test_update_tier_invalid_monthly_price PASSED       [  2%]
+tests/test_admin.py::test_update_tier_success PASSED                     [  2%]
+tests/test_admin.py::test_delete_user_not_found PASSED                   [  2%]
+tests/test_admin.py::test_delete_username_not_found PASSED               [  2%]
+tests/test_admin.py::test_delete_primary_username_blocked PASSED         [  2%]
+tests/test_admin.py::test_admin_csrf_invalid_token_returns_bad_request PASSED [  2%]
+tests/test_agent_daily_issue_runner.py::test_runner_defaults_repo_dir_to_checkout_root PASSED [  2%]
+tests/test_agent_daily_issue_runner.py::test_runner_defaults_to_approved_codex_model_and_reasoning PASSED [  2%]
+tests/test_agent_daily_issue_runner.py::test_runner_defaults_to_ten_minute_idle_polling PASSED [  2%]
+tests/test_agent_daily_issue_runner.py::test_runner_defaults_idle_status_state_file_outside_lock_dir PASSED [  2%]
+tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_proceeds_when_5h_has_capacity PASSED [  2%]
+tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_sleeps_until_low_5h_quota_resets PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_backs_off_when_reset_is_stale PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_idle_codex_status_check_skips_when_recent PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_idle_codex_status_check_runs_when_due PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_count_open_bot_prs_excluding_heads_fails_closed_when_pr_query_fails PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_prepare_runner_exec_snapshot_copies_script_for_stable_execution PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_runner_preflight_switches_to_base_branch PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_runner_preflight_discards_local_changes PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_cleanup_resets_successful_runner_worktree_to_base_branch PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_cleanup_resets_failed_runner_worktree_on_issue_branch PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_cleanup_releases_runner_lock_after_worktree_reset PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_runner_lock_skips_when_existing_runner_is_active PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_find_open_issue_pr_to_resume_selects_issue_branch PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_main_resumes_open_issue_pr_before_selecting_new_work PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_main_resumes_open_issue_pr_with_missing_branch_monitors_by_number PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap_when_bot_pr_exists PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap_when_human_pr_exists PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_main_resumes_in_progress_issue_before_selecting_new_work PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap_when_no_issue_is_available PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_runner_status_prefixes_lines_with_local_timestamp PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_main_bootstrap_does_not_prune_docker_system PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_build_pr_title_omits_codex_daily_prefix PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_build_pr_title_uses_diagnostic_title_for_diagnostic_pr PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_build_branch_name_uses_issue_prefix PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_build_epic_branch_name_uses_epic_prefix PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_ensure_worktree_on_branch_checks_out_expected_branch PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_ensure_head_commit_on_branch_moves_issue_branch_and_repairs_main PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_require_branch_has_unique_commits_blocks_empty_pr_branch PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_resolve_issue_parent_epic_outputs_parent_metadata PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_resolve_issue_parent_epic_passes_issue_number_as_graphql_int PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_resolve_project_status_edit_args_outputs_project_field_and_option_ids PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_resolve_issue_project_item_id_outputs_matching_project_item PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_set_issue_project_status_uses_graphql_mutation PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_add_issue_to_project_status_adds_missing_item_and_updates_status PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_add_issue_to_project_status_warns_when_status_update_fails PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_coverage_gap_snapshot_from_log_reports_latest_missed_rows PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_open_coverage_gap_issue_after_pr_creates_agent_eligible_issue PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_filters_open_issues_in_target_status PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_paginates_before_filtering PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_supports_custom_status_name PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_main_allows_existing_epic_pr_before_runtime_bootstrap PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_main_marks_issue_in_progress_before_runtime_bootstrap PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_main_uses_fetched_origin_epic_ref_for_child_pr_uniqueness_check PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_write_pr_body_for_child_issue_references_epic_and_closes_child_issue PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_build_issue_prompt_defines_manual_testing_as_human_reviewer_steps PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_main_marks_issue_ready_for_review_after_opening_pr PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_persisted_runner_log_excludes_codex_transcript PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_persisted_runner_log_redacts_developer_metadata PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_verbose_codex_output_streams_to_console_only PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_run_codex_from_prompt_reports_no_credits_without_transcript PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_run_codex_from_prompt_ignores_positive_credit_telemetry PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_run_codex_from_prompt_reports_usage_limit_without_retries PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_adds_plain_language_summary PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_explains_log_only_run PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_explains_diagnostic_pr PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_matches_network_errors PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_rejects_tls_vulnerability_text PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_runtime_schema_files_changed_detects_branch_schema_diff_from_runtime_base PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_restore_runtime_generated_static_artifacts_cleans_bootstrap_noise PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_restore_non_log_worktree_changes_uses_staged_and_worktree_restore PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_run_check_capture_times_out_stuck_check PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_runtime_bootstrap_retries_retryable_registry_failure PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_runtime_bootstrap_retries_retryable_pypi_dns_failure PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_runtime_bootstrap_does_not_retry_non_retryable_failure PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_runtime_bootstrap_does_not_retry_seed_eoferror PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_resolve_bot_git_signing_key_uses_existing_ssh_git_config PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_resolve_bot_git_signing_key_ignores_non_ssh_git_config PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_assert_ssh_signing_ready_does_not_require_local_private_key_file PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_require_positive_integer_rejects_zero PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_require_positive_integer_rejects_zero_for_runtime_bootstrap_retry_delay PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_failure_signature_from_text_returns_structured_markers PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_failure_signature_from_text_falls_back_when_no_marker_matches PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_build_fix_prompt_withholds_raw_check_output PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_recent_failure_block_from_text_extracts_recent_actionable_context PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_recent_failure_block_from_text_redacts_secret_like_values PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_recent_failure_block_keeps_traceback_when_coverage_table_follows PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_failure_excerpt_from_text_redacts_sensitive_values PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_stops_after_max_attempts PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_retries_when_post_fix_changes_collapse_to_log_only PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_has_non_log_changes_ignores_preexisting_branch_commits PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_summarize_pr_feedback_reports_unresolved_threads_and_comments PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_summarize_pr_feedback_reports_unresolved_outdated_threads PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_summarize_pr_feedback_ignores_untrusted_review_feedback PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_summarize_pr_feedback_uses_only_trusted_review_thread_comments PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_summarize_pr_feedback_reports_failing_and_pending_checks PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_skips_when_delay_disabled PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_skips_when_pr_number_unavailable PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_fetch_pr_checks_json_accepts_pending_exit_code PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_fetch_pr_checks_json_accepts_failing_exit_code PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_reports_pr_checks PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_polls_until_pr_closes PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_pr_feedback_action_waits_for_pending_checks PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_pr_feedback_action_key_ignores_pending_count_changes PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_addresses_actionable_feedback_once PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_address_pr_feedback_replies_and_resolves_review_threads PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_pr_feedback_thread_targets_only_include_team_members_or_codex PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_resolve_pr_number_from_ref_prefers_pr_url_without_gh_lookup PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_main_refuses_review_pr_when_issue_loop_fails PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_main_continues_after_pr_create_when_pr_number_lookup_fails PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_main_keeps_pr_branch_checked_out_until_feedback_monitor_returns PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_fix_attempt_loop_stops_after_max_attempts PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_fix_attempt_loop_stops_when_codex_is_unavailable PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_fix_attempt_loop_does_not_run_extra_post_test_gate PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_run_local_workflow_checks_runs_lint_then_test_only PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_run_local_workflow_checks_stops_after_non_fixable_lint_failure PASSED [  8%]
+tests/test_authentication_log_model.py::test_authentication_log_init_sets_optional_fields PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_register_login_and_2fa_challenge PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_notifications_generic_mode PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_notifications_field_content_mode PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_prefers_client_encrypted_body PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_falls_back_to_server_encrypt PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_uses_client_body_for_all_enabled_recipients PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_2fa_enable_then_disable_round_trip PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_onboarding_notifications_and_directory_persist_expected_state PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_directory_users_surface_verified_and_unverified_accounts PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_whistleblower_message_flow_defaults_and_actions PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_message_actions_do_not_cross_user_boundaries PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_authenticated_settings_profile_and_auth_round_trip PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_authenticated_encryption_and_data_export_flow PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_paid_user_alias_vision_and_subscription_controls PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_admin_branding_guidance_and_registration_controls PASSED [  9%]
+tests/test_ccpa_compliance.py::test_ccpa_compliance_evidence_policy_and_functionality PASSED [  9%]
+tests/test_cli_commands.py::test_reg_settings_command_outputs_current_values PASSED [  9%]
+tests/test_cli_commands.py::test_reg_toggle_commands_update_org_settings PASSED [  9%]
+tests/test_cli_commands.py::test_reg_code_commands_create_list_and_delete PASSED [  9%]
+tests/test_cli_commands.py::test_reg_code_create_avoids_dash_prefixed_codes PASSED [  9%]
+tests/test_cli_commands.py::test_password_hash_report_outputs_legacy_count_and_removal_gate PASSED [  9%]
+tests/test_cli_commands.py::test_password_hash_report_blocks_when_measured_legacy_successes_non_zero PASSED [  9%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_blocks_when_legacy_rows_remain PASSED [  9%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_succeeds_when_legacy_rows_and_volume_are_zero PASSED [ 10%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_accepts_reviewed_in_repo_legacy_verifier_path PASSED [ 10%]
+tests/test_cli_commands.py::test_stripe_configure_skips_when_secret_missing PASSED [ 10%]
+tests/test_cli_commands.py::test_stripe_configure_creates_missing_tiers_when_lookup_returns_none PASSED [ 10%]
+tests/test_cli_commands.py::test_stripe_configure_runs_premium_setup_when_secret_present PASSED [ 10%]
+tests/test_cli_commands.py::test_stripe_start_worker_skips_without_secret PASSED [ 10%]
+tests/test_cli_commands.py::test_stripe_start_worker_runs_async_worker PASSED [ 10%]
+tests/test_config.py::test_config_parse_string PASSED                    [ 10%]
+tests/test_config.py::test_config_parse_json PASSED                      [ 10%]
+tests/test_config.py::test_config_parse_json_fail PASSED                 [ 10%]
+tests/test_config.py::test_parse_alias_mode PASSED                       [ 10%]
+tests/test_config.py::test_preferred_url_scheme_defaults PASSED          [ 10%]
+tests/test_config.py::test_preferred_url_scheme_override PASSED          [ 10%]
+tests/test_config.py::test_preferred_url_scheme_invalid_value PASSED     [ 10%]
+tests/test_config.py::test_public_base_url_loads PASSED                  [ 10%]
+tests/test_config.py::test_public_base_url_invalid[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 10%]
+tests/test_config.py::test_public_base_url_invalid[https://example.com/path-PUBLIC_BASE_URL must not include a path] PASSED [ 10%]
+tests/test_config.py::test_public_base_url_invalid[https://example.com/?q=1-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 10%]
+tests/test_config.py::test_public_base_url_invalid[https://example.com/#frag-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 11%]
+tests/test_config.py::test_smtp_notification_reply_to_loads PASSED       [ 11%]
+tests/test_config.py::test_password_hash_write_use_werkzeug_scrypt_flag_defaults_false_and_parses_true PASSED [ 11%]
+tests/test_config.py::test_password_hash_rehash_on_auth_flag_defaults_false_and_parses_true PASSED [ 11%]
+tests/test_config.py::test_splash_screen_duration_defaults_to_two_seconds_and_parses_override PASSED [ 11%]
+tests/test_content_safety.py::test_contains_disallowed_text_rejects_empty_input PASSED [ 11%]
+tests/test_content_safety.py::test_contains_disallowed_text_applies_allowlist_before_engine PASSED [ 11%]
+tests/test_content_safety.py::test_profanity_engine_returns_none_and_logs_once_when_library_missing PASSED [ 11%]
+tests/test_content_safety.py::test_contains_disallowed_text_returns_false_when_engine_missing PASSED [ 11%]
+tests/test_content_safety.py::test_profanity_engine_loads_library_wordlist PASSED [ 11%]
+tests/test_coverage_push.py::test_cli_stripe_configure_creates_missing_tiers PASSED [ 11%]
+tests/test_coverage_push.py::test_button_widgets_and_coerce_status PASSED [ 11%]
+tests/test_coverage_push.py::test_custom_validators_negative_paths PASSED [ 11%]
+tests/test_coverage_push.py::test_email_forwarding_form_requires_smtp_fields PASSED [ 11%]
+tests/test_coverage_push.py::test_email_forwarding_form_validate_short_circuits_when_base_invalid PASSED [ 11%]
+tests/test_coverage_push.py::test_set_homepage_username_form_rejects_unknown_user PASSED [ 11%]
+tests/test_coverage_push.py::test_base_smtp_config_not_implemented PASSED [ 11%]
+tests/test_coverage_push.py::test_is_safe_smtp_host_rejects_invalid_ip PASSED [ 11%]
+tests/test_coverage_push.py::test_send_email_decodes_bytes_and_returns_false_when_no_attempts PASSED [ 11%]
+tests/test_coverage_push.py::test_message_status_text_upsert_delete_paths PASSED [ 12%]
+tests/test_coverage_push.py::test_encrypted_session_invalid_token_invalid_json_and_missing_key PASSED [ 12%]
+tests/test_coverage_push.py::test_data_export_invalid_form_returns_400 PASSED [ 12%]
+tests/test_coverage_push.py::test_data_export_encrypt_requires_pgp PASSED [ 12%]
+tests/test_coverage_push.py::test_data_export_encrypt_failure_redirects_to_advanced PASSED [ 12%]
+tests/test_coverage_push.py::test_build_zip_skips_non_pgp_and_unencrypted_values PASSED [ 12%]
+tests/test_coverage_push.py::test_write_pgp_messages_handles_empty_username_ids PASSED [ 12%]
+tests/test_coverage_push.py::test_write_pgp_messages_skips_unencrypted_field_values PASSED [ 12%]
+tests/test_coverage_push.py::test_user_alias_mode_edge_cases PASSED      [ 12%]
+tests/test_coverage_push.py::test_user_notification_recipient_limit_edge_cases PASSED [ 12%]
+tests/test_coverage_push.py::test_user_init_rejects_direct_password_hash_assignment PASSED [ 12%]
+tests/test_coverage_push.py::test_health_json_route PASSED               [ 12%]
+tests/test_coverage_push.py::test_load_config_additional_branches PASSED [ 12%]
+tests/test_coverage_push.py::test_registration_toggle_false_paths PASSED [ 12%]
+tests/test_coverage_push.py::test_blob_storage_none_driver_when_missing_config PASSED [ 12%]
+tests/test_coverage_push.py::test_encrypt_helpers_branch_types PASSED    [ 12%]
+tests/test_coverage_push.py::test_handle_email_forwarding_form_smtp_validation_exception PASSED [ 12%]
+tests/test_coverage_push.py::test_notifications_toggle_false_flash_paths PASSED [ 12%]
+tests/test_coverage_push.py::test_notifications_toggle_include_content_true_path PASSED [ 13%]
+tests/test_coverage_push.py::test_authentication_required_redirects_to_2fa_when_not_authenticated PASSED [ 13%]
+tests/test_coverage_push.py::test_authentication_required_clears_session_on_session_id_mismatch PASSED [ 13%]
+tests/test_coverage_push.py::test_authentication_required_clears_session_when_user_id_missing PASSED [ 13%]
+tests/test_coverage_push.py::test_admin_authentication_required_forbids_non_admin PASSED [ 13%]
+tests/test_coverage_push.py::test_create_products_and_prices_finds_product_in_list PASSED [ 13%]
+tests/test_coverage_push.py::test_create_products_and_prices_reuses_existing_default_price PASSED [ 13%]
+tests/test_coverage_push.py::test_create_products_and_prices_price_already_exists_path PASSED [ 13%]
+tests/test_coverage_push.py::test_create_products_and_prices_recreates_price_when_existing_id_invalid PASSED [ 13%]
+tests/test_coverage_push.py::test_utils_if_not_none_and_parse_bool PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_enums_defensive_paths PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_model_repr_and_field_definition_move_up_noop PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_field_value_remaining_paths PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_hushline_init_remaining_paths PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_crypto_encrypt_message_string_branch PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_stripe_invoice_remaining_paths PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_alias_route_delete_button_path PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_branding_delete_logo_multirow_safety PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_branding_delete_splash_logo_multirow_safety PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_guidance_none_prompts_default_path PASSED [ 14%]
+tests/test_coverage_push_remaining.py::test_settings_common_remaining_paths PASSED [ 14%]
+tests/test_coverage_push_remaining.py::test_enable_2fa_invalid_code_path PASSED [ 14%]
+tests/test_coverage_push_remaining.py::test_worker_no_pending_event_hits_continue PASSED [ 14%]
+tests/test_crypto.py::test_get_encryption_key_requires_env PASSED        [ 14%]
+tests/test_crypto.py::test_scoped_key_derivation_changes_key PASSED      [ 14%]
+tests/test_crypto.py::test_encrypt_and_decrypt_field PASSED              [ 14%]
+tests/test_crypto.py::test_encrypted_field_envelope_roundtrips_wrapped_fernet PASSED [ 14%]
+tests/test_crypto.py::test_encrypted_field_aad_is_canonical_and_stable PASSED [ 14%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values0] PASSED [ 14%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values1] PASSED [ 14%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values2] PASSED [ 14%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values3] PASSED [ 14%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values4] PASSED [ 14%]
+tests/test_crypto.py::test_encrypted_field_aead_prototype_requires_expected_domain_and_aad PASSED [ 14%]
+tests/test_crypto.py::test_legacy_fernet_token_has_no_envelope PASSED    [ 14%]
+tests/test_crypto.py::test_unknown_encrypted_field_envelope_version_fails_closed PASSED [ 14%]
+tests/test_crypto.py::test_malformed_encrypted_field_envelopes_fail_closed[hlfield:] PASSED [ 14%]
+tests/test_crypto.py::test_malformed_encrypted_field_envelopes_fail_closed[hlfield:not-json] PASSED [ 15%]
+tests/test_crypto.py::test_malformed_encrypted_field_envelopes_fail_closed[hlfield:W10] PASSED [ 15%]
+tests/test_crypto.py::test_malformed_encrypted_field_envelopes_fail_closed[hlfield:eyJhbGciOiJmZXJuZXQiLCJ2IjoxfQ] PASSED [ 15%]
+tests/test_crypto.py::test_malformed_encrypted_field_envelopes_fail_closed[hlfield:eyJhbGciOiJ1bmtub3duIiwiY3QiOiJjaXBoZXJ0ZXh0IiwidiI6MX0] PASSED [ 15%]
+tests/test_crypto.py::test_malformed_encrypted_field_envelopes_fail_closed[hlfield:eyJhbGciOiJmZXJuZXQiLCJjdCI6IiIsInYiOjF9] PASSED [ 15%]
+tests/test_crypto.py::test_malformed_encrypted_field_envelopes_fail_closed[hlfield:eyJhbGciOiJmZXJuZXQiLCJjdCI6MSwidiI6MX0] PASSED [ 15%]
+tests/test_crypto.py::test_encrypt_field_uses_zero_timestamp PASSED      [ 15%]
+tests/test_crypto.py::test_none_roundtrips PASSED                        [ 15%]
+tests/test_crypto.py::test_pgp_helpers PASSED                            [ 15%]
+tests/test_crypto.py::test_pgp_helpers_invalid_key PASSED                [ 15%]
+tests/test_crypto.py::test_encrypt_message_uses_all_recipient_keys PASSED [ 15%]
+tests/test_crypto.py::test_load_recipient_certs_requires_at_least_one_key PASSED [ 15%]
+tests/test_crypto.py::test_gen_reply_slug_uses_diceware_words PASSED     [ 15%]
+tests/test_data_export.py::test_data_export_requires_auth PASSED         [ 15%]
+tests/test_data_export.py::test_data_export_zip_contains_csv_and_pgp PASSED [ 15%]
+tests/test_data_export.py::test_data_export_encrypted_export PASSED      [ 15%]
+tests/test_data_export.py::test_data_export_only_includes_current_user PASSED [ 15%]
+tests/test_delete_account.py::test_delete_account PASSED                 [ 15%]
+tests/test_delete_account.py::test_cannot_delete_only_admin_account PASSED [ 15%]
+tests/test_delete_account.py::test_delete_account_multiple_admins PASSED [ 16%]
+tests/test_delete_account.py::test_delete_account_redirects_to_login_without_user_id PASSED [ 16%]
+tests/test_delete_account.py::test_delete_account_redirects_to_login_when_user_missing PASSED [ 16%]
+tests/test_deployment_migrations.py::test_staging_compose_uses_migration_sidecar PASSED [ 16%]
+tests/test_deployment_migrations.py::test_staging_compose_disables_app_startup_migrations PASSED [ 16%]
+tests/test_deployment_migrations.py::test_local_dev_data_sidecars_fail_fast_instead_of_restarting PASSED [ 16%]
+tests/test_deployment_migrations.py::test_prod_start_script_supports_disabling_startup_migrations PASSED [ 16%]
+tests/test_dev_data.py::test_default_users_include_korean_directory_account PASSED [ 16%]
+tests/test_dev_data.py::test_default_users_seed_paid_artvandelay_with_three_notification_recipients PASSED [ 16%]
+tests/test_directory.py::test_globaleaks_seed_has_rows PASSED            [ 16%]
+tests/test_directory.py::test_directory_accessible PASSED                [ 16%]
+tests/test_directory.py::test_directory_public_record_banner_links_to_admin PASSED [ 16%]
+tests/test_directory.py::test_directory_securedrop_banner_links_to_admin_without_tor_copy PASSED [ 16%]
+tests/test_directory.py::test_directory_globaleaks_banner_links_to_admin_without_tor_copy PASSED [ 16%]
+tests/test_directory.py::test_directory_newsrooms_banner_links_to_admin PASSED [ 16%]
+tests/test_directory.py::test_directory_all_tab_banner_links_to_admin PASSED [ 16%]
+tests/test_directory.py::test_directory_hides_tab_bar_when_verified_tabs_disabled PASSED [ 16%]
+tests/test_directory.py::test_directory_users_json_excludes_public_records_when_verified_tabs_disabled PASSED [ 16%]
+tests/test_directory.py::test_directory_lists_only_opted_in_users PASSED [ 17%]
+tests/test_directory.py::test_directory_session_user_json_defaults_to_logged_out PASSED [ 17%]
+tests/test_directory.py::test_directory_session_user_json_logged_in PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_includes_display_name_fallback_and_flags PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified_non_admin_display_names_for_caution[admin] PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified_non_admin_display_names_for_caution[Admin] PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified_non_admin_display_names_for_caution[hushline] PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified_non_admin_display_names_for_caution[Hush Line] PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified_non_admin_display_names_for_caution[hush line admin] PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified_non_admin_display_names_for_caution[admin of hush line] PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified_non_admin_display_names_for_caution[The Hush-Line Admin] PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_does_not_flag_verified_or_admin_suspicious_display_names PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_flags_suspicious_username_when_display_name_missing PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_includes_unverified_info_only_korean_account PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_marks_recipient_key_only_account_as_message_capable PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_includes_account_category PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_includes_normalized_user_location PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_includes_legacy_account_category_label PASSED [ 17%]
+tests/test_directory.py::test_directory_self_reported_attorneys_render_in_attorneys_tab PASSED [ 18%]
+tests/test_directory.py::test_directory_self_reported_journalists_and_newsrooms_render_in_newsrooms_tab PASSED [ 18%]
+tests/test_directory.py::test_directory_filters_newsrooms_by_country_and_region_query_params PASSED [ 18%]
+tests/test_directory.py::test_directory_filters_multi_country_newsrooms_by_each_country_query_param PASSED [ 18%]
+tests/test_directory.py::test_directory_filters_self_reported_attorneys_by_country_and_region_query_params PASSED [ 18%]
+tests/test_directory.py::test_directory_public_records_render_only_in_public_records_and_all PASSED [ 18%]
+tests/test_directory.py::test_directory_users_json_includes_public_record_rows PASSED [ 18%]
+tests/test_directory.py::test_directory_session_user_json_reflects_login_state PASSED [ 18%]
+tests/test_directory.py::test_directory_filter_json_returns_empty_metadata_when_verified_tabs_disabled[directory_attorney_filters] PASSED [ 18%]
+tests/test_directory.py::test_directory_filter_json_returns_empty_metadata_when_verified_tabs_disabled[directory_newsroom_filters] PASSED [ 18%]
+tests/test_directory.py::test_directory_all_filters_json_returns_empty_metadata_when_verified_tabs_disabled PASSED [ 18%]
+tests/test_directory.py::test_directory_users_json_excludes_verified_tab_sources_when_disabled PASSED [ 18%]
+tests/test_directory.py::test_directory_card_bio_uses_bio_length_limit_with_ascii_ellipsis PASSED [ 18%]
+tests/test_directory.py::test_directory_users_json_truncates_long_automated_listing_bios PASSED [ 18%]
+tests/test_directory.py::test_directory_public_record_cards_truncate_long_automated_listing_bios PASSED [ 18%]
+tests/test_directory.py::test_directory_public_record_cards_do_not_show_location PASSED [ 18%]
+tests/test_directory.py::test_directory_users_json_includes_legacy_public_record_rows PASSED [ 18%]
+tests/test_directory.py::test_directory_filters_public_records_by_country_and_region_query_params PASSED [ 18%]
+tests/test_directory.py::test_directory_attorney_filter_panel_hidden_by_default PASSED [ 18%]
+tests/test_directory.py::test_directory_newsroom_filter_panel_hidden_by_default PASSED [ 19%]
+tests/test_directory.py::test_directory_all_filter_panel_hidden_by_default PASSED [ 19%]
+tests/test_directory.py::test_directory_attorney_filter_panel_shows_selected_filters PASSED [ 19%]
+tests/test_directory.py::test_directory_newsroom_filter_panel_shows_selected_filters PASSED [ 19%]
+tests/test_directory.py::test_directory_all_filter_panel_shows_selected_filters PASSED [ 19%]
+tests/test_directory.py::test_directory_all_filters_do_not_change_attorney_or_newsroom_panels PASSED [ 19%]
+tests/test_directory.py::test_directory_users_json_filters_only_public_record_rows_by_query_params PASSED [ 19%]
+tests/test_directory.py::test_directory_users_json_filters_only_newsroom_rows_by_query_params PASSED [ 19%]
+tests/test_directory.py::test_directory_users_json_filters_all_rows_by_country_and_region_query_params PASSED [ 19%]
+tests/test_directory.py::test_directory_users_json_filters_all_rows_by_listing_type_query_params PASSED [ 19%]
+tests/test_directory.py::test_directory_users_json_filters_all_rows_by_combined_geography_and_listing_type_query_params PASSED [ 19%]
+tests/test_directory.py::test_directory_attorney_filters_json_reflects_active_query_filters PASSED [ 19%]
+tests/test_directory.py::test_directory_attorney_filters_json_includes_self_reported_attorneys PASSED [ 19%]
+tests/test_directory.py::test_directory_newsroom_filters_json_includes_self_reported_newsrooms PASSED [ 19%]
+tests/test_directory.py::test_directory_newsroom_filters_json_includes_automated_newsroom_listings PASSED [ 19%]
+tests/test_directory.py::test_directory_all_filters_json_reflects_active_query_filters PASSED [ 19%]
+tests/test_directory.py::test_directory_all_filters_json_updates_country_counts_for_verified_listing_type PASSED [ 19%]
+tests/test_directory.py::test_directory_all_filters_json_is_empty_when_verified_tabs_disabled PASSED [ 19%]
+tests/test_directory.py::test_listing_matches_attorney_filters_wrapper_uses_listing_geography PASSED [ 20%]
+tests/test_directory.py::test_newsroom_listing_matches_filters_wrapper_uses_listing_geography PASSED [ 20%]
+tests/test_directory.py::test_newsroom_automated_sources_skips_missing_source_metadata PASSED [ 20%]
+tests/test_directory.py::test_newsrooms_listing_includes_self_reported_journalism_accounts PASSED [ 20%]
+tests/test_directory.py::test_all_directory_entry_matches_unknown_listing_type_returns_false PASSED [ 20%]
+tests/test_directory.py::test_normalized_attorney_filter_country_returns_none_for_blank_values PASSED [ 20%]
+tests/test_directory.py::test_attorney_filter_state_infers_country_from_region_selection PASSED [ 20%]
+tests/test_directory.py::test_attorney_filter_state_clears_invalid_region_code PASSED [ 20%]
+tests/test_directory.py::test_newsroom_filter_state_infers_country_from_region_selection PASSED [ 20%]
+tests/test_directory.py::test_username_matches_attorney_filters_rejects_country_mismatch PASSED [ 20%]
+tests/test_directory.py::test_attorney_filter_metadata_skips_missing_country_and_subdivision_code PASSED [ 20%]
+tests/test_directory.py::test_directory_attorney_filters_include_normalized_country_values_outside_legacy_code_map PASSED [ 20%]
+tests/test_directory.py::test_directory_newsroom_filters_include_normalized_country_values_outside_legacy_code_map PASSED [ 20%]
+tests/test_directory.py::test_directory_attorney_filters_support_non_us_subdivisions PASSED [ 20%]
+tests/test_directory.py::test_directory_newsroom_filters_support_non_us_subdivisions PASSED [ 20%]
+tests/test_directory.py::test_directory_attorney_filters_json_ignores_untrusted_query_values PASSED [ 20%]
+tests/test_directory.py::test_directory_newsroom_filters_json_ignores_untrusted_query_values PASSED [ 20%]
+tests/test_directory.py::test_directory_attorney_filters_json_returns_empty_metadata_when_verified_tabs_disabled PASSED [ 20%]
+tests/test_directory.py::test_directory_newsroom_filters_json_returns_empty_metadata_when_verified_tabs_disabled PASSED [ 20%]
+tests/test_directory.py::test_directory_securedrop_render_only_in_securedrop_and_all PASSED [ 21%]
+tests/test_directory.py::test_directory_globaleaks_render_only_in_globaleaks_and_all PASSED [ 21%]
+tests/test_directory.py::test_directory_users_json_includes_globaleaks_rows PASSED [ 21%]
+tests/test_directory.py::test_directory_globaleaks_cards_do_not_show_location PASSED [ 21%]
+tests/test_directory.py::test_newsroom_seed_has_rows PASSED              [ 21%]
+tests/test_directory.py::test_directory_users_json_includes_newsroom_rows PASSED [ 21%]
+tests/test_directory.py::test_directory_users_json_preserves_multi_country_newsroom_rows PASSED [ 21%]
+tests/test_directory.py::test_directory_newsroom_cards_do_not_show_location PASSED [ 21%]
+tests/test_directory.py::test_directory_users_json_includes_securedrop_rows PASSED [ 21%]
+tests/test_directory.py::test_directory_securedrop_cards_do_not_show_location PASSED [ 21%]
+tests/test_directory.py::test_public_record_listing_normalizes_us_state_into_country_and_subdivision PASSED [ 21%]
+tests/test_directory.py::test_public_record_listing_normalizes_legacy_country_stored_in_state PASSED [ 21%]
+tests/test_directory.py::test_public_record_listing_preserves_non_us_subdivision_code PASSED [ 21%]
+tests/test_directory.py::test_public_record_listing_load_seed_rows_returns_empty_list_for_missing_file PASSED [ 21%]
+tests/test_directory.py::test_public_record_listings_deduplicate_strict_and_legacy_seed_collisions PASSED [ 21%]
+tests/test_directory.py::test_securedrop_listing_keeps_multi_country_scope_without_forcing_primary_country PASSED [ 21%]
+tests/test_directory.py::test_directory_all_tab_is_homogeneous_with_admin_first_and_info_only_badge PASSED [ 21%]
+tests/test_directory.py::test_directory_attorney_and_journalist_tabs_show_info_only_badge PASSED [ 21%]
+tests/test_directory.py::test_directory_all_tab_does_not_promote_non_admin_named_admin PASSED [ 22%]
+tests/test_directory.py::test_directory_all_tab_moves_caution_accounts_to_bottom PASSED [ 22%]
+tests/test_directory.py::test_directory_all_tab_orders_users_by_display_name_after_admin_pin PASSED [ 22%]
+tests/test_directory.py::test_directory_all_tab_preserves_transliterated_display_name_order PASSED [ 22%]
+tests/test_directory.py::test_directory_users_json_preserves_grouped_feed_order_for_non_all_tabs PASSED [ 22%]
+tests/test_directory.py::test_directory_users_json_exposes_all_tab_sort_fields_for_transliterated_order PASSED [ 22%]
+tests/test_directory.py::test_directory_users_json_preserves_empty_transliterated_sort_keys PASSED [ 22%]
+tests/test_directory.py::test_public_record_seed_regions_have_coverage PASSED [ 22%]
+tests/test_directory.py::test_public_record_listing_page_is_read_only PASSED [ 22%]
+tests/test_directory.py::test_public_record_listing_route_rejects_post PASSED [ 22%]
+tests/test_directory.py::test_public_record_listing_route_hidden_when_verified_tabs_disabled PASSED [ 22%]
+tests/test_directory.py::test_directory_listing_routes_return_404_for_missing_slugs[public_record_listing-hushline.routes.directory.get_public_record_listing] PASSED [ 22%]
+tests/test_directory.py::test_directory_listing_routes_return_404_for_missing_slugs[globaleaks_listing-hushline.routes.directory.get_globaleaks_directory_listing] PASSED [ 22%]
+tests/test_directory.py::test_directory_listing_routes_return_404_for_missing_slugs[newsroom_listing-hushline.routes.directory.get_newsroom_directory_listing] PASSED [ 22%]
+tests/test_directory.py::test_directory_listing_routes_return_404_for_missing_slugs[securedrop_listing-hushline.routes.directory.get_securedrop_directory_listing] PASSED [ 22%]
+tests/test_directory.py::test_securedrop_listing_page_is_read_only PASSED [ 22%]
+tests/test_directory.py::test_globaleaks_listing_page_is_read_only PASSED [ 22%]
+tests/test_directory.py::test_globaleaks_listing_page_mentions_tor_for_onion_submission PASSED [ 22%]
+tests/test_directory.py::test_globaleaks_listing_route_hidden_when_verified_tabs_disabled PASSED [ 22%]
+tests/test_directory.py::test_newsroom_listing_page_is_read_only PASSED  [ 23%]
+tests/test_directory.py::test_newsroom_listing_page_renders_source_aware_copy_for_network_entries PASSED [ 23%]
+tests/test_directory.py::test_newsroom_listing_route_hidden_when_verified_tabs_disabled PASSED [ 23%]
+tests/test_directory.py::test_securedrop_listing_page_omits_landing_page_link_when_missing PASSED [ 23%]
+tests/test_directory.py::test_securedrop_listing_route_hidden_when_verified_tabs_disabled PASSED [ 23%]
+tests/test_directory.py::test_public_record_listing_slug_cannot_be_messaged PASSED [ 23%]
+tests/test_directory.py::test_globaleaks_listing_slug_cannot_be_messaged PASSED [ 23%]
+tests/test_directory.py::test_newsroom_listing_slug_cannot_be_messaged PASSED [ 23%]
+tests/test_directory_listing_geography.py::test_build_directory_geography_normalizes_us_subdivision_codes[IL-Illinois-IL] PASSED [ 23%]
+tests/test_directory_listing_geography.py::test_build_directory_geography_normalizes_us_subdivision_codes[Illinois-Illinois-IL] PASSED [ 23%]
+tests/test_directory_listing_geography.py::test_directory_listing_geography_location_variants[geography0-Illinois] PASSED [ 23%]
+tests/test_directory_listing_geography.py::test_directory_listing_geography_location_variants[geography1-Illinois, United States] PASSED [ 23%]
+tests/test_directory_listing_geography.py::test_directory_listing_geography_location_variants[geography2-Australia] PASSED [ 23%]
+tests/test_directory_listing_geography.py::test_directory_listing_geography_location_variants[geography3-All countries, USA] PASSED [ 23%]
+tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_state_as_subdivision_when_country_present PASSED [ 23%]
+tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_us_state_code_when_country_missing PASSED [ 23%]
+tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_non_us_state_value_as_country_when_missing PASSED [ 23%]
+tests/test_directory_listing_geography.py::test_build_directory_geography_keeps_non_us_subdivision_strings PASSED [ 23%]
+tests/test_docker_runtime_images.py::test_dev_and_prod_dockerfiles_use_the_same_python_313_bookworm_runtime_image PASSED [ 24%]
+tests/test_docs_library_mirror.py::test_library_docs_mirror_contains_required_pages PASSED [ 24%]
+tests/test_docs_library_mirror.py::test_library_docs_relative_links_resolve PASSED [ 24%]
+tests/test_docs_library_mirror.py::test_embeddable_form_docs_are_linked_from_indexes_and_security_docs PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_defaults_to_empty_generated_allowlist PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_covers_guest_directory_verified_subtabs PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_disables_full_page_for_heavy_directory_scenes PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshot_capture_suppresses_first_load_splash PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshot_capture_filters_to_manifest_capture_files PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshot_allowlist_resolves_only_referenced_images PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshot_allowlist_filters_current_tree PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_artvandelay_notifications_waits_for_third_recipient PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_guest_message_submission_skips_choice_list_fill PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_guest_artvandelay_profile_scenes_reset_all_custom_fields PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_marks_state_preparation_scenes_always_visit PASSED [ 24%]
+tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_artvandelay_profile_cleanup_accepts_delete_confirmations PASSED [ 24%]
+tests/test_email.py::test_create_smtp_config_variants PASSED             [ 24%]
+tests/test_email.py::test_create_smtp_config_invalid_encryption PASSED   [ 24%]
+tests/test_email.py::test_ssl_smtp_login_authenticates_over_ssl PASSED   [ 25%]
+tests/test_email.py::test_starttls_smtp_login_upgrades_with_default_tls_context PASSED [ 25%]
+tests/test_email.py::test_is_safe_smtp_host_validation PASSED            [ 25%]
+tests/test_email.py::test_send_email_rejects_unsafe_host PASSED          [ 25%]
+tests/test_email.py::test_send_email_returns_false_when_config_invalid PASSED [ 25%]
+tests/test_email.py::test_send_email_success_and_retry PASSED            [ 25%]
+tests/test_email.py::test_send_email_returns_false_when_final_login_attempt_fails PASSED [ 25%]
+tests/test_email.py::test_send_email_does_not_retry_after_message_submission_attempt PASSED [ 25%]
+tests/test_email.py::test_send_email_recipient_refusal_returns_false PASSED [ 25%]
+tests/test_email.py::test_send_email_returns_false_when_attempts_disabled PASSED [ 25%]
+tests/test_email.py::test_send_email_sets_reply_to_header PASSED         [ 25%]
+tests/test_email.py::test_send_email_uses_single_part_plain_text_body PASSED [ 25%]
+tests/test_email.py::test_send_email_keeps_inline_pgp_body_as_top_level_text PASSED [ 25%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_extracts_auth_results_and_dkim_key PASSED [ 25%]
+tests/test_email_headers.py::test_email_headers_page_renders PASSED      [ 25%]
+tests/test_email_headers.py::test_email_headers_export_requires_authentication PASSED [ 25%]
+tests/test_email_headers.py::test_email_headers_page_renders_authenticated PASSED [ 25%]
+tests/test_email_headers.py::test_email_headers_post_without_dkim_still_reports_auth_results PASSED [ 25%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_marks_likely_forged_on_triple_fail PASSED [ 25%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_marks_valid_on_spf_dmarc_pass_without_dkim PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_marks_appears_inauthentic PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_rejects_empty_input PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_with_header_body_mix_parses_headers_only PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_warns_on_unparseable_from_and_incomplete_dkim PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_handles_dns_lookup_errors[raised0-not_found-No DKIM key found] PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_handles_dns_lookup_errors[raised1-error-DNS lookup failed: NoAnswer] PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_handles_dns_lookup_errors[raised2-error-DNS lookup failed: NoNameservers] PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_handles_dns_lookup_errors[raised3-error-DNS lookup failed: Timeout] PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_handles_dns_lookup_errors[raised4-error-DNS error: DNSException] PASSED [ 26%]
+tests/test_email_headers.py::test_create_evidence_zip_contains_pdf_json_and_valid_checksums PASSED [ 26%]
+tests/test_email_headers.py::test_email_headers_export_zip_contains_evidence_artifacts PASSED [ 26%]
+tests/test_email_headers.py::test_email_headers_post_invalid_form_shows_validation_flash PASSED [ 26%]
+tests/test_email_headers.py::test_email_headers_post_value_error_shows_flash PASSED [ 26%]
+tests/test_email_headers.py::test_email_headers_missing_csrf_preserves_invalid_post_behavior PASSED [ 26%]
+tests/test_email_headers.py::test_email_headers_export_invalid_form_redirects_with_flash PASSED [ 26%]
+tests/test_email_headers.py::test_email_headers_export_missing_csrf_redirects_with_flash PASSED [ 26%]
+tests/test_email_headers.py::test_email_headers_export_value_error_redirects_with_flash PASSED [ 26%]
+tests/test_email_headers.py::test_parse_tag_value_pairs_ignores_invalid_parts_and_empty_keys PASSED [ 27%]
+tests/test_email_headers.py::test_build_interpretation_includes_strong_chain_multiple_signatures_and_strong_keys PASSED [ 27%]
+tests/test_email_headers.py::test_render_minimal_pdf_renders_when_no_lines_provided PASSED [ 27%]
+tests/test_email_headers.py::test_render_report_pdf_includes_none_sections_and_warnings_block PASSED [ 27%]
+tests/test_email_headers.py::test_create_evidence_zip_includes_lookup_error_details PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_global_embed_enablement_defaults_disabled PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_primary_profile_requires_opt_in_and_exact_allowed_origin PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_requires_current_paid_super_user PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_alias_embed_opt_in_is_independent_from_primary_profile PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[ https://tips.example] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[*] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://*.example] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[ftp://tips.example] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example/path] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example?campaign=1] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example#fragment] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://user:[redacted-email]] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example:] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example;.onion] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example .onion] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\t.onion] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\n.onion] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\x0c.onion] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\r.onion] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_origin_normalization_canonicalizes_host_and_ports PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_origin_normalization_rejects_invalid_ports_and_deduplicates PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_origin_normalization_rejects_parsed_wildcard_host PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_default_port_allowlist_matches_browser_serialized_origin[https://Tips.Example:443-https://tips.example-https://tips.example] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_default_port_allowlist_matches_browser_serialized_origin[http://localhost:80-http://localhost-http://localhost] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_default_port_allowlist_matches_browser_serialized_origin[http://127.0.0.2:80-http://127.0.0.2-http://127.0.0.2] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_rejects_non_exception_http_origins PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_requires_at_least_one_exact_allowed_origin PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_admin_disablement_blocks_profile PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_preserves_missing_key_and_suspension_rejection PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_alias_embed_requires_owner_eligibility PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_admin_embeddable_forms_default_disabled PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_is_disabled_by_default PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_profile_opted_out PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_origin_allowlist PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_recipient_key PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_suspended_target PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_unknown_target PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_supports_alias PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_does_not_require_session_cookie PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_accepts_client_encrypted_fields PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_submission_operational_counters_exclude_sensitive_request_data PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_throttles_per_profile_without_payload_storage PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_throttles_per_source_bucket_across_profiles PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_does_not_record_limited_attempts PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_persists_outside_flask_extension_state PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_handles_unknown_source_and_deployment_scope PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_evicts_stale_global_state PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_requires_embed_form_token PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_invalid_csrf_token PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_owner_guard_mismatch PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_captcha_failure PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_missing_required_field PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_suspension PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_recipient_key_removed PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_uses_same_enabled_custom_fields PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_malformed_recipient_ciphertexts_use_generic_notification_body PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_invalid_recipient_ciphertexts_use_generic_notification_body[] PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_invalid_recipient_ciphertexts_use_generic_notification_body[{"not-id": {}, "123": "not-an-object"}] PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_has_no_postmessage_submission_path PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_profile_settings_do_not_render_embed_settings PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_developer_embed_settings_do_not_show_snippet_when_globally_disabled PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_non_super_non_admin_user_cannot_access_developer_settings PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_developer_settings_requires_primary_username PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_settings_nav_shows_developer_for_admin_or_current_paid_super_user PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_admin_non_super_user_can_access_developer_global_embed_settings_only PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_admin_non_super_user_cannot_update_profile_embed_settings PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_developer_embed_settings_require_usable_recipient_key PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_admin_can_toggle_embeddable_forms PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_non_admin_cannot_toggle_embeddable_forms PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_primary_embed_settings_update_origins_and_render_iframe_snippet PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_template_has_compact_trust_chrome_and_form PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_renders_additional_profile_fields_like_full_profile PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_keyboard_flow_and_mobile_accessibility_chrome PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_required_chrome_survives_recipient_branding_settings PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_template_shows_caution_state PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_template_ignores_sender_query_values PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_primary_embed_settings_reject_invalid_origin PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_embed_settings_require_message_capable_owner PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_alias_embed_settings_are_independent PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_alias_embed_settings_reject_invalid_origin PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_alias_embed_settings_require_alias_owner PASSED [ 31%]
+tests/test_encrypted_field_inventory.py::test_encrypted_field_property_inventory_is_complete PASSED [ 31%]
+tests/test_encrypted_field_inventory.py::test_encrypted_field_inventory_columns_match_models PASSED [ 31%]
+tests/test_encrypted_field_inventory.py::test_encrypted_field_domain_contract_covers_inventory PASSED [ 31%]
+tests/test_encrypted_field_inventory.py::test_user_encrypted_properties_store_fernet_ciphertext PASSED [ 31%]
+tests/test_encrypted_field_inventory.py::test_notification_recipient_properties_store_fernet_ciphertext PASSED [ 31%]
+tests/test_encrypted_field_inventory.py::test_field_value_stores_encrypted_custom_message_value_as_fernet_ciphertext PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_legacy_fernet_user_fields_decrypt_through_properties PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_legacy_fernet_notification_recipient_fields_decrypt PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_legacy_fernet_field_value_decrypts_encrypted_custom_message_value PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_versioned_envelope_field_ciphertext_decrypts_through_properties[User.totp_secret] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_versioned_envelope_field_ciphertext_decrypts_through_properties[User.email] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_versioned_envelope_field_ciphertext_decrypts_through_properties[User.smtp_server] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_versioned_envelope_field_ciphertext_decrypts_through_properties[User.smtp_username] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_versioned_envelope_field_ciphertext_decrypts_through_properties[User.smtp_password] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_versioned_envelope_field_ciphertext_decrypts_through_properties[User.pgp_key] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_versioned_envelope_field_ciphertext_decrypts_through_properties[NotificationRecipient.email] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_versioned_envelope_field_ciphertext_decrypts_through_properties[NotificationRecipient.pgp_key] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_versioned_envelope_field_ciphertext_decrypts_through_properties[FieldValue.value] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.totp_secret] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.email] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.smtp_server] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.smtp_username] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.smtp_password] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.pgp_key] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[NotificationRecipient.email] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[NotificationRecipient.pgp_key] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[FieldValue.value] PASSED [ 33%]
+tests/test_external_urls.py::test_normalize_public_base_url_strips_trailing_slash PASSED [ 33%]
+tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 33%]
+tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://-PUBLIC_BASE_URL must include a host] PASSED [ 33%]
+tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://example.com/path-PUBLIC_BASE_URL must not include a path] PASSED [ 33%]
+tests/test_external_urls.py::test_canonical_external_url_prefers_public_base_url PASSED [ 33%]
+tests/test_external_urls.py::test_canonical_external_url_falls_back_to_request_derived_url_in_dev_and_testing[config_overrides0] PASSED [ 33%]
+tests/test_external_urls.py::test_canonical_external_url_falls_back_to_request_derived_url_in_dev_and_testing[config_overrides1] PASSED [ 33%]
+tests/test_external_urls.py::test_canonical_external_url_falls_back_to_request_derived_url_in_dev_and_testing[config_overrides2] PASSED [ 33%]
+tests/test_external_urls.py::test_canonical_external_url_requires_canonical_config_in_production PASSED [ 33%]
+tests/test_fields.py::test_add_fields_and_move_up PASSED                 [ 33%]
+tests/test_fields.py::test_add_fields_and_move_down PASSED               [ 33%]
+tests/test_fields.py::test_field_value_encryption PASSED                 [ 33%]
+tests/test_fields.py::test_field_value_unencryption PASSED               [ 33%]
+tests/test_fields.py::test_field_value_encryption_uses_all_enabled_recipient_keys PASSED [ 33%]
+tests/test_first_user.py::test_no_users_redirect_to_register PASSED      [ 34%]
+tests/test_first_user.py::test_no_users_register_should_show_alert PASSED [ 34%]
+tests/test_first_user.py::test_some_users_register_should_hide_alert PASSED [ 34%]
+tests/test_first_user.py::test_first_user_is_admin PASSED                [ 34%]
+tests/test_first_user.py::test_registration_does_not_grant_admin_after_stale_first_user_check PASSED [ 34%]
+tests/test_first_user.py::test_second_user_is_not_admin PASSED           [ 34%]
+tests/test_frontend_compat.py::test_package_json_declares_node_20_plus PASSED [ 34%]
+tests/test_frontend_compat.py::test_webpack_compose_services_use_lockfile_guard_script PASSED [ 34%]
+tests/test_frontend_compat.py::test_static_js_bundles_avoid_eval_wrappers PASSED [ 34%]
+tests/test_frontend_compat.py::test_client_side_encryption_has_platform_guards PASSED [ 34%]
+tests/test_frontend_compat.py::test_profile_template_avoids_inline_submit_handlers PASSED [ 34%]
+tests/test_frontend_compat.py::test_verified_url_icon_uses_image_assets PASSED [ 34%]
+tests/test_frontend_compat.py::test_submit_spinner_hooks_exist_for_scoped_forms PASSED [ 34%]
+tests/test_frontend_compat.py::test_first_load_splash_hooks_exist PASSED [ 34%]
+tests/test_frontend_compat.py::test_native_pwa_splash_assets_and_manifest_fallback_exist PASSED [ 34%]
+tests/test_frontend_compat.py::test_service_worker_does_not_cache_navigation_html PASSED [ 34%]
+tests/test_frontend_compat.py::test_directory_search_accessibility_hooks_exist PASSED [ 34%]
+tests/test_frontend_compat.py::test_directory_sticky_active_tab_scroll_to_top_hook_exists PASSED [ 34%]
+tests/test_frontend_compat.py::test_directory_tab_scroll_buttons_clamp_to_valid_bounds PASSED [ 34%]
+tests/test_frontend_compat.py::test_inbox_sticky_nav_hooks_exist PASSED  [ 35%]
+tests/test_frontend_compat.py::test_settings_field_delete_confirmation_blocks_submit_on_cancel PASSED [ 35%]
+tests/test_frontend_compat.py::test_settings_sticky_nav_hooks_exist PASSED [ 35%]
+tests/test_frontend_compat.py::test_profile_location_settings_use_country_select_and_dependency_script PASSED [ 35%]
+tests/test_frontend_compat.py::test_profile_settings_template_contains_updated_ui_copy PASSED [ 35%]
+tests/test_frontend_compat.py::test_settings_field_builder_select_hooks_are_wrapper_safe PASSED [ 35%]
+tests/test_gdpr_compliance.py::test_gdpr_compliance_evidence_policy_and_functionality PASSED [ 35%]
+tests/test_globaleaks_directory_listing_model.py::test_globaleaks_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 35%]
+tests/test_globaleaks_directory_listing_model.py::test_globaleaks_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 35%]
+tests/test_globaleaks_directory_listing_model.py::test_get_globaleaks_directory_listing_matches_slug_case_insensitively PASSED [ 35%]
+tests/test_globaleaks_directory_listing_model.py::test_build_globaleaks_listing_infers_host_from_submission_url PASSED [ 35%]
+tests/test_globaleaks_directory_listing_model.py::test_globaleaks_directory_listing_properties_expose_geography_and_onion_detection PASSED [ 35%]
+tests/test_globaleaks_directory_listing_model.py::test_globaleaks_seed_path_points_to_committed_dataset PASSED [ 35%]
+tests/test_globaleaks_directory_refresh.py::test_normalize_string_list_handles_split_deduping_and_invalid_inputs PASSED [ 35%]
+tests/test_globaleaks_directory_refresh.py::test_normalize_http_url_validates_required_and_optional_fields PASSED [ 35%]
+tests/test_globaleaks_directory_refresh.py::test_infer_scheme_uses_port_module_cert_and_http_fallback PASSED [ 35%]
+tests/test_globaleaks_directory_refresh.py::test_choose_submission_url_uses_website_http_location_and_host_fallbacks PASSED [ 35%]
+tests/test_globaleaks_directory_refresh.py::test_choose_host_falls_back_to_candidate_hosts_or_errors PASSED [ 35%]
+tests/test_globaleaks_directory_refresh.py::test_candidate_hosts_normalizes_and_skips_blank_or_duplicate_values PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_rejects_empty_slug_after_normalization PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows1-Normalized row slug must be a string] PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows2-Duplicate GlobaLeaks listing slug: globaleaks~shared] PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_index_known_rows_by_host_ignores_blank_url_fields PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_extract_discovery_links_filters_excluded_duplicate_and_non_candidate_hosts PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_is_deterministic_and_schema_compatible PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_rejects_duplicates PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_requires_submission_host_or_url PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_rejects_invalid_explicit_submission_url PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_fetch_globaleaks_directory_rows_scrapes_usecase_pages_and_preserves_known_rows PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_fetch_globaleaks_directory_rows_skips_hosts_seen_on_earlier_pages PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_fetch_globaleaks_directory_rows_wraps_request_failures PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_fetch_globaleaks_directory_rows_fails_closed_when_no_candidates_are_found PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_render_globaleaks_refresh_summary PASSED [ 36%]
+tests/test_helpers.py::test_form_to_data_flattens_prefixed_subforms PASSED [ 36%]
+tests/test_helpers.py::test_form_to_data_targets_only_selected_submit_button PASSED [ 36%]
+tests/test_helpers.py::test_form_to_data_flattens_fieldlist_subforms PASSED [ 36%]
+tests/test_inbox.py::test_delete_own_message PASSED                      [ 37%]
+tests/test_inbox.py::test_cannot_delete_other_user_message PASSED        [ 37%]
+tests/test_inbox.py::test_filter_on_status PASSED                        [ 37%]
+tests/test_inbox.py::test_inbox_invalid_status_returns_bad_request PASSED [ 37%]
+tests/test_inbox.py::test_inbox_missing_user_row_returns_not_found PASSED [ 37%]
+tests/test_info.py::test_info_available PASSED                           [ 37%]
+tests/test_info.py::test_site_webmanifest_reflects_branding PASSED       [ 37%]
+tests/test_info.py::test_site_webmanifest_includes_uploaded_logo_icon PASSED [ 37%]
+tests/test_invite_code_model.py::test_invite_code_repr_includes_code PASSED [ 37%]
+tests/test_make_admin.py::test_toggle_admin_prints_when_user_missing PASSED [ 37%]
+tests/test_make_admin.py::test_toggle_admin_flips_admin_flag_case_insensitive PASSED [ 37%]
+tests/test_make_admin.py::test_make_admin_main_without_username_exits PASSED [ 37%]
+tests/test_make_admin.py::test_make_admin_main_with_username_runs PASSED [ 37%]
+tests/test_makefile.py::test_fix_target_runs_ruff_fix_before_formatting PASSED [ 37%]
+tests/test_makefile.py::test_lint_target_keeps_format_check_before_ruff_check PASSED [ 37%]
+tests/test_makefile.py::test_prettier_targets_skip_generated_static_js_glob PASSED [ 37%]
+tests/test_makefile.py::test_test_target_writes_html_coverage_to_tmp_by_default PASSED [ 37%]
+tests/test_md.py::test_md_to_html_returns_markup_input_unchanged PASSED  [ 37%]
+tests/test_md.py::test_md_to_html_sanitizes_disallowed_tags_and_keeps_links PASSED [ 38%]
+tests/test_migrations.py::test_linear_revision_history PASSED            [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[46aedec8fd9b] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[5410668e15ad] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[be0744a5679f] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[0b1321c8de13] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[cf2a880aff10] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[4a53667aff6e] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[b6a1e3f5a2b1] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[7d6a9f2f8c1a] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[2e3e5b1f2b3c] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[9f7c4c3ea9a1] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[3c1b2a4d5e6f] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[8f3f1f0a1b2c] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[1a2b3c4d5e6a] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[c4f8e2a1b6d9] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[84f1d3b2c6e7] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[d1f0e9c2b7aa] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[2d8a1f7c9b41] PASSED    [ 38%]
+tests/test_migrations.py::test_downgrade_with_data[46aedec8fd9b] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[5410668e15ad] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[be0744a5679f] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[0b1321c8de13] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[cf2a880aff10] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[4a53667aff6e] XFAIL   [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[b6a1e3f5a2b1] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[7d6a9f2f8c1a] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[2e3e5b1f2b3c] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[9f7c4c3ea9a1] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[3c1b2a4d5e6f] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[8f3f1f0a1b2c] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[1a2b3c4d5e6a] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[c4f8e2a1b6d9] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[84f1d3b2c6e7] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[d1f0e9c2b7aa] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[2d8a1f7c9b41] PASSED  [ 39%]
+tests/test_migrations.py::test_double_upgrade[46aedec8fd9b] PASSED       [ 39%]
+tests/test_migrations.py::test_double_upgrade[5410668e15ad] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[be0744a5679f] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[0b1321c8de13] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[cf2a880aff10] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[4a53667aff6e] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[b6a1e3f5a2b1] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[7d6a9f2f8c1a] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[2e3e5b1f2b3c] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[9f7c4c3ea9a1] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[3c1b2a4d5e6f] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[8f3f1f0a1b2c] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[1a2b3c4d5e6a] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[c4f8e2a1b6d9] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[84f1d3b2c6e7] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[d1f0e9c2b7aa] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[2d8a1f7c9b41] PASSED       [ 40%]
+tests/test_native_dependencies.py::test_cryptography_fernet_and_scrypt_runtime PASSED [ 40%]
+tests/test_native_dependencies.py::test_pysequoia_cert_parse_and_encrypt_runtime PASSED [ 40%]
+tests/test_native_dependencies.py::test_psycopg_connects_and_executes_query PASSED [ 40%]
+tests/test_native_dependencies.py::test_greenlet_switch_runtime PASSED   [ 41%]
+tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 41%]
+tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 41%]
+tests/test_newsroom_directory_listing.py::test_get_newsroom_directory_listing_matches_slug_case_insensitively PASSED [ 41%]
+tests/test_newsroom_directory_listing.py::test_build_newsroom_listing_exposes_geography_properties PASSED [ 41%]
+tests/test_newsroom_directory_listing.py::test_newsroom_seed_path_points_to_committed_dataset PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_non_retryable_http_error_immediately PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_reraises_last_error_from_post_loop_fallback PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_fallback_error_when_no_attempts_run PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_should_retry_request_error_returns_false_for_non_retryable_errors PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_normalize_string_list_handles_split_deduping_and_invalid_inputs PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_normalize_http_url_validates_required_and_optional_fields PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_normalize_http_url_covers_optional_and_required_error_edges PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_normalize_country_subdivision_and_listing_slug_handle_blank_and_fallback_values PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_extract_organization_urls_filters_duplicates_and_non_listing_links PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_extract_european_network_urls_filters_duplicates_and_non_listing_links PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_extract_source_browse_page_urls_for_european_networks_follows_public_pages PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_text_and_core_detail_extractors_skip_incomplete_nodes_and_plain_text_lists PASSED [ 41%]
+tests/test_newsroom_directory_refresh.py::test_parse_location_handles_blank_city_country_and_single_part_inputs PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_parse_location_normalizes_united_states_and_state_abbreviations PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_normalizes_baseline_fields PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_parse_newsroom_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_european_network_helper_extractors_cover_missing_sections_and_mixed_children PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_normalized_row_shapes PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row0-Missing required newsroom id] PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row1-Missing required newsroom slug] PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row2-Missing required newsroom name] PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_non_string_and_duplicate_slugs PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_rejects_duplicate_ids_and_slugs PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_is_deterministic_and_schema_compatible PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_seen_browse_and_detail_urls PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_raises_when_no_listings_are_discovered PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_wraps_detail_request_failures PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_browse_urls_seen_after_queueing PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_uses_public_explore_urls_only PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_discovers_european_networks_across_public_browse_pages PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_wraps_request_errors PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_retries_transient_gateway_timeout PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_render_newsroom_refresh_summary_includes_counts PASSED [ 43%]
+tests/test_notifications.py::test_notifications_disabled PASSED          [ 43%]
+tests/test_notifications.py::test_notifications_enabled_no_content PASSED [ 43%]
+tests/test_notifications.py::test_notifications_enabled_no_content_delivers_to_all_enabled_recipients PASSED [ 43%]
+tests/test_notifications.py::test_message_submission_deduplicates_notification_recipient_email_addresses PASSED [ 43%]
+tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body PASSED [ 43%]
+tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body_delivers_to_all_enabled_recipients PASSED [ 43%]
+tests/test_notifications.py::test_notifications_multi_recipient_missing_field_ciphertext_uses_generic_body PASSED [ 43%]
+tests/test_notifications.py::test_notifications_multi_recipient_non_object_field_ciphertext_payload_uses_generic_body PASSED [ 43%]
+tests/test_notifications.py::test_notifications_multi_recipient_uses_recipient_specific_field_ciphertext PASSED [ 43%]
+tests/test_notifications.py::test_notifications_enabled_yes_content_yes_encrypted_body PASSED [ 43%]
+tests/test_notifications.py::test_notifications_full_body_encryption_embedded_markers_use_server_fallback PASSED [ 43%]
+tests/test_notifications.py::test_notifications_full_body_encryption_uses_client_body_for_all_enabled_recipients PASSED [ 43%]
+tests/test_notifications.py::test_notifications_full_body_multi_recipient_does_not_wrap_encrypted_fields PASSED [ 43%]
+tests/test_notifications.py::test_notifications_full_body_encryption_server_fallback PASSED [ 43%]
+tests/test_notifications.py::test_notifications_full_body_encryption_fallback_uses_all_enabled_recipient_keys PASSED [ 43%]
+tests/test_onboarding.py::test_onboarding_flow PASSED                    [ 44%]
+tests/test_onboarding.py::test_onboarding_directory_opt_out_persists_false PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_directory_opt_out_overrides_prepopulated_true PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_skip PASSED                    [ 44%]
+tests/test_onboarding.py::test_onboarding_proton_search_prefills_manual_key PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[display_name] PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[bio] PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[pgp_key] PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[enable_email_notifications] PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_include_message_content] PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_encrypt_entire_body] PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email] PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[show_in_directory] PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_redirects_to_inbox_when_already_complete PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_allows_non_profile_step_when_already_complete PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_handles_missing_primary_username PASSED [ 44%]
+tests/test_onboarding.py::test_submitted_onboarding_form_selects_expected_step_form PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_encryption_unknown_method_returns_bad_request PASSED [ 44%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_key_shows_error PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_proton_fetch_failure_shows_error PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_notifications_requires_pgp_key PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_missing_user_redirects_login PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_invalid_step_defaults_to_profile PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_post_invalid_step_defaults_to_profile PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_profile_invalid_form_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_profile_invalid_form_preserves_submitted_values PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_preserves_submitted_email PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_proton_key_without_encryption_subkey_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_proton_no_key_found_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_proton_non_200_response_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_missing_key_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_whitespace_key_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_form_returns_400_with_csrf PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_non_encryptable_key_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_notifications_invalid_form_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_profile_requires_csrf_token PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_notifications_requires_csrf_token PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_directory_invalid_form_returns_400_with_csrf PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_unknown_step_post_returns_400 PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_directory_redirects_to_select_tier_when_stripe_enabled PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_skip_missing_user_redirects_login PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_skip_invalid_form_redirects_onboarding_with_csrf PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_skip_redirects_to_select_tier_when_enabled PASSED [ 46%]
+tests/test_onboarding.py::test_webpack_build_includes_onboarding_bundle PASSED [ 46%]
+tests/test_password_hasher.py::test_verify_password_uses_legacy_passlib_scrypt_fixture_and_logs_success PASSED [ 46%]
+tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_legacy_passlib_scrypt_fixture PASSED [ 46%]
+tests/test_password_hasher.py::test_legacy_passlib_scrypt_fixture_documents_prefix_and_cost_baseline PASSED [ 46%]
+tests/test_password_hasher.py::test_verify_password_uses_native_werkzeug_scrypt_hash_and_logs_success PASSED [ 46%]
+tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_native_werkzeug_scrypt_hash PASSED [ 46%]
+tests/test_password_hasher.py::test_verify_password_routes_non_scrypt_native_prefixes_to_primary_verifier PASSED [ 46%]
+tests/test_password_hasher.py::test_verify_primary_password_hash_rejects_non_scrypt_native_prefix PASSED [ 46%]
+tests/test_password_hasher.py::test_verify_password_unknown_prefix_fails_closed_without_mutating_user PASSED [ 46%]
+tests/test_password_hasher.py::test_verify_password_malformed_legacy_hash_fails_closed PASSED [ 46%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_without_app_context PASSED [ 46%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_skips_non_legacy_hashes PASSED [ 47%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_when_disabled PASSED [ 47%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_rehashes_legacy_hash_when_enabled PASSED [ 47%]
+tests/test_password_hasher.py::test_get_password_hash_prefix_returns_unknown_for_plaintext_like_values PASSED [ 47%]
+tests/test_password_hasher.py::test_hash_password_logs_write_counter_without_sensitive_data PASSED [ 47%]
+tests/test_password_hasher.py::test_hash_password_uses_pinned_werkzeug_scrypt_method_when_enabled PASSED [ 47%]
+tests/test_password_hasher.py::test_pinned_werkzeug_scrypt_method_matches_legacy_passlib_cost_baseline PASSED [ 47%]
+tests/test_password_hasher.py::test_password_hash_telemetry_helpers_noop_without_app_context PASSED [ 47%]
+tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[True-password_hash_rehash_on_auth_success_total] PASSED [ 47%]
+tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[False-password_hash_rehash_on_auth_failure_total] PASSED [ 47%]
+tests/test_premium.py::test_create_products_and_prices PASSED            [ 47%]
+tests/test_premium.py::test_update_price_existing PASSED                 [ 47%]
+tests/test_premium.py::test_update_price_new PASSED                      [ 47%]
+tests/test_premium.py::test_create_customer PASSED                       [ 47%]
+tests/test_premium.py::test_create_customer_updates_existing_customer PASSED [ 47%]
+tests/test_premium.py::test_create_customer_recreates_when_modify_fails PASSED [ 47%]
+tests/test_premium.py::test_get_subscription PASSED                      [ 47%]
+tests/test_premium.py::test_get_business_price_string_formats PASSED     [ 47%]
+tests/test_premium.py::test_get_business_price_string_missing_tier PASSED [ 47%]
+tests/test_premium.py::test_create_products_and_prices_missing_business_tier PASSED [ 48%]
+tests/test_premium.py::test_update_price_without_product_id_logs_and_returns PASSED [ 48%]
+tests/test_premium.py::test_get_subscription_none_when_missing_subscription_id PASSED [ 48%]
+tests/test_premium.py::test_handle_subscription_created PASSED           [ 48%]
+tests/test_premium.py::test_handle_subscription_created_raises_for_missing_user PASSED [ 48%]
+tests/test_premium.py::test_handle_subscription_updated_upgrade PASSED   [ 48%]
+tests/test_premium.py::test_handle_subscription_updated_downgrade PASSED [ 48%]
+tests/test_premium.py::test_handle_subscription_updated_raises_for_missing_subscription PASSED [ 48%]
+tests/test_premium.py::test_handle_subscription_deleted PASSED           [ 48%]
+tests/test_premium.py::test_handle_subscription_deleted_raises_for_missing_subscription PASSED [ 48%]
+tests/test_premium.py::test_handle_invoice_created PASSED                [ 48%]
+tests/test_premium.py::test_handle_invoice_created_value_error_is_handled PASSED [ 48%]
+tests/test_premium.py::test_handle_invoice_updated PASSED                [ 48%]
+tests/test_premium.py::test_handle_invoice_updated_refreshes_receipt_url PASSED [ 48%]
+tests/test_premium.py::test_premium_index_links_receipts_through_authenticated_route PASSED [ 48%]
+tests/test_premium.py::test_receipt_route_refreshes_stale_url_before_redirect PASSED [ 48%]
+tests/test_premium.py::test_receipt_url_from_invoice_prefers_pdf_when_hosted_url_missing PASSED [ 48%]
+tests/test_premium.py::test_receipt_url_from_invoice_returns_none_without_hosted_url_or_pdf PASSED [ 48%]
+tests/test_premium.py::test_receipt_route_redirects_to_stale_url_when_stripe_refresh_fails PASSED [ 49%]
+tests/test_premium.py::test_receipt_route_flashes_when_no_receipt_url_available PASSED [ 49%]
+tests/test_premium.py::test_receipt_route_redirects_to_login_when_user_missing_inside_route PASSED [ 49%]
+tests/test_premium.py::test_receipt_route_returns_404_for_missing_invoice PASSED [ 49%]
+tests/test_premium.py::test_handle_invoice_updated_raises_for_missing_invoice PASSED [ 49%]
+tests/test_premium.py::test_upgrade_post_user_already_on_business_tier PASSED [ 49%]
+tests/test_premium.py::test_upgrade_process PASSED                       [ 49%]
+tests/test_premium.py::test_upgrade_process_uses_public_base_url_for_success_url PASSED [ 49%]
+tests/test_premium.py::test_update_payment_method_creates_billing_portal_session PASSED [ 49%]
+tests/test_premium.py::test_update_payment_method_requires_active_subscription PASSED [ 49%]
+tests/test_premium.py::test_update_payment_method_stripe_error PASSED    [ 49%]
+tests/test_premium.py::test_update_payment_method_aborts_when_portal_session_has_no_url PASSED [ 49%]
+tests/test_premium.py::test_disable_autorenew_no_user_in_session PASSED  [ 49%]
+tests/test_premium.py::test_disable_autorenew_no_subscription PASSED     [ 49%]
+tests/test_premium.py::test_disable_autorenew_success PASSED             [ 49%]
+tests/test_premium.py::test_disable_autorenew_stripe_error PASSED        [ 49%]
+tests/test_premium.py::test_enable_autorenew_no_user_in_session PASSED   [ 49%]
+tests/test_premium.py::test_enable_autorenew_no_subscription PASSED      [ 49%]
+tests/test_premium.py::test_enable_autorenew_success PASSED              [ 50%]
+tests/test_premium.py::test_enable_autorenew_stripe_error PASSED         [ 50%]
+tests/test_premium.py::test_cancel_no_user_in_session PASSED             [ 50%]
+tests/test_premium.py::test_cancel_no_subscription PASSED                [ 50%]
+tests/test_premium.py::test_cancel_success PASSED                        [ 50%]
+tests/test_premium.py::test_cancel_stripe_error PASSED                   [ 50%]
+tests/test_premium.py::test_premium_select_tier_redirects_when_onboarding_incomplete PASSED [ 50%]
+tests/test_premium.py::test_premium_select_free_sets_free_tier_when_unset PASSED [ 50%]
+tests/test_premium.py::test_premium_status_business_user_flashes_success PASSED [ 50%]
+tests/test_premium.py::test_premium_index_warns_on_incomplete_subscription PASSED [ 50%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.index-get] PASSED [ 50%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_tier-get] PASSED [ 50%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_free-post] PASSED [ 50%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.upgrade-post] PASSED [ 50%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.update_payment_method-post] PASSED [ 50%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.disable_autorenew-post] PASSED [ 50%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.enable_autorenew-post] PASSED [ 50%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.cancel-post] PASSED [ 50%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.status-get] PASSED [ 50%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.index-get] PASSED [ 51%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_tier-get] PASSED [ 51%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_free-post] PASSED [ 51%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.upgrade-post] PASSED [ 51%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.update_payment_method-post] PASSED [ 51%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.disable_autorenew-post] PASSED [ 51%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.enable_autorenew-post] PASSED [ 51%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.cancel-post] PASSED [ 51%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.status-get] PASSED [ 51%]
+tests/test_premium.py::test_premium_select_tier_renders_for_complete_user PASSED [ 51%]
+tests/test_premium.py::test_premium_waiting_page_renders PASSED          [ 51%]
+tests/test_premium.py::test_upgrade_missing_business_tier PASSED         [ 51%]
+tests/test_premium.py::test_upgrade_missing_business_price_id PASSED     [ 51%]
+tests/test_premium.py::test_upgrade_create_customer_failure PASSED       [ 51%]
+tests/test_premium.py::test_upgrade_checkout_creation_failure PASSED     [ 51%]
+tests/test_premium.py::test_upgrade_checkout_session_without_url_returns_500 PASSED [ 51%]
+tests/test_premium.py::test_premium_webhook_rejects_invalid_payload PASSED [ 51%]
+tests/test_premium.py::test_premium_webhook_rejects_invalid_signature PASSED [ 51%]
+tests/test_premium.py::test_premium_webhook_ignores_duplicate_event PASSED [ 52%]
+tests/test_premium.py::test_premium_webhook_stores_new_event PASSED      [ 52%]
+tests/test_premium.py::test_worker_processes_subscription_created_event PASSED [ 52%]
+tests/test_premium.py::test_worker_marks_event_error_when_handler_raises PASSED [ 52%]
+tests/test_premium.py::test_worker_waits_for_tables_before_starting PASSED [ 52%]
+tests/test_premium.py::test_worker_processes_subscription_updated_and_deleted_events PASSED [ 52%]
+tests/test_premium.py::test_worker_processes_invoice_created_event PASSED [ 52%]
+tests/test_premium.py::test_worker_processes_invoice_payment_succeeded_event PASSED [ 52%]
+tests/test_profile.py::test_profile_header PASSED                        [ 52%]
+tests/test_profile.py::test_profile_accepts_case_insensitive_username PASSED [ 52%]
+tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_non_admin_display_name PASSED [ 52%]
+tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_username_when_display_name_missing PASSED [ 52%]
+tests/test_profile.py::test_profile_404_for_unknown_username PASSED      [ 52%]
+tests/test_profile.py::test_profile_404s_when_case_insensitive_lookup_is_ambiguous PASSED [ 52%]
+tests/test_profile.py::test_profile_does_not_expose_owner_user_id PASSED [ 52%]
+tests/test_profile.py::test_profile_submit_message PASSED                [ 52%]
+tests/test_profile.py::test_profile_submit_message_to_alias PASSED       [ 52%]
+tests/test_profile.py::test_profile_failed_submit_preserves_input PASSED [ 52%]
+tests/test_profile.py::test_profile_rejects_owner_guard_mismatch PASSED  [ 52%]
+tests/test_profile.py::test_embed_profile_rejects_non_numeric_captcha PASSED [ 53%]
+tests/test_profile.py::test_embed_profile_rejects_expired_captcha_token PASSED [ 53%]
+tests/test_profile.py::test_embed_profile_rejects_bad_captcha_token PASSED [ 53%]
+tests/test_profile.py::test_embed_profile_rejects_captcha_token_for_different_profile PASSED [ 53%]
+tests/test_profile.py::test_embed_profile_post_404s_if_account_is_suspended_after_render PASSED [ 53%]
+tests/test_profile.py::test_embed_profile_rejects_if_account_is_suspended_during_submission PASSED [ 53%]
+tests/test_profile.py::test_embed_profile_rejects_if_recipient_keys_are_removed_during_submission PASSED [ 53%]
+tests/test_profile.py::test_profile_pgp_required PASSED                  [ 53%]
+tests/test_profile.py::test_profile_allows_submission_with_recipient_key_when_legacy_user_key_missing PASSED [ 53%]
+tests/test_profile.py::test_profile_allows_submission_with_legacy_key_when_primary_recipient_lacks_key PASSED [ 53%]
+tests/test_profile.py::test_profile_submit_message_with_recipient_key_when_legacy_user_key_missing PASSED [ 53%]
+tests/test_profile.py::test_profile_submit_message_ignores_enabled_recipient_without_key PASSED [ 53%]
+tests/test_profile.py::test_profile_suspended_state_disables_message_form_with_pgp_key PASSED [ 53%]
+tests/test_profile.py::test_profile_post_rejects_when_target_has_no_pgp_key PASSED [ 53%]
+tests/test_profile.py::test_profile_post_rejects_when_target_is_suspended PASSED [ 53%]
+tests/test_profile.py::test_profile_post_rejects_alias_when_owner_is_suspended PASSED [ 53%]
+tests/test_profile.py::test_profile_post_form_validation_errors_are_rendered PASSED [ 53%]
+tests/test_profile.py::test_profile_requires_csrf_token PASSED           [ 53%]
+tests/test_profile.py::test_profile_full_body_encryption_fallback_to_generic_when_no_fields PASSED [ 54%]
+tests/test_profile.py::test_profile_full_body_encryption_exception_falls_back_to_generic PASSED [ 54%]
+tests/test_profile.py::test_profile_full_body_encryption_uses_server_fallback_when_client_body_missing PASSED [ 54%]
+tests/test_profile.py::test_profile_notification_without_message_content_sends_generic_body PASSED [ 54%]
+tests/test_profile.py::test_profile_single_recipient_notification_can_include_stored_message_content PASSED [ 54%]
+tests/test_profile.py::test_profile_extra_fields PASSED                  [ 54%]
+tests/test_profile.py::test_profile_field_encryption_labels PASSED       [ 54%]
+tests/test_profile.py::test_profile_account_category_renders_first_extra_field PASSED [ 54%]
+tests/test_profile.py::test_profile_location_renders_as_single_extra_field PASSED [ 54%]
+tests/test_profile.py::test_profile_location_keeps_full_names_outside_us PASSED [ 54%]
+tests/test_profile.py::test_redirect_submit_message_route PASSED         [ 54%]
+tests/test_profile.py::test_submission_success_without_reply_slug_redirects_directory PASSED [ 54%]
+tests/test_profile.py::test_submission_success_404_when_message_missing PASSED [ 54%]
+tests/test_profile.py::test_submission_success_uses_public_base_url_for_reply_link PASSED [ 54%]
+tests/test_public_directory_snapshot_report.py::test_build_snapshot_filters_to_public_hushline_users PASSED [ 54%]
+tests/test_public_directory_snapshot_report.py::test_build_markdown_report_reports_added_and_removed_usernames PASSED [ 54%]
+tests/test_public_directory_snapshot_report.py::test_build_readme_report_renders_natural_language_and_history_table PASSED [ 54%]
+tests/test_public_directory_snapshot_report.py::test_resolve_history_baselines_uses_latest_sync_and_week_old_snapshot PASSED [ 54%]
+tests/test_public_directory_snapshot_report.py::test_load_summary_history_includes_current_summary_and_sorts_descending PASSED [ 54%]
+tests/test_public_record_refresh.py::test_default_us_region_state_map_includes_all_50_states PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_is_deterministic_and_schema_compatible PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_preserves_existing_identifiers PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_duplicate_id_or_slug PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_enforces_region_targets PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_above_region_targets PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_flags_and_drops_link_failures PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_on_transient_link_failures PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_legacy_self_reported_source_label PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_source_matching_website PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_missing_us_source_url PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_cross_state_source_policy PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_generic_us_source_url PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_ohio_record_fragment_source_url PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_ohio_generic_home_fragment_source_url PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_synthetic_listing_marker PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_search_source_url PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_source_url PASSED [ 55%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_non_chambers_hosts_with_chambers_substrings PASSED [ 56%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_retries_then_succeeds PASSED [ 56%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_marks_404_as_definitive_failure PASSED [ 56%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_rejects_invalid_arguments PASSED [ 56%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_server_error_after_retries PASSED [ 56%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_request_exception_reason PASSED [ 56%]
+tests/test_public_record_refresh.py::test_render_refresh_summary_includes_dropped_ids_and_link_failures PASSED [ 56%]
+tests/test_public_record_refresh.py::test_parse_chambers_index_entries_skips_invalid_rows_and_sorts PASSED [ 56%]
+tests/test_public_record_refresh.py::test_fetch_json_payload_handles_non_200_and_successful_json PASSED [ 56%]
+tests/test_public_record_refresh.py::test_discovered_description_handles_tag_list_shapes PASSED [ 56%]
+tests/test_public_record_refresh.py::test_validate_regions_rejects_unknown_region PASSED [ 56%]
+tests/test_public_record_refresh.py::test_chambers_public_profile_url_helpers_cover_supported_and_invalid_inputs PASSED [ 56%]
+tests/test_public_record_refresh.py::test_apply_region_targets_handles_none_and_invalid_target_configurations PASSED [ 56%]
+tests/test_public_record_refresh.py::test_normalization_helpers_validate_and_filter_values PASSED [ 56%]
+tests/test_public_record_refresh.py::test_discover_seed_rows_respects_zero_limit_and_maximum PASSED [ 56%]
+tests/test_public_record_refresh.py::test_discover_noop_official_public_record_rows_returns_empty_list PASSED [ 56%]
+tests/test_public_record_refresh.py::test_parse_chambers_index_entries_returns_empty_for_non_list_payload PASSED [ 56%]
+tests/test_public_record_refresh.py::test_fetch_json_payload_handles_exceptions_and_invalid_json PASSED [ 56%]
+tests/test_public_record_refresh.py::test_chambers_discovery_helpers_cover_locations_tags_and_url_normalization PASSED [ 56%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_validates_arguments_and_missing_adapters PASSED [ 57%]
+tests/test_public_record_refresh.py::test_authoritative_source_and_url_helper_branches PASSED [ 57%]
+tests/test_public_record_refresh.py::test_validate_links_skips_empty_fields_and_region_lookup_requires_mapping PASSED [ 57%]
+tests/test_public_record_refresh.py::test_discover_chambers_public_record_rows_is_disabled PASSED [ 57%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_strict_accepts_full_coverage PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_covers_current_implemented_states PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AK] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AL] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AR] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AZ] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CA] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CO] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CT] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[DE] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[FL] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[GA] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[HI] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IA] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ID] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IL] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IN] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KS] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KY] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[LA] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MA] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MD] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ME] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MI] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MN] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MO] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MS] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MT] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NC] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ND] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NE] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NH] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NJ] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NM] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NV] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NY] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OH] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OK] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OR] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[PA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[RI] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SC] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SD] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TN] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TX] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[UT] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VT] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WI] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WV] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WY] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AK] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AL] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AR] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AZ] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CA] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CO] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CT] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-DE] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-FL] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-GA] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-HI] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IA] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ID] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IL] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IN] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KS] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KY] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-LA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MD] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ME] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MI] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MN] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MO] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MS] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MT] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NC] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ND] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NE] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NH] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NJ] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NM] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NV] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NY] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OH] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OK] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OR] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-PA] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-RI] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SC] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SD] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TN] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TX] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-UT] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VA] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VT] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WA] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WI] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WV] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WY] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AK] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AL] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AR] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AZ] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CO] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CT] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-DE] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-FL] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-GA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-HI] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ID] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IL] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IN] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KS] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KY] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-LA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MD] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ME] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MI] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MN] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MO] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MS] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MT] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NC] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ND] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NE] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NH] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NJ] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NM] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NV] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NY] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OH] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OK] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OR] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-PA] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-RI] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SC] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SD] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TN] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TX] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-UT] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VA] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VT] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WA] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WI] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WV] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WY] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AK] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AL] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AR] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AZ] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CA] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CO] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CT] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-DE] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-FL] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-GA] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-HI] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IA] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ID] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IL] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IN] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KS] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KY] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-LA] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MA] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MD] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ME] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MI] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MN] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MO] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MS] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MT] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NC] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ND] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NE] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NH] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NJ] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NM] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NV] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NY] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OH] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OK] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OR] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-PA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-RI] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SC] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SD] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-TN] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-TX] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-UT] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-VA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-VT] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WA] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WI] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WV] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WY] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_california_seeds PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen-Alaska Bar Association public directory-https://member.alaskabar.org/cv5/cgi-bin/memberdll.dll/Info?CUSTOMERCD=8744&WRP=Customer_Profile.htm] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers-Alabama State Bar public directory-https://members.alabar.org/Member_Portal/Member_Portal/Sections/AP.aspx] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik-Arkansas Bar Association public directory-https://www.arkbar.com/?pg=board-of-trustees] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali-State Bar of Arizona public directory-https://www.azbar.org/for-legal-professionals/practice-tools-management/member-directory/?m=Anthony-Cali-177781] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock-Colorado Bar Association public directory-https://community.cobar.org/profile/contributions/contributions-achievements?UserKey=330f70ad-afc9-44f0-b8b1-6b55108bc275] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown-Connecticut Bar Association public directory-https://members.ctbar.org/member/thelaborlawyer] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott-Delaware Courts published opinion-https://courts.delaware.gov/Opinions/Download.aspx?id=342050] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.-The Florida Bar public directory-https://www.floridabar.org/directories/find-mbr/profile/?num=123000] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton-State Bar of Georgia speaker profile-https://icle.gabar.org/speaker/todd-stanton-1261014] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz-Hawaii State Bar Association attorney recognition record-https://hsba.org/HSBA_2020/About_Us/Living_Legend_Lawyers_.aspx] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin-Iowa State Bar Association jury verdict record-https://services.iowabar.org/IB/JuryVerdicts.nsf/b96238336212630c85258ca1000240fd/e71fe5f6f6d3242d872589900011edc5!OpenDocument] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser-Idaho State Bar attorney profile-https://isb.idaho.gov/blog/trudy-hanson-fouser/] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler-Indiana State Bar public directory-https://www.inbar.org/members/?id=30400364] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady-Kansas Judicial Branch published opinion-https://kscourts.gov/Cases-Decisions/Decisions/Published/Brown-v-Ford-Storage-and-Moving-Co-Inc] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks-Kentucky Bar Association public directory-https://www.kybar.org/members/?id=42347567] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer-Louisiana Attorney Disciplinary Board attorney records-https://www.ladb.org/DR/Document.cfm?docket=24-DB-014] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey-Massachusetts BBO attorney records-https://bbopublic.massbbo.org/web/f/SJC_WellBeing_Cmte_Report.pdf] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker-Maryland Courts attorney discipline records-https://www.courts.state.md.us/attygrievance/sanctions07] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher-Maine Board of Overseers of the Bar public directory-https://mebarconnect.mainebar.org/people/daniel-eccher] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese-State Bar of Michigan public directory-https://connect.michbar.org/laborlaw[redacted-path] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman-Minnesota Courts attorney records-https://mncourts.gov/help-topics/Legal-Paraprofessional-Program/standing-committee] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips-The Missouri Bar public directory-https://news.mobar.org/jerina-d-phillips-receives-2025-diversity-champion-award/] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MS-seed-joel-frank-dillard-public-record~joel-frank-dillard-Joel Frank Dillard-The Mississippi Bar public directory-https://www.msbar.org/inside-the-bar/sections/labor-employment-law/] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm-State Bar of Montana public directory-https://www.montanabar.org/About-Us/Sections-and-Committees] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams-North Carolina State Bar public directory-https://www.ncbar.gov/for-lawyers/directories/leadership/state-bar-officers/] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson-North Dakota Court System attorney directory-https://www.ndcourts.gov/lawyers/06402] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau-Nebraska Judicial Branch case record-https://supremecourt.nebraska.gov/courts/supreme-court/supreme-court-call/city-omaha-v-professional-firefighters-association-omaha] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns-New Hampshire Bar Association CLE speaker profile-https://member.nhbar.org/calendar/event/34th-annual-labor-and-employment-law-update] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins-NJ Courts attorney certification records-https://www.njcourts.gov/notices/order-board-attorney-certification-new-chair-and-vice-chair-designations-certification] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy-State Bar of New Mexico public directory-https://www.sbnm.org/cvweb/cgi-bin/Utilities.dll?View=INMEMBERDETAILS&RECORDNO=1&CUSTOMERNO=11321] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck-State Bar of Nevada public directory-https://nvbar.org/for-lawyers/bar-service-opportunities/join-a-section/labor-and-employment-law-section/] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone-New York Courts attorney directory-https://decisions.courts.state.ny.us/ad3/Decisions/2023/CV-22-1940.pdf] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough-Oklahoma Bar Association public directory-https://ams.okbar.org/eweb/DynamicPage.aspx?Action=Add&DoNotSave=yes&ObjectKeyFrom=1A83491A-9853-4C87-86A4-F7D95601C2E2&ParentDataObject=Invoice+Detail&ParentObject=CentralizedOrderEntry&WebCode=ProdDetailAdd&ivd_cst_key=00000000-0000-0000-0000-000000000000&ivd_cst_ship_key=00000000-0000-0000-0000-000000000000&ivd_formkey=69202792-63d7-4ba2-bf4e-a0da41270555&ivd_prc_prd_key=F5FDCC21-BBDF-4D41-944F-5351AD775A80] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland-Oregon State Bar public directory-https://www.osbar.org/sections/labor.html] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson-Pennsylvania Disciplinary Board attorney directory-https://www.padisciplinaryboard.org/for-the-public/find-attorney/attorney-detail/85957] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof-Rhode Island Judiciary attorney records-https://www.courts.ri.gov/attorney-resources/Pages/Board-of-Bar-Examiners-default.aspx] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe-South Carolina Bar public directory-https://www.scbar.org/for-lawyers/networking/sections/employment-and-labor-law-section/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger-State Bar of South Dakota public directory-https://www.statebarofsouthdakota.com/project-rural-practice/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez-State Bar of Texas public directory-https://www.texasbar.com/AM/Template.cfm?ContactID=157597&template=%2FCustomsource%2FMemberDirectory%2FMemberDirectoryDetail.cfm] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen-Utah Courts public legal directory-https://www.utcourts.gov/en/about/administration/committees/ethics-advisory-committee.html] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt-Virginia State Bar public directory-https://virginialawyer.vsb.org/articles/professional-notices?article_id=5100257&i=859839] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VT-seed-jeremy-s-grant-public-record~jeremy-s-grant-Jeremy S. Grant-Vermont Bar Association public directory-https://www.vtbar.org/2025-annual-meeting-in-review/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus-State Bar of Wisconsin public directory-https://www.wisbar.org/NewsPublications/WisconsinLawyer/WisconsinLawyerPDFs/97/01/20_24.pdf] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess-West Virginia State Bar public directory-https://wvbar.org/wp-content/uploads/2024/04/24-25-Active-List-UPDATED.pdf] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke-Wyoming State Bar public directory-https://www.wyomingbar.org/about-us/bar-leadership/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MS-seed-joel-frank-dillard-public-record~joel-frank-dillard-Joel Frank Dillard] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[VT-seed-jeremy-s-grant-public-record~jeremy-s-grant-Jeremy S. Grant] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_washington_seed PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_washington_seed PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_ohio_seed PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_ohio_seed PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_tennessee_seeds PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_tennessee_seeds PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_illinois_seeds PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_illinois_seeds PASSED [ 73%]
+tests/test_public_record_refresh_workflow.py::test_public_record_quarterly_refresh_workflow_uses_correction_pr_flow PASSED [ 73%]
+tests/test_public_record_refresh_workflow.py::test_refresh_public_record_corrections_make_target_matches_workflow_semantics PASSED [ 73%]
+tests/test_public_record_refresh_workflow.py::test_refresh_report_matches_structured_values PASSED [ 73%]
+tests/test_public_record_refresh_workflow.py::test_sync_provenance_roadmap_updates_baseline_and_adapter_count PASSED [ 73%]
+tests/test_public_record_refresh_workflow.py::test_sync_provenance_roadmap_preserves_eu_planning_section PASSED [ 73%]
+tests/test_public_record_refresh_workflow.py::test_public_record_provenance_roadmap_documents_eu_phase_0b_policy PASSED [ 73%]
+tests/test_public_record_refresh_workflow.py::test_public_record_provenance_roadmap_documents_eu_phase_0c_feasibility PASSED [ 73%]
+tests/test_public_record_refresh_workflow.py::test_public_record_provenance_roadmap_documents_eu_phase_0d_shared_requirements PASSED [ 73%]
+tests/test_public_record_refresh_workflow.py::test_public_record_provenance_roadmap_documents_eu_phase_0e_rollout_backlog PASSED [ 74%]
+tests/test_refresh_newsroom_directory_listings_script.py::test_serialize_rows_is_deterministic_without_node_tooling PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_registration_disabled PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_registration_disabled_first_user PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_registration_with_invite_code_disabled PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_registration_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_registration_with_invite_code_enabled PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_registration_rejects_case_insensitive_duplicate PASSED [ 74%]
+tests/test_registration_and_login.py::test_username_db_constraint_rejects_case_insensitive_duplicate PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_registration_handles_case_insensitive_race_integrity_error PASSED [ 74%]
+tests/test_registration_and_login.py::test_register_page_loads PASSED    [ 74%]
+tests/test_registration_and_login.py::test_register_requires_csrf_token PASSED [ 74%]
+tests/test_registration_and_login.py::test_login_page_loads PASSED       [ 74%]
+tests/test_registration_and_login.py::test_login_invalid_post_shows_errors_and_preserves_username PASSED [ 74%]
+tests/test_registration_and_login.py::test_login_requires_csrf_token PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_login_after_registration PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_login_case_insensitive PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_login_with_incorrect_password PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_login_with_native_werkzeug_scrypt_hash PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_login_rehashes_legacy_passlib_hash_when_enabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_login_does_not_rehash_legacy_passlib_hash_when_disabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_login_rehash_failure_preserves_legacy_passlib_hash PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_login_handles_case_insensitive_duplicate_rows PASSED [ 75%]
+tests/test_replies.py::test_message_reply_404_for_unknown_slug PASSED    [ 75%]
+tests/test_replies.py::test_default_replies PASSED                       [ 75%]
+tests/test_replies.py::test_custom_replies PASSED                        [ 75%]
+tests/test_replies.py::test_set_custom_replies PASSED                    [ 75%]
+tests/test_replies.py::test_settings_replies_prefills_default_status_text PASSED [ 75%]
+tests/test_replies.py::test_settings_replies_prefills_custom_status_text_when_present PASSED [ 75%]
+tests/test_replies.py::test_set_custom_replies_redirects_back_with_success_flash PASSED [ 75%]
+tests/test_replies.py::test_set_default_replies_keeps_builtin_default_without_persisting_override PASSED [ 75%]
+tests/test_replies.py::test_message_page PASSED                          [ 75%]
+tests/test_replies.py::test_message_page_wrong_user PASSED               [ 75%]
+tests/test_replies.py::test_set_message_status_success PASSED            [ 75%]
+tests/test_replies.py::test_set_message_status_invalid_form PASSED       [ 75%]
+tests/test_replies.py::test_set_message_status_message_not_found PASSED  [ 75%]
+tests/test_replies.py::test_set_message_status_multiple_rows_guard PASSED [ 75%]
+tests/test_replies.py::test_settings_replies_invalid_form_returns_400 PASSED [ 76%]
+tests/test_replies.py::test_settings_replies_invalid_status_renders_field_error_and_does_not_persist PASSED [ 76%]
+tests/test_replies.py::test_settings_replies_missing_csrf_renders_error_on_submitted_form PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_sends_per_field PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_sends_per_field_to_all_enabled_recipients PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_blocks_other_users_messages PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_requires_email_notifications PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_requires_csrf_token PASSED [ 76%]
+tests/test_resend_message.py::test_resend_button_visible_with_required_settings PASSED [ 76%]
+tests/test_resend_message.py::test_resend_button_hidden_without_notifications_or_content PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_full_body_uses_existing_armored_value_without_reencryption PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_full_body_reuses_armored_value_for_duplicate_shared_recipient_key PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_full_body_encrypts_value_with_embedded_pgp_header_substring PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value_for_all_enabled_recipients PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_full_body_encryption_failure_falls_back_to_generic PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_full_body_multi_recipient_armored_value_falls_back_to_generic PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_include_content_false_sends_generic PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_include_content_false_sends_generic_to_all_enabled_recipients PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_include_content_true_with_empty_values_sends_generic PASSED [ 77%]
+tests/test_routes_auth.py::test_register_redirects_when_already_logged_in PASSED [ 77%]
+tests/test_routes_auth.py::test_register_rejects_incorrect_captcha PASSED [ 77%]
+tests/test_routes_auth.py::test_register_rejects_invalid_invite_code PASSED [ 77%]
+tests/test_routes_auth.py::test_register_rejects_expired_invite_code PASSED [ 77%]
+tests/test_routes_auth.py::test_register_requires_invite_code_by_default_for_first_user PASSED [ 77%]
+tests/test_routes_auth.py::test_register_valid_invite_code_deletes_code PASSED [ 77%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_invalid_session_state PASSED [ 77%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_non_legacy_source_hash PASSED [ 77%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_mismatched_source_digest PASSED [ 77%]
+tests/test_routes_auth.py::test_register_handles_unexpected_integrity_error PASSED [ 77%]
+tests/test_routes_auth.py::test_login_redirects_when_already_logged_in PASSED [ 77%]
+tests/test_routes_auth.py::test_login_redirects_to_select_tier_when_premium_enabled PASSED [ 77%]
+tests/test_routes_auth.py::test_login_redirects_to_original_protected_page PASSED [ 77%]
+tests/test_routes_auth.py::test_password_reset_request_is_generic_and_sends_only_for_eligible_account PASSED [ 77%]
+tests/test_routes_auth.py::test_find_primary_username_returns_none_and_logs_when_query_is_ambiguous PASSED [ 77%]
+tests/test_routes_auth.py::test_password_reset_sets_new_password_and_consumes_token PASSED [ 77%]
+tests/test_routes_auth.py::test_password_reset_get_renders_form_for_active_token PASSED [ 77%]
+tests/test_routes_auth.py::test_password_reset_rejects_expired_and_unknown_tokens PASSED [ 78%]
+tests/test_routes_auth.py::test_password_reset_request_rate_limits_repeated_identifier PASSED [ 78%]
+tests/test_routes_auth.py::test_password_reset_request_rejects_incorrect_captcha PASSED [ 78%]
+tests/test_routes_auth.py::test_stash_post_auth_redirect_skips_logout_and_preserves_session PASSED [ 78%]
+tests/test_routes_auth.py::test_stash_post_auth_redirect_rejects_unsafe_target_and_preserves_session PASSED [ 78%]
+tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[None] PASSED [ 78%]
+tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[bind1] PASSED [ 78%]
+tests/test_routes_auth.py::test_register_rejects_when_first_user_recheck_finds_existing_user PASSED [ 78%]
+tests/test_routes_auth.py::test_login_clears_auth_session_when_2fa_commit_fails PASSED [ 78%]
+tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_login_and_clears_session_for_missing_user PASSED [ 78%]
+tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_inbox_when_already_authenticated PASSED [ 78%]
+tests/test_routes_auth.py::test_verify_2fa_login_rejects_when_user_has_no_totp_secret PASSED [ 78%]
+tests/test_routes_auth.py::test_verify_2fa_login_requires_csrf_token PASSED [ 78%]
+tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_onboarding PASSED [ 78%]
+tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_select_tier_when_enabled PASSED [ 78%]
+tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_original_protected_page PASSED [ 78%]
+tests/test_routes_auth.py::test_verify_2fa_login_failed_rehash_commit_clears_auth_session PASSED [ 78%]
+tests/test_routes_common.py::test_valid_username_validator PASSED        [ 78%]
+tests/test_routes_common.py::test_get_directory_usernames_sorts_admin_first_and_normalized PASSED [ 79%]
+tests/test_routes_common.py::test_validate_captcha PASSED                [ 79%]
+tests/test_routes_common.py::test_get_ip_address_success PASSED          [ 79%]
+tests/test_routes_common.py::test_get_ip_address_fallback PASSED         [ 79%]
+tests/test_routes_common.py::test_show_directory_caution_badge_honors_explicit_cautious_override PASSED [ 79%]
+tests/test_routes_common.py::test_do_send_email_returns_early_without_enabled_notifications PASSED [ 79%]
+tests/test_routes_common.py::test_do_send_email_uses_user_custom_smtp PASSED [ 79%]
+tests/test_routes_common.py::test_do_send_email_sends_to_each_enabled_recipient PASSED [ 79%]
+tests/test_routes_common.py::test_do_send_email_deduplicates_recipient_email_addresses PASSED [ 79%]
+tests/test_routes_common.py::test_do_send_email_retries_duplicate_address_after_false_result PASSED [ 79%]
+tests/test_routes_common.py::test_send_email_to_user_recipients_accepts_recipient_body_factory PASSED [ 79%]
+tests/test_routes_common.py::test_send_email_to_user_recipients_skips_empty_recipient_body PASSED [ 79%]
+tests/test_routes_common.py::test_notification_email_encryption_target_returns_all_enabled_keys PASSED [ 79%]
+tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_without_primary_row PASSED [ 79%]
+tests/test_routes_common.py::test_notification_email_encryption_target_falls_back_to_legacy_user_key PASSED [ 79%]
+tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_when_primary_row_lacks_key PASSED [ 79%]
+tests/test_routes_common.py::test_notification_email_encryption_target_uses_non_primary_recipient_without_legacy_key PASSED [ 79%]
+tests/test_routes_common.py::test_notification_email_encryption_target_ignores_enabled_recipient_without_key PASSED [ 79%]
+tests/test_routes_common.py::test_notification_email_encryption_target_collapses_duplicate_keys_to_single_key PASSED [ 79%]
+tests/test_routes_common.py::test_notification_email_encryption_target_deduplicates_repeated_keys_in_multi_key_mode PASSED [ 80%]
+tests/test_routes_common.py::test_notification_recipient_public_key_entries_skip_unsaved_recipients PASSED [ 80%]
+tests/test_routes_common.py::test_notification_recipient_encryption_target_uses_legacy_primary_key PASSED [ 80%]
+tests/test_routes_common.py::test_notification_recipient_encryption_target_uses_legacy_key_for_primary_row PASSED [ 80%]
+tests/test_routes_common.py::test_notification_recipient_encryption_target_returns_none_without_key PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_continues_after_single_recipient_failure PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_uses_default_smtp PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_uses_notifications_address_as_reply_to_fallback PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_skips_recipient_without_email PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_catches_errors PASSED    [ 80%]
+tests/test_routes_common.py::test_do_send_email_skips_when_default_smtp_incomplete PASSED [ 80%]
+tests/test_routes_common.py::test_formatters PASSED                      [ 80%]
+tests/test_routes_forms.py::test_login_password_max_matches_registration PASSED [ 80%]
+tests/test_routes_forms.py::test_login_username_max_matches_registration PASSED [ 80%]
+tests/test_routes_forms.py::test_dynamic_message_form_skips_disabled_fields_and_maps_names PASSED [ 80%]
+tests/test_routes_forms.py::test_dynamic_message_form_unknown_field_type_raises PASSED [ 80%]
+tests/test_routes_forms.py::test_dynamic_message_form_choice_fields_select_and_multicheckbox PASSED [ 80%]
+tests/test_routes_forms.py::test_onboarding_profile_form_rejects_disallowed_language PASSED [ 80%]
+tests/test_routes_init.py::test_info_route_renders_server_ip PASSED      [ 81%]
+tests/test_routes_init.py::test_health_json_route_returns_ok PASSED      [ 81%]
+tests/test_safe_template.py::test_empty PASSED                           [ 81%]
+tests/test_safe_template.py::test_no_vars PASSED                         [ 81%]
+tests/test_safe_template.py::test_missing_var PASSED                     [ 81%]
+tests/test_safe_template.py::test_invalid_var_syntax PASSED              [ 81%]
+tests/test_safe_template.py::test_unclosed_var PASSED                    [ 81%]
+tests/test_safe_template.py::test_unopened_var PASSED                    [ 81%]
+tests/test_safe_template.py::test_invalid_var_value PASSED               [ 81%]
+tests/test_safe_template.py::test_single_var PASSED                      [ 81%]
+tests/test_safe_template.py::test_multiple_vars PASSED                   [ 81%]
+tests/test_secure_session.py::TestSessionEnabled::test_get_set PASSED    [ 81%]
+tests/test_secure_session.py::TestSessionEnabled::test_key_only_session_access_sets_vary_cookie PASSED [ 81%]
+tests/test_secure_session.py::TestNoSessionEnabled::test_no_session PASSED [ 81%]
+tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_missing_seed_file PASSED [ 81%]
+tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_non_list_seed_json PASSED [ 81%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_is_deterministic_and_schema_compatible PASSED [ 81%]
+tests/test_securedrop_directory_refresh.py::test_normalize_string_list_filters_invalid_blank_and_duplicate_values PASSED [ 81%]
+tests/test_securedrop_directory_refresh.py::test_normalize_http_url_validates_required_and_optional_missing_values PASSED [ 81%]
+tests/test_securedrop_directory_refresh.py::test_choose_website_requires_a_usable_url PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_requires_onion_address PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_rejects_invalid_required_directory_url PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_sanitizes_optional_and_website_urls PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_rejects_empty_slug_after_normalization PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows1-Duplicate SecureDrop listing id: securedrop-one] PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows2-Normalized row slug must be a string] PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows3-Duplicate SecureDrop listing slug: securedrop~shared] PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_requests_expected_shape PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_list_payload PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_object_payload_items PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_render_securedrop_refresh_summary PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_summary_row_label_falls_back_to_name_id_or_unnamed_listing PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_append_summary_section_skips_empty_entries PASSED [ 82%]
+tests/test_security_headers.py::test_csp PASSED                          [ 82%]
+tests/test_security_headers.py::test_csp_script_src_elem_disallows_inline_scripts PASSED [ 82%]
+tests/test_security_headers.py::test_custom_splash_logo_keeps_csp_enforced PASSED [ 82%]
+tests/test_security_headers.py::test_native_pwa_startup_splash_keeps_csp_enforced PASSED [ 83%]
+tests/test_security_headers.py::test_profile_page_keeps_csp_enforced PASSED [ 83%]
+tests/test_security_headers.py::test_settings_profile_keeps_frame_restrictions PASSED [ 83%]
+tests/test_security_headers.py::test_embed_profile_uses_allowed_origin_frame_ancestors PASSED [ 83%]
+tests/test_security_headers.py::test_password_reset_pages_keep_csp_enforced PASSED [ 83%]
+tests/test_security_headers.py::test_base_template_uses_external_no_js_bootstrap_script PASSED [ 83%]
+tests/test_security_headers.py::test_x_frame_options PASSED              [ 83%]
+tests/test_security_headers.py::test_x_content_type_options PASSED       [ 83%]
+tests/test_security_headers.py::test_permissions_policy PASSED           [ 83%]
+tests/test_security_headers.py::test_referrer_policy PASSED              [ 83%]
+tests/test_security_headers.py::test_x_xss_protection PASSED             [ 83%]
+tests/test_security_headers.py::test_strict_transport_security PASSED    [ 83%]
+tests/test_security_headers.py::test_no_strict_transport_security_onion PASSED [ 83%]
+tests/test_settings.py::test_user_account_category_persists PASSED       [ 83%]
+tests/test_settings.py::test_user_location_persists PASSED               [ 83%]
+tests/test_settings.py::test_notification_recipient_shadow_persists_from_legacy_fields PASSED [ 83%]
+tests/test_settings.py::test_user_ensure_primary_notification_recipient_returns_existing_recipient PASSED [ 83%]
+tests/test_settings.py::test_settings_page_loads PASSED                  [ 83%]
+tests/test_settings.py::test_settings_profile_page_renders_updated_profile_copy PASSED [ 84%]
+tests/test_settings.py::test_change_display_name PASSED                  [ 84%]
+tests/test_settings.py::test_change_username PASSED                      [ 84%]
+tests/test_settings.py::test_change_username_rejects_case_insensitive_duplicate PASSED [ 84%]
+tests/test_settings.py::test_settings_auth_requires_csrf_token PASSED    [ 84%]
+tests/test_settings.py::test_invalid_username_post_shows_only_username_errors_and_no_password_side_effect PASSED [ 84%]
+tests/test_settings.py::test_invalid_password_post_shows_only_password_errors_and_preserves_password_hash PASSED [ 84%]
+tests/test_settings.py::test_username_post_does_not_trigger_password_form_validation PASSED [ 84%]
+tests/test_settings.py::test_password_post_does_not_trigger_username_form_validation PASSED [ 84%]
+tests/test_settings.py::test_change_password PASSED                      [ 84%]
+tests/test_settings.py::test_change_password_revokes_sibling_session PASSED [ 84%]
+tests/test_settings.py::test_change_password_from_native_werkzeug_scrypt_hash PASSED [ 84%]
+tests/test_settings.py::test_change_password_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 84%]
+tests/test_settings.py::test_add_pgp_key PASSED                          [ 84%]
+tests/test_settings.py::test_add_invalid_pgp_key PASSED                  [ 84%]
+tests/test_settings.py::test_encryption_invalid_manual_key_form_shows_only_manual_key_errors PASSED [ 84%]
+tests/test_settings.py::test_add_pgp_key_without_encryption_subkey PASSED [ 84%]
+tests/test_settings.py::test_add_pgp_key_proton_redirects_to_encryption PASSED [ 84%]
+tests/test_settings.py::test_add_pgp_key_proton_invalid_form_redirects_index PASSED [ 84%]
+tests/test_settings.py::test_add_pgp_key_proton_invalid_email_does_not_fetch_lookup PASSED [ 85%]
+tests/test_settings.py::test_add_pgp_key_proton_request_exception_redirects_encryption PASSED [ 85%]
+tests/test_settings.py::test_add_pgp_key_proton_non_encryptable_key_redirects_encryption PASSED [ 85%]
+tests/test_settings.py::test_add_pgp_key_proton_invalid_key_redirects_encryption PASSED [ 85%]
+tests/test_settings.py::test_add_pgp_key_proton_non_200_redirects_encryption PASSED [ 85%]
+tests/test_settings.py::test_advanced_settings_page_loads PASSED         [ 85%]
+tests/test_settings.py::test_update_smtp_settings_reject_private_host PASSED [ 85%]
+tests/test_settings.py::test_notifications_invalid_email_forwarding_post_shows_only_forwarding_errors PASSED [ 85%]
+tests/test_settings.py::test_add_notification_recipient PASSED           [ 85%]
+tests/test_settings.py::test_free_user_cannot_add_second_notification_recipient PASSED [ 85%]
+tests/test_settings.py::test_business_user_can_add_second_notification_recipient PASSED [ 85%]
+tests/test_settings.py::test_new_notification_recipient_page_renders_proton_lookup PASSED [ 85%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_prefills_form PASSED [ 85%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_invalid_email_returns_400 PASSED [ 85%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_error_returns_400 PASSED [ 85%]
+tests/test_settings.py::test_add_notification_recipient_rejects_invalid_pgp_key PASSED [ 85%]
+tests/test_settings.py::test_add_notification_recipient_rejects_non_encryptable_pgp_key PASSED [ 85%]
+tests/test_settings.py::test_edit_notification_recipient PASSED          [ 85%]
+tests/test_settings.py::test_notification_recipient_page_missing_recipient_redirects_to_notifications PASSED [ 86%]
+tests/test_settings.py::test_edit_notification_recipient_proton_lookup_prefills_form PASSED [ 86%]
+tests/test_settings.py::test_edit_notification_recipient_syncs_legacy_pgp_key PASSED [ 86%]
+tests/test_settings.py::test_disabling_last_notification_recipient_disables_delivery_settings PASSED [ 86%]
+tests/test_settings.py::test_delete_notification_recipient_removes_it PASSED [ 86%]
+tests/test_settings.py::test_delete_notification_recipient_returns_404_when_missing PASSED [ 86%]
+tests/test_settings.py::test_delete_notification_recipient_returns_400_for_invalid_form PASSED [ 86%]
+tests/test_settings.py::test_enabled_recipient_requires_key_when_content_included PASSED [ 86%]
+tests/test_settings.py::test_notifications_page_rejects_content_toggle_without_encryptable_recipient PASSED [ 86%]
+tests/test_settings.py::test_notifications_page_lists_recipient_drill_ins_for_business_user PASSED [ 86%]
+tests/test_settings.py::test_notifications_page_uses_any_message_recipient_key_for_message_capable_warning PASSED [ 86%]
+tests/test_settings.py::test_notifications_page_shows_upgrade_when_free_user_reaches_recipient_limit PASSED [ 86%]
+tests/test_settings.py::test_notification_recipient_page_renders_edit_form PASSED [ 86%]
+tests/test_settings.py::test_notification_recipient_page_groups_toggles_together PASSED [ 86%]
+tests/test_settings.py::test_notification_recipient_toggle_enabled_rejects_unencryptable_recipient PASSED [ 86%]
+tests/test_settings.py::test_notification_recipient_toggle_enabled_can_enable_recipient PASSED [ 86%]
+tests/test_settings.py::test_notification_recipient_page_rejects_content_toggle_without_encryptable_recipient PASSED [ 86%]
+tests/test_settings.py::test_notification_recipient_page_toggle_include_content_enables PASSED [ 86%]
+tests/test_settings.py::test_notification_recipient_page_toggle_include_content_disables PASSED [ 86%]
+tests/test_settings.py::test_notification_recipient_page_toggle_encrypt_entire_body_enables PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_page_toggle_encrypt_entire_body_disables PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_invalid_post_returns_400 PASSED [ 87%]
+tests/test_settings.py::test_notifications_business_tier_display_price_handles_missing_and_decimal_tiers PASSED [ 87%]
+tests/test_settings.py::test_update_smtp_settings_starttls PASSED        [ 87%]
+tests/test_settings.py::test_update_smtp_settings_ssl PASSED             [ 87%]
+tests/test_settings.py::test_update_smtp_settings_default_forwarding PASSED [ 87%]
+tests/test_settings.py::test_toggle_notifications_setting PASSED         [ 87%]
+tests/test_settings.py::test_toggle_include_content_setting PASSED       [ 87%]
+tests/test_settings.py::test_toggle_encrypt_entire_body_setting PASSED   [ 87%]
+tests/test_settings.py::test_toggle_recipient_enabled_setting PASSED     [ 87%]
+tests/test_settings.py::test_notifications_invalid_post_returns_400 PASSED [ 87%]
+tests/test_settings.py::test_add_alias PASSED                            [ 87%]
+tests/test_settings.py::test_add_alias_fails_when_alias_mode_is_never PASSED [ 87%]
+tests/test_settings.py::test_add_alias_not_exceed_max PASSED             [ 87%]
+tests/test_settings.py::test_add_alias_duplicate PASSED                  [ 87%]
+tests/test_settings.py::test_add_alias_duplicate_case_insensitive PASSED [ 87%]
+tests/test_settings.py::test_alias_page_loads PASSED                     [ 87%]
+tests/test_settings.py::test_delete_alias PASSED                         [ 88%]
+tests/test_settings.py::test_delete_alias_requires_csrf_token PASSED     [ 88%]
+tests/test_settings.py::test_delete_account PASSED                       [ 88%]
+tests/test_settings.py::test_alias_change_display_name PASSED            [ 88%]
+tests/test_settings.py::test_change_bio PASSED                           [ 88%]
+tests/test_settings.py::test_change_bio_invalid_post_renders_error_and_preserves_submitted_bio PASSED [ 88%]
+tests/test_settings.py::test_change_account_category PASSED              [ 88%]
+tests/test_settings.py::test_change_account_category_rejects_invalid_value PASSED [ 88%]
+tests/test_settings.py::test_change_profile_location PASSED              [ 88%]
+tests/test_settings.py::test_change_profile_location_clears_incomplete_dependency_chain PASSED [ 88%]
+tests/test_settings.py::test_change_profile_location_clears_city_when_city_field_is_omitted PASSED [ 88%]
+tests/test_settings.py::test_profile_states_endpoint_returns_country_scoped_options PASSED [ 88%]
+tests/test_settings.py::test_profile_cities_endpoint_returns_state_scoped_options PASSED [ 88%]
+tests/test_settings.py::test_alias_change_bio PASSED                     [ 88%]
+tests/test_settings.py::test_alias_change_bio_invalid_post_renders_error_and_preserves_submitted_bio PASSED [ 88%]
+tests/test_settings.py::test_alias_change_bio_preserves_account_category PASSED [ 88%]
+tests/test_settings.py::test_alias_change_bio_preserves_account_location PASSED [ 88%]
+tests/test_settings.py::test_change_directory_visibility PASSED          [ 88%]
+tests/test_settings.py::test_alias_change_directory_visibility PASSED    [ 88%]
+tests/test_settings.py::test_update_brand_primary_color PASSED           [ 89%]
+tests/test_settings.py::test_update_brand_app_name PASSED                [ 89%]
+tests/test_settings.py::test_update_brand_logo PASSED                    [ 89%]
+tests/test_settings.py::test_update_brand_logo_requires_file PASSED      [ 89%]
+tests/test_settings.py::test_update_splash_logo_does_not_change_brand_logo PASSED [ 89%]
+tests/test_settings.py::test_update_splash_logo_requires_file PASSED     [ 89%]
+tests/test_settings.py::test_toggle_splash_screen PASSED                 [ 89%]
+tests/test_settings.py::test_enable_disable_guidance PASSED              [ 89%]
+tests/test_settings.py::test_update_guidance_emergency_exit PASSED       [ 89%]
+tests/test_settings.py::test_update_guidance_emergency_exit_requires_url PASSED [ 89%]
+tests/test_settings.py::test_update_guidance_prompts PASSED              [ 89%]
+tests/test_settings.py::test_update_guidance_prompt_accepts_expanded_length PASSED [ 89%]
+tests/test_settings.py::test_update_guidance_prompt_rejects_text_over_expanded_length PASSED [ 89%]
+tests/test_settings.py::test_diretory_intro_text PASSED                  [ 89%]
+tests/test_settings.py::test_directory_intro_text_reset_to_default PASSED [ 89%]
+tests/test_settings.py::test_directory_intro_text_reset_aborts_when_multiple_rows_would_delete PASSED [ 89%]
+tests/test_settings.py::test_homepage_user PASSED                        [ 89%]
+tests/test_settings.py::test_homepage_reset_when_already_default PASSED  [ 89%]
+tests/test_settings.py::test_homepage_reset_multiple_rows_error PASSED   [ 90%]
+tests/test_settings.py::test_index_clears_invalid_session_user PASSED    [ 90%]
+tests/test_settings.py::test_index_warns_when_homepage_username_missing PASSED [ 90%]
+tests/test_settings.py::test_index_redirects_authenticated_user_to_inbox PASSED [ 90%]
+tests/test_settings.py::test_update_profile_header PASSED                [ 90%]
+tests/test_settings.py::test_update_profile_header_reset_when_already_default PASSED [ 90%]
+tests/test_settings.py::test_update_profile_header_reset_multiple_rows_error PASSED [ 90%]
+tests/test_settings.py::test_profile_fields_enabled PASSED               [ 90%]
+tests/test_settings.py::test_profile_fields_disabled PASSED              [ 90%]
+tests/test_settings.py::test_alias_fields_enabled PASSED                 [ 90%]
+tests/test_settings.py::test_alias_fields_disabled PASSED                [ 90%]
+tests/test_settings.py::test_hide_donate_button PASSED                   [ 90%]
+tests/test_settings.py::test_encryption_post_invalid_form_returns_400 PASSED [ 90%]
+tests/test_settings.py::test_alias_route_missing_alias_returns_404 PASSED [ 90%]
+tests/test_settings.py::test_delete_alias_missing_alias_returns_404 PASSED [ 90%]
+tests/test_settings.py::test_alias_fields_missing_alias_redirects_index PASSED [ 90%]
+tests/test_settings.py::test_alias_route_invalid_post_returns_400 PASSED [ 90%]
+tests/test_settings.py::test_alias_fields_post_uses_handle_field_post_result PASSED [ 90%]
+tests/test_settings.py::test_profile_route_raises_if_primary_username_missing PASSED [ 90%]
+tests/test_settings.py::test_profile_fields_raises_if_primary_username_missing PASSED [ 91%]
+tests/test_settings.py::test_profile_invalid_post_returns_400 PASSED     [ 91%]
+tests/test_settings.py::test_profile_renders_business_price_with_two_decimals PASSED [ 91%]
+tests/test_settings.py::test_business_tier_display_price_returns_empty_when_tier_missing PASSED [ 91%]
+tests/test_settings.py::test_business_tier_display_price_omits_decimal_for_whole_dollars PASSED [ 91%]
+tests/test_settings.py::test_profile_fields_post_uses_handle_field_post_result PASSED [ 91%]
+tests/test_settings.py::test_profile_fields_invalid_add_post_renders_errors_without_creating_field PASSED [ 91%]
+tests/test_settings.py::test_profile_fields_invalid_update_post_renders_errors_without_updating_field PASSED [ 91%]
+tests/test_settings.py::test_profile_fields_invalid_delete_post_renders_errors_without_deleting_field PASSED [ 91%]
+tests/test_settings.py::test_alias_fields_invalid_add_post_renders_errors_without_creating_field PASSED [ 91%]
+tests/test_settings_common.py::test_set_and_unset_field_attribute PASSED [ 91%]
+tests/test_settings_common.py::test_set_input_disabled_toggle PASSED     [ 91%]
+tests/test_settings_common.py::test_settings_forms_reject_disallowed_language PASSED [ 91%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_account_category PASSED [ 91%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_country PASSED [ 91%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_subdivision_for_country PASSED [ 91%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_city_for_subdivision PASSED [ 91%]
+tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[] PASSED [ 91%]
+tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[   ] PASSED [ 92%]
+tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[Atlantis] PASSED [ 92%]
+tests/test_settings_common.py::test_state_options_returns_empty_for_unknown_country PASSED [ 92%]
+tests/test_settings_common.py::test_city_options_for_state_returns_empty_for_unresolved_inputs[Atlantis-Illinois] PASSED [ 92%]
+tests/test_settings_common.py::test_city_options_for_state_returns_empty_for_unresolved_inputs[United States-Atlantis] PASSED [ 92%]
+tests/test_settings_common.py::test_city_choice_value_returns_none_for_blank_or_unknown_city PASSED [ 92%]
+tests/test_settings_common.py::test_city_choice_value_returns_first_match_when_multiple_cities_exist PASSED [ 92%]
+tests/test_settings_common.py::test_normalize_city_name_returns_none_for_unresolved_or_empty_inputs[None-United States-Illinois] PASSED [ 92%]
+tests/test_settings_common.py::test_normalize_city_name_returns_none_for_unresolved_or_empty_inputs[   -United States-Illinois] PASSED [ 92%]
+tests/test_settings_common.py::test_normalize_city_name_returns_none_for_unresolved_or_empty_inputs[Chicago-Atlantis-Illinois] PASSED [ 92%]
+tests/test_settings_common.py::test_normalize_city_name_returns_none_for_unresolved_or_empty_inputs[Chicago-United States-Atlantis] PASSED [ 92%]
+tests/test_settings_common.py::test_normalize_subdivision_name_returns_trimmed_value_for_unknown_country PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_allows_empty_city_without_normalizing PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_validate_city_returns_early_for_blank_field PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_country_choice PASSED [ 92%]
+tests/test_settings_common.py::test_strip_whitespace_leaves_non_string_values_unchanged PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_subdivision_and_city_labels PASSED [ 92%]
+tests/test_settings_common.py::test_city_choice_label_returns_raw_value_when_lookup_is_ambiguous PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_account_category_choices_are_split PASSED [ 93%]
+tests/test_settings_common.py::test_create_profile_forms_disables_location_inputs_until_dependencies PASSED [ 93%]
+tests/test_settings_common.py::test_create_profile_forms_selects_saved_subdivision_and_city PASSED [ 93%]
+tests/test_settings_common.py::test_embed_settings_form_requires_origin_when_enabled PASSED [ 93%]
+tests/test_settings_common.py::test_handle_embed_settings_form_requires_paid_plan PASSED [ 93%]
+tests/test_settings_common.py::test_is_blocked_ip_classification PASSED  [ 93%]
+tests/test_settings_common.py::test_is_safe_verification_url_non_https_rejected_in_production PASSED [ 93%]
+tests/test_settings_common.py::test_is_safe_verification_url_missing_hostname_rejected PASSED [ 93%]
+tests/test_settings_common.py::test_is_safe_verification_url_testing_short_circuit PASSED [ 93%]
+tests/test_settings_common.py::test_is_safe_verification_url_dns_error_rejected PASSED [ 93%]
+tests/test_settings_common.py::test_is_safe_verification_url_resolved_private_rejected PASSED [ 93%]
+tests/test_settings_common.py::test_is_safe_verification_url_resolved_public_allowed PASSED [ 93%]
+tests/test_settings_common.py::test_resolve_safe_verification_url_returns_pinned_addresses PASSED [ 93%]
+tests/test_settings_common.py::test_static_verification_resolver_refuses_unvalidated_hosts PASSED [ 93%]
+tests/test_settings_common.py::test_resolve_safe_verification_url_rejects_when_no_usable_addresses PASSED [ 93%]
+tests/test_settings_common.py::test_fetch_verification_html_disables_redirects PASSED [ 93%]
+tests/test_settings_common.py::test_fetch_verification_html_uses_pinned_address_connector PASSED [ 93%]
+tests/test_settings_common.py::test_is_safe_verification_url_direct_private_ip_rejected PASSED [ 93%]
+tests/test_settings_common.py::test_is_safe_verification_url_resolved_blocked_ip_rejected PASSED [ 93%]
+tests/test_settings_common.py::test_verify_url_handles_client_error PASSED [ 94%]
+tests/test_settings_common.py::test_verify_url_returns_early_when_url_is_not_safe PASSED [ 94%]
+tests/test_settings_common.py::test_verify_url_fetches_with_pinned_resolved_addresses PASSED [ 94%]
+tests/test_settings_common.py::test_verify_url_marks_field_verified_when_profile_link_present PASSED [ 94%]
+tests/test_settings_common.py::test_verify_url_leaves_field_unverified_when_no_matching_profile_link PASSED [ 94%]
+tests/test_settings_common.py::test_handle_update_bio_reraises_task_exceptions_in_testing PASSED [ 94%]
+tests/test_settings_common.py::test_handle_update_bio_logs_task_exceptions_when_not_testing PASSED [ 94%]
+tests/test_settings_common.py::test_handle_update_bio_uses_public_base_url_for_profile_verification PASSED [ 94%]
+tests/test_settings_common.py::test_handle_new_alias_form_unique_violation_returns_none PASSED [ 94%]
+tests/test_settings_common.py::test_handle_new_alias_form_integrity_error_returns_none PASSED [ 94%]
+tests/test_settings_common.py::test_handle_change_username_form_unique_violation_flashes_taken PASSED [ 94%]
+tests/test_settings_common.py::test_handle_change_username_form_internal_error_flashes_generic_error PASSED [ 94%]
+tests/test_settings_common.py::test_handle_change_password_form_rejects_wrong_old_password PASSED [ 94%]
+tests/test_settings_common.py::test_handle_pgp_key_form_empty_value_clears_only_public_key PASSED [ 94%]
+tests/test_settings_common.py::test_handle_profile_post_invalid_form_returns_none PASSED [ 94%]
+tests/test_settings_common.py::test_handle_profile_post_updates_directory_visibility PASSED [ 94%]
+tests/test_settings_common.py::test_handle_field_post_add_branch PASSED  [ 94%]
+tests/test_settings_common.py::test_handle_field_post_update_branch PASSED [ 94%]
+tests/test_settings_common.py::test_handle_field_post_delete_branch PASSED [ 95%]
+tests/test_settings_common.py::test_handle_field_post_move_up_and_down_branches PASSED [ 95%]
+tests/test_settings_common.py::test_handle_field_post_rejects_invalid_field_id PASSED [ 95%]
+tests/test_settings_common.py::test_handle_field_post_rejects_fields_owned_by_another_user[update] PASSED [ 95%]
+tests/test_settings_common.py::test_handle_field_post_rejects_fields_owned_by_another_user[delete] PASSED [ 95%]
+tests/test_settings_common.py::test_handle_field_post_rejects_fields_owned_by_another_user[move_up] PASSED [ 95%]
+tests/test_settings_common.py::test_handle_field_post_rejects_fields_owned_by_another_user[move_down] PASSED [ 95%]
+tests/test_settings_common.py::test_build_field_forms_populates_choice_entries PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_settings_disabled_returns_unauthorized PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_toggle_enabled PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_toggle_enabled_does_not_validate_other_forms PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_toggle_codes_required PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_create_invite_code PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_delete_invite_code PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_delete_invite_code_not_found PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_invalid_form_submission PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_invalid_delete_submission_preserves_redirect_and_flash PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_missing_csrf_redirects_with_invalid_submission_flash PASSED [ 95%]
+tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_enable_when_not_configured PASSED [ 95%]
+tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_disable_when_already_configured PASSED [ 96%]
+tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_login_without_user_id PASSED [ 96%]
+tests/test_settings_twofa.py::test_disable_2fa_clears_secret PASSED      [ 96%]
+tests/test_settings_twofa.py::test_disable_2fa_redirects_to_login_without_user_id PASSED [ 96%]
+tests/test_settings_twofa.py::test_confirm_disable_2fa_page_loads PASSED [ 96%]
+tests/test_settings_twofa.py::test_verify_2fa_setup_redirects_to_login_for_missing_user PASSED [ 96%]
+tests/test_settings_twofa.py::test_verify_2fa_setup_without_totp_secret_redirects_back_to_enable PASSED [ 96%]
+tests/test_settings_twofa.py::test_verify_2fa_setup_invalid_code_redirects_back_to_enable PASSED [ 96%]
+tests/test_settings_twofa.py::test_verify_2fa_setup_valid_code_redirects_logout_and_clears_setup_flag PASSED [ 96%]
+tests/test_splash_screen.py::test_first_load_splash_markup_uses_default_duration PASSED [ 96%]
+tests/test_splash_screen.py::test_native_pwa_startup_splash_defaults_to_declared PASSED [ 96%]
+tests/test_splash_screen.py::test_native_pwa_startup_splash_is_not_declared_with_first_load_splash PASSED [ 96%]
+tests/test_splash_screen.py::test_first_load_splash_duration_uses_runtime_config PASSED [ 96%]
+tests/test_splash_screen.py::test_first_load_splash_uses_brand_logo_fallback PASSED [ 96%]
+tests/test_splash_screen.py::test_first_load_splash_uses_custom_splash_logo PASSED [ 96%]
+tests/test_splash_screen.py::test_first_load_splash_uses_versioned_custom_splash_logo PASSED [ 96%]
+tests/test_splash_screen.py::test_first_load_splash_defaults_to_disabled PASSED [ 96%]
+tests/test_splash_screen.py::test_first_load_splash_can_be_disabled PASSED [ 96%]
+tests/test_static_typing_config.py::test_mypy_targets_python_313_semantics PASSED [ 97%]
+tests/test_storage.py::TestFsDriver::test_put_and_serve PASSED           [ 97%]
+tests/test_storage.py::TestFsDriver::test_put_and_delete PASSED          [ 97%]
+tests/test_storage.py::TestS3Driver::test_put_and_serve PASSED           [ 97%]
+tests/test_storage.py::TestS3Driver::test_put_and_delete PASSED          [ 97%]
+tests/test_storage.py::test_storage_driver_methods_raise_not_implemented PASSED [ 97%]
+tests/test_storage.py::test_fs_driver_rejects_relative_root PASSED       [ 97%]
+tests/test_storage.py::test_fs_driver_rejects_non_absolute_full_path PASSED [ 97%]
+tests/test_storage.py::test_fs_driver_rejects_windows_reserved_device_names PASSED [ 97%]
+tests/test_storage.py::test_fs_driver_allows_empty_and_dot_only_path_segments PASSED [ 97%]
+tests/test_storage.py::test_s3_driver_private_serve_uses_presigned_url PASSED [ 97%]
+tests/test_storage.py::test_blob_storage_init_rejects_unknown_driver PASSED [ 97%]
+tests/test_storage.py::test_blob_storage_init_rejects_double_registration PASSED [ 97%]
+tests/test_storage.py::test_blob_storage_abort_when_driver_not_configured PASSED [ 97%]
+tests/test_user_profile_location.py::test_user_new_session_id_returns_distinct_tokens PASSED [ 97%]
+tests/test_user_profile_location.py::test_profile_location_returns_country_when_us_geography_only_has_country PASSED [ 97%]
+tests/test_user_profile_location.py::test_profile_location_spells_out_state_when_city_missing PASSED [ 97%]
+tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_state_missing PASSED [ 97%]
+tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_it_is_the_only_field PASSED [ 97%]
+tests/test_user_profile_location.py::test_profile_location_returns_none_for_inconsistent_empty_us_geography PASSED [ 98%]
+tests/test_utils.py::test_redirect_to_self_uses_current_endpoint_and_view_args PASSED [ 98%]
+tests/test_utils.py::test_if_not_none_applies_to_falsey_values_by_default PASSED [ 98%]
+tests/test_utils.py::test_parse_bool_false_and_invalid_values PASSED     [ 98%]
+tests/test_verify_url.py::test_verify_url PASSED                         [ 98%]
+tests/test_verify_url.py::test_verify_url_fail PASSED                    [ 98%]
+tests/test_verify_url.py::test_verify_url_request PASSED                 [ 98%]
+tests/test_verify_url.py::test_verify_url_request_fail PASSED            [ 98%]
+tests/test_verify_url.py::test_verify_url_blocks_private_ip_in_production PASSED [ 98%]
+tests/test_verify_url.py::test_verify_url_blocks_localhost_in_production PASSED [ 98%]
+tests/test_verify_url.py::test_verify_url_blocks_localhost_localdomain_in_production PASSED [ 98%]
+tests/test_verify_url.py::test_verify_url_blocks_unspecified_ip_in_production PASSED [ 98%]
+tests/test_vision.py::test_vision_requires_authentication PASSED         [ 98%]
+tests/test_vision.py::test_vision_redirects_to_login_when_session_user_missing PASSED [ 98%]
+tests/test_vision.py::test_vision_redirects_with_flash_when_user_missing_after_auth PASSED [ 98%]
+tests/test_vision.py::test_vision_renders_for_free_user PASSED           [ 98%]
+tests/test_vision.py::test_vision_renders_for_paid_user PASSED           [ 98%]
+tests/test_weekly_agent_report_runner.py::test_report_addresses_and_title_are_fixed PASSED [ 98%]
+tests/test_weekly_agent_report_runner.py::test_default_sources_match_monitored_logs PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_collect_events_from_hushline_runner_log PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_parse_log_timestamp_uses_timezone_abbreviation_during_fallback PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_collect_events_from_social_runner_log PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_render_report_groups_completed_attention_and_noop_events PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_send_with_mail_app_uses_native_mail_and_fixed_envelope PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_send_with_mail_app_reports_osascript_timeout_and_cleans_tempfile PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_send_with_mail_app_treats_mail_apple_event_timeout_as_handoff_warning PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_main_persists_report_body_by_default PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_main_dry_run_does_not_write_default_persisted_report PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_main_prunes_old_persisted_reports PASSED [ 99%]
+tests/test_weekly_agent_report_runner.py::test_main_no_persist_skips_default_report_artifact PASSED [ 99%]
+tests/test_workflow_pr_head_qualification.py::test_cross_repo_auto_merge_workflows_use_owner_qualified_pr_heads PASSED [ 99%]
+tests/test_workflow_pr_head_qualification.py::test_public_directory_weekly_report_refreshes_stats_branch_lease_before_push PASSED [ 99%]
+tests/test_workflow_pr_head_qualification.py::test_screenshots_archive_workflow_publishes_directly_without_pr_flow PASSED [ 99%]
+tests/test_workflow_pr_head_qualification.py::test_screenshots_workflow_publishes_current_folder_to_website_directly PASSED [ 99%]
+tests/test_workflow_pr_head_qualification.py::test_dev_deploy_workflow_generates_session_fernet_key_for_terraform_runs PASSED [ 99%]
+tests/test_workflow_pr_head_qualification.py::test_tests_workflow_lint_job_uses_host_python_313 PASSED [ 99%]
+tests/test_workflow_pr_head_qualification.py::test_dependency_audit_workflow_only_runs_python_audit_when_poetry_lock_changes PASSED [100%]
+
+---------- coverage: platform linux, python 3.13.13-final-0 ----------
+Name                                             Stmts   Miss  Cover
+--------------------------------------------------------------------
+hushline/__init__.py                               160      0   100%
+hushline/admin.py                                  187      0   100%
+hushline/auth.py                                    73      0   100%
+hushline/cli_password_hash.py                       56      0   100%
+hushline/cli_reg.py                                 47      0   100%
+hushline/cli_stripe.py                              32      0   100%
+hushline/config.py                                 130      0   100%
+hushline/content_safety.py                          40      0   100%
+hushline/crypto.py                                 222     17    92%
+hushline/db.py                                       6      0   100%
+hushline/email.py                                  109      0   100%
+hushline/email_headers.py                          353      0   100%
+hushline/embeds.py                                  72      0   100%
+hushline/external_urls.py                           25      0   100%
+hushline/forms.py                                   78      0   100%
+hushline/geo.py                                    147      0   100%
+hushline/globaleaks_directory_refresh.py           265      0   100%
+hushline/make_admin.py                              20      0   100%
+hushline/md.py                                       7      0   100%
+hushline/model/__init__.py                          21      0   100%
+hushline/model/authentication_log.py                19      0   100%
+hushline/model/directory_listing_geography.py       93      0   100%
+hushline/model/embed_rate_limit_attempt.py          17      0   100%
+hushline/model/enums.py                            162      0   100%
+hushline/model/field_definition.py                  61      0   100%
+hushline/model/field_value.py                       49      0   100%
+hushline/model/globaleaks_directory_listing.py      65      0   100%
+hushline/model/invite_code.py                       23      0   100%
+hushline/model/message.py                           31      0   100%
+hushline/model/message_status_text.py               30      0   100%
+hushline/model/newsroom_directory_listing.py        62      0   100%
+hushline/model/notification_recipient.py            32      0   100%
+hushline/model/organization_setting.py              46      0   100%
+hushline/model/password_reset_attempt.py            16      0   100%
+hushline/model/password_reset_token.py              31      0   100%
+hushline/model/public_record_listing.py             68      0   100%
+hushline/model/securedrop_directory_listing.py      59      0   100%
+hushline/model/stripe_event.py                      22      0   100%
+hushline/model/stripe_invoice.py                    46      0   100%
+hushline/model/tier.py                              27      0   100%
+hushline/model/user.py                             273      0   100%
+hushline/model/username.py                         152      0   100%
+hushline/newsroom_directory_refresh.py             446      0   100%
+hushline/password_hasher.py                         95      0   100%
+hushline/premium.py                                450      0   100%
+hushline/public_record_refresh.py                  826      0   100%
+hushline/routes/__init__.py                         31      0   100%
+hushline/routes/auth.py                            333      0   100%
+hushline/routes/common.py                          123      0   100%
+hushline/routes/directory.py                       338      0   100%
+hushline/routes/email_headers.py                    45      0   100%
+hushline/routes/forms.py                            87      0   100%
+hushline/routes/inbox.py                            27      0   100%
+hushline/routes/index.py                            36      0   100%
+hushline/routes/message.py                         106      0   100%
+hushline/routes/onboarding.py                      147      0   100%
+hushline/routes/profile.py                         272      0   100%
+hushline/routes/tools.py                             2      0   100%
+hushline/routes/vision.py                           15      0   100%
+hushline/safe_template.py                           34      0   100%
+hushline/secure_session.py                          60      0   100%
+hushline/securedrop_directory_refresh.py           152      0   100%
+hushline/settings/__init__.py                       37      0   100%
+hushline/settings/admin.py                          39      0   100%
+hushline/settings/advanced.py                       13      0   100%
+hushline/settings/aliases.py                        93      0   100%
+hushline/settings/auth.py                           32      0   100%
+hushline/settings/branding.py                      154      0   100%
+hushline/settings/common.py                        374      0   100%
+hushline/settings/data_export.py                    99      0   100%
+hushline/settings/delete_account.py                 25      0   100%
+hushline/settings/developer.py                      34      0   100%
+hushline/settings/encryption.py                     27      0   100%
+hushline/settings/forms.py                         203      0   100%
+hushline/settings/guidance.py                       66      0   100%
+hushline/settings/notifications.py                 295      0   100%
+hushline/settings/profile.py                        66      0   100%
+hushline/settings/proton.py                         41      0   100%
+hushline/settings/registration.py                   77      0   100%
+hushline/settings/replies.py                        40      0   100%
+hushline/settings/twofa.py                          74      0   100%
+hushline/storage.py                                127      0   100%
+hushline/user_deletion.py                           18      0   100%
+hushline/utils.py                                   21      0   100%
+hushline/version.py                                  1      0   100%
+--------------------------------------------------------------------
+TOTAL                                             9015     17    99%
+Coverage HTML written to dir /tmp/hushline-htmlcov
+
+
+========== 1843 passed, 1 deselected, 1 xfailed in 396.83s (0:06:36) ===========
+Pruning old runner logs, keeping newest 10.
+[codex/daily-issue-2014 9b028bd0] chore: agent daily for #2014 (epic #2013)
+ 6 files changed, 2896 insertions(+), 4315 deletions(-)
+ delete mode 100644 docs/agent-logs/run-20260519T232044Z-issue-1990.txt
+ create mode 100644 docs/agent-logs/run-20260526T042438Z-issue-2014.txt
+Remote branch 'codex/daily-issue-2014' does not exist; creating it with a standard push.
+remote: 
+remote: Create a pull request for 'codex/daily-issue-2014' on GitHub by visiting:        
+remote:      https://github.com/scidsg/hushline/pull/new/codex/daily-issue-2014        
+remote: 
+To github.com:scidsg/hushline.git
+ * [new branch]        codex/daily-issue-2014 -> codex/daily-issue-2014
+branch 'codex/daily-issue-2014' set up to track 'origin/codex/daily-issue-2014'.
+Opened PR: https://github.com/scidsg/hushline/pull/2027
+==> Mark issue #2014 as Ready for Review
+Opened coverage gap issue: https://github.com/scidsg/hushline/issues/2028
+==> Add coverage gap issue #2028 to Agent Eligible


### PR DESCRIPTION
## Summary
- Restores `docs/agent-logs/run-20260526T042438Z-issue-2014.txt` that PR #2053 accidentally renamed into the #2042 runner log.
- Leaves `docs/agent-logs/run-20260526T201022Z-issue-2042.txt` intact so both per-run logs exist on the epic branch.

## Why
PR #2053 had an unresolved review comment noting that the runner log was added as a rename rather than a new file. That broke the one-file-per-run audit trail required by `AGENTS.md`.

## Validation
- `git diff --check`
- `make lint`
- `make test` was started and reached 91% with all executed tests passing, then the environment killed it with exit 137 before completion. No assertion failure was reported before termination.

## Manual Testing
Not applicable; this is a log restoration only.

## Risk
Low. This PR restores a historical audit log and does not change application code, migrations, configuration, or runtime behavior.