### PR TITLE
Fix stale coverage-gap snapshot parsing from daily runner logs

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -2842,11 +2842,11 @@ coverage_gap_snapshot_from_log() {
     }
     in_table && /^TOTAL[[:space:]]+/ {
       current_total = $0
+      final_header = current_header
+      final_total = current_total
+      final_count = current_count
+      delete final_rows
       if (current_count > 0) {
-        final_header = current_header
-        final_total = current_total
-        final_count = current_count
-        delete final_rows
         for (i = 1; i <= current_count; i += 1) {
           final_rows[i] = current_rows[i]
         }

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -1498,6 +1498,37 @@ coverage_gap_snapshot_from_log {shlex.quote(str(check_log))}
     assert "TOTAL                                            8881     36    99%" in result.stdout
 
 
+def test_coverage_gap_snapshot_from_log_uses_latest_table_when_latest_has_no_misses(
+    tmp_path: Path,
+) -> None:
+    check_log = tmp_path / "check.log"
+    check_log.write_text(
+        """
+older run
+Name                                             Stmts   Miss  Cover
+--------------------------------------------------------------------
+hushline/old.py                                    10      1    90%
+TOTAL                                              10      1    90%
+latest run
+Name                                             Stmts   Miss  Cover
+--------------------------------------------------------------------
+hushline/new.py                                    22      0   100%
+TOTAL                                              22      0   100%
+""",
+        encoding="utf-8",
+    )
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+coverage_gap_snapshot_from_log {shlex.quote(str(check_log))}
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == ""
+
+
 def test_open_coverage_gap_issue_after_pr_creates_agent_eligible_issue(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
### Motivation

- The coverage-table parser in `coverage_gap_snapshot_from_log` could retain an older missed-rows snapshot when a later coverage table had zero misses, causing false-positive follow-up issues.

### Description

- Update the `awk` logic in `scripts/agent_daily_issue_runner.sh::coverage_gap_snapshot_from_log` so the parser always records the most recent table header/total/count at each `TOTAL` line, and only copies per-file rows when the current table has misses.
- This clears previously captured missed-row state when the newest table has no misses so the output reflects the latest table only.
- Add a regression test `test_coverage_gap_snapshot_from_log_uses_latest_table_when_latest_has_no_misses` in `tests/test_agent_daily_issue_runner.py` that reproduces the stale-state scenario and asserts empty output for a latest zero-miss table.

### Testing

- Ran the targeted test command `pytest -q tests/test_agent_daily_issue_runner.py -k "coverage_gap_snapshot_from_log"` and the tests passed (`2 passed, 111 deselected`).
- No full-suite or lint changes were performed in this patch; recommend running `make lint` and `make test` in CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a16b649f77c832f9887e37132f5fcd1)