### PR TITLE
Block runner on Codex access limits

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -230,7 +230,7 @@ if (!primary) {
 const usedPercent = Number(primary.usedPercent);
 const windowDurationMins = Number(primary.windowDurationMins);
 const resetsAt = Number(primary.resetsAt);
-const reachedType = limits.rateLimitReachedType || "";
+const reachedType = limits.rateLimitReachedType || "null";
 if (!Number.isFinite(usedPercent) || !Number.isFinite(windowDurationMins) || !Number.isFinite(resetsAt)) {
   process.exit(2);
 }
@@ -241,6 +241,19 @@ process.stdout.write([
   reachedType,
 ].join("\t"));
 '
+}
+
+codex_status_reached_type_blocks_issue_work() {
+  local reached_type="$1"
+
+  case "$reached_type" in
+    "" | "null" | "primary")
+      return 1
+      ;;
+    *)
+      return 0
+      ;;
+  esac
 }
 
 wait_for_codex_status_credit_window() {
@@ -279,6 +292,11 @@ wait_for_codex_status_credit_window() {
       remaining_percent=0
     fi
     echo "Codex /status: primary ${window_duration_mins}m window ${used_percent}% used; ${remaining_percent}% remaining; resets at ${reset_label}."
+
+    if codex_status_reached_type_blocks_issue_work "$reached_type"; then
+      echo "Blocked: Codex /status reported non-window limit type '${reached_type}'; refusing to start assigned work until Codex access is restored." >&2
+      return 1
+    fi
 
     if (( window_duration_mins == 300 && remaining_percent < CODEX_STATUS_MIN_REMAINING_PERCENT )); then
       now_epoch="$(date +%s)"
@@ -3973,7 +3991,10 @@ main() {
     exit 0
   fi
 
-  wait_for_codex_status_credit_window
+  if ! wait_for_codex_status_credit_window; then
+    runner_status "Skipped: Codex /status reported a blocking access limit; leaving assigned issue #${ISSUE_NUMBER} in ${PROJECT_STATUS_IN_PROGRESS}."
+    exit 0
+  fi
 
   EPIC_ISSUE_NUMBER=""
   EPIC_ISSUE_TITLE=""

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -94,6 +94,58 @@ wait_for_codex_status_credit_window
     assert "unexpected-sleep" not in result.stdout
 
 
+def test_wait_for_codex_status_credit_window_blocks_workspace_credit_depletion() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CODEX_STATUS_CHECK_ENABLED=1
+HUSHLINE_DAILY_CODEX_STATUS_JSON='{{"rateLimits":{{"primary":{{"usedPercent":1,"windowDurationMins":300,"resetsAt":1779683479}},"secondary":null,"rateLimitReachedType":"workspace_member_credits_depleted"}}}}'
+sleep() {{
+  printf 'unexpected-sleep:%s\\n' "$1"
+  return 1
+}}
+set +e
+wait_for_codex_status_credit_window
+rc=$?
+set -e
+printf 'rc=%s\\n' "$rc"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Codex /status: primary 300m window 1% used; 99% remaining" in result.stdout
+    assert "rc=1" in result.stdout
+    assert "unexpected-sleep" not in result.stdout
+    assert "non-window limit type 'workspace_member_credits_depleted'" in result.stderr
+    assert "5h window still has capacity; proceeding" not in result.stdout
+
+
+def test_wait_for_codex_status_credit_window_allows_shared_usage_without_credit_balance() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CODEX_STATUS_CHECK_ENABLED=1
+HUSHLINE_DAILY_CODEX_STATUS_JSON='{{"rateLimits":{{"primary":{{"usedPercent":1,"windowDurationMins":300,"resetsAt":1779683479}},"secondary":{{"usedPercent":55,"windowDurationMins":10080,"resetsAt":1780201172}},"credits":{{"hasCredits":false,"unlimited":false,"balance":"0"}},"planType":"plus","rateLimitReachedType":null}}}}'
+sleep() {{
+  printf 'unexpected-sleep:%s\\n' "$1"
+  return 1
+}}
+set +e
+wait_for_codex_status_credit_window
+rc=$?
+set -e
+printf 'rc=%s\\n' "$rc"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "Codex /status: primary 300m window 1% used; 99% remaining" in result.stdout
+    assert "rc=0" in result.stdout
+    assert "unexpected-sleep" not in result.stdout
+    assert "credits.hasCredits=false" not in result.stderr
+    assert "5h window still has capacity; proceeding" not in result.stdout
+
+
 def test_wait_for_codex_status_credit_window_sleeps_until_low_5h_quota_resets(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## What changed

- Treat non-window Codex `/status` limit types as blocking before the daily issue runner starts assigned work.
- Preserve `primary` quota handling for the 5-hour window, including waiting when the primary window is low.
- Keep shared agentic usage working when `/status` reports `credits.hasCredits=false` but `rateLimitReachedType=null`.
- Add runner tests for the `workspace_member_credits_depleted` failure mode and shared-usage status shape.

## Why

The runner logs showed a contradictory state: the primary 300m window had 99% remaining, but Codex also reported `rateLimitReachedType='workspace_member_credits_depleted'`. The runner logged that signal and continued anyway, then burned time resetting the worktree/Docker and failed during Codex execution. This change fails closed on non-window access limits before expensive or mutating work begins.

## Validation

- `bash -n scripts/agent_daily_issue_runner.sh`
- `docker compose run --rm app poetry run pytest tests/test_agent_daily_issue_runner.py -q` -> 112 passed
- Live agent 001 smoke check with `CODEX_HOME=/Users/scidsg/.codex-hushline-agent-001`: `rateLimitReachedType=null`, primary 99% remaining, gate returned `rc=0`
- `make lint`
- `make audit-python`
- `make audit-node-runtime`
- `make test` passed once before the final shared-usage correction: 1806 passed, 1 deselected, 1 xfailed
- Final `make test` rerun after Docker reset reached 95%+ with the changed runner tests passing, then hit the known local Postgres shared-memory/recovery failure documented in `AGENTS.md`: `could not resize shared memory segment ... No space left on device`

## Manual testing

- Verified agent 001 login state with `env CODEX_HOME=/Users/scidsg/.codex-hushline-agent-001 codex login status`.
- Verified launchd service `org.scidsg.hushline-code-agent` is not currently loaded while this PR is unmerged.

## Risks

Low. The change only affects the pre-work Codex status gate. It should reduce destructive/noisy runner loops by exiting before repository reset, Docker reset, and Codex execution when Codex reports a non-window access limit.