### PR TITLE
#2057 Phase 13: deepen encrypted-field migration downgrade and rollback tests

### DIFF
--- a/docs/agent-logs/run-20260527T094627Z-issue-2057.txt
+++ b/docs/agent-logs/run-20260527T094627Z-issue-2057.txt
@@ -7316,3 +7316,19 @@ Coverage HTML written to dir /tmp/hushline-htmlcov
 
 
 ========== 1903 passed, 1 deselected, 1 xfailed in 418.06s (0:06:58) ===========
+Pruning old runner logs, keeping newest 10.
+[codex/daily-issue-2057 665b86c6] chore: agent daily for #2057 (epic #2013)
+ 3 files changed, 3419 insertions(+), 2745 deletions(-)
+ rename docs/agent-logs/{run-20260526T055615Z-issue-2018.txt => run-20260527T094627Z-issue-2057.txt} (79%)
+Remote branch 'codex/daily-issue-2057' does not exist; creating it with a standard push.
+remote: 
+remote: Create a pull request for 'codex/daily-issue-2057' on GitHub by visiting:        
+remote:      https://github.com/scidsg/hushline/pull/new/codex/daily-issue-2057        
+remote: 
+To github.com:scidsg/hushline.git
+ * [new branch]        codex/daily-issue-2057 -> codex/daily-issue-2057
+branch 'codex/daily-issue-2057' set up to track 'origin/codex/daily-issue-2057'.
+Opened PR: https://github.com/scidsg/hushline/pull/2068
+==> Mark issue #2057 as Ready for Review
+Opened coverage gap issue: https://github.com/scidsg/hushline/issues/2069
+==> Add coverage gap issue #2069 to Agent Eligible

--- a/docs/agent-logs/run-20260527T094627Z-issue-2057.txt
+++ b/docs/agent-logs/run-20260527T094627Z-issue-2057.txt
@@ -1,38 +1,42 @@
 Daily runner log
-Timestamp (UTC): 20260526T055615Z
-Issue: #2018
+Timestamp (UTC): 20260527T094627Z
+Issue: #2057
 Repository: scidsg/hushline
 
-[2026-05-25 22:56:15 PDT] Starting daily issue runner check.
+[2026-05-27 02:46:27 PDT] Starting daily issue runner check.
 Runner Codex config: [redacted]
+[2026-05-27 02:46:27 PDT] Switching checkout from 'codex/fix-predictable-/tmp-runner-lock-vulnerability' to 'main' before runner work.
+Switched to branch 'main'
+Your branch is up to date with 'origin/main'.
+HEAD is now at bc0de908 Block runner on Codex access limits (#2062)
 Open human-authored PR count: 0
 Open project issues in In Progress: 0
-Selected issue #2018 from project queue.
+Selected issue #2057 from project queue.
 ==> Check Codex /status usage limits
-Codex /status: primary 300m window 34% used; 66% remaining; resets at 2026-05-26 02:25:55 PDT.
-Issue #2018 is a child of epic #2013.
+Codex /status: primary 300m window 20% used; 80% remaining; resets at 2026-05-27 03:53:46 PDT.
+Issue #2057 is a child of epic #2013.
 Open unrelated bot PR count: 0
-Allowed bot PR heads: codex/epic-2013, codex/daily-issue-2018
+Allowed bot PR heads: codex/epic-2013, codex/daily-issue-2057
 ==> Fetch latest from origin
+From github.com:scidsg/hushline
+   bc0de908..56d2007b  main            -> origin/main
+   958d6469..950002f5  codex/epic-2013 -> origin/codex/epic-2013
 ==> Checkout main
 Already on 'main'
-Your branch is up to date with 'origin/main'.
+Your branch is behind 'origin/main' by 3 commits, and can be fast-forwarded.
+  (use "git pull" to update your local branch)
 ==> Reset to origin/main
-HEAD is now at d893290f Document issue 411 crypto feasibility (#2012)
+HEAD is now at 56d2007b fix: use repo-owned path for daily runner lock default (#2067)
 ==> Remove untracked files
-==> Mark issue #2018 as In Progress
+==> Mark issue #2057 as In Progress
 ==> Configure bot git identity
 ==> Stop and remove Docker resources
  Container hushline-app-1 Stopping 
- Container hushline-webpack-1 Stopping 
- Container hushline-webpack-1 Stopped 
- Container hushline-webpack-1 Removing 
- Container hushline-webpack-1 Removed 
  Container hushline-app-1 Stopped 
  Container hushline-app-1 Removing 
  Container hushline-app-1 Removed 
- Container hushline-blob-storage-1 Stopping 
  Container hushline-dev_data-1 Stopping 
+ Container hushline-blob-storage-1 Stopping 
  Container hushline-dev_data-1 Stopped 
  Container hushline-dev_data-1 Removing 
  Container hushline-dev_data-1 Removed 
@@ -43,15 +47,13 @@ HEAD is now at d893290f Document issue 411 crypto feasibility (#2012)
  Container hushline-blob-storage-1 Stopped 
  Container hushline-blob-storage-1 Removing 
  Container hushline-blob-storage-1 Removed 
- Volume hushline_hushline-node-modules Removing 
  Network hushline_default Removing 
- Volume hushline_hushline-node-modules Removed 
  Network hushline_default Removed 
 ==> Kill all Docker containers
 ==> Kill processes on runner ports
 ==> Start Docker stack
- Image hushline-app Building 
  Image hushline-dev_data Building 
+ Image hushline-app Building 
 #1 [internal] load local bake definitions
 #1 reading from stdin 913B done
 #1 DONE 0.0s
@@ -61,75 +63,79 @@ HEAD is now at d893290f Document issue 411 crypto feasibility (#2012)
 #2 DONE 0.0s
 
 #3 [dev_data internal] load metadata for docker.io/library/python:3.13-slim-bookworm
-#3 DONE 0.7s
+#3 DONE 0.9s
 
 #4 [dev_data internal] load .dockerignore
-#4 transferring context: 144B done
+#4 transferring context: 144B 0.0s done
 #4 DONE 0.0s
 
-#5 [app 1/8] FROM docker.io/library/python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2
-#5 resolve docker.io/library/python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2 done
+#5 [dev_data 1/8] FROM docker.io/library/python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2
+#5 resolve docker.io/library/python:3.13-slim-bookworm@sha256:e4fa1f978c539608a10cdf74700ac32a3f719dfc6e8b6b6001da82deb36302a2 0.0s done
 #5 DONE 0.0s
 
 #6 [dev_data internal] load build context
-#6 transferring context: 68B done
+#6 transferring context: 68B 0.0s done
 #6 DONE 0.0s
 
 #7 [dev_data 2/8] RUN apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 update &&     apt-get -o Acquire::Retries=10 -o Acquire::http::Timeout=30 -o Acquire::https::Timeout=30 install -y --fix-missing --no-install-recommends     curl     build-essential     clang     pkg-config     libffi-dev     libpq-dev     libpcsclite-dev     nettle-dev     nodejs     npm &&     rm -rf /var/lib/apt/lists/*
 #7 CACHED
 
-#8 [dev_data 3/8] RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+#8 [dev_data 4/8] RUN python -m pip install --no-cache-dir --upgrade "pip>=26,<27" &&     python -m pip install --no-cache-dir poetry
 #8 CACHED
 
-#9 [dev_data 7/8] COPY pyproject.toml poetry.lock ./
+#9 [dev_data 5/8] RUN npm install --global prettier@3.3.3
 #9 CACHED
 
-#10 [dev_data 5/8] RUN npm install --global prettier@3.3.3
+#10 [dev_data 3/8] RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
 #10 CACHED
 
 #11 [dev_data 6/8] WORKDIR /app
 #11 CACHED
 
-#12 [dev_data 4/8] RUN python -m pip install --no-cache-dir --upgrade "pip>=26,<27" &&     python -m pip install --no-cache-dir poetry
+#12 [dev_data 7/8] COPY pyproject.toml poetry.lock ./
 #12 CACHED
 
 #13 [dev_data 8/8] RUN poetry install --no-root
 #13 CACHED
 
 #14 [app] exporting to image
-#14 exporting layers done
+#14 exporting layers
+#14 exporting layers 0.0s done
 #14 exporting manifest sha256:20e1330ead784b3b4a37a3acea3db4aa98e346dca655290d3a5942674c6064c7 done
 #14 exporting config sha256:b50f065c3f5a68cada72c89c9cc6d8669785b7c34a53088afcf5934f85c82199 done
-#14 exporting attestation manifest sha256:78b99ec5c1e8438f9e0bb0b568dfac59f20934674329d4d70d63f4b4c00cf3e9 0.1s done
-#14 exporting manifest list sha256:294bd523b8c68b980d52e0c9364aa748fcec5a37211a17d84dea16047e9ea0b4
-#14 exporting manifest list sha256:294bd523b8c68b980d52e0c9364aa748fcec5a37211a17d84dea16047e9ea0b4 0.0s done
+#14 exporting attestation manifest sha256:8967dd337dd95761cf25863521dbf28ae1b9c1f66506bb36bf37087836691d4c
+#14 exporting attestation manifest sha256:8967dd337dd95761cf25863521dbf28ae1b9c1f66506bb36bf37087836691d4c 0.1s done
+#14 exporting manifest list sha256:aa69a2c91d8b5ce4afa05585701bceb6ade4d6320834e9722bd530520afec6aa 0.0s done
 #14 naming to docker.io/library/hushline-app:latest done
-#14 unpacking to docker.io/library/hushline-app:latest done
-#14 DONE 0.1s
+#14 unpacking to docker.io/library/hushline-app:latest 0.0s done
+#14 DONE 0.2s
 
 #15 [dev_data] exporting to image
 #15 exporting layers done
-#15 exporting manifest sha256:d4d633a72f43512c563be3aa798001aec4bc9772275dea375596d56fb485e3b3 done
+#15 exporting manifest sha256:d4d633a72f43512c563be3aa798001aec4bc9772275dea375596d56fb485e3b3 0.0s done
 #15 exporting config sha256:8ee7dc3a1036e4843c6345fca685e34af0c98f80f49352995b79d3dceec9d7e6 done
-#15 exporting attestation manifest sha256:4189989e92b26cd97c283415d43638dc86d3ba48ae8a1d22ff5c18098d842dbf 0.1s done
-#15 exporting manifest list sha256:9b5c500551edf899301a2e67d785cf65320d54c3add9c498f01030d1be0f2fb1 0.0s done
+#15 exporting attestation manifest sha256:1a9f7c2b16ae629ed4a34a95f04f55627cb9433a58f0d907d9d66ed8af357f55 0.1s done
+#15 exporting manifest list sha256:4ccff0eb6cda5b99683c4705dab4bfaef5ffba5cf0fcc0148f068fa77fb3ba75 0.0s done
 #15 naming to docker.io/library/hushline-dev_data:latest done
-#15 unpacking to docker.io/library/hushline-dev_data:latest done
-#15 DONE 0.1s
+#15 unpacking to docker.io/library/hushline-dev_data:latest 0.0s done
+#15 DONE 0.2s
 
-#16 [app] resolving provenance for metadata file
-#16 DONE 0.0s
+#16 [dev_data] resolving provenance for metadata file
+#16 ...
 
-#17 [dev_data] resolving provenance for metadata file
-#17 DONE 0.0s
- Image hushline-app Built 
+#17 [app] resolving provenance for metadata file
+#17 DONE 0.1s
+
+#16 [dev_data] resolving provenance for metadata file
+#16 DONE 0.1s
  Image hushline-dev_data Built 
+ Image hushline-app Built 
  Network hushline_default Creating 
  Network hushline_default Created 
  Volume hushline_hushline-node-modules Creating 
  Volume hushline_hushline-node-modules Created 
- Container hushline-blob-storage-1 Creating 
  Container hushline-postgres-1 Creating 
+ Container hushline-blob-storage-1 Creating 
  Container hushline-webpack-1 Creating 
  Container hushline-webpack-1 Created 
  Container hushline-blob-storage-1 Created 
@@ -138,12 +144,12 @@ HEAD is now at d893290f Document issue 411 crypto feasibility (#2012)
  Container hushline-dev_data-1 Created 
  Container hushline-app-1 Creating 
  Container hushline-app-1 Created 
- Container hushline-webpack-1 Starting 
  Container hushline-postgres-1 Starting 
+ Container hushline-webpack-1 Starting 
  Container hushline-blob-storage-1 Starting 
+ Container hushline-blob-storage-1 Started 
  Container hushline-postgres-1 Started 
  Container hushline-postgres-1 Waiting 
- Container hushline-blob-storage-1 Started 
  Container hushline-webpack-1 Started 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
@@ -160,31 +166,31 @@ HEAD is now at d893290f Document issue 411 crypto feasibility (#2012)
  Container hushline-postgres-1 Running 
  Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
- Container hushline-dev_data-run-93be7a274bd9 Creating 
- Container hushline-dev_data-run-93be7a274bd9 Created 
+ Container hushline-dev_data-run-835b4fcc3d3f Creating 
+ Container hushline-dev_data-run-835b4fcc3d3f Created 
 poetry run ./scripts/dev_migrations.py
 Creating database tables
 Database tables created
 poetry run ./scripts/dev_data.py
-2026-05-26 05:57:09,945:INFO:Password hash counter
-2026-05-26 05:57:10,126:INFO:Password hash counter
-2026-05-26 05:57:10,304:INFO:Password hash counter
-2026-05-26 05:57:10,479:INFO:Password hash counter
-2026-05-26 05:57:10,668:INFO:Password hash counter
-2026-05-26 05:57:10,859:INFO:Password hash counter
-2026-05-26 05:57:11,035:INFO:Password hash counter
-2026-05-26 05:57:11,210:INFO:Password hash counter
-2026-05-26 05:57:11,388:INFO:Password hash counter
-2026-05-26 05:57:11,564:INFO:Password hash counter
-2026-05-26 05:57:11,744:INFO:Password hash counter
-2026-05-26 05:57:11,939:INFO:Password hash counter
-2026-05-26 05:57:12,117:INFO:Password hash counter
-2026-05-26 05:57:12,292:INFO:Password hash counter
-2026-05-26 05:57:12,468:INFO:Password hash counter
-2026-05-26 05:57:12,649:INFO:Password hash counter
-2026-05-26 05:57:12,832:INFO:Password hash counter
-2026-05-26 05:57:13,043:INFO:Password hash counter
-2026-05-26 05:57:13,225:INFO:Password hash counter
+2026-05-27 09:48:02,589:INFO:Password hash counter
+2026-05-27 09:48:02,774:INFO:Password hash counter
+2026-05-27 09:48:02,956:INFO:Password hash counter
+2026-05-27 09:48:03,135:INFO:Password hash counter
+2026-05-27 09:48:03,339:INFO:Password hash counter
+2026-05-27 09:48:03,519:INFO:Password hash counter
+2026-05-27 09:48:03,696:INFO:Password hash counter
+2026-05-27 09:48:03,872:INFO:Password hash counter
+2026-05-27 09:48:04,049:INFO:Password hash counter
+2026-05-27 09:48:04,227:INFO:Password hash counter
+2026-05-27 09:48:04,427:INFO:Password hash counter
+2026-05-27 09:48:04,602:INFO:Password hash counter
+2026-05-27 09:48:04,778:INFO:Password hash counter
+2026-05-27 09:48:04,953:INFO:Password hash counter
+2026-05-27 09:48:05,129:INFO:Password hash counter
+2026-05-27 09:48:05,308:INFO:Password hash counter
+2026-05-27 09:48:05,512:INFO:Password hash counter
+2026-05-27 09:48:05,692:INFO:Password hash counter
+2026-05-27 09:48:05,869:INFO:Password hash counter
 Adding dev data
 Tier:
   name = Free
@@ -236,12 +242,12 @@ Restoring generated static JS artifacts dirtied by runtime bootstrap.
  M hushline/static/js/directory_verified.js
  M hushline/static/js/settings-location.js
 ==> Fetch epic base branch codex/epic-2013
-==> Create branch codex/daily-issue-2018 from origin/codex/epic-2013
-Switched to a new branch 'codex/daily-issue-2018'
-branch 'codex/daily-issue-2018' set up to track 'origin/codex/epic-2013'.
+==> Create branch codex/daily-issue-2057 from origin/codex/epic-2013
+Switched to a new branch 'codex/daily-issue-2057'
+branch 'codex/daily-issue-2057' set up to track 'origin/codex/epic-2013'.
 ==> Codex issue attempt 1
 Codex execution started; transcript output is excluded from persisted run logs.
-Prompt stats: bytes=3387 lines=59 words=487
+Prompt stats: bytes=3456 lines=53 words=500
 Pre-Codex worktree snapshot:
 git status --short:
 (clean)
@@ -250,29 +256,128 @@ Non-log changed files:
 Codex execution completed.
 Post-Codex worktree snapshot:
 git status --short:
- M docs/ISSUE-411-SYMMETRIC-CRYPTO-FEASIBILITY.md
- M docs/README.md
-?? docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
-?? tests/test_encrypted_field_migration_runbook.py
+ M tests/migrations/revision_b2039e7c0a1d.py
+ M tests/test_migrations.py
 Non-log changed files:
-docs/ISSUE-411-SYMMETRIC-CRYPTO-FEASIBILITY.md
-docs/README.md
-docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
-tests/test_encrypted_field_migration_runbook.py
+tests/migrations/revision_b2039e7c0a1d.py
+tests/test_migrations.py
 Codex final message:
-Implemented the runbook for issue #2018.
+Implemented issue #2057 with a test-only diff.
 
 Changed:
-- Added [ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md]([redacted-path]
-- Linked it from [docs/README.md]([redacted-path]
-- Cross-linked it from the Phase 5 section in [ISSUE-411-SYMMETRIC-CRYPTO-FEASIBILITY.md]([redacted-path]
-- Added doc coverage tests in [test_encrypted_field_migration_runbook.py]([redacted-path]
+- Expanded `b2039e7c0a1d` migration fixtures to cover legacy, safe envelope, null, and empty values across all widened encrypted columns.
+- Parameterized oversized downgrade refusal across every envelope-ready widened column.
+- Added rollback readability coverage proving mixed legacy/envelope ciphertext remains decryptable after downgrade with legacy writes restored.
+- Added CLI preflight coverage before and after the widening migration.
+- Added preservation checks so failed downgrades leave existing DB values intact.
 
-The runbook covers local/staging/production execution, preflight counts and decryptability, dry runs, small batches, idempotent resume, per-row verification, backup/restore rehearsal, progress/failure reporting, and rollback with the old reader preserved.
-
-Validation not run locally; the runner will run `make lint` and `make test`.
+Validation:
+- Ran `git diff --check`.
+- Did not run `make lint` or `make test`; the runner handles those checks.
 ==> Refresh local runtime after schema changes
-Skipped: no schema-affecting files changed.
+==> Start Docker stack
+ Network hushline_default Creating 
+ Network hushline_default Created 
+ Container hushline-postgres-1 Creating 
+ Container hushline-blob-storage-1 Creating 
+ Container hushline-blob-storage-1 Created 
+ Container hushline-postgres-1 Created 
+ Container hushline-dev_data-1 Creating 
+ Container hushline-dev_data-1 Created 
+ Container hushline-app-1 Creating 
+ Container hushline-app-1 Created 
+ Container hushline-blob-storage-1 Starting 
+ Container hushline-postgres-1 Starting 
+ Container hushline-blob-storage-1 Started 
+ Container hushline-postgres-1 Started 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-1 Starting 
+ Container hushline-app-1 Started 
+==> Seed development data
+ Container hushline-postgres-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-run-688b7f02b046 Creating 
+ Container hushline-dev_data-run-688b7f02b046 Created 
+poetry run ./scripts/dev_migrations.py
+Creating database tables
+Database tables created
+poetry run ./scripts/dev_data.py
+2026-05-27 09:54:11,481:INFO:Password hash counter
+2026-05-27 09:54:11,672:INFO:Password hash counter
+2026-05-27 09:54:11,861:INFO:Password hash counter
+2026-05-27 09:54:12,045:INFO:Password hash counter
+2026-05-27 09:54:12,253:INFO:Password hash counter
+2026-05-27 09:54:12,439:INFO:Password hash counter
+2026-05-27 09:54:12,625:INFO:Password hash counter
+2026-05-27 09:54:12,807:INFO:Password hash counter
+2026-05-27 09:54:12,993:INFO:Password hash counter
+2026-05-27 09:54:13,177:INFO:Password hash counter
+2026-05-27 09:54:13,383:INFO:Password hash counter
+2026-05-27 09:54:13,566:INFO:Password hash counter
+2026-05-27 09:54:13,750:INFO:Password hash counter
+2026-05-27 09:54:13,933:INFO:Password hash counter
+2026-05-27 09:54:14,117:INFO:Password hash counter
+2026-05-27 09:54:14,306:INFO:Password hash counter
+2026-05-27 09:54:14,510:INFO:Password hash counter
+2026-05-27 09:54:14,696:INFO:Password hash counter
+2026-05-27 09:54:14,881:INFO:Password hash counter
+Adding dev data
+Tier:
+  name = Free
+  monthly_amount = 0
+Tier:
+  name = Super User
+  monthly_amount = 500
+Dev data added
+User updated:
+  username = admin
+User updated:
+  username = artvandelay
+User updated:
+  username = jerryseinfeld
+User updated:
+  username = georgecostanza
+User updated:
+  username = elainebenes
+User updated:
+  username = cosmokramer
+User updated:
+  username = newman
+User updated:
+  username = frankcostanza
+User updated:
+  username = michaelbluth
+User updated:
+  username = gobbluth
+User updated:
+  username = busterbluth
+User updated:
+  username = lucillebluth
+User updated:
+  username = tobiasfunke
+User updated:
+  username = larrydavid
+User updated:
+  username = jeffgreene
+User updated:
+  username = leonblack
+User updated:
+  username = dwightschrute
+User updated:
+  username = martymcfly
+User updated:
+  username = georgecostanzakr
+Public storage bucket: public
 ==> Run lint
 docker compose run --rm app poetry run ruff format --check && \
 	docker compose run --rm app poetry run ruff check --output-format full && \
@@ -284,42 +389,17 @@ docker compose run --rm app poetry run ruff format --check && \
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
- Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
  Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-e173dd2dcc28 Creating 
- Container hushline-app-run-e173dd2dcc28 Created 
-229 files already formatted
- Container hushline-blob-storage-1 Running 
- Container hushline-postgres-1 Running 
- Container hushline-postgres-1 Waiting 
- Container hushline-postgres-1 Healthy 
- Container hushline-dev_data-1 Starting 
- Container hushline-dev_data-1 Started 
- Container hushline-dev_data-1 Waiting 
- Container hushline-postgres-1 Waiting 
- Container hushline-blob-storage-1 Waiting 
- Container hushline-postgres-1 Healthy 
- Container hushline-blob-storage-1 Healthy 
- Container hushline-dev_data-1 Exited 
- Container hushline-app-run-e5dd73a6cb13 Creating 
- Container hushline-app-run-e5dd73a6cb13 Created 
-tests/test_encrypted_field_migration_runbook.py:1:1: I001 [*] Import block is un-sorted or un-formatted
-  |
-1 | / from pathlib import Path
-2 | | 
-3 | | 
-4 | | REPO_ROOT = Path(__file__).resolve().parents[1]
-  | |_^ I001
-5 |   RUNBOOK = REPO_ROOT / "docs" / "ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md"
-  |
-  = help: Organize imports
-
-Found 1 error.
-[*] 1 fixable with the `--fix` option.
+ Container hushline-app-run-9fde414a9aa3 Creating 
+ Container hushline-app-run-9fde414a9aa3 Created 
+Would reformat: tests/migrations/revision_b2039e7c0a1d.py
+Would reformat: tests/test_migrations.py
+2 files would be reformatted, 233 files already formatted
 
 make: *** [lint] Error 1
 Self-heal: applying deterministic lint fix via make fix.
@@ -328,41 +408,42 @@ docker compose run --rm app sh -lc 'set -e; \
 		poetry run ruff check --fix || true; \
 		poetry run ruff format; \
 		if [ -x node_modules/.bin/prettier ] && node_modules/.bin/prettier --version >/dev/null 2>&1; then node_modules/.bin/prettier --ignore-path /dev/null --write ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; elif command -v prettier >/dev/null 2>&1 && prettier --version >/dev/null 2>&1; then prettier --ignore-path /dev/null --write ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; else echo "Error: prettier/node is unavailable in this environment." >&2; exit 1; fi'
- Container hushline-postgres-1 Running 
  Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Running 
  Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
- Container hushline-blob-storage-1 Waiting 
  Container hushline-dev_data-1 Waiting 
  Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-377be827fdad Creating 
- Container hushline-app-run-377be827fdad Created 
-Found 1 error (1 fixed, 0 remaining).
-229 files left unchanged
-AGENTS.md 81ms (unchanged)
-README.md 27ms (unchanged)
-SECURITY.md 10ms (unchanged)
-docs/AGENT-RUNNER.md 43ms (unchanged)
-docs/AGENTIC-CODE-POLICY.md 1ms (unchanged)
-docs/ARCHITECTURE.md 3ms (unchanged)
+ Container hushline-app-run-7ee9640da2eb Creating 
+ Container hushline-app-run-7ee9640da2eb Created 
+Found 2 errors (2 fixed, 0 remaining).
+2 files reformatted, 233 files left unchanged
+AGENTS.md 99ms (unchanged)
+README.md 32ms (unchanged)
+SECURITY.md 11ms (unchanged)
+docs/AGENT-RUNNER.md 52ms (unchanged)
+docs/AGENTIC-CODE-POLICY.md 2ms (unchanged)
+docs/ARCHITECTURE.md 4ms (unchanged)
 docs/DEV.md 3ms (unchanged)
 docs/EMBEDDABLE-E2EE-PROFILE-FORMS-FEASIBILITY.md 43ms (unchanged)
 docs/EMBEDDABLE-FORMS-ADMIN.md 6ms (unchanged)
-docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md 24ms (unchanged)
-docs/ENCRYPTED-FIELD-MODERNIZATION-ADR.md 21ms (unchanged)
-docs/FLASK-WTF-WTFORMS-MODERNIZATION-STRATEGY.md 28ms (unchanged)
-docs/GLOBALEAKS-DIRECTORY-SYNC.md 4ms (unchanged)
-docs/ISO-37002.md 136ms (unchanged)
-docs/ISSUE-411-SYMMETRIC-CRYPTO-FEASIBILITY.md 41ms (unchanged)
-docs/library/getting-started/new-user-onboarding.md 3ms (unchanged)
+docs/ENCRYPTED-FIELD-AEAD-EVALUATION.md 18ms (unchanged)
+docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md 28ms (unchanged)
+docs/ENCRYPTED-FIELD-MODERNIZATION-ADR.md 26ms (unchanged)
+docs/FLASK-WTF-WTFORMS-MODERNIZATION-STRATEGY.md 30ms (unchanged)
+docs/GLOBALEAKS-DIRECTORY-SYNC.md 3ms (unchanged)
+docs/ISO-37002.md 157ms (unchanged)
+docs/ISSUE-411-SYMMETRIC-CRYPTO-FEASIBILITY.md 43ms (unchanged)
+docs/library/getting-started/new-user-onboarding.md 6ms (unchanged)
 docs/library/getting-started/prep-your-account.md 5ms (unchanged)
-docs/library/getting-started/README.md 1ms (unchanged)
-docs/library/getting-started/secure-your-account.md 3ms (unchanged)
+docs/library/getting-started/README.md 2ms (unchanged)
+docs/library/getting-started/secure-your-account.md 4ms (unchanged)
 docs/library/getting-started/share-your-tip-line.md 3ms (unchanged)
 docs/library/getting-started/start-here.md 4ms (unchanged)
 docs/library/personal-server/README.md 1ms (unchanged)
@@ -370,111 +451,113 @@ docs/library/personal-server/specs.md 3ms (unchanged)
 docs/library/personal-server/the-hush-line-personal-server.md 4ms (unchanged)
 docs/library/README.md 2ms (unchanged)
 docs/library/using-your-tip-line/account-verification.md 3ms (unchanged)
-docs/library/using-your-tip-line/dark-mode.md 3ms (unchanged)
+docs/library/using-your-tip-line/dark-mode.md 2ms (unchanged)
 docs/library/using-your-tip-line/download-your-data.md 2ms (unchanged)
-docs/library/using-your-tip-line/email-validation.md 2ms (unchanged)
-docs/library/using-your-tip-line/embeddable-forms.md 3ms (unchanged)
+docs/library/using-your-tip-line/email-validation.md 4ms (unchanged)
+docs/library/using-your-tip-line/embeddable-forms.md 5ms (unchanged)
 docs/library/using-your-tip-line/message-statuses.md 3ms (unchanged)
-docs/library/using-your-tip-line/reading-messages.md 2ms (unchanged)
-docs/library/using-your-tip-line/README.md 2ms (unchanged)
+docs/library/using-your-tip-line/reading-messages.md 3ms (unchanged)
+docs/library/using-your-tip-line/README.md 1ms (unchanged)
 docs/library/using-your-tip-line/tools.md 2ms (unchanged)
-docs/library/using-your-tip-line/vision-assistant.md 2ms (unchanged)
+docs/library/using-your-tip-line/vision-assistant.md 3ms (unchanged)
 docs/library/using-your-tip-line/your-inbox.md 3ms (unchanged)
 docs/library/welcome/README.md 1ms (unchanged)
-docs/library/welcome/welcome-to-hush-line.md 3ms (unchanged)
+docs/library/welcome/welcome-to-hush-line.md 4ms (unchanged)
 docs/LOCAL-CONTRIBUTOR-ONBOARDING-PROMPT.md 3ms (unchanged)
-docs/NEWSROOM-DIRECTORY-DATA.md 2ms (unchanged)
-docs/PRIVACY.md 11ms (unchanged)
-docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md 77ms (unchanged)
-docs/PYTHON-3.13-UPGRADE-READINESS.md 10ms (unchanged)
+docs/NEWSROOM-DIRECTORY-DATA.md 3ms (unchanged)
+docs/OPERATIONAL-KEY-MANAGEMENT-DESIGN.md 14ms (unchanged)
+docs/PASSWORD-HASH-MODERNIZATION-EVALUATION.md 14ms (unchanged)
+docs/PRIVACY.md 14ms (unchanged)
+docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md 74ms (unchanged)
+docs/PYTHON-3.13-UPGRADE-READINESS.md 11ms (unchanged)
 docs/README.md 3ms (unchanged)
-docs/screenshots/README.md 3ms (unchanged)
-docs/screenshots/releases/dark-debug/manifest.json 29ms (unchanged)
-docs/screenshots/releases/dark-target-check/manifest.json 3ms (unchanged)
+docs/screenshots/README.md 2ms (unchanged)
+docs/screenshots/releases/dark-debug/manifest.json 36ms (unchanged)
+docs/screenshots/releases/dark-target-check/manifest.json 4ms (unchanged)
 docs/screenshots/releases/latest/manifest.json 2ms (unchanged)
 docs/screenshots/releases/latest/README.md 1ms (unchanged)
-docs/screenshots/releases/one-off-directory/manifest.json 2ms (unchanged)
-docs/screenshots/releases/one-off-directory/README.md 1ms (unchanged)
-docs/screenshots/releases/recipient-qa/manifest.json 4ms (unchanged)
+docs/screenshots/releases/one-off-directory/manifest.json 3ms (unchanged)
+docs/screenshots/releases/one-off-directory/README.md 2ms (unchanged)
+docs/screenshots/releases/recipient-qa/manifest.json 5ms (unchanged)
 docs/screenshots/releases/recipient-qa/README.md 4ms (unchanged)
-docs/screenshots/scenes.first-user.json 1ms (unchanged)
-docs/screenshots/scenes.json 28ms (unchanged)
+docs/screenshots/scenes.first-user.json 2ms (unchanged)
+docs/screenshots/scenes.json 33ms (unchanged)
 docs/SECUREDROP-DIRECTORY-SYNC.md 3ms (unchanged)
-docs/SECURITY-AUDIT-HITLIST.md 53ms (unchanged)
+docs/SECURITY-AUDIT-HITLIST.md 59ms (unchanged)
 docs/TERMS.md 5ms (unchanged)
-docs/THREAT-MODEL.md 18ms (unchanged)
+docs/THREAT-MODEL.md 21ms (unchanged)
 docs/UI-TEXT-AUDIT.md 12ms (unchanged)
-docs/USE-CASES.md 32ms (unchanged)
-docs/WHISTLEBLOWER-PROTECTION-ACCOUNTABILITY-WALL-FEASIBILITY.md 31ms (unchanged)
+docs/USE-CASES.md 34ms (unchanged)
+docs/WHISTLEBLOWER-PROTECTION-ACCOUNTABILITY-WALL-FEASIBILITY.md 34ms (unchanged)
 .github/workflows/build-latest.yml 21ms (unchanged)
-.github/workflows/build-release.yml 5ms (unchanged)
-.github/workflows/bump-personal-server-after-release.yml 11ms (unchanged)
-.github/workflows/bump-staging-after-release.yml 8ms (unchanged)
-.github/workflows/ccpa-compliance.yml 3ms (unchanged)
+.github/workflows/build-release.yml 6ms (unchanged)
+.github/workflows/bump-personal-server-after-release.yml 14ms (unchanged)
+.github/workflows/bump-staging-after-release.yml 11ms (unchanged)
+.github/workflows/ccpa-compliance.yml 4ms (unchanged)
 .github/workflows/close-epic-child-issue-on-merge.yml 2ms (unchanged)
-.github/workflows/dependency-security-audit.yml 6ms (unchanged)
-.github/workflows/dev_deploy.yml 9ms (unchanged)
-.github/workflows/docs-screenshots.yml 10ms (unchanged)
+.github/workflows/dependency-security-audit.yml 5ms (unchanged)
+.github/workflows/dev_deploy.yml 10ms (unchanged)
+.github/workflows/docs-screenshots.yml 17ms (unchanged)
 .github/workflows/e2ee-privacy-regressions.yml 2ms (unchanged)
 .github/workflows/gdpr-compliance.yml 2ms (unchanged)
-.github/workflows/globaleaks-directory-refresh.yml 3ms (unchanged)
+.github/workflows/globaleaks-directory-refresh.yml 4ms (unchanged)
 .github/workflows/lighthouse-performance.yml 2ms (unchanged)
 .github/workflows/lighthouse.yml 3ms (unchanged)
-.github/workflows/migration-smoke.yml 2ms (unchanged)
-.github/workflows/public-directory-weekly-report.yml 3ms (unchanged)
+.github/workflows/migration-smoke.yml 3ms (unchanged)
+.github/workflows/public-directory-weekly-report.yml 5ms (unchanged)
 .github/workflows/public-record-link-check.yml 2ms (unchanged)
-.github/workflows/public-record-quarterly-refresh.yml 3ms (unchanged)
+.github/workflows/public-record-quarterly-refresh.yml 4ms (unchanged)
 .github/workflows/publish-docs-screenshots.yml 4ms (unchanged)
-.github/workflows/securedrop-directory-refresh.yml 3ms (unchanged)
+.github/workflows/securedrop-directory-refresh.yml 5ms (unchanged)
 .github/workflows/tests.yml 3ms (unchanged)
-.github/workflows/w3c-validators.yml 2ms (unchanged)
+.github/workflows/w3c-validators.yml 3ms (unchanged)
 .github/workflows/workflow-security.yml 3ms (unchanged)
-hushline/data/globaleaks_instances.json 4ms (unchanged)
-hushline/data/newsroom_directory_listings.json 252ms (unchanged)
-hushline/data/public_record_law_firms.json 32ms (unchanged)
+hushline/data/globaleaks_instances.json 3ms (unchanged)
+hushline/data/newsroom_directory_listings.json 317ms (unchanged)
+hushline/data/public_record_law_firms.json 37ms (unchanged)
 hushline/data/public_record_law_firms_legacy.json 6ms (unchanged)
-hushline/data/securedrop_directory_instances.json 4ms (unchanged)
+hushline/data/securedrop_directory_instances.json 7ms (unchanged)
 hushline/static/manifest.json 0ms (unchanged)
-hushline/static/no-js.js 8ms (unchanged)
-hushline/static/js/directory_verified.js 102ms (unchanged)
-hushline/static/js/settings-location.js 13ms (unchanged)
+hushline/static/no-js.js 9ms (unchanged)
+hushline/static/js/directory_verified.js 125ms (unchanged)
+hushline/static/js/settings-location.js 14ms (unchanged)
 /Library/Developer/CommandLineTools/usr/bin/make lint
 docker compose run --rm app poetry run ruff format --check && \
 	docker compose run --rm app poetry run ruff check --output-format full && \
 	docker compose run --rm app poetry run mypy . && \
 	docker compose run --rm app sh -lc 'if [ -x node_modules/.bin/prettier ] && node_modules/.bin/prettier --version >/dev/null 2>&1; then node_modules/.bin/prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; elif command -v prettier >/dev/null 2>&1 && prettier --version >/dev/null 2>&1; then prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js; else echo "Error: prettier/node is unavailable in this environment." >&2; exit 1; fi'
+ Container hushline-postgres-1 Running 
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-f3a81cded159 Creating 
+ Container hushline-app-run-f3a81cded159 Created 
+235 files already formatted
  Container hushline-blob-storage-1 Running 
  Container hushline-postgres-1 Running 
  Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
+ Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
  Container hushline-dev_data-1 Waiting 
- Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-c05f2abed0c8 Creating 
- Container hushline-app-run-c05f2abed0c8 Created 
-229 files already formatted
- Container hushline-blob-storage-1 Running 
- Container hushline-postgres-1 Running 
- Container hushline-postgres-1 Waiting 
- Container hushline-postgres-1 Healthy 
- Container hushline-dev_data-1 Starting 
- Container hushline-dev_data-1 Started 
- Container hushline-blob-storage-1 Waiting 
- Container hushline-dev_data-1 Waiting 
- Container hushline-postgres-1 Waiting 
- Container hushline-postgres-1 Healthy 
- Container hushline-blob-storage-1 Healthy 
- Container hushline-dev_data-1 Exited 
- Container hushline-app-run-f446f26c76be Creating 
- Container hushline-app-run-f446f26c76be Created 
+ Container hushline-app-run-4a40322cabed Creating 
+ Container hushline-app-run-4a40322cabed Created 
 All checks passed!
- Container hushline-postgres-1 Running 
  Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Running 
  Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
@@ -485,26 +568,140 @@ All checks passed!
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-2f0c006fd1f3 Creating 
- Container hushline-app-run-2f0c006fd1f3 Created 
-Success: no issues found in 228 source files
- Container hushline-postgres-1 Running 
- Container hushline-blob-storage-1 Running 
+ Container hushline-app-run-1aeab6b1f5d7 Creating 
+ Container hushline-app-run-1aeab6b1f5d7 Created 
+tests/test_migrations.py:263: error: Item "None" of "str | None" has no attribute "startswith"  [union-attr]
+Found 1 error in 1 file (checked 234 source files)
+
+make[1]: *** [lint] Error 1
+make: *** [fix] Error 2
+Workflow checks failed; Codex self-heal attempt 1.
+Codex execution started; transcript output is excluded from persisted run logs.
+Prompt stats: bytes=7088 lines=108 words=765
+Pre-Codex worktree snapshot:
+git status --short:
+ M tests/migrations/revision_b2039e7c0a1d.py
+ M tests/test_migrations.py
+Non-log changed files:
+tests/migrations/revision_b2039e7c0a1d.py
+tests/test_migrations.py
+Codex execution completed.
+Post-Codex worktree snapshot:
+git status --short:
+ M tests/migrations/revision_b2039e7c0a1d.py
+ M tests/test_migrations.py
+Non-log changed files:
+tests/migrations/revision_b2039e7c0a1d.py
+tests/test_migrations.py
+Codex final message:
+Fixed the mypy failure in [tests/test_migrations.py]([redacted-path] by narrowing `crypto.decrypt_field()` before calling `startswith()`.
+
+I did not run local validation; the runner will rerun `make lint` and `make test`.
+==> Refresh local runtime after schema changes
+==> Start Docker stack
+ Network hushline_default Creating 
+ Network hushline_default Created 
+ Container hushline-blob-storage-1 Creating 
+ Container hushline-postgres-1 Creating 
+ Container hushline-postgres-1 Created 
+ Container hushline-blob-storage-1 Created 
+ Container hushline-dev_data-1 Creating 
+ Container hushline-dev_data-1 Created 
+ Container hushline-app-1 Creating 
+ Container hushline-app-1 Created 
+ Container hushline-postgres-1 Starting 
+ Container hushline-blob-storage-1 Starting 
+ Container hushline-postgres-1 Started 
  Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Started 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
- Container hushline-dev_data-1 Waiting 
  Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-aff068372c4f Creating 
- Container hushline-app-run-aff068372c4f Created 
-Checking formatting...
-All matched files use Prettier code style!
-==> Re-run lint after deterministic auto-fix
+ Container hushline-app-1 Starting 
+ Container hushline-app-1 Started 
+==> Seed development data
+ Container hushline-postgres-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-run-b75ee7f763c2 Creating 
+ Container hushline-dev_data-run-b75ee7f763c2 Created 
+poetry run ./scripts/dev_migrations.py
+Creating database tables
+Database tables created
+poetry run ./scripts/dev_data.py
+2026-05-27 09:56:00,396:INFO:Password hash counter
+2026-05-27 09:56:00,585:INFO:Password hash counter
+2026-05-27 09:56:00,772:INFO:Password hash counter
+2026-05-27 09:56:00,955:INFO:Password hash counter
+2026-05-27 09:56:01,163:INFO:Password hash counter
+2026-05-27 09:56:01,346:INFO:Password hash counter
+2026-05-27 09:56:01,529:INFO:Password hash counter
+2026-05-27 09:56:01,711:INFO:Password hash counter
+2026-05-27 09:56:01,894:INFO:Password hash counter
+2026-05-27 09:56:02,077:INFO:Password hash counter
+2026-05-27 09:56:02,283:INFO:Password hash counter
+2026-05-27 09:56:02,465:INFO:Password hash counter
+2026-05-27 09:56:02,647:INFO:Password hash counter
+2026-05-27 09:56:02,829:INFO:Password hash counter
+2026-05-27 09:56:03,012:INFO:Password hash counter
+2026-05-27 09:56:03,195:INFO:Password hash counter
+2026-05-27 09:56:03,401:INFO:Password hash counter
+2026-05-27 09:56:03,584:INFO:Password hash counter
+2026-05-27 09:56:03,768:INFO:Password hash counter
+Adding dev data
+Tier:
+  name = Free
+  monthly_amount = 0
+Tier:
+  name = Super User
+  monthly_amount = 500
+Dev data added
+User updated:
+  username = admin
+User updated:
+  username = artvandelay
+User updated:
+  username = jerryseinfeld
+User updated:
+  username = georgecostanza
+User updated:
+  username = elainebenes
+User updated:
+  username = cosmokramer
+User updated:
+  username = newman
+User updated:
+  username = frankcostanza
+User updated:
+  username = michaelbluth
+User updated:
+  username = gobbluth
+User updated:
+  username = busterbluth
+User updated:
+  username = lucillebluth
+User updated:
+  username = tobiasfunke
+User updated:
+  username = larrydavid
+User updated:
+  username = jeffgreene
+User updated:
+  username = leonblack
+User updated:
+  username = dwightschrute
+User updated:
+  username = martymcfly
+User updated:
+  username = georgecostanzakr
+Public storage bucket: public
+==> Run lint
 docker compose run --rm app poetry run ruff format --check && \
 	docker compose run --rm app poetry run ruff check --output-format full && \
 	docker compose run --rm app poetry run mypy . && \
@@ -515,30 +712,45 @@ docker compose run --rm app poetry run ruff format --check && \
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
- Container hushline-dev_data-1 Waiting 
  Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-f50f9f842732 Creating 
- Container hushline-app-run-f50f9f842732 Created 
-229 files already formatted
+ Container hushline-app-run-c0995f88af3a Creating 
+ Container hushline-app-run-c0995f88af3a Created 
+235 files already formatted
  Container hushline-blob-storage-1 Running 
  Container hushline-postgres-1 Running 
  Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
+ Container hushline-dev_data-1 Waiting 
  Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
- Container hushline-dev_data-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-0cde2745168d Creating 
- Container hushline-app-run-0cde2745168d Created 
+ Container hushline-app-run-465b138e24c5 Creating 
+ Container hushline-app-run-465b138e24c5 Created 
 All checks passed!
+ Container hushline-postgres-1 Running 
+ Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-run-fe9e3086c9ce Creating 
+ Container hushline-app-run-fe9e3086c9ce Created 
+Success: no issues found in 234 source files
  Container hushline-blob-storage-1 Running 
  Container hushline-postgres-1 Running 
  Container hushline-postgres-1 Waiting 
@@ -548,26 +760,11 @@ All checks passed!
  Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
  Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
- Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-370de487c149 Creating 
- Container hushline-app-run-370de487c149 Created 
-Success: no issues found in 228 source files
- Container hushline-blob-storage-1 Running 
- Container hushline-postgres-1 Running 
- Container hushline-postgres-1 Waiting 
- Container hushline-postgres-1 Healthy 
- Container hushline-dev_data-1 Starting 
- Container hushline-dev_data-1 Started 
- Container hushline-postgres-1 Waiting 
- Container hushline-blob-storage-1 Waiting 
- Container hushline-dev_data-1 Waiting 
- Container hushline-blob-storage-1 Healthy 
- Container hushline-postgres-1 Healthy 
- Container hushline-dev_data-1 Exited 
- Container hushline-app-run-fa9531b790e7 Creating 
- Container hushline-app-run-fa9531b790e7 Created 
+ Container hushline-app-run-6f5aa67db898 Creating 
+ Container hushline-app-run-6f5aa67db898 Created 
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run test (full suite)
@@ -584,14 +781,14 @@ docker compose run --rm app poetry run pytest --cov hushline --cov-report term -
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
+ Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
  Container hushline-dev_data-1 Waiting 
- Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-6bf2d3e246a1 Creating 
- Container hushline-app-run-6bf2d3e246a1 Created 
+ Container hushline-app-run-a2a18eff089d Creating 
+ Container hushline-app-run-a2a18eff089d Created 
 ============================= test session starts ==============================
 platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.5.0 -- /root/.cache/pypoetry/virtualenvs/hushline-9TtSrW0h-py3.13/bin/python
 cachedir: .pytest_cache
@@ -599,7 +796,7 @@ rootdir: /app
 configfile: pyproject.toml
 plugins: cov-5.0.0, asyncio-1.3.0, mock-3.14.0
 asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
-collecting ... collected 1863 items / 1 deselected / 1862 selected
+collecting ... collected 1905 items / 1 deselected / 1904 selected
 
 tests/test_2fa.py::test_enable_2fa PASSED                                [  0%]
 tests/test_2fa.py::test_valid_2fa_should_login PASSED                    [  0%]
@@ -619,7 +816,7 @@ tests/test_admin.py::test_admin_settings_clamps_invalid_page_requests PASSED [  
 tests/test_admin.py::test_admin_settings_searches_all_usernames_before_paginating PASSED [  0%]
 tests/test_admin.py::test_admin_settings_hides_verified_on_nonmanaged_service PASSED [  0%]
 tests/test_admin.py::test_toggle_verified_on_managed_service PASSED      [  0%]
-tests/test_admin.py::test_toggle_verified_on_nonmanaged_service PASSED   [  1%]
+tests/test_admin.py::test_toggle_verified_on_nonmanaged_service PASSED   [  0%]
 tests/test_admin.py::test_toggle_admin_only_admin PASSED                 [  1%]
 tests/test_admin.py::test_toggle_admin_multiple_admins PASSED            [  1%]
 tests/test_admin.py::test_toggle_verified_alias_on_managed_service PASSED [  1%]
@@ -638,7 +835,7 @@ tests/test_admin.py::test_toggle_cautious_updates_user PASSED            [  1%]
 tests/test_admin.py::test_toggle_suspended_updates_user PASSED           [  1%]
 tests/test_admin.py::test_toggle_suspended_clears_user_state PASSED      [  1%]
 tests/test_admin.py::test_update_account_category_validates_and_updates_user PASSED [  1%]
-tests/test_admin.py::test_update_account_category_rejects_missing_field_and_unknown_user PASSED [  2%]
+tests/test_admin.py::test_update_account_category_rejects_missing_field_and_unknown_user PASSED [  1%]
 tests/test_admin.py::test_toggle_cautious_user_not_found PASSED          [  2%]
 tests/test_admin.py::test_toggle_suspended_forbidden_for_non_admin PASSED [  2%]
 tests/test_admin.py::test_toggle_suspended_user_not_found PASSED         [  2%]
@@ -656,8 +853,8 @@ tests/test_agent_daily_issue_runner.py::test_runner_defaults_to_approved_codex_m
 tests/test_agent_daily_issue_runner.py::test_runner_defaults_to_ten_minute_idle_polling PASSED [  2%]
 tests/test_agent_daily_issue_runner.py::test_runner_defaults_idle_status_state_file_outside_lock_dir PASSED [  2%]
 tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_proceeds_when_5h_has_capacity PASSED [  2%]
-tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_sleeps_until_low_5h_quota_resets PASSED [  3%]
-tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_backs_off_when_reset_is_stale PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_sleeps_until_low_5h_quota_resets PASSED [  2%]
+tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_backs_off_when_reset_is_stale PASSED [  2%]
 tests/test_agent_daily_issue_runner.py::test_idle_codex_status_check_skips_when_recent PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_idle_codex_status_check_runs_when_due PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_count_open_bot_prs_excluding_heads_fails_closed_when_pr_query_fails PASSED [  3%]
@@ -675,8 +872,8 @@ tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap
 tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap_when_human_pr_exists PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_main_resumes_in_progress_issue_before_selecting_new_work PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap_when_no_issue_is_available PASSED [  3%]
-tests/test_agent_daily_issue_runner.py::test_runner_status_prefixes_lines_with_local_timestamp PASSED [  4%]
-tests/test_agent_daily_issue_runner.py::test_main_bootstrap_does_not_prune_docker_system PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_runner_status_prefixes_lines_with_local_timestamp PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_main_bootstrap_does_not_prune_docker_system PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_build_pr_title_omits_codex_daily_prefix PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_build_pr_title_uses_diagnostic_title_for_diagnostic_pr PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_build_branch_name_uses_issue_prefix PASSED [  4%]
@@ -694,8 +891,8 @@ tests/test_agent_daily_issue_runner.py::test_add_issue_to_project_status_warns_w
 tests/test_agent_daily_issue_runner.py::test_coverage_gap_snapshot_from_log_reports_latest_missed_rows PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_open_coverage_gap_issue_after_pr_creates_agent_eligible_issue PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_filters_open_issues_in_target_status PASSED [  4%]
-tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_paginates_before_filtering PASSED [  5%]
-tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_supports_custom_status_name PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_paginates_before_filtering PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_supports_custom_status_name PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_main_allows_existing_epic_pr_before_runtime_bootstrap PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_main_marks_issue_in_progress_before_runtime_bootstrap PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_main_uses_fetched_origin_epic_ref_for_child_pr_uniqueness_check PASSED [  5%]
@@ -712,9 +909,9 @@ tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_adds_plain_
 tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_explains_log_only_run PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_explains_diagnostic_pr PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_matches_network_errors PASSED [  5%]
-tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_rejects_tls_vulnerability_text PASSED [  6%]
-tests/test_agent_daily_issue_runner.py::test_runtime_schema_files_changed_detects_branch_schema_diff_from_runtime_base PASSED [  6%]
-tests/test_agent_daily_issue_runner.py::test_restore_runtime_generated_static_artifacts_cleans_bootstrap_noise PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_rejects_tls_vulnerability_text PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_runtime_schema_files_changed_detects_branch_schema_diff_from_runtime_base PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_restore_runtime_generated_static_artifacts_cleans_bootstrap_noise PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_restore_non_log_worktree_changes_uses_staged_and_worktree_restore PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_run_check_capture_times_out_stuck_check PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_runtime_bootstrap_retries_retryable_registry_failure PASSED [  6%]
@@ -731,9 +928,9 @@ tests/test_agent_daily_issue_runner.py::test_failure_signature_from_text_falls_b
 tests/test_agent_daily_issue_runner.py::test_build_fix_prompt_withholds_raw_check_output PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_recent_failure_block_from_text_extracts_recent_actionable_context PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_recent_failure_block_from_text_redacts_secret_like_values PASSED [  6%]
-tests/test_agent_daily_issue_runner.py::test_recent_failure_block_keeps_traceback_when_coverage_table_follows PASSED [  7%]
-tests/test_agent_daily_issue_runner.py::test_failure_excerpt_from_text_redacts_sensitive_values PASSED [  7%]
-tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_stops_after_max_attempts PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_recent_failure_block_keeps_traceback_when_coverage_table_follows PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_failure_excerpt_from_text_redacts_sensitive_values PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_stops_after_max_attempts PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_retries_when_post_fix_changes_collapse_to_log_only PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_has_non_log_changes_ignores_preexisting_branch_commits PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_summarize_pr_feedback_reports_unresolved_threads_and_comments PASSED [  7%]
@@ -749,10 +946,10 @@ tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_repor
 tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_polls_until_pr_closes PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_pr_feedback_action_waits_for_pending_checks PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_pr_feedback_action_key_ignores_pending_count_changes PASSED [  7%]
-tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_addresses_actionable_feedback_once PASSED [  8%]
-tests/test_agent_daily_issue_runner.py::test_address_pr_feedback_replies_and_resolves_review_threads PASSED [  8%]
-tests/test_agent_daily_issue_runner.py::test_pr_feedback_thread_targets_only_include_team_members_or_codex PASSED [  8%]
-tests/test_agent_daily_issue_runner.py::test_resolve_pr_number_from_ref_prefers_pr_url_without_gh_lookup PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_addresses_actionable_feedback_once PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_address_pr_feedback_replies_and_resolves_review_threads PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_pr_feedback_thread_targets_only_include_team_members_or_codex PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_resolve_pr_number_from_ref_prefers_pr_url_without_gh_lookup PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_main_refuses_review_pr_when_issue_loop_fails PASSED [  8%]
 tests/test_agent_daily_issue_runner.py::test_main_continues_after_pr_create_when_pr_number_lookup_fails PASSED [  8%]
 tests/test_agent_daily_issue_runner.py::test_main_keeps_pr_branch_checked_out_until_feedback_monitor_returns PASSED [  8%]
@@ -768,10 +965,10 @@ tests/test_behavior_contracts.py::test_contract_notifications_field_content_mode
 tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_prefers_client_encrypted_body PASSED [  8%]
 tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_falls_back_to_server_encrypt PASSED [  8%]
 tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_uses_client_body_for_all_enabled_recipients PASSED [  8%]
-tests/test_behavior_contracts.py::test_contract_2fa_enable_then_disable_round_trip PASSED [  9%]
-tests/test_behavior_contracts.py::test_contract_onboarding_notifications_and_directory_persist_expected_state PASSED [  9%]
-tests/test_behavior_contracts.py::test_contract_directory_users_surface_verified_and_unverified_accounts PASSED [  9%]
-tests/test_behavior_contracts.py::test_contract_whistleblower_message_flow_defaults_and_actions PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_2fa_enable_then_disable_round_trip PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_onboarding_notifications_and_directory_persist_expected_state PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_directory_users_surface_verified_and_unverified_accounts PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_whistleblower_message_flow_defaults_and_actions PASSED [  8%]
 tests/test_behavior_contracts.py::test_contract_message_actions_do_not_cross_user_boundaries PASSED [  9%]
 tests/test_behavior_contracts.py::test_contract_authenticated_settings_profile_and_auth_round_trip PASSED [  9%]
 tests/test_behavior_contracts.py::test_contract_authenticated_encryption_and_data_export_flow PASSED [  9%]
@@ -782,11 +979,19 @@ tests/test_cli_commands.py::test_reg_settings_command_outputs_current_values PAS
 tests/test_cli_commands.py::test_reg_toggle_commands_update_org_settings PASSED [  9%]
 tests/test_cli_commands.py::test_reg_code_commands_create_list_and_delete PASSED [  9%]
 tests/test_cli_commands.py::test_reg_code_create_avoids_dash_prefixed_codes PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_reports_ready_without_sensitive_values PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_blocks_malformed_ciphertext PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_blocks_schema_that_is_not_envelope_ready PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_blocks_missing_schema_without_crashing PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_dry_run_reports_without_writing PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_live_rewrites_and_verifies_post_write PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_live_resumes_after_interruption PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_failure_report_omits_sensitive_values PASSED [  9%]
 tests/test_cli_commands.py::test_password_hash_report_outputs_legacy_count_and_removal_gate PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_report_blocks_when_measured_legacy_successes_non_zero PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_can_remove_passlib_blocks_when_legacy_rows_remain PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_can_remove_passlib_succeeds_when_legacy_rows_and_volume_are_zero PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_can_remove_passlib_accepts_reviewed_in_repo_legacy_verifier_path PASSED [  9%]
+tests/test_cli_commands.py::test_password_hash_report_blocks_when_measured_legacy_successes_non_zero PASSED [ 10%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_blocks_when_legacy_rows_remain PASSED [ 10%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_succeeds_when_legacy_rows_and_volume_are_zero PASSED [ 10%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_accepts_reviewed_in_repo_legacy_verifier_path PASSED [ 10%]
 tests/test_cli_commands.py::test_stripe_configure_skips_when_secret_missing PASSED [ 10%]
 tests/test_cli_commands.py::test_stripe_configure_creates_missing_tiers_when_lookup_returns_none PASSED [ 10%]
 tests/test_cli_commands.py::test_stripe_configure_runs_premium_setup_when_secret_present PASSED [ 10%]
@@ -802,9 +1007,9 @@ tests/test_config.py::test_preferred_url_scheme_invalid_value PASSED     [ 10%]
 tests/test_config.py::test_public_base_url_loads PASSED                  [ 10%]
 tests/test_config.py::test_public_base_url_invalid[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 10%]
 tests/test_config.py::test_public_base_url_invalid[https://example.com/path-PUBLIC_BASE_URL must not include a path] PASSED [ 10%]
-tests/test_config.py::test_public_base_url_invalid[https://example.com/?q=1-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 10%]
-tests/test_config.py::test_public_base_url_invalid[https://example.com/#frag-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 10%]
-tests/test_config.py::test_smtp_notification_reply_to_loads PASSED       [ 10%]
+tests/test_config.py::test_public_base_url_invalid[https://example.com/?q=1-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 11%]
+tests/test_config.py::test_public_base_url_invalid[https://example.com/#frag-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 11%]
+tests/test_config.py::test_smtp_notification_reply_to_loads PASSED       [ 11%]
 tests/test_config.py::test_password_hash_write_use_werkzeug_scrypt_flag_defaults_false_and_parses_true PASSED [ 11%]
 tests/test_config.py::test_password_hash_rehash_on_auth_flag_defaults_false_and_parses_true PASSED [ 11%]
 tests/test_config.py::test_encrypted_field_write_format_defaults_legacy_and_parses_envelope PASSED [ 11%]
@@ -821,9 +1026,9 @@ tests/test_coverage_push.py::test_custom_validators_negative_paths PASSED [ 11%]
 tests/test_coverage_push.py::test_email_forwarding_form_requires_smtp_fields PASSED [ 11%]
 tests/test_coverage_push.py::test_email_forwarding_form_validate_short_circuits_when_base_invalid PASSED [ 11%]
 tests/test_coverage_push.py::test_set_homepage_username_form_rejects_unknown_user PASSED [ 11%]
-tests/test_coverage_push.py::test_base_smtp_config_not_implemented PASSED [ 11%]
-tests/test_coverage_push.py::test_is_safe_smtp_host_rejects_invalid_ip PASSED [ 11%]
-tests/test_coverage_push.py::test_send_email_decodes_bytes_and_returns_false_when_no_attempts PASSED [ 11%]
+tests/test_coverage_push.py::test_base_smtp_config_not_implemented PASSED [ 12%]
+tests/test_coverage_push.py::test_is_safe_smtp_host_rejects_invalid_ip PASSED [ 12%]
+tests/test_coverage_push.py::test_send_email_decodes_bytes_and_returns_false_when_no_attempts PASSED [ 12%]
 tests/test_coverage_push.py::test_message_status_text_upsert_delete_paths PASSED [ 12%]
 tests/test_coverage_push.py::test_encrypted_session_invalid_token_invalid_json_and_missing_key PASSED [ 12%]
 tests/test_coverage_push.py::test_data_export_invalid_form_returns_400 PASSED [ 12%]
@@ -840,9 +1045,9 @@ tests/test_coverage_push.py::test_load_config_additional_branches PASSED [ 12%]
 tests/test_coverage_push.py::test_registration_toggle_false_paths PASSED [ 12%]
 tests/test_coverage_push.py::test_blob_storage_none_driver_when_missing_config PASSED [ 12%]
 tests/test_coverage_push.py::test_encrypt_helpers_branch_types PASSED    [ 12%]
-tests/test_coverage_push.py::test_handle_email_forwarding_form_smtp_validation_exception PASSED [ 12%]
-tests/test_coverage_push.py::test_notifications_toggle_false_flash_paths PASSED [ 12%]
-tests/test_coverage_push.py::test_notifications_toggle_include_content_true_path PASSED [ 12%]
+tests/test_coverage_push.py::test_handle_email_forwarding_form_smtp_validation_exception PASSED [ 13%]
+tests/test_coverage_push.py::test_notifications_toggle_false_flash_paths PASSED [ 13%]
+tests/test_coverage_push.py::test_notifications_toggle_include_content_true_path PASSED [ 13%]
 tests/test_coverage_push.py::test_authentication_required_redirects_to_2fa_when_not_authenticated PASSED [ 13%]
 tests/test_coverage_push.py::test_authentication_required_clears_session_on_session_id_mismatch PASSED [ 13%]
 tests/test_coverage_push.py::test_authentication_required_clears_session_when_user_id_missing PASSED [ 13%]
@@ -859,8 +1064,8 @@ tests/test_coverage_push_remaining.py::test_hushline_init_remaining_paths PASSED
 tests/test_coverage_push_remaining.py::test_crypto_encrypt_message_string_branch PASSED [ 13%]
 tests/test_coverage_push_remaining.py::test_stripe_invoice_remaining_paths PASSED [ 13%]
 tests/test_coverage_push_remaining.py::test_alias_route_delete_button_path PASSED [ 13%]
-tests/test_coverage_push_remaining.py::test_branding_delete_logo_multirow_safety PASSED [ 13%]
-tests/test_coverage_push_remaining.py::test_branding_delete_splash_logo_multirow_safety PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_branding_delete_logo_multirow_safety PASSED [ 14%]
+tests/test_coverage_push_remaining.py::test_branding_delete_splash_logo_multirow_safety PASSED [ 14%]
 tests/test_coverage_push_remaining.py::test_guidance_none_prompts_default_path PASSED [ 14%]
 tests/test_coverage_push_remaining.py::test_settings_common_remaining_paths PASSED [ 14%]
 tests/test_coverage_push_remaining.py::test_enable_2fa_invalid_code_path PASSED [ 14%]
@@ -870,6 +1075,7 @@ tests/test_crypto.py::test_scoped_key_derivation_changes_key PASSED      [ 14%]
 tests/test_crypto.py::test_encrypt_and_decrypt_field PASSED              [ 14%]
 tests/test_crypto.py::test_encrypt_field_defaults_to_legacy_fernet_write_format PASSED [ 14%]
 tests/test_crypto.py::test_encrypt_field_can_write_versioned_fernet_envelope PASSED [ 14%]
+tests/test_crypto.py::test_encrypt_field_envelope_write_requires_schema_check_context PASSED [ 14%]
 tests/test_crypto.py::test_encrypt_field_transition_reads_legacy_and_envelope_formats PASSED [ 14%]
 tests/test_crypto.py::test_encrypt_field_uses_app_configured_write_format PASSED [ 14%]
 tests/test_crypto.py::test_encrypted_field_envelope_roundtrips_wrapped_fernet PASSED [ 14%]
@@ -877,9 +1083,9 @@ tests/test_crypto.py::test_encrypted_field_aad_is_canonical_and_stable PASSED [ 
 tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values0] PASSED [ 14%]
 tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values1] PASSED [ 14%]
 tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values2] PASSED [ 14%]
-tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values3] PASSED [ 14%]
-tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values4] PASSED [ 14%]
-tests/test_crypto.py::test_encrypted_field_aead_prototype_requires_expected_domain_and_aad PASSED [ 14%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values3] PASSED [ 15%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values4] PASSED [ 15%]
+tests/test_crypto.py::test_encrypted_field_aead_prototype_requires_expected_domain_and_aad PASSED [ 15%]
 tests/test_crypto.py::test_legacy_fernet_token_has_no_envelope PASSED    [ 15%]
 tests/test_crypto.py::test_unknown_encrypted_field_envelope_version_fails_closed PASSED [ 15%]
 tests/test_crypto.py::test_malformed_encrypted_field_envelopes_fail_closed[hlfield:] PASSED [ 15%]
@@ -896,8 +1102,8 @@ tests/test_crypto.py::test_pgp_helpers_invalid_key PASSED                [ 15%]
 tests/test_crypto.py::test_encrypt_message_uses_all_recipient_keys PASSED [ 15%]
 tests/test_crypto.py::test_load_recipient_certs_requires_at_least_one_key PASSED [ 15%]
 tests/test_crypto.py::test_gen_reply_slug_uses_diceware_words PASSED     [ 15%]
-tests/test_data_export.py::test_data_export_requires_auth PASSED         [ 15%]
-tests/test_data_export.py::test_data_export_zip_contains_csv_and_pgp PASSED [ 15%]
+tests/test_data_export.py::test_data_export_requires_auth PASSED         [ 16%]
+tests/test_data_export.py::test_data_export_zip_contains_csv_and_pgp PASSED [ 16%]
 tests/test_data_export.py::test_data_export_encrypted_export PASSED      [ 16%]
 tests/test_data_export.py::test_data_export_only_includes_current_user PASSED [ 16%]
 tests/test_delete_account.py::test_delete_account PASSED                 [ 16%]
@@ -915,8 +1121,8 @@ tests/test_directory.py::test_globaleaks_seed_has_rows PASSED            [ 16%]
 tests/test_directory.py::test_directory_accessible PASSED                [ 16%]
 tests/test_directory.py::test_directory_public_record_banner_links_to_admin PASSED [ 16%]
 tests/test_directory.py::test_directory_securedrop_banner_links_to_admin_without_tor_copy PASSED [ 16%]
-tests/test_directory.py::test_directory_globaleaks_banner_links_to_admin_without_tor_copy PASSED [ 16%]
-tests/test_directory.py::test_directory_newsrooms_banner_links_to_admin PASSED [ 16%]
+tests/test_directory.py::test_directory_globaleaks_banner_links_to_admin_without_tor_copy PASSED [ 17%]
+tests/test_directory.py::test_directory_newsrooms_banner_links_to_admin PASSED [ 17%]
 tests/test_directory.py::test_directory_all_tab_banner_links_to_admin PASSED [ 17%]
 tests/test_directory.py::test_directory_hides_tab_bar_when_verified_tabs_disabled PASSED [ 17%]
 tests/test_directory.py::test_directory_users_json_excludes_public_records_when_verified_tabs_disabled PASSED [ 17%]
@@ -934,8 +1140,8 @@ tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified
 tests/test_directory.py::test_directory_users_json_does_not_flag_verified_or_admin_suspicious_display_names PASSED [ 17%]
 tests/test_directory.py::test_directory_users_json_flags_suspicious_username_when_display_name_missing PASSED [ 17%]
 tests/test_directory.py::test_directory_users_json_includes_unverified_info_only_korean_account PASSED [ 17%]
-tests/test_directory.py::test_directory_users_json_marks_recipient_key_only_account_as_message_capable PASSED [ 17%]
-tests/test_directory.py::test_directory_users_json_includes_account_category PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_marks_recipient_key_only_account_as_message_capable PASSED [ 18%]
+tests/test_directory.py::test_directory_users_json_includes_account_category PASSED [ 18%]
 tests/test_directory.py::test_directory_users_json_includes_normalized_user_location PASSED [ 18%]
 tests/test_directory.py::test_directory_users_json_includes_legacy_account_category_label PASSED [ 18%]
 tests/test_directory.py::test_directory_self_reported_attorneys_render_in_attorneys_tab PASSED [ 18%]
@@ -953,7 +1159,7 @@ tests/test_directory.py::test_directory_users_json_excludes_verified_tab_sources
 tests/test_directory.py::test_directory_card_bio_uses_bio_length_limit_with_ascii_ellipsis PASSED [ 18%]
 tests/test_directory.py::test_directory_users_json_truncates_long_automated_listing_bios PASSED [ 18%]
 tests/test_directory.py::test_directory_public_record_cards_truncate_long_automated_listing_bios PASSED [ 18%]
-tests/test_directory.py::test_directory_public_record_cards_do_not_show_location PASSED [ 18%]
+tests/test_directory.py::test_directory_public_record_cards_do_not_show_location PASSED [ 19%]
 tests/test_directory.py::test_directory_users_json_includes_legacy_public_record_rows PASSED [ 19%]
 tests/test_directory.py::test_directory_filters_public_records_by_country_and_region_query_params PASSED [ 19%]
 tests/test_directory.py::test_directory_attorney_filter_panel_hidden_by_default PASSED [ 19%]
@@ -972,7 +1178,7 @@ tests/test_directory.py::test_directory_attorney_filters_json_reflects_active_qu
 tests/test_directory.py::test_directory_attorney_filters_json_includes_self_reported_attorneys PASSED [ 19%]
 tests/test_directory.py::test_directory_newsroom_filters_json_includes_self_reported_newsrooms PASSED [ 19%]
 tests/test_directory.py::test_directory_newsroom_filters_json_includes_automated_newsroom_listings PASSED [ 19%]
-tests/test_directory.py::test_directory_all_filters_json_reflects_active_query_filters PASSED [ 19%]
+tests/test_directory.py::test_directory_all_filters_json_reflects_active_query_filters PASSED [ 20%]
 tests/test_directory.py::test_directory_all_filters_json_updates_country_counts_for_verified_listing_type PASSED [ 20%]
 tests/test_directory.py::test_directory_all_filters_json_is_empty_when_verified_tabs_disabled PASSED [ 20%]
 tests/test_directory.py::test_listing_matches_attorney_filters_wrapper_uses_listing_geography PASSED [ 20%]
@@ -991,7 +1197,7 @@ tests/test_directory.py::test_directory_newsroom_filters_include_normalized_coun
 tests/test_directory.py::test_directory_attorney_filters_support_non_us_subdivisions PASSED [ 20%]
 tests/test_directory.py::test_directory_newsroom_filters_support_non_us_subdivisions PASSED [ 20%]
 tests/test_directory.py::test_directory_attorney_filters_json_ignores_untrusted_query_values PASSED [ 20%]
-tests/test_directory.py::test_directory_newsroom_filters_json_ignores_untrusted_query_values PASSED [ 20%]
+tests/test_directory.py::test_directory_newsroom_filters_json_ignores_untrusted_query_values PASSED [ 21%]
 tests/test_directory.py::test_directory_attorney_filters_json_returns_empty_metadata_when_verified_tabs_disabled PASSED [ 21%]
 tests/test_directory.py::test_directory_newsroom_filters_json_returns_empty_metadata_when_verified_tabs_disabled PASSED [ 21%]
 tests/test_directory.py::test_directory_securedrop_render_only_in_securedrop_and_all PASSED [ 21%]
@@ -1047,7 +1253,7 @@ tests/test_directory_listing_geography.py::test_directory_listing_geography_loca
 tests/test_directory_listing_geography.py::test_directory_listing_geography_location_variants[geography3-All countries, USA] PASSED [ 23%]
 tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_state_as_subdivision_when_country_present PASSED [ 23%]
 tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_us_state_code_when_country_missing PASSED [ 23%]
-tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_non_us_state_value_as_country_when_missing PASSED [ 24%]
+tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_non_us_state_value_as_country_when_missing PASSED [ 23%]
 tests/test_directory_listing_geography.py::test_build_directory_geography_keeps_non_us_subdivision_strings PASSED [ 24%]
 tests/test_docker_runtime_images.py::test_dev_and_prod_dockerfiles_use_the_same_python_313_bookworm_runtime_image PASSED [ 24%]
 tests/test_docs_library_mirror.py::test_library_docs_mirror_contains_required_pages PASSED [ 24%]
@@ -1066,7 +1272,7 @@ tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_guest_ar
 tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_marks_state_preparation_scenes_always_visit PASSED [ 24%]
 tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_artvandelay_profile_cleanup_accepts_delete_confirmations PASSED [ 24%]
 tests/test_email.py::test_create_smtp_config_variants PASSED             [ 24%]
-tests/test_email.py::test_create_smtp_config_invalid_encryption PASSED   [ 25%]
+tests/test_email.py::test_create_smtp_config_invalid_encryption PASSED   [ 24%]
 tests/test_email.py::test_ssl_smtp_login_authenticates_over_ssl PASSED   [ 25%]
 tests/test_email.py::test_starttls_smtp_login_upgrades_with_default_tls_context PASSED [ 25%]
 tests/test_email.py::test_is_safe_smtp_host_validation PASSED            [ 25%]
@@ -1085,8 +1291,8 @@ tests/test_email_headers.py::test_email_headers_page_renders PASSED      [ 25%]
 tests/test_email_headers.py::test_email_headers_export_requires_authentication PASSED [ 25%]
 tests/test_email_headers.py::test_email_headers_page_renders_authenticated PASSED [ 25%]
 tests/test_email_headers.py::test_email_headers_post_without_dkim_still_reports_auth_results PASSED [ 25%]
-tests/test_email_headers.py::test_analyze_raw_email_headers_marks_likely_forged_on_triple_fail PASSED [ 26%]
-tests/test_email_headers.py::test_analyze_raw_email_headers_marks_valid_on_spf_dmarc_pass_without_dkim PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_marks_likely_forged_on_triple_fail PASSED [ 25%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_marks_valid_on_spf_dmarc_pass_without_dkim PASSED [ 25%]
 tests/test_email_headers.py::test_analyze_raw_email_headers_marks_appears_inauthentic PASSED [ 26%]
 tests/test_email_headers.py::test_analyze_raw_email_headers_rejects_empty_input PASSED [ 26%]
 tests/test_email_headers.py::test_analyze_raw_email_headers_with_header_body_mix_parses_headers_only PASSED [ 26%]
@@ -1103,9 +1309,9 @@ tests/test_email_headers.py::test_email_headers_post_value_error_shows_flash PAS
 tests/test_email_headers.py::test_email_headers_missing_csrf_preserves_invalid_post_behavior PASSED [ 26%]
 tests/test_email_headers.py::test_email_headers_export_invalid_form_redirects_with_flash PASSED [ 26%]
 tests/test_email_headers.py::test_email_headers_export_missing_csrf_redirects_with_flash PASSED [ 26%]
-tests/test_email_headers.py::test_email_headers_export_value_error_redirects_with_flash PASSED [ 27%]
-tests/test_email_headers.py::test_parse_tag_value_pairs_ignores_invalid_parts_and_empty_keys PASSED [ 27%]
-tests/test_email_headers.py::test_build_interpretation_includes_strong_chain_multiple_signatures_and_strong_keys PASSED [ 27%]
+tests/test_email_headers.py::test_email_headers_export_value_error_redirects_with_flash PASSED [ 26%]
+tests/test_email_headers.py::test_parse_tag_value_pairs_ignores_invalid_parts_and_empty_keys PASSED [ 26%]
+tests/test_email_headers.py::test_build_interpretation_includes_strong_chain_multiple_signatures_and_strong_keys PASSED [ 26%]
 tests/test_email_headers.py::test_render_minimal_pdf_renders_when_no_lines_provided PASSED [ 27%]
 tests/test_email_headers.py::test_render_report_pdf_includes_none_sections_and_warnings_block PASSED [ 27%]
 tests/test_email_headers.py::test_create_evidence_zip_includes_lookup_error_details PASSED [ 27%]
@@ -1122,9 +1328,9 @@ tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example?campaign=1] PASSED [ 27%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example#fragment] PASSED [ 27%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://user:[redacted-email]] PASSED [ 27%]
-tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example:] PASSED [ 28%]
-tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example;.onion] PASSED [ 28%]
-tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example .onion] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example:] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example;.onion] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example .onion] PASSED [ 27%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\t.onion] PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\n.onion] PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\x0c.onion] PASSED [ 28%]
@@ -1140,10 +1346,10 @@ tests/test_embeddable_forms_model.py::test_embed_requires_at_least_one_exact_all
 tests/test_embeddable_forms_model.py::test_embed_admin_disablement_blocks_profile PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_embed_preserves_missing_key_and_suspension_rejection PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_alias_embed_requires_owner_eligibility PASSED [ 28%]
-tests/test_embeddable_forms_settings.py::test_admin_embeddable_forms_default_disabled PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_route_is_disabled_by_default PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_profile_opted_out PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_origin_allowlist PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_admin_embeddable_forms_default_disabled PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_is_disabled_by_default PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_profile_opted_out PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_origin_allowlist PASSED [ 28%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_recipient_key PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_suspended_target PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_unknown_target PASSED [ 29%]
@@ -1159,10 +1365,10 @@ tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_handles_u
 tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_evicts_stale_global_state PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_requires_embed_form_token PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_invalid_csrf_token PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_owner_guard_mismatch PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_captcha_failure PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_missing_required_field PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_suspension PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_owner_guard_mismatch PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_captcha_failure PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_missing_required_field PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_suspension PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_recipient_key_removed PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_uses_same_enabled_custom_fields PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_malformed_recipient_ciphertexts_use_generic_notification_body PASSED [ 30%]
@@ -1178,10 +1384,10 @@ tests/test_embeddable_forms_settings.py::test_admin_non_super_user_can_access_de
 tests/test_embeddable_forms_settings.py::test_admin_non_super_user_cannot_update_profile_embed_settings PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_developer_embed_settings_require_usable_recipient_key PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_admin_can_toggle_embeddable_forms PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_non_admin_cannot_toggle_embeddable_forms PASSED [ 31%]
-tests/test_embeddable_forms_settings.py::test_primary_embed_settings_update_origins_and_render_iframe_snippet PASSED [ 31%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_template_has_compact_trust_chrome_and_form PASSED [ 31%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_non_admin_cannot_toggle_embeddable_forms PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_primary_embed_settings_update_origins_and_render_iframe_snippet PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_template_has_compact_trust_chrome_and_form PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_renders_additional_profile_fields_like_full_profile PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_keyboard_flow_and_mobile_accessibility_chrome PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_required_chrome_survives_recipient_branding_settings PASSED [ 31%]
@@ -1192,12 +1398,15 @@ tests/test_embeddable_forms_settings.py::test_embed_settings_require_message_cap
 tests/test_embeddable_forms_settings.py::test_alias_embed_settings_are_independent PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_alias_embed_settings_reject_invalid_origin PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_alias_embed_settings_require_alias_owner PASSED [ 31%]
+tests/test_encrypted_field_aead_evaluation.py::test_encrypted_field_aead_evaluation_exists_and_is_linked PASSED [ 31%]
+tests/test_encrypted_field_aead_evaluation.py::test_encrypted_field_aead_evaluation_covers_required_options PASSED [ 31%]
+tests/test_encrypted_field_aead_evaluation.py::test_encrypted_field_aead_evaluation_locks_recommendation_and_guardrails PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_encrypted_field_property_inventory_is_complete PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_encrypted_field_inventory_columns_match_models PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_encrypted_field_domain_contract_covers_inventory PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_user_encrypted_properties_store_fernet_ciphertext PASSED [ 31%]
-tests/test_encrypted_field_inventory.py::test_notification_recipient_properties_store_fernet_ciphertext PASSED [ 32%]
-tests/test_encrypted_field_inventory.py::test_field_value_stores_encrypted_custom_message_value_as_fernet_ciphertext PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_notification_recipient_properties_store_fernet_ciphertext PASSED [ 31%]
+tests/test_encrypted_field_inventory.py::test_field_value_stores_encrypted_custom_message_value_as_fernet_ciphertext PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_legacy_fernet_user_fields_decrypt_through_properties PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_legacy_fernet_notification_recipient_fields_decrypt PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_legacy_fernet_field_value_decrypts_encrypted_custom_message_value PASSED [ 32%]
@@ -1215,10 +1424,19 @@ tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_s
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.smtp_server] PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.smtp_username] PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.smtp_password] PASSED [ 32%]
-tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.pgp_key] PASSED [ 33%]
-tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[NotificationRecipient.email] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.pgp_key] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[NotificationRecipient.email] PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[NotificationRecipient.pgp_key] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[FieldValue.value] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.totp_secret] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.email] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.smtp_server] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.smtp_username] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.smtp_password] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.pgp_key] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[NotificationRecipient.email] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[NotificationRecipient.pgp_key] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[FieldValue.value] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.totp_secret] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.email] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.smtp_server] PASSED [ 33%]
@@ -1227,13 +1445,13 @@ tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_cipherte
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.pgp_key] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[NotificationRecipient.email] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[NotificationRecipient.pgp_key] PASSED [ 33%]
-tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[FieldValue.value] PASSED [ 33%]
-tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_exists_and_is_linked PASSED [ 33%]
-tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_covers_required_execution_paths PASSED [ 33%]
-tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_locks_security_guardrails FAILED [ 33%]
-tests/test_external_urls.py::test_normalize_public_base_url_strips_trailing_slash PASSED [ 33%]
-tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 33%]
-tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://-PUBLIC_BASE_URL must include a host] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[FieldValue.value] PASSED [ 34%]
+tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_exists_and_is_linked PASSED [ 34%]
+tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_covers_required_execution_paths PASSED [ 34%]
+tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_locks_security_guardrails PASSED [ 34%]
+tests/test_external_urls.py::test_normalize_public_base_url_strips_trailing_slash PASSED [ 34%]
+tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 34%]
+tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://-PUBLIC_BASE_URL must include a host] PASSED [ 34%]
 tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://example.com/path-PUBLIC_BASE_URL must not include a path] PASSED [ 34%]
 tests/test_external_urls.py::test_canonical_external_url_prefers_public_base_url PASSED [ 34%]
 tests/test_external_urls.py::test_canonical_external_url_falls_back_to_request_derived_url_in_dev_and_testing[config_overrides0] PASSED [ 34%]
@@ -1246,12 +1464,12 @@ tests/test_fields.py::test_field_value_encryption PASSED                 [ 34%]
 tests/test_fields.py::test_field_value_unencryption PASSED               [ 34%]
 tests/test_fields.py::test_field_value_encryption_uses_all_enabled_recipient_keys PASSED [ 34%]
 tests/test_first_user.py::test_no_users_redirect_to_register PASSED      [ 34%]
-tests/test_first_user.py::test_no_users_register_should_show_alert PASSED [ 34%]
-tests/test_first_user.py::test_some_users_register_should_hide_alert PASSED [ 34%]
-tests/test_first_user.py::test_first_user_is_admin PASSED                [ 34%]
-tests/test_first_user.py::test_registration_does_not_grant_admin_after_stale_first_user_check PASSED [ 34%]
-tests/test_first_user.py::test_second_user_is_not_admin PASSED           [ 34%]
-tests/test_frontend_compat.py::test_package_json_declares_node_20_plus PASSED [ 34%]
+tests/test_first_user.py::test_no_users_register_should_show_alert PASSED [ 35%]
+tests/test_first_user.py::test_some_users_register_should_hide_alert PASSED [ 35%]
+tests/test_first_user.py::test_first_user_is_admin PASSED                [ 35%]
+tests/test_first_user.py::test_registration_does_not_grant_admin_after_stale_first_user_check PASSED [ 35%]
+tests/test_first_user.py::test_second_user_is_not_admin PASSED           [ 35%]
+tests/test_frontend_compat.py::test_package_json_declares_node_20_plus PASSED [ 35%]
 tests/test_frontend_compat.py::test_webpack_compose_services_use_lockfile_guard_script PASSED [ 35%]
 tests/test_frontend_compat.py::test_static_js_bundles_avoid_eval_wrappers PASSED [ 35%]
 tests/test_frontend_compat.py::test_client_side_encryption_has_platform_guards PASSED [ 35%]
@@ -1265,12 +1483,12 @@ tests/test_frontend_compat.py::test_directory_search_accessibility_hooks_exist P
 tests/test_frontend_compat.py::test_directory_sticky_active_tab_scroll_to_top_hook_exists PASSED [ 35%]
 tests/test_frontend_compat.py::test_directory_tab_scroll_buttons_clamp_to_valid_bounds PASSED [ 35%]
 tests/test_frontend_compat.py::test_inbox_sticky_nav_hooks_exist PASSED  [ 35%]
-tests/test_frontend_compat.py::test_settings_field_delete_confirmation_blocks_submit_on_cancel PASSED [ 35%]
-tests/test_frontend_compat.py::test_settings_sticky_nav_hooks_exist PASSED [ 35%]
-tests/test_frontend_compat.py::test_profile_location_settings_use_country_select_and_dependency_script PASSED [ 35%]
-tests/test_frontend_compat.py::test_profile_settings_template_contains_updated_ui_copy PASSED [ 35%]
-tests/test_frontend_compat.py::test_settings_field_builder_select_hooks_are_wrapper_safe PASSED [ 35%]
-tests/test_gdpr_compliance.py::test_gdpr_compliance_evidence_policy_and_functionality PASSED [ 35%]
+tests/test_frontend_compat.py::test_settings_field_delete_confirmation_blocks_submit_on_cancel PASSED [ 36%]
+tests/test_frontend_compat.py::test_settings_sticky_nav_hooks_exist PASSED [ 36%]
+tests/test_frontend_compat.py::test_profile_location_settings_use_country_select_and_dependency_script PASSED [ 36%]
+tests/test_frontend_compat.py::test_profile_settings_template_contains_updated_ui_copy PASSED [ 36%]
+tests/test_frontend_compat.py::test_settings_field_builder_select_hooks_are_wrapper_safe PASSED [ 36%]
+tests/test_gdpr_compliance.py::test_gdpr_compliance_evidence_policy_and_functionality PASSED [ 36%]
 tests/test_globaleaks_directory_listing_model.py::test_globaleaks_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 36%]
 tests/test_globaleaks_directory_listing_model.py::test_globaleaks_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 36%]
 tests/test_globaleaks_directory_listing_model.py::test_get_globaleaks_directory_listing_matches_slug_case_insensitively PASSED [ 36%]
@@ -1284,11 +1502,11 @@ tests/test_globaleaks_directory_refresh.py::test_choose_submission_url_uses_webs
 tests/test_globaleaks_directory_refresh.py::test_choose_host_falls_back_to_candidate_hosts_or_errors PASSED [ 36%]
 tests/test_globaleaks_directory_refresh.py::test_candidate_hosts_normalizes_and_skips_blank_or_duplicate_values PASSED [ 36%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_rejects_empty_slug_after_normalization PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows1-Normalized row slug must be a string] PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows2-Duplicate GlobaLeaks listing slug: globaleaks~shared] PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_index_known_rows_by_host_ignores_blank_url_fields PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_extract_discovery_links_filters_excluded_duplicate_and_non_candidate_hosts PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows1-Normalized row slug must be a string] PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows2-Duplicate GlobaLeaks listing slug: globaleaks~shared] PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_index_known_rows_by_host_ignores_blank_url_fields PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_extract_discovery_links_filters_excluded_duplicate_and_non_candidate_hosts PASSED [ 37%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_is_deterministic_and_schema_compatible PASSED [ 37%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_rejects_duplicates PASSED [ 37%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_requires_submission_host_or_url PASSED [ 37%]
@@ -1303,11 +1521,11 @@ tests/test_helpers.py::test_form_to_data_targets_only_selected_submit_button PAS
 tests/test_helpers.py::test_form_to_data_flattens_fieldlist_subforms PASSED [ 37%]
 tests/test_inbox.py::test_delete_own_message PASSED                      [ 37%]
 tests/test_inbox.py::test_cannot_delete_other_user_message PASSED        [ 37%]
-tests/test_inbox.py::test_filter_on_status PASSED                        [ 37%]
-tests/test_inbox.py::test_inbox_invalid_status_returns_bad_request PASSED [ 37%]
-tests/test_inbox.py::test_inbox_missing_user_row_returns_not_found PASSED [ 37%]
-tests/test_info.py::test_info_available PASSED                           [ 37%]
-tests/test_info.py::test_site_webmanifest_reflects_branding PASSED       [ 37%]
+tests/test_inbox.py::test_filter_on_status PASSED                        [ 38%]
+tests/test_inbox.py::test_inbox_invalid_status_returns_bad_request PASSED [ 38%]
+tests/test_inbox.py::test_inbox_missing_user_row_returns_not_found PASSED [ 38%]
+tests/test_info.py::test_info_available PASSED                           [ 38%]
+tests/test_info.py::test_site_webmanifest_reflects_branding PASSED       [ 38%]
 tests/test_info.py::test_site_webmanifest_includes_uploaded_logo_icon PASSED [ 38%]
 tests/test_invite_code_model.py::test_invite_code_repr_includes_code PASSED [ 38%]
 tests/test_make_admin.py::test_toggle_admin_prints_when_user_missing PASSED [ 38%]
@@ -1322,11 +1540,11 @@ tests/test_md.py::test_md_to_html_returns_markup_input_unchanged PASSED  [ 38%]
 tests/test_md.py::test_md_to_html_sanitizes_disallowed_tags_and_keeps_links PASSED [ 38%]
 tests/test_migrations.py::test_linear_revision_history PASSED            [ 38%]
 tests/test_migrations.py::test_upgrade_with_data[46aedec8fd9b] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[5410668e15ad] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[be0744a5679f] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[0b1321c8de13] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[cf2a880aff10] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[4a53667aff6e] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[5410668e15ad] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[be0744a5679f] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[0b1321c8de13] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[cf2a880aff10] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[4a53667aff6e] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[b6a1e3f5a2b1] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[7d6a9f2f8c1a] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[2e3e5b1f2b3c] PASSED    [ 39%]
@@ -1338,13 +1556,14 @@ tests/test_migrations.py::test_upgrade_with_data[c4f8e2a1b6d9] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[84f1d3b2c6e7] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[d1f0e9c2b7aa] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[2d8a1f7c9b41] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[b2039e7c0a1d] PASSED    [ 39%]
 tests/test_migrations.py::test_downgrade_with_data[46aedec8fd9b] PASSED  [ 39%]
 tests/test_migrations.py::test_downgrade_with_data[5410668e15ad] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[be0744a5679f] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[0b1321c8de13] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[cf2a880aff10] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[4a53667aff6e] XFAIL   [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[b6a1e3f5a2b1] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[be0744a5679f] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[0b1321c8de13] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[cf2a880aff10] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[4a53667aff6e] XFAIL   [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[b6a1e3f5a2b1] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[7d6a9f2f8c1a] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[2e3e5b1f2b3c] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[9f7c4c3ea9a1] PASSED  [ 40%]
@@ -1355,15 +1574,16 @@ tests/test_migrations.py::test_downgrade_with_data[c4f8e2a1b6d9] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[84f1d3b2c6e7] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[d1f0e9c2b7aa] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[2d8a1f7c9b41] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[b2039e7c0a1d] PASSED  [ 40%]
 tests/test_migrations.py::test_double_upgrade[46aedec8fd9b] PASSED       [ 40%]
 tests/test_migrations.py::test_double_upgrade[5410668e15ad] PASSED       [ 40%]
 tests/test_migrations.py::test_double_upgrade[be0744a5679f] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[0b1321c8de13] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[cf2a880aff10] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[4a53667aff6e] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[b6a1e3f5a2b1] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[7d6a9f2f8c1a] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[2e3e5b1f2b3c] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[0b1321c8de13] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[cf2a880aff10] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[4a53667aff6e] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[b6a1e3f5a2b1] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[7d6a9f2f8c1a] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[2e3e5b1f2b3c] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[9f7c4c3ea9a1] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[3c1b2a4d5e6f] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[8f3f1f0a1b2c] PASSED       [ 41%]
@@ -1372,575 +1592,594 @@ tests/test_migrations.py::test_double_upgrade[c4f8e2a1b6d9] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[84f1d3b2c6e7] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[d1f0e9c2b7aa] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[2d8a1f7c9b41] PASSED       [ 41%]
-tests/test_native_dependencies.py::test_cryptography_fernet_and_scrypt_runtime PASSED [ 41%]
-tests/test_native_dependencies.py::test_pysequoia_cert_parse_and_encrypt_runtime PASSED [ 41%]
-tests/test_native_dependencies.py::test_psycopg_connects_and_executes_query PASSED [ 41%]
-tests/test_native_dependencies.py::test_greenlet_switch_runtime PASSED   [ 41%]
-tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_get_newsroom_directory_listing_matches_slug_case_insensitively PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_build_newsroom_listing_exposes_geography_properties PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_newsroom_seed_path_points_to_committed_dataset PASSED [ 41%]
-tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_non_retryable_http_error_immediately PASSED [ 41%]
-tests/test_newsroom_directory_refresh.py::test_get_with_retries_reraises_last_error_from_post_loop_fallback PASSED [ 41%]
-tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_fallback_error_when_no_attempts_run PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_should_retry_request_error_returns_false_for_non_retryable_errors PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_string_list_handles_split_deduping_and_invalid_inputs PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_http_url_validates_required_and_optional_fields PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_http_url_covers_optional_and_required_error_edges PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_country_subdivision_and_listing_slug_handle_blank_and_fallback_values PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_extract_organization_urls_filters_duplicates_and_non_listing_links PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_extract_european_network_urls_filters_duplicates_and_non_listing_links PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_extract_source_browse_page_urls_for_european_networks_follows_public_pages PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_text_and_core_detail_extractors_skip_incomplete_nodes_and_plain_text_lists PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_location_handles_blank_city_country_and_single_part_inputs PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_location_normalizes_united_states_and_state_abbreviations PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_normalizes_baseline_fields PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_newsroom_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_european_network_helper_extractors_cover_missing_sections_and_mixed_children PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_normalized_row_shapes PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row0-Missing required newsroom id] PASSED [ 42%]
+tests/test_migrations.py::test_double_upgrade[b2039e7c0a1d] PASSED       [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-totp_secret] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-email] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-smtp_server] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-smtp_username] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-smtp_password] PASSED [ 42%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[notification_recipients-email] PASSED [ 42%]
+tests/test_migrations.py::test_envelope_schema_readiness_columns_match_widening_migration PASSED [ 42%]
+tests/test_migrations.py::test_encrypted_field_preflight_tracks_widening_migration_readiness PASSED [ 42%]
+tests/test_migrations.py::test_legacy_encrypted_field_writes_do_not_require_envelope_schema PASSED [ 42%]
+tests/test_migrations.py::test_envelope_encrypted_field_writes_reject_pre_migration_schema PASSED [ 42%]
+tests/test_migrations.py::test_envelope_encrypted_field_writes_accept_widened_schema PASSED [ 42%]
+tests/test_migrations.py::test_downgrade_preserves_mixed_ciphertexts_readable_by_dual_reader FAILED [ 42%]
+tests/test_native_dependencies.py::test_cryptography_fernet_and_scrypt_runtime PASSED [ 42%]
+tests/test_native_dependencies.py::test_pysequoia_cert_parse_and_encrypt_runtime PASSED [ 42%]
+tests/test_native_dependencies.py::test_psycopg_connects_and_executes_query PASSED [ 42%]
+tests/test_native_dependencies.py::test_greenlet_switch_runtime PASSED   [ 42%]
+tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_get_newsroom_directory_listing_matches_slug_case_insensitively PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_build_newsroom_listing_exposes_geography_properties PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_newsroom_seed_path_points_to_committed_dataset PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_non_retryable_http_error_immediately PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_reraises_last_error_from_post_loop_fallback PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_fallback_error_when_no_attempts_run PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_should_retry_request_error_returns_false_for_non_retryable_errors PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_string_list_handles_split_deduping_and_invalid_inputs PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_http_url_validates_required_and_optional_fields PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_http_url_covers_optional_and_required_error_edges PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_country_subdivision_and_listing_slug_handle_blank_and_fallback_values PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_extract_organization_urls_filters_duplicates_and_non_listing_links PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_extract_european_network_urls_filters_duplicates_and_non_listing_links PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_extract_source_browse_page_urls_for_european_networks_follows_public_pages PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_text_and_core_detail_extractors_skip_incomplete_nodes_and_plain_text_lists PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_location_handles_blank_city_country_and_single_part_inputs PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_location_normalizes_united_states_and_state_abbreviations PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_normalizes_baseline_fields PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_newsroom_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_european_network_helper_extractors_cover_missing_sections_and_mixed_children PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_normalized_row_shapes PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row0-Missing required newsroom id] PASSED [ 43%]
 tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row1-Missing required newsroom slug] PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row2-Missing required newsroom name] PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_non_string_and_duplicate_slugs PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_rejects_duplicate_ids_and_slugs PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_is_deterministic_and_schema_compatible PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_seen_browse_and_detail_urls PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_raises_when_no_listings_are_discovered PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_wraps_detail_request_failures PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_browse_urls_seen_after_queueing PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_uses_public_explore_urls_only PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_discovers_european_networks_across_public_browse_pages PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_wraps_request_errors PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_retries_transient_gateway_timeout PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_render_newsroom_refresh_summary_includes_counts PASSED [ 43%]
-tests/test_notifications.py::test_notifications_disabled PASSED          [ 43%]
-tests/test_notifications.py::test_notifications_enabled_no_content PASSED [ 43%]
-tests/test_notifications.py::test_notifications_enabled_no_content_delivers_to_all_enabled_recipients PASSED [ 43%]
-tests/test_notifications.py::test_message_submission_deduplicates_notification_recipient_email_addresses PASSED [ 43%]
-tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row2-Missing required newsroom name] PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_non_string_and_duplicate_slugs PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_rejects_duplicate_ids_and_slugs PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_is_deterministic_and_schema_compatible PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_seen_browse_and_detail_urls PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_raises_when_no_listings_are_discovered PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_wraps_detail_request_failures PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_browse_urls_seen_after_queueing PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_uses_public_explore_urls_only PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_discovers_european_networks_across_public_browse_pages PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_wraps_request_errors PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_retries_transient_gateway_timeout PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_render_newsroom_refresh_summary_includes_counts PASSED [ 44%]
+tests/test_notifications.py::test_notifications_disabled PASSED          [ 44%]
+tests/test_notifications.py::test_notifications_enabled_no_content PASSED [ 44%]
+tests/test_notifications.py::test_notifications_enabled_no_content_delivers_to_all_enabled_recipients PASSED [ 44%]
+tests/test_notifications.py::test_message_submission_deduplicates_notification_recipient_email_addresses PASSED [ 44%]
+tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body PASSED [ 44%]
 tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body_delivers_to_all_enabled_recipients PASSED [ 44%]
-tests/test_notifications.py::test_notifications_multi_recipient_missing_field_ciphertext_uses_generic_body PASSED [ 44%]
-tests/test_notifications.py::test_notifications_multi_recipient_non_object_field_ciphertext_payload_uses_generic_body PASSED [ 44%]
-tests/test_notifications.py::test_notifications_multi_recipient_uses_recipient_specific_field_ciphertext PASSED [ 44%]
-tests/test_notifications.py::test_notifications_enabled_yes_content_yes_encrypted_body PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_embedded_markers_use_server_fallback PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_uses_client_body_for_all_enabled_recipients PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_multi_recipient_does_not_wrap_encrypted_fields PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_server_fallback PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_fallback_uses_all_enabled_recipient_keys PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_flow PASSED                    [ 44%]
-tests/test_onboarding.py::test_onboarding_directory_opt_out_persists_false PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_directory_opt_out_overrides_prepopulated_true PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_skip PASSED                    [ 44%]
-tests/test_onboarding.py::test_onboarding_proton_search_prefills_manual_key PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[display_name] PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[bio] PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[pgp_key] PASSED [ 44%]
+tests/test_notifications.py::test_notifications_multi_recipient_missing_field_ciphertext_uses_generic_body PASSED [ 45%]
+tests/test_notifications.py::test_notifications_multi_recipient_non_object_field_ciphertext_payload_uses_generic_body PASSED [ 45%]
+tests/test_notifications.py::test_notifications_multi_recipient_uses_recipient_specific_field_ciphertext PASSED [ 45%]
+tests/test_notifications.py::test_notifications_enabled_yes_content_yes_encrypted_body PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_embedded_markers_use_server_fallback PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_uses_client_body_for_all_enabled_recipients PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_multi_recipient_does_not_wrap_encrypted_fields PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_server_fallback PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_fallback_uses_all_enabled_recipient_keys PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_flow PASSED                    [ 45%]
+tests/test_onboarding.py::test_onboarding_directory_opt_out_persists_false PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_directory_opt_out_overrides_prepopulated_true PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_skip PASSED                    [ 45%]
+tests/test_onboarding.py::test_onboarding_proton_search_prefills_manual_key PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[display_name] PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[bio] PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[pgp_key] PASSED [ 45%]
 tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[enable_email_notifications] PASSED [ 45%]
 tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_include_message_content] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_encrypt_entire_body] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[show_in_directory] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_redirects_to_inbox_when_already_complete PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_allows_non_profile_step_when_already_complete PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_handles_missing_primary_username PASSED [ 45%]
-tests/test_onboarding.py::test_submitted_onboarding_form_selects_expected_step_form PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_encryption_unknown_method_returns_bad_request PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_key_shows_error PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_proton_fetch_failure_shows_error PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_notifications_requires_pgp_key PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_missing_user_redirects_login PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_invalid_step_defaults_to_profile PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_post_invalid_step_defaults_to_profile PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_profile_invalid_form_returns_400 PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_profile_invalid_form_preserves_submitted_values PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_encrypt_entire_body] PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email] PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[show_in_directory] PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_redirects_to_inbox_when_already_complete PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_allows_non_profile_step_when_already_complete PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_handles_missing_primary_username PASSED [ 46%]
+tests/test_onboarding.py::test_submitted_onboarding_form_selects_expected_step_form PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_encryption_unknown_method_returns_bad_request PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_key_shows_error PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_proton_fetch_failure_shows_error PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_notifications_requires_pgp_key PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_missing_user_redirects_login PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_invalid_step_defaults_to_profile PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_post_invalid_step_defaults_to_profile PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_profile_invalid_form_returns_400 PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_profile_invalid_form_preserves_submitted_values PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_returns_400 PASSED [ 46%]
 tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_preserves_submitted_email PASSED [ 46%]
 tests/test_onboarding.py::test_onboarding_proton_key_without_encryption_subkey_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_proton_no_key_found_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_proton_non_200_response_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_missing_key_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_whitespace_key_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_form_returns_400_with_csrf PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_non_encryptable_key_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_notifications_invalid_form_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_profile_requires_csrf_token PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_notifications_requires_csrf_token PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_directory_invalid_form_returns_400_with_csrf PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_unknown_step_post_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_directory_redirects_to_select_tier_when_stripe_enabled PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_skip_missing_user_redirects_login PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_skip_invalid_form_redirects_onboarding_with_csrf PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_skip_redirects_to_select_tier_when_enabled PASSED [ 46%]
-tests/test_onboarding.py::test_webpack_build_includes_onboarding_bundle PASSED [ 46%]
-tests/test_password_hasher.py::test_verify_password_uses_legacy_passlib_scrypt_fixture_and_logs_success PASSED [ 46%]
-tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_legacy_passlib_scrypt_fixture PASSED [ 47%]
-tests/test_password_hasher.py::test_legacy_passlib_scrypt_fixture_documents_prefix_and_cost_baseline PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_uses_native_werkzeug_scrypt_hash_and_logs_success PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_native_werkzeug_scrypt_hash PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_routes_non_scrypt_native_prefixes_to_primary_verifier PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_primary_password_hash_rejects_non_scrypt_native_prefix PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_unknown_prefix_fails_closed_without_mutating_user PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_malformed_legacy_hash_fails_closed PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_without_app_context PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_skips_non_legacy_hashes PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_when_disabled PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_rehashes_legacy_hash_when_enabled PASSED [ 47%]
-tests/test_password_hasher.py::test_get_password_hash_prefix_returns_unknown_for_plaintext_like_values PASSED [ 47%]
-tests/test_password_hasher.py::test_hash_password_logs_write_counter_without_sensitive_data PASSED [ 47%]
-tests/test_password_hasher.py::test_hash_password_uses_pinned_werkzeug_scrypt_method_when_enabled PASSED [ 47%]
-tests/test_password_hasher.py::test_pinned_werkzeug_scrypt_method_matches_legacy_passlib_cost_baseline PASSED [ 47%]
-tests/test_password_hasher.py::test_password_hash_telemetry_helpers_noop_without_app_context PASSED [ 47%]
-tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[True-password_hash_rehash_on_auth_success_total] PASSED [ 47%]
-tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[False-password_hash_rehash_on_auth_failure_total] PASSED [ 48%]
-tests/test_premium.py::test_create_products_and_prices PASSED            [ 48%]
-tests/test_premium.py::test_update_price_existing PASSED                 [ 48%]
-tests/test_premium.py::test_update_price_new PASSED                      [ 48%]
-tests/test_premium.py::test_create_customer PASSED                       [ 48%]
-tests/test_premium.py::test_create_customer_updates_existing_customer PASSED [ 48%]
-tests/test_premium.py::test_create_customer_recreates_when_modify_fails PASSED [ 48%]
-tests/test_premium.py::test_get_subscription PASSED                      [ 48%]
-tests/test_premium.py::test_get_business_price_string_formats PASSED     [ 48%]
-tests/test_premium.py::test_get_business_price_string_missing_tier PASSED [ 48%]
-tests/test_premium.py::test_create_products_and_prices_missing_business_tier PASSED [ 48%]
-tests/test_premium.py::test_update_price_without_product_id_logs_and_returns PASSED [ 48%]
-tests/test_premium.py::test_get_subscription_none_when_missing_subscription_id PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_created PASSED           [ 48%]
-tests/test_premium.py::test_handle_subscription_created_raises_for_missing_user PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_updated_upgrade PASSED   [ 48%]
-tests/test_premium.py::test_handle_subscription_updated_downgrade PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_updated_raises_for_missing_subscription PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_deleted PASSED           [ 48%]
-tests/test_premium.py::test_handle_subscription_deleted_raises_for_missing_subscription PASSED [ 49%]
-tests/test_premium.py::test_handle_invoice_created PASSED                [ 49%]
-tests/test_premium.py::test_handle_invoice_created_value_error_is_handled PASSED [ 49%]
-tests/test_premium.py::test_handle_invoice_updated PASSED                [ 49%]
-tests/test_premium.py::test_handle_invoice_updated_refreshes_receipt_url PASSED [ 49%]
-tests/test_premium.py::test_premium_index_links_receipts_through_authenticated_route PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_refreshes_stale_url_before_redirect PASSED [ 49%]
-tests/test_premium.py::test_receipt_url_from_invoice_prefers_pdf_when_hosted_url_missing PASSED [ 49%]
-tests/test_premium.py::test_receipt_url_from_invoice_returns_none_without_hosted_url_or_pdf PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_redirects_to_stale_url_when_stripe_refresh_fails PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_flashes_when_no_receipt_url_available PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_redirects_to_login_when_user_missing_inside_route PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_returns_404_for_missing_invoice PASSED [ 49%]
-tests/test_premium.py::test_handle_invoice_updated_raises_for_missing_invoice PASSED [ 49%]
-tests/test_premium.py::test_upgrade_post_user_already_on_business_tier PASSED [ 49%]
-tests/test_premium.py::test_upgrade_process PASSED                       [ 49%]
-tests/test_premium.py::test_upgrade_process_uses_public_base_url_for_success_url PASSED [ 49%]
-tests/test_premium.py::test_update_payment_method_creates_billing_portal_session PASSED [ 49%]
-tests/test_premium.py::test_update_payment_method_requires_active_subscription PASSED [ 50%]
-tests/test_premium.py::test_update_payment_method_stripe_error PASSED    [ 50%]
-tests/test_premium.py::test_update_payment_method_aborts_when_portal_session_has_no_url PASSED [ 50%]
-tests/test_premium.py::test_disable_autorenew_no_user_in_session PASSED  [ 50%]
-tests/test_premium.py::test_disable_autorenew_no_subscription PASSED     [ 50%]
-tests/test_premium.py::test_disable_autorenew_success PASSED             [ 50%]
-tests/test_premium.py::test_disable_autorenew_stripe_error PASSED        [ 50%]
-tests/test_premium.py::test_enable_autorenew_no_user_in_session PASSED   [ 50%]
-tests/test_premium.py::test_enable_autorenew_no_subscription PASSED      [ 50%]
-tests/test_premium.py::test_enable_autorenew_success PASSED              [ 50%]
-tests/test_premium.py::test_enable_autorenew_stripe_error PASSED         [ 50%]
-tests/test_premium.py::test_cancel_no_user_in_session PASSED             [ 50%]
-tests/test_premium.py::test_cancel_no_subscription PASSED                [ 50%]
-tests/test_premium.py::test_cancel_success PASSED                        [ 50%]
-tests/test_premium.py::test_cancel_stripe_error PASSED                   [ 50%]
-tests/test_premium.py::test_premium_select_tier_redirects_when_onboarding_incomplete PASSED [ 50%]
-tests/test_premium.py::test_premium_select_free_sets_free_tier_when_unset PASSED [ 50%]
-tests/test_premium.py::test_premium_status_business_user_flashes_success PASSED [ 50%]
-tests/test_premium.py::test_premium_index_warns_on_incomplete_subscription PASSED [ 50%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.index-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_tier-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_free-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.upgrade-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.update_payment_method-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.disable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.enable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.cancel-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.status-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.index-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_tier-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_free-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.upgrade-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.update_payment_method-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.disable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.enable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.cancel-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.status-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_select_tier_renders_for_complete_user PASSED [ 51%]
-tests/test_premium.py::test_premium_waiting_page_renders PASSED          [ 52%]
-tests/test_premium.py::test_upgrade_missing_business_tier PASSED         [ 52%]
-tests/test_premium.py::test_upgrade_missing_business_price_id PASSED     [ 52%]
-tests/test_premium.py::test_upgrade_create_customer_failure PASSED       [ 52%]
-tests/test_premium.py::test_upgrade_checkout_creation_failure PASSED     [ 52%]
-tests/test_premium.py::test_upgrade_checkout_session_without_url_returns_500 PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_rejects_invalid_payload PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_rejects_invalid_signature PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_ignores_duplicate_event PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_stores_new_event PASSED      [ 52%]
-tests/test_premium.py::test_worker_processes_subscription_created_event PASSED [ 52%]
-tests/test_premium.py::test_worker_marks_event_error_when_handler_raises PASSED [ 52%]
-tests/test_premium.py::test_worker_waits_for_tables_before_starting PASSED [ 52%]
-tests/test_premium.py::test_worker_processes_subscription_updated_and_deleted_events PASSED [ 52%]
-tests/test_premium.py::test_worker_processes_invoice_created_event PASSED [ 52%]
-tests/test_premium.py::test_worker_processes_invoice_payment_succeeded_event PASSED [ 52%]
-tests/test_profile.py::test_profile_header PASSED                        [ 52%]
-tests/test_profile.py::test_profile_accepts_case_insensitive_username PASSED [ 52%]
-tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_non_admin_display_name PASSED [ 53%]
-tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_username_when_display_name_missing PASSED [ 53%]
-tests/test_profile.py::test_profile_404_for_unknown_username PASSED      [ 53%]
-tests/test_profile.py::test_profile_404s_when_case_insensitive_lookup_is_ambiguous PASSED [ 53%]
-tests/test_profile.py::test_profile_does_not_expose_owner_user_id PASSED [ 53%]
-tests/test_profile.py::test_profile_submit_message PASSED                [ 53%]
-tests/test_profile.py::test_profile_submit_message_to_alias PASSED       [ 53%]
-tests/test_profile.py::test_profile_failed_submit_preserves_input PASSED [ 53%]
-tests/test_profile.py::test_profile_rejects_owner_guard_mismatch PASSED  [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_non_numeric_captcha PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_expired_captcha_token PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_bad_captcha_token PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_captcha_token_for_different_profile PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_post_404s_if_account_is_suspended_after_render PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_if_account_is_suspended_during_submission PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_if_recipient_keys_are_removed_during_submission PASSED [ 53%]
-tests/test_profile.py::test_profile_pgp_required PASSED                  [ 53%]
-tests/test_profile.py::test_profile_allows_submission_with_recipient_key_when_legacy_user_key_missing PASSED [ 53%]
-tests/test_profile.py::test_profile_allows_submission_with_legacy_key_when_primary_recipient_lacks_key PASSED [ 53%]
-tests/test_profile.py::test_profile_submit_message_with_recipient_key_when_legacy_user_key_missing PASSED [ 54%]
-tests/test_profile.py::test_profile_submit_message_ignores_enabled_recipient_without_key PASSED [ 54%]
-tests/test_profile.py::test_profile_suspended_state_disables_message_form_with_pgp_key PASSED [ 54%]
-tests/test_profile.py::test_profile_post_rejects_when_target_has_no_pgp_key PASSED [ 54%]
-tests/test_profile.py::test_profile_post_rejects_when_target_is_suspended PASSED [ 54%]
-tests/test_profile.py::test_profile_post_rejects_alias_when_owner_is_suspended PASSED [ 54%]
-tests/test_profile.py::test_profile_post_form_validation_errors_are_rendered PASSED [ 54%]
-tests/test_profile.py::test_profile_requires_csrf_token PASSED           [ 54%]
-tests/test_profile.py::test_profile_full_body_encryption_fallback_to_generic_when_no_fields PASSED [ 54%]
-tests/test_profile.py::test_profile_full_body_encryption_exception_falls_back_to_generic PASSED [ 54%]
-tests/test_profile.py::test_profile_full_body_encryption_uses_server_fallback_when_client_body_missing PASSED [ 54%]
-tests/test_profile.py::test_profile_notification_without_message_content_sends_generic_body PASSED [ 54%]
-tests/test_profile.py::test_profile_single_recipient_notification_can_include_stored_message_content PASSED [ 54%]
-tests/test_profile.py::test_profile_extra_fields PASSED                  [ 54%]
-tests/test_profile.py::test_profile_field_encryption_labels PASSED       [ 54%]
-tests/test_profile.py::test_profile_account_category_renders_first_extra_field PASSED [ 54%]
-tests/test_profile.py::test_profile_location_renders_as_single_extra_field PASSED [ 54%]
-tests/test_profile.py::test_profile_location_keeps_full_names_outside_us PASSED [ 54%]
-tests/test_profile.py::test_redirect_submit_message_route PASSED         [ 54%]
-tests/test_profile.py::test_submission_success_without_reply_slug_redirects_directory PASSED [ 55%]
-tests/test_profile.py::test_submission_success_404_when_message_missing PASSED [ 55%]
-tests/test_profile.py::test_submission_success_uses_public_base_url_for_reply_link PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_build_snapshot_filters_to_public_hushline_users PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_build_markdown_report_reports_added_and_removed_usernames PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_build_readme_report_renders_natural_language_and_history_table PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_resolve_history_baselines_uses_latest_sync_and_week_old_snapshot PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_load_summary_history_includes_current_summary_and_sorts_descending PASSED [ 55%]
-tests/test_public_record_refresh.py::test_default_us_region_state_map_includes_all_50_states PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_is_deterministic_and_schema_compatible PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_preserves_existing_identifiers PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_duplicate_id_or_slug PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_enforces_region_targets PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_above_region_targets PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_flags_and_drops_link_failures PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_on_transient_link_failures PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_legacy_self_reported_source_label PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_source_matching_website PASSED [ 55%]
+tests/test_onboarding.py::test_onboarding_proton_no_key_found_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_proton_non_200_response_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_missing_key_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_whitespace_key_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_form_returns_400_with_csrf PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_non_encryptable_key_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_notifications_invalid_form_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_profile_requires_csrf_token PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_notifications_requires_csrf_token PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_directory_invalid_form_returns_400_with_csrf PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_unknown_step_post_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_directory_redirects_to_select_tier_when_stripe_enabled PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_skip_missing_user_redirects_login PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_skip_invalid_form_redirects_onboarding_with_csrf PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_skip_redirects_to_select_tier_when_enabled PASSED [ 47%]
+tests/test_onboarding.py::test_webpack_build_includes_onboarding_bundle PASSED [ 47%]
+tests/test_operational_key_management_design.py::test_operational_key_management_design_exists_and_is_linked PASSED [ 47%]
+tests/test_operational_key_management_design.py::test_operational_key_management_design_covers_required_topics PASSED [ 47%]
+tests/test_operational_key_management_design.py::test_operational_key_management_design_locks_recommendation_and_guardrails PASSED [ 47%]
+tests/test_password_hash_modernization_evaluation.py::test_password_hash_modernization_evaluation_exists_and_is_linked PASSED [ 48%]
+tests/test_password_hash_modernization_evaluation.py::test_password_hash_modernization_evaluation_covers_required_decision_points PASSED [ 48%]
+tests/test_password_hash_modernization_evaluation.py::test_password_hash_modernization_evaluation_locks_guardrails PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_uses_legacy_passlib_scrypt_fixture_and_logs_success PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_legacy_passlib_scrypt_fixture PASSED [ 48%]
+tests/test_password_hasher.py::test_legacy_passlib_scrypt_fixture_documents_prefix_and_cost_baseline PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_uses_native_werkzeug_scrypt_hash_and_logs_success PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_native_werkzeug_scrypt_hash PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_routes_non_scrypt_native_prefixes_to_primary_verifier PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_primary_password_hash_rejects_non_scrypt_native_prefix PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_unknown_prefix_fails_closed_without_mutating_user PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_malformed_legacy_hash_fails_closed PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_without_app_context PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_skips_non_legacy_hashes PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_when_disabled PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_rehashes_legacy_hash_when_enabled PASSED [ 48%]
+tests/test_password_hasher.py::test_get_password_hash_prefix_returns_unknown_for_plaintext_like_values PASSED [ 48%]
+tests/test_password_hasher.py::test_hash_password_logs_write_counter_without_sensitive_data PASSED [ 48%]
+tests/test_password_hasher.py::test_hash_password_uses_pinned_werkzeug_scrypt_method_when_enabled PASSED [ 48%]
+tests/test_password_hasher.py::test_pinned_werkzeug_scrypt_method_matches_legacy_passlib_cost_baseline PASSED [ 49%]
+tests/test_password_hasher.py::test_password_hash_telemetry_helpers_noop_without_app_context PASSED [ 49%]
+tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[True-password_hash_rehash_on_auth_success_total] PASSED [ 49%]
+tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[False-password_hash_rehash_on_auth_failure_total] PASSED [ 49%]
+tests/test_premium.py::test_create_products_and_prices PASSED            [ 49%]
+tests/test_premium.py::test_update_price_existing PASSED                 [ 49%]
+tests/test_premium.py::test_update_price_new PASSED                      [ 49%]
+tests/test_premium.py::test_create_customer PASSED                       [ 49%]
+tests/test_premium.py::test_create_customer_updates_existing_customer PASSED [ 49%]
+tests/test_premium.py::test_create_customer_recreates_when_modify_fails PASSED [ 49%]
+tests/test_premium.py::test_get_subscription PASSED                      [ 49%]
+tests/test_premium.py::test_get_business_price_string_formats PASSED     [ 49%]
+tests/test_premium.py::test_get_business_price_string_missing_tier PASSED [ 49%]
+tests/test_premium.py::test_create_products_and_prices_missing_business_tier PASSED [ 49%]
+tests/test_premium.py::test_update_price_without_product_id_logs_and_returns PASSED [ 49%]
+tests/test_premium.py::test_get_subscription_none_when_missing_subscription_id PASSED [ 49%]
+tests/test_premium.py::test_handle_subscription_created PASSED           [ 49%]
+tests/test_premium.py::test_handle_subscription_created_raises_for_missing_user PASSED [ 49%]
+tests/test_premium.py::test_handle_subscription_updated_upgrade PASSED   [ 49%]
+tests/test_premium.py::test_handle_subscription_updated_downgrade PASSED [ 50%]
+tests/test_premium.py::test_handle_subscription_updated_raises_for_missing_subscription PASSED [ 50%]
+tests/test_premium.py::test_handle_subscription_deleted PASSED           [ 50%]
+tests/test_premium.py::test_handle_subscription_deleted_raises_for_missing_subscription PASSED [ 50%]
+tests/test_premium.py::test_handle_invoice_created PASSED                [ 50%]
+tests/test_premium.py::test_handle_invoice_created_value_error_is_handled PASSED [ 50%]
+tests/test_premium.py::test_handle_invoice_updated PASSED                [ 50%]
+tests/test_premium.py::test_handle_invoice_updated_refreshes_receipt_url PASSED [ 50%]
+tests/test_premium.py::test_premium_index_links_receipts_through_authenticated_route PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_refreshes_stale_url_before_redirect PASSED [ 50%]
+tests/test_premium.py::test_receipt_url_from_invoice_prefers_pdf_when_hosted_url_missing PASSED [ 50%]
+tests/test_premium.py::test_receipt_url_from_invoice_returns_none_without_hosted_url_or_pdf PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_redirects_to_stale_url_when_stripe_refresh_fails PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_flashes_when_no_receipt_url_available PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_redirects_to_login_when_user_missing_inside_route PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_returns_404_for_missing_invoice PASSED [ 50%]
+tests/test_premium.py::test_handle_invoice_updated_raises_for_missing_invoice PASSED [ 50%]
+tests/test_premium.py::test_upgrade_post_user_already_on_business_tier PASSED [ 50%]
+tests/test_premium.py::test_upgrade_process PASSED                       [ 50%]
+tests/test_premium.py::test_upgrade_process_uses_public_base_url_for_success_url PASSED [ 50%]
+tests/test_premium.py::test_update_payment_method_creates_billing_portal_session PASSED [ 51%]
+tests/test_premium.py::test_update_payment_method_requires_active_subscription PASSED [ 51%]
+tests/test_premium.py::test_update_payment_method_stripe_error PASSED    [ 51%]
+tests/test_premium.py::test_update_payment_method_aborts_when_portal_session_has_no_url PASSED [ 51%]
+tests/test_premium.py::test_disable_autorenew_no_user_in_session PASSED  [ 51%]
+tests/test_premium.py::test_disable_autorenew_no_subscription PASSED     [ 51%]
+tests/test_premium.py::test_disable_autorenew_success PASSED             [ 51%]
+tests/test_premium.py::test_disable_autorenew_stripe_error PASSED        [ 51%]
+tests/test_premium.py::test_enable_autorenew_no_user_in_session PASSED   [ 51%]
+tests/test_premium.py::test_enable_autorenew_no_subscription PASSED      [ 51%]
+tests/test_premium.py::test_enable_autorenew_success PASSED              [ 51%]
+tests/test_premium.py::test_enable_autorenew_stripe_error PASSED         [ 51%]
+tests/test_premium.py::test_cancel_no_user_in_session PASSED             [ 51%]
+tests/test_premium.py::test_cancel_no_subscription PASSED                [ 51%]
+tests/test_premium.py::test_cancel_success PASSED                        [ 51%]
+tests/test_premium.py::test_cancel_stripe_error PASSED                   [ 51%]
+tests/test_premium.py::test_premium_select_tier_redirects_when_onboarding_incomplete PASSED [ 51%]
+tests/test_premium.py::test_premium_select_free_sets_free_tier_when_unset PASSED [ 51%]
+tests/test_premium.py::test_premium_status_business_user_flashes_success PASSED [ 51%]
+tests/test_premium.py::test_premium_index_warns_on_incomplete_subscription PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.index-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_tier-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_free-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.upgrade-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.update_payment_method-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.disable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.enable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.cancel-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.status-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.index-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_tier-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_free-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.upgrade-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.update_payment_method-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.disable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.enable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.cancel-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.status-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_select_tier_renders_for_complete_user PASSED [ 53%]
+tests/test_premium.py::test_premium_waiting_page_renders PASSED          [ 53%]
+tests/test_premium.py::test_upgrade_missing_business_tier PASSED         [ 53%]
+tests/test_premium.py::test_upgrade_missing_business_price_id PASSED     [ 53%]
+tests/test_premium.py::test_upgrade_create_customer_failure PASSED       [ 53%]
+tests/test_premium.py::test_upgrade_checkout_creation_failure PASSED     [ 53%]
+tests/test_premium.py::test_upgrade_checkout_session_without_url_returns_500 PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_rejects_invalid_payload PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_rejects_invalid_signature PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_ignores_duplicate_event PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_stores_new_event PASSED      [ 53%]
+tests/test_premium.py::test_worker_processes_subscription_created_event PASSED [ 53%]
+tests/test_premium.py::test_worker_marks_event_error_when_handler_raises PASSED [ 53%]
+tests/test_premium.py::test_worker_waits_for_tables_before_starting PASSED [ 53%]
+tests/test_premium.py::test_worker_processes_subscription_updated_and_deleted_events PASSED [ 53%]
+tests/test_premium.py::test_worker_processes_invoice_created_event PASSED [ 53%]
+tests/test_premium.py::test_worker_processes_invoice_payment_succeeded_event PASSED [ 53%]
+tests/test_profile.py::test_profile_header PASSED                        [ 53%]
+tests/test_profile.py::test_profile_accepts_case_insensitive_username PASSED [ 53%]
+tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_non_admin_display_name PASSED [ 54%]
+tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_username_when_display_name_missing PASSED [ 54%]
+tests/test_profile.py::test_profile_404_for_unknown_username PASSED      [ 54%]
+tests/test_profile.py::test_profile_404s_when_case_insensitive_lookup_is_ambiguous PASSED [ 54%]
+tests/test_profile.py::test_profile_does_not_expose_owner_user_id PASSED [ 54%]
+tests/test_profile.py::test_profile_submit_message PASSED                [ 54%]
+tests/test_profile.py::test_profile_submit_message_to_alias PASSED       [ 54%]
+tests/test_profile.py::test_profile_failed_submit_preserves_input PASSED [ 54%]
+tests/test_profile.py::test_profile_rejects_owner_guard_mismatch PASSED  [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_non_numeric_captcha PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_expired_captcha_token PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_bad_captcha_token PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_captcha_token_for_different_profile PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_post_404s_if_account_is_suspended_after_render PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_if_account_is_suspended_during_submission PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_if_recipient_keys_are_removed_during_submission PASSED [ 54%]
+tests/test_profile.py::test_profile_pgp_required PASSED                  [ 54%]
+tests/test_profile.py::test_profile_allows_submission_with_recipient_key_when_legacy_user_key_missing PASSED [ 54%]
+tests/test_profile.py::test_profile_allows_submission_with_legacy_key_when_primary_recipient_lacks_key PASSED [ 54%]
+tests/test_profile.py::test_profile_submit_message_with_recipient_key_when_legacy_user_key_missing PASSED [ 55%]
+tests/test_profile.py::test_profile_submit_message_ignores_enabled_recipient_without_key PASSED [ 55%]
+tests/test_profile.py::test_profile_suspended_state_disables_message_form_with_pgp_key PASSED [ 55%]
+tests/test_profile.py::test_profile_post_rejects_when_target_has_no_pgp_key PASSED [ 55%]
+tests/test_profile.py::test_profile_post_rejects_when_target_is_suspended PASSED [ 55%]
+tests/test_profile.py::test_profile_post_rejects_alias_when_owner_is_suspended PASSED [ 55%]
+tests/test_profile.py::test_profile_post_form_validation_errors_are_rendered PASSED [ 55%]
+tests/test_profile.py::test_profile_requires_csrf_token PASSED           [ 55%]
+tests/test_profile.py::test_profile_full_body_encryption_fallback_to_generic_when_no_fields PASSED [ 55%]
+tests/test_profile.py::test_profile_full_body_encryption_exception_falls_back_to_generic PASSED [ 55%]
+tests/test_profile.py::test_profile_full_body_encryption_uses_server_fallback_when_client_body_missing PASSED [ 55%]
+tests/test_profile.py::test_profile_notification_without_message_content_sends_generic_body PASSED [ 55%]
+tests/test_profile.py::test_profile_single_recipient_notification_can_include_stored_message_content PASSED [ 55%]
+tests/test_profile.py::test_profile_extra_fields PASSED                  [ 55%]
+tests/test_profile.py::test_profile_field_encryption_labels PASSED       [ 55%]
+tests/test_profile.py::test_profile_account_category_renders_first_extra_field PASSED [ 55%]
+tests/test_profile.py::test_profile_location_renders_as_single_extra_field PASSED [ 55%]
+tests/test_profile.py::test_profile_location_keeps_full_names_outside_us PASSED [ 55%]
+tests/test_profile.py::test_redirect_submit_message_route PASSED         [ 55%]
+tests/test_profile.py::test_submission_success_without_reply_slug_redirects_directory PASSED [ 56%]
+tests/test_profile.py::test_submission_success_404_when_message_missing PASSED [ 56%]
+tests/test_profile.py::test_submission_success_uses_public_base_url_for_reply_link PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_build_snapshot_filters_to_public_hushline_users PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_build_markdown_report_reports_added_and_removed_usernames PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_build_readme_report_renders_natural_language_and_history_table PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_resolve_history_baselines_uses_latest_sync_and_week_old_snapshot PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_load_summary_history_includes_current_summary_and_sorts_descending PASSED [ 56%]
+tests/test_public_record_refresh.py::test_default_us_region_state_map_includes_all_50_states PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_is_deterministic_and_schema_compatible PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_preserves_existing_identifiers PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_duplicate_id_or_slug PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_enforces_region_targets PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_above_region_targets PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_flags_and_drops_link_failures PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_on_transient_link_failures PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_legacy_self_reported_source_label PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_source_matching_website PASSED [ 56%]
 tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_missing_us_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_cross_state_source_policy PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_generic_us_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_ohio_record_fragment_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_ohio_generic_home_fragment_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_synthetic_listing_marker PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_search_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_non_chambers_hosts_with_chambers_substrings PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_retries_then_succeeds PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_marks_404_as_definitive_failure PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_rejects_invalid_arguments PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_server_error_after_retries PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_request_exception_reason PASSED [ 56%]
-tests/test_public_record_refresh.py::test_render_refresh_summary_includes_dropped_ids_and_link_failures PASSED [ 56%]
-tests/test_public_record_refresh.py::test_parse_chambers_index_entries_skips_invalid_rows_and_sorts PASSED [ 56%]
-tests/test_public_record_refresh.py::test_fetch_json_payload_handles_non_200_and_successful_json PASSED [ 56%]
-tests/test_public_record_refresh.py::test_discovered_description_handles_tag_list_shapes PASSED [ 56%]
-tests/test_public_record_refresh.py::test_validate_regions_rejects_unknown_region PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_cross_state_source_policy PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_generic_us_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_ohio_record_fragment_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_ohio_generic_home_fragment_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_synthetic_listing_marker PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_search_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_non_chambers_hosts_with_chambers_substrings PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_retries_then_succeeds PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_marks_404_as_definitive_failure PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_rejects_invalid_arguments PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_server_error_after_retries PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_request_exception_reason PASSED [ 57%]
+tests/test_public_record_refresh.py::test_render_refresh_summary_includes_dropped_ids_and_link_failures PASSED [ 57%]
+tests/test_public_record_refresh.py::test_parse_chambers_index_entries_skips_invalid_rows_and_sorts PASSED [ 57%]
+tests/test_public_record_refresh.py::test_fetch_json_payload_handles_non_200_and_successful_json PASSED [ 57%]
+tests/test_public_record_refresh.py::test_discovered_description_handles_tag_list_shapes PASSED [ 57%]
+tests/test_public_record_refresh.py::test_validate_regions_rejects_unknown_region PASSED [ 57%]
 tests/test_public_record_refresh.py::test_chambers_public_profile_url_helpers_cover_supported_and_invalid_inputs PASSED [ 57%]
-tests/test_public_record_refresh.py::test_apply_region_targets_handles_none_and_invalid_target_configurations PASSED [ 57%]
-tests/test_public_record_refresh.py::test_normalization_helpers_validate_and_filter_values PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_seed_rows_respects_zero_limit_and_maximum PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_noop_official_public_record_rows_returns_empty_list PASSED [ 57%]
-tests/test_public_record_refresh.py::test_parse_chambers_index_entries_returns_empty_for_non_list_payload PASSED [ 57%]
-tests/test_public_record_refresh.py::test_fetch_json_payload_handles_exceptions_and_invalid_json PASSED [ 57%]
-tests/test_public_record_refresh.py::test_chambers_discovery_helpers_cover_locations_tags_and_url_normalization PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_validates_arguments_and_missing_adapters PASSED [ 57%]
-tests/test_public_record_refresh.py::test_authoritative_source_and_url_helper_branches PASSED [ 57%]
-tests/test_public_record_refresh.py::test_validate_links_skips_empty_fields_and_region_lookup_requires_mapping PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_chambers_public_record_rows_is_disabled PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_strict_accepts_full_coverage PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_covers_current_implemented_states PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AK] PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AL] PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AR] PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AZ] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_apply_region_targets_handles_none_and_invalid_target_configurations PASSED [ 58%]
+tests/test_public_record_refresh.py::test_normalization_helpers_validate_and_filter_values PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_seed_rows_respects_zero_limit_and_maximum PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_noop_official_public_record_rows_returns_empty_list PASSED [ 58%]
+tests/test_public_record_refresh.py::test_parse_chambers_index_entries_returns_empty_for_non_list_payload PASSED [ 58%]
+tests/test_public_record_refresh.py::test_fetch_json_payload_handles_exceptions_and_invalid_json PASSED [ 58%]
+tests/test_public_record_refresh.py::test_chambers_discovery_helpers_cover_locations_tags_and_url_normalization PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_validates_arguments_and_missing_adapters PASSED [ 58%]
+tests/test_public_record_refresh.py::test_authoritative_source_and_url_helper_branches PASSED [ 58%]
+tests/test_public_record_refresh.py::test_validate_links_skips_empty_fields_and_region_lookup_requires_mapping PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_chambers_public_record_rows_is_disabled PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_strict_accepts_full_coverage PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_covers_current_implemented_states PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AK] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AL] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AR] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AZ] PASSED [ 58%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CA] PASSED [ 58%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CO] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CT] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[DE] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[FL] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[GA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[HI] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ID] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IL] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IN] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KS] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KY] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[LA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MD] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ME] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MI] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MN] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CT] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[DE] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[FL] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[GA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[HI] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ID] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IL] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IN] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KS] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KY] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[LA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MD] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ME] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MI] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MN] PASSED [ 59%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MO] PASSED [ 59%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MS] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MT] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NC] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ND] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NE] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NH] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NJ] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NM] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NV] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NY] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OH] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OK] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OR] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[PA] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[RI] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SC] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SD] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TN] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MT] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NC] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ND] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NE] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NH] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NJ] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NM] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NV] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NY] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OH] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OK] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OR] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[PA] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[RI] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SC] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SD] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TN] PASSED [ 60%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TX] PASSED [ 60%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[UT] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VA] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VT] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WA] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WI] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WV] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WY] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AK] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AL] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AR] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AZ] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CA] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CO] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CT] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-DE] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-FL] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-GA] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VT] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WI] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WV] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WY] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AK] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AL] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AR] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AZ] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CO] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CT] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-DE] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-FL] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-GA] PASSED [ 61%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-HI] PASSED [ 61%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IA] PASSED [ 61%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ID] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IL] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IN] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KS] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KY] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-LA] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MA] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MD] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ME] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MI] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MN] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MO] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MS] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MT] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NC] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ND] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NE] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IL] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IN] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KS] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KY] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-LA] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MA] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MD] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ME] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MI] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MN] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MO] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MS] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MT] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NC] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ND] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NE] PASSED [ 62%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NH] PASSED [ 62%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NJ] PASSED [ 62%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NM] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NV] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NY] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OH] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OK] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OR] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-PA] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-RI] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SC] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SD] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TN] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TX] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-UT] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VA] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VT] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WA] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WI] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NV] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NY] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OH] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OK] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OR] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-PA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-RI] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SC] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SD] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TN] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TX] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-UT] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VT] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WI] PASSED [ 63%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WV] PASSED [ 63%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WY] PASSED [ 63%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AK] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AL] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AR] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AZ] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CA] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CO] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CT] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-DE] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-FL] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-GA] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-HI] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IA] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ID] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IL] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IN] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KS] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AL] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AR] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AZ] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CA] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CO] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CT] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-DE] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-FL] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-GA] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-HI] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IA] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ID] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IL] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IN] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KS] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KY] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-LA] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MA] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MD] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ME] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MI] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MN] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MO] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MS] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MT] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NC] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ND] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NE] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NH] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NJ] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NM] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NV] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NY] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OH] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ME] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MI] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MN] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MO] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MS] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MT] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NC] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ND] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NE] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NH] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NJ] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NM] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NV] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NY] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OH] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OK] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OR] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-PA] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-RI] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SC] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SD] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TN] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TX] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-UT] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VA] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VT] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WA] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WI] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WV] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WY] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AK] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AL] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AR] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SC] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SD] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TN] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TX] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-UT] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VA] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VT] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WA] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WI] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WV] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WY] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AK] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AL] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AR] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AZ] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CA] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CO] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CT] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-DE] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-FL] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-GA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-HI] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ID] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IL] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IN] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KS] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KY] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-LA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MD] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ME] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MI] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-FL] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-GA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-HI] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ID] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IL] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IN] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KS] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KY] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-LA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MD] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ME] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MI] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MN] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MO] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MS] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MT] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NC] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ND] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NE] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NH] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NJ] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NM] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NV] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NY] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OH] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OK] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OR] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-PA] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-RI] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SC] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SD] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ND] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NE] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NH] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NJ] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NM] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NV] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NY] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OH] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OK] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OR] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-PA] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-RI] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SC] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SD] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-TN] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-TX] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-UT] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-VA] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-VT] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WA] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WI] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WV] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WY] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_california_seeds PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen-Alaska Bar Association public directory-https://member.alaskabar.org/cv5/cgi-bin/memberdll.dll/Info?CUSTOMERCD=8744&WRP=Customer_Profile.htm] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers-Alabama State Bar public directory-https://members.alabar.org/Member_Portal/Member_Portal/Sections/AP.aspx] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik-Arkansas Bar Association public directory-https://www.arkbar.com/?pg=board-of-trustees] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali-State Bar of Arizona public directory-https://www.azbar.org/for-legal-professionals/practice-tools-management/member-directory/?m=Anthony-Cali-177781] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock-Colorado Bar Association public directory-https://community.cobar.org/profile/contributions/contributions-achievements?UserKey=330f70ad-afc9-44f0-b8b1-6b55108bc275] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown-Connecticut Bar Association public directory-https://members.ctbar.org/member/thelaborlawyer] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott-Delaware Courts published opinion-https://courts.delaware.gov/Opinions/Download.aspx?id=342050] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.-The Florida Bar public directory-https://www.floridabar.org/directories/find-mbr/profile/?num=123000] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WA] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WI] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WV] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WY] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_california_seeds PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen-Alaska Bar Association public directory-https://member.alaskabar.org/cv5/cgi-bin/memberdll.dll/Info?CUSTOMERCD=8744&WRP=Customer_Profile.htm] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers-Alabama State Bar public directory-https://members.alabar.org/Member_Portal/Member_Portal/Sections/AP.aspx] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik-Arkansas Bar Association public directory-https://www.arkbar.com/?pg=board-of-trustees] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali-State Bar of Arizona public directory-https://www.azbar.org/for-legal-professionals/practice-tools-management/member-directory/?m=Anthony-Cali-177781] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock-Colorado Bar Association public directory-https://community.cobar.org/profile/contributions/contributions-achievements?UserKey=330f70ad-afc9-44f0-b8b1-6b55108bc275] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown-Connecticut Bar Association public directory-https://members.ctbar.org/member/thelaborlawyer] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott-Delaware Courts published opinion-https://courts.delaware.gov/Opinions/Download.aspx?id=342050] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.-The Florida Bar public directory-https://www.floridabar.org/directories/find-mbr/profile/?num=123000] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton-State Bar of Georgia speaker profile-https://icle.gabar.org/speaker/todd-stanton-1261014] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz-Hawaii State Bar Association attorney recognition record-https://hsba.org/HSBA_2020/About_Us/Living_Legend_Lawyers_.aspx] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin-Iowa State Bar Association jury verdict record-https://services.iowabar.org/IB/JuryVerdicts.nsf/b96238336212630c85258ca1000240fd/e71fe5f6f6d3242d872589900011edc5!OpenDocument] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser-Idaho State Bar attorney profile-https://isb.idaho.gov/blog/trudy-hanson-fouser/] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler-Indiana State Bar public directory-https://www.inbar.org/members/?id=30400364] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady-Kansas Judicial Branch published opinion-https://kscourts.gov/Cases-Decisions/Decisions/Published/Brown-v-Ford-Storage-and-Moving-Co-Inc] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks-Kentucky Bar Association public directory-https://www.kybar.org/members/?id=42347567] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer-Louisiana Attorney Disciplinary Board attorney records-https://www.ladb.org/DR/Document.cfm?docket=24-DB-014] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey-Massachusetts BBO attorney records-https://bbopublic.massbbo.org/web/f/SJC_WellBeing_Cmte_Report.pdf] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker-Maryland Courts attorney discipline records-https://www.courts.state.md.us/attygrievance/sanctions07] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher-Maine Board of Overseers of the Bar public directory-https://mebarconnect.mainebar.org/people/daniel-eccher] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese-State Bar of Michigan public directory-https://connect.michbar.org/laborlaw[redacted-path] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman-Minnesota Courts attorney records-https://mncourts.gov/help-topics/Legal-Paraprofessional-Program/standing-committee] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips-The Missouri Bar public directory-https://news.mobar.org/jerina-d-phillips-receives-2025-diversity-champion-award/] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MS-seed-joel-frank-dillard-public-record~joel-frank-dillard-Joel Frank Dillard-The Mississippi Bar public directory-https://www.msbar.org/inside-the-bar/sections/labor-employment-law/] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm-State Bar of Montana public directory-https://www.montanabar.org/About-Us/Sections-and-Committees] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams-North Carolina State Bar public directory-https://www.ncbar.gov/for-lawyers/directories/leadership/state-bar-officers/] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson-North Dakota Court System attorney directory-https://www.ndcourts.gov/lawyers/06402] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau-Nebraska Judicial Branch case record-https://supremecourt.nebraska.gov/courts/supreme-court/supreme-court-call/city-omaha-v-professional-firefighters-association-omaha] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks-Kentucky Bar Association public directory-https://www.kybar.org/members/?id=42347567] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer-Louisiana Attorney Disciplinary Board attorney records-https://www.ladb.org/DR/Document.cfm?docket=24-DB-014] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey-Massachusetts BBO attorney records-https://bbopublic.massbbo.org/web/f/SJC_WellBeing_Cmte_Report.pdf] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker-Maryland Courts attorney discipline records-https://www.courts.state.md.us/attygrievance/sanctions07] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher-Maine Board of Overseers of the Bar public directory-https://mebarconnect.mainebar.org/people/daniel-eccher] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese-State Bar of Michigan public directory-https://connect.michbar.org/laborlaw[redacted-path] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman-Minnesota Courts attorney records-https://mncourts.gov/help-topics/Legal-Paraprofessional-Program/standing-committee] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips-The Missouri Bar public directory-https://news.mobar.org/jerina-d-phillips-receives-2025-diversity-champion-award/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MS-seed-joel-frank-dillard-public-record~joel-frank-dillard-Joel Frank Dillard-The Mississippi Bar public directory-https://www.msbar.org/inside-the-bar/sections/labor-employment-law/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm-State Bar of Montana public directory-https://www.montanabar.org/About-Us/Sections-and-Committees] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams-North Carolina State Bar public directory-https://www.ncbar.gov/for-lawyers/directories/leadership/state-bar-officers/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson-North Dakota Court System attorney directory-https://www.ndcourts.gov/lawyers/06402] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau-Nebraska Judicial Branch case record-https://supremecourt.nebraska.gov/courts/supreme-court/supreme-court-call/city-omaha-v-professional-firefighters-association-omaha] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns-New Hampshire Bar Association CLE speaker profile-https://member.nhbar.org/calendar/event/34th-annual-labor-and-employment-law-update] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins-NJ Courts attorney certification records-https://www.njcourts.gov/notices/order-board-attorney-certification-new-chair-and-vice-chair-designations-certification] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy-State Bar of New Mexico public directory-https://www.sbnm.org/cvweb/cgi-bin/Utilities.dll?View=INMEMBERDETAILS&RECORDNO=1&CUSTOMERNO=11321] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck-State Bar of Nevada public directory-https://nvbar.org/for-lawyers/bar-service-opportunities/join-a-section/labor-and-employment-law-section/] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone-New York Courts attorney directory-https://decisions.courts.state.ny.us/ad3/Decisions/2023/CV-22-1940.pdf] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough-Oklahoma Bar Association public directory-https://ams.okbar.org/eweb/DynamicPage.aspx?Action=Add&DoNotSave=yes&ObjectKeyFrom=1A83491A-9853-4C87-86A4-F7D95601C2E2&ParentDataObject=Invoice+Detail&ParentObject=CentralizedOrderEntry&WebCode=ProdDetailAdd&ivd_cst_key=00000000-0000-0000-0000-000000000000&ivd_cst_ship_key=00000000-0000-0000-0000-000000000000&ivd_formkey=69202792-63d7-4ba2-bf4e-a0da41270555&ivd_prc_prd_key=F5FDCC21-BBDF-4D41-944F-5351AD775A80] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland-Oregon State Bar public directory-https://www.osbar.org/sections/labor.html] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson-Pennsylvania Disciplinary Board attorney directory-https://www.padisciplinaryboard.org/for-the-public/find-attorney/attorney-detail/85957] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof-Rhode Island Judiciary attorney records-https://www.courts.ri.gov/attorney-resources/Pages/Board-of-Bar-Examiners-default.aspx] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe-South Carolina Bar public directory-https://www.scbar.org/for-lawyers/networking/sections/employment-and-labor-law-section/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger-State Bar of South Dakota public directory-https://www.statebarofsouthdakota.com/project-rural-practice/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez-State Bar of Texas public directory-https://www.texasbar.com/AM/Template.cfm?ContactID=157597&template=%2FCustomsource%2FMemberDirectory%2FMemberDirectoryDetail.cfm] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen-Utah Courts public legal directory-https://www.utcourts.gov/en/about/administration/committees/ethics-advisory-committee.html] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt-Virginia State Bar public directory-https://virginialawyer.vsb.org/articles/professional-notices?article_id=5100257&i=859839] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VT-seed-jeremy-s-grant-public-record~jeremy-s-grant-Jeremy S. Grant-Vermont Bar Association public directory-https://www.vtbar.org/2025-annual-meeting-in-review/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus-State Bar of Wisconsin public directory-https://www.wisbar.org/NewsPublications/WisconsinLawyer/WisconsinLawyerPDFs/97/01/20_24.pdf] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess-West Virginia State Bar public directory-https://wvbar.org/wp-content/uploads/2024/04/24-25-Active-List-UPDATED.pdf] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke-Wyoming State Bar public directory-https://www.wyomingbar.org/about-us/bar-leadership/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland-Oregon State Bar public directory-https://www.osbar.org/sections/labor.html] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson-Pennsylvania Disciplinary Board attorney directory-https://www.padisciplinaryboard.org/for-the-public/find-attorney/attorney-detail/85957] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof-Rhode Island Judiciary attorney records-https://www.courts.ri.gov/attorney-resources/Pages/Board-of-Bar-Examiners-default.aspx] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe-South Carolina Bar public directory-https://www.scbar.org/for-lawyers/networking/sections/employment-and-labor-law-section/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger-State Bar of South Dakota public directory-https://www.statebarofsouthdakota.com/project-rural-practice/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez-State Bar of Texas public directory-https://www.texasbar.com/AM/Template.cfm?ContactID=157597&template=%2FCustomsource%2FMemberDirectory%2FMemberDirectoryDetail.cfm] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen-Utah Courts public legal directory-https://www.utcourts.gov/en/about/administration/committees/ethics-advisory-committee.html] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt-Virginia State Bar public directory-https://virginialawyer.vsb.org/articles/professional-notices?article_id=5100257&i=859839] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VT-seed-jeremy-s-grant-public-record~jeremy-s-grant-Jeremy S. Grant-Vermont Bar Association public directory-https://www.vtbar.org/2025-annual-meeting-in-review/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus-State Bar of Wisconsin public directory-https://www.wisbar.org/NewsPublications/WisconsinLawyer/WisconsinLawyerPDFs/97/01/20_24.pdf] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess-West Virginia State Bar public directory-https://wvbar.org/wp-content/uploads/2024/04/24-25-Active-List-UPDATED.pdf] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke-Wyoming State Bar public directory-https://www.wyomingbar.org/about-us/bar-leadership/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips] PASSED [ 72%]
@@ -1948,18 +2187,18 @@ tests/test_public_record_refresh.py::test_discover_official_us_state_public_reco
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt] PASSED [ 73%]
@@ -1967,17 +2206,17 @@ tests/test_public_record_refresh.py::test_discover_official_us_state_public_reco
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke] PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_washington_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_washington_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_ohio_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_ohio_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_tennessee_seeds PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_tennessee_seeds PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_illinois_seeds PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_illinois_seeds PASSED [ 73%]
-tests/test_public_record_refresh_workflow.py::test_public_record_quarterly_refresh_workflow_uses_correction_pr_flow PASSED [ 73%]
-tests/test_public_record_refresh_workflow.py::test_refresh_public_record_corrections_make_target_matches_workflow_semantics PASSED [ 73%]
-tests/test_public_record_refresh_workflow.py::test_refresh_report_matches_structured_values PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_washington_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_washington_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_ohio_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_ohio_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_tennessee_seeds PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_tennessee_seeds PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_illinois_seeds PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_illinois_seeds PASSED [ 74%]
+tests/test_public_record_refresh_workflow.py::test_public_record_quarterly_refresh_workflow_uses_correction_pr_flow PASSED [ 74%]
+tests/test_public_record_refresh_workflow.py::test_refresh_public_record_corrections_make_target_matches_workflow_semantics PASSED [ 74%]
+tests/test_public_record_refresh_workflow.py::test_refresh_report_matches_structured_values PASSED [ 74%]
 tests/test_public_record_refresh_workflow.py::test_sync_provenance_roadmap_updates_baseline_and_adapter_count PASSED [ 74%]
 tests/test_public_record_refresh_workflow.py::test_sync_provenance_roadmap_preserves_eu_planning_section PASSED [ 74%]
 tests/test_public_record_refresh_workflow.py::test_public_record_provenance_roadmap_documents_eu_phase_0b_policy PASSED [ 74%]
@@ -1986,17 +2225,17 @@ tests/test_public_record_refresh_workflow.py::test_public_record_provenance_road
 tests/test_public_record_refresh_workflow.py::test_public_record_provenance_roadmap_documents_eu_phase_0e_rollout_backlog PASSED [ 74%]
 tests/test_refresh_newsroom_directory_listings_script.py::test_serialize_rows_is_deterministic_without_node_tooling PASSED [ 74%]
 tests/test_registration_and_login.py::test_user_registration_disabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_disabled_first_user PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_with_invite_code_disabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_with_invite_code_enabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_rejects_case_insensitive_duplicate PASSED [ 74%]
-tests/test_registration_and_login.py::test_username_db_constraint_rejects_case_insensitive_duplicate PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_handles_case_insensitive_race_integrity_error PASSED [ 74%]
-tests/test_registration_and_login.py::test_register_page_loads PASSED    [ 74%]
-tests/test_registration_and_login.py::test_register_requires_csrf_token PASSED [ 74%]
-tests/test_registration_and_login.py::test_login_page_loads PASSED       [ 74%]
-tests/test_registration_and_login.py::test_login_invalid_post_shows_errors_and_preserves_username PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_registration_disabled_first_user PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_with_invite_code_disabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_with_invite_code_enabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_rejects_case_insensitive_duplicate PASSED [ 75%]
+tests/test_registration_and_login.py::test_username_db_constraint_rejects_case_insensitive_duplicate PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_handles_case_insensitive_race_integrity_error PASSED [ 75%]
+tests/test_registration_and_login.py::test_register_page_loads PASSED    [ 75%]
+tests/test_registration_and_login.py::test_register_requires_csrf_token PASSED [ 75%]
+tests/test_registration_and_login.py::test_login_page_loads PASSED       [ 75%]
+tests/test_registration_and_login.py::test_login_invalid_post_shows_errors_and_preserves_username PASSED [ 75%]
 tests/test_registration_and_login.py::test_login_requires_csrf_token PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_after_registration PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_case_insensitive PASSED [ 75%]
@@ -2006,16 +2245,16 @@ tests/test_registration_and_login.py::test_user_login_rehashes_legacy_passlib_ha
 tests/test_registration_and_login.py::test_user_login_does_not_rehash_legacy_passlib_hash_when_disabled PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_rehash_failure_preserves_legacy_passlib_hash PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_handles_case_insensitive_duplicate_rows PASSED [ 75%]
-tests/test_replies.py::test_message_reply_404_for_unknown_slug PASSED    [ 75%]
-tests/test_replies.py::test_default_replies PASSED                       [ 75%]
-tests/test_replies.py::test_custom_replies PASSED                        [ 75%]
-tests/test_replies.py::test_set_custom_replies PASSED                    [ 75%]
-tests/test_replies.py::test_settings_replies_prefills_default_status_text PASSED [ 75%]
-tests/test_replies.py::test_settings_replies_prefills_custom_status_text_when_present PASSED [ 75%]
-tests/test_replies.py::test_set_custom_replies_redirects_back_with_success_flash PASSED [ 75%]
-tests/test_replies.py::test_set_default_replies_keeps_builtin_default_without_persisting_override PASSED [ 75%]
-tests/test_replies.py::test_message_page PASSED                          [ 75%]
-tests/test_replies.py::test_message_page_wrong_user PASSED               [ 75%]
+tests/test_replies.py::test_message_reply_404_for_unknown_slug PASSED    [ 76%]
+tests/test_replies.py::test_default_replies PASSED                       [ 76%]
+tests/test_replies.py::test_custom_replies PASSED                        [ 76%]
+tests/test_replies.py::test_set_custom_replies PASSED                    [ 76%]
+tests/test_replies.py::test_settings_replies_prefills_default_status_text PASSED [ 76%]
+tests/test_replies.py::test_settings_replies_prefills_custom_status_text_when_present PASSED [ 76%]
+tests/test_replies.py::test_set_custom_replies_redirects_back_with_success_flash PASSED [ 76%]
+tests/test_replies.py::test_set_default_replies_keeps_builtin_default_without_persisting_override PASSED [ 76%]
+tests/test_replies.py::test_message_page PASSED                          [ 76%]
+tests/test_replies.py::test_message_page_wrong_user PASSED               [ 76%]
 tests/test_replies.py::test_set_message_status_success PASSED            [ 76%]
 tests/test_replies.py::test_set_message_status_invalid_form PASSED       [ 76%]
 tests/test_replies.py::test_set_message_status_message_not_found PASSED  [ 76%]
@@ -2025,15 +2264,15 @@ tests/test_replies.py::test_settings_replies_invalid_status_renders_field_error_
 tests/test_replies.py::test_settings_replies_missing_csrf_renders_error_on_submitted_form PASSED [ 76%]
 tests/test_resend_message.py::test_resend_message_sends_per_field PASSED [ 76%]
 tests/test_resend_message.py::test_resend_message_sends_per_field_to_all_enabled_recipients PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_blocks_other_users_messages PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_requires_email_notifications PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_requires_csrf_token PASSED [ 76%]
-tests/test_resend_message.py::test_resend_button_visible_with_required_settings PASSED [ 76%]
-tests/test_resend_message.py::test_resend_button_hidden_without_notifications_or_content PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_uses_existing_armored_value_without_reencryption PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_reuses_armored_value_for_duplicate_shared_recipient_key PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_encrypts_value_with_embedded_pgp_header_substring PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_blocks_other_users_messages PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_requires_email_notifications PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_requires_csrf_token PASSED [ 77%]
+tests/test_resend_message.py::test_resend_button_visible_with_required_settings PASSED [ 77%]
+tests/test_resend_message.py::test_resend_button_hidden_without_notifications_or_content PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_uses_existing_armored_value_without_reencryption PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_reuses_armored_value_for_duplicate_shared_recipient_key PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_encrypts_value_with_embedded_pgp_header_substring PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value PASSED [ 77%]
 tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value_for_all_enabled_recipients PASSED [ 77%]
 tests/test_resend_message.py::test_resend_message_full_body_encryption_failure_falls_back_to_generic PASSED [ 77%]
 tests/test_resend_message.py::test_resend_message_full_body_multi_recipient_armored_value_falls_back_to_generic PASSED [ 77%]
@@ -2044,15 +2283,15 @@ tests/test_routes_auth.py::test_register_redirects_when_already_logged_in PASSED
 tests/test_routes_auth.py::test_register_rejects_incorrect_captcha PASSED [ 77%]
 tests/test_routes_auth.py::test_register_rejects_invalid_invite_code PASSED [ 77%]
 tests/test_routes_auth.py::test_register_rejects_expired_invite_code PASSED [ 77%]
-tests/test_routes_auth.py::test_register_requires_invite_code_by_default_for_first_user PASSED [ 77%]
-tests/test_routes_auth.py::test_register_valid_invite_code_deletes_code PASSED [ 77%]
-tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_invalid_session_state PASSED [ 77%]
-tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_non_legacy_source_hash PASSED [ 77%]
-tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_mismatched_source_digest PASSED [ 77%]
-tests/test_routes_auth.py::test_register_handles_unexpected_integrity_error PASSED [ 77%]
-tests/test_routes_auth.py::test_login_redirects_when_already_logged_in PASSED [ 77%]
-tests/test_routes_auth.py::test_login_redirects_to_select_tier_when_premium_enabled PASSED [ 77%]
-tests/test_routes_auth.py::test_login_redirects_to_original_protected_page PASSED [ 77%]
+tests/test_routes_auth.py::test_register_requires_invite_code_by_default_for_first_user PASSED [ 78%]
+tests/test_routes_auth.py::test_register_valid_invite_code_deletes_code PASSED [ 78%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_invalid_session_state PASSED [ 78%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_non_legacy_source_hash PASSED [ 78%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_mismatched_source_digest PASSED [ 78%]
+tests/test_routes_auth.py::test_register_handles_unexpected_integrity_error PASSED [ 78%]
+tests/test_routes_auth.py::test_login_redirects_when_already_logged_in PASSED [ 78%]
+tests/test_routes_auth.py::test_login_redirects_to_select_tier_when_premium_enabled PASSED [ 78%]
+tests/test_routes_auth.py::test_login_redirects_to_original_protected_page PASSED [ 78%]
 tests/test_routes_auth.py::test_password_reset_request_is_generic_and_sends_only_for_eligible_account PASSED [ 78%]
 tests/test_routes_auth.py::test_find_primary_username_returns_none_and_logs_when_query_is_ambiguous PASSED [ 78%]
 tests/test_routes_auth.py::test_password_reset_sets_new_password_and_consumes_token PASSED [ 78%]
@@ -2063,14 +2302,14 @@ tests/test_routes_auth.py::test_password_reset_request_rejects_incorrect_captcha
 tests/test_routes_auth.py::test_stash_post_auth_redirect_skips_logout_and_preserves_session PASSED [ 78%]
 tests/test_routes_auth.py::test_stash_post_auth_redirect_rejects_unsafe_target_and_preserves_session PASSED [ 78%]
 tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[None] PASSED [ 78%]
-tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[bind1] PASSED [ 78%]
-tests/test_routes_auth.py::test_register_rejects_when_first_user_recheck_finds_existing_user PASSED [ 78%]
-tests/test_routes_auth.py::test_login_clears_auth_session_when_2fa_commit_fails PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_login_and_clears_session_for_missing_user PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_inbox_when_already_authenticated PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_rejects_when_user_has_no_totp_secret PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_requires_csrf_token PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_onboarding PASSED [ 78%]
+tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[bind1] PASSED [ 79%]
+tests/test_routes_auth.py::test_register_rejects_when_first_user_recheck_finds_existing_user PASSED [ 79%]
+tests/test_routes_auth.py::test_login_clears_auth_session_when_2fa_commit_fails PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_login_and_clears_session_for_missing_user PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_inbox_when_already_authenticated PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_rejects_when_user_has_no_totp_secret PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_requires_csrf_token PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_onboarding PASSED [ 79%]
 tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_select_tier_when_enabled PASSED [ 79%]
 tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_original_protected_page PASSED [ 79%]
 tests/test_routes_auth.py::test_verify_2fa_login_failed_rehash_commit_clears_auth_session PASSED [ 79%]
@@ -2082,14 +2321,14 @@ tests/test_routes_common.py::test_get_ip_address_fallback PASSED         [ 79%]
 tests/test_routes_common.py::test_show_directory_caution_badge_honors_explicit_cautious_override PASSED [ 79%]
 tests/test_routes_common.py::test_do_send_email_returns_early_without_enabled_notifications PASSED [ 79%]
 tests/test_routes_common.py::test_do_send_email_uses_user_custom_smtp PASSED [ 79%]
-tests/test_routes_common.py::test_do_send_email_sends_to_each_enabled_recipient PASSED [ 79%]
-tests/test_routes_common.py::test_do_send_email_deduplicates_recipient_email_addresses PASSED [ 79%]
-tests/test_routes_common.py::test_do_send_email_retries_duplicate_address_after_false_result PASSED [ 79%]
-tests/test_routes_common.py::test_send_email_to_user_recipients_accepts_recipient_body_factory PASSED [ 79%]
-tests/test_routes_common.py::test_send_email_to_user_recipients_skips_empty_recipient_body PASSED [ 79%]
-tests/test_routes_common.py::test_notification_email_encryption_target_returns_all_enabled_keys PASSED [ 79%]
-tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_without_primary_row PASSED [ 79%]
-tests/test_routes_common.py::test_notification_email_encryption_target_falls_back_to_legacy_user_key PASSED [ 79%]
+tests/test_routes_common.py::test_do_send_email_sends_to_each_enabled_recipient PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_deduplicates_recipient_email_addresses PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_retries_duplicate_address_after_false_result PASSED [ 80%]
+tests/test_routes_common.py::test_send_email_to_user_recipients_accepts_recipient_body_factory PASSED [ 80%]
+tests/test_routes_common.py::test_send_email_to_user_recipients_skips_empty_recipient_body PASSED [ 80%]
+tests/test_routes_common.py::test_notification_email_encryption_target_returns_all_enabled_keys PASSED [ 80%]
+tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_without_primary_row PASSED [ 80%]
+tests/test_routes_common.py::test_notification_email_encryption_target_falls_back_to_legacy_user_key PASSED [ 80%]
 tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_when_primary_row_lacks_key PASSED [ 80%]
 tests/test_routes_common.py::test_notification_email_encryption_target_uses_non_primary_recipient_without_legacy_key PASSED [ 80%]
 tests/test_routes_common.py::test_notification_email_encryption_target_ignores_enabled_recipient_without_key PASSED [ 80%]
@@ -2101,14 +2340,14 @@ tests/test_routes_common.py::test_notification_recipient_encryption_target_uses_
 tests/test_routes_common.py::test_notification_recipient_encryption_target_returns_none_without_key PASSED [ 80%]
 tests/test_routes_common.py::test_do_send_email_continues_after_single_recipient_failure PASSED [ 80%]
 tests/test_routes_common.py::test_do_send_email_uses_default_smtp PASSED [ 80%]
-tests/test_routes_common.py::test_do_send_email_uses_notifications_address_as_reply_to_fallback PASSED [ 80%]
-tests/test_routes_common.py::test_do_send_email_skips_recipient_without_email PASSED [ 80%]
-tests/test_routes_common.py::test_do_send_email_catches_errors PASSED    [ 80%]
-tests/test_routes_common.py::test_do_send_email_skips_when_default_smtp_incomplete PASSED [ 80%]
-tests/test_routes_common.py::test_formatters PASSED                      [ 80%]
-tests/test_routes_forms.py::test_login_password_max_matches_registration PASSED [ 80%]
-tests/test_routes_forms.py::test_login_username_max_matches_registration PASSED [ 80%]
-tests/test_routes_forms.py::test_dynamic_message_form_skips_disabled_fields_and_maps_names PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_uses_notifications_address_as_reply_to_fallback PASSED [ 81%]
+tests/test_routes_common.py::test_do_send_email_skips_recipient_without_email PASSED [ 81%]
+tests/test_routes_common.py::test_do_send_email_catches_errors PASSED    [ 81%]
+tests/test_routes_common.py::test_do_send_email_skips_when_default_smtp_incomplete PASSED [ 81%]
+tests/test_routes_common.py::test_formatters PASSED                      [ 81%]
+tests/test_routes_forms.py::test_login_password_max_matches_registration PASSED [ 81%]
+tests/test_routes_forms.py::test_login_username_max_matches_registration PASSED [ 81%]
+tests/test_routes_forms.py::test_dynamic_message_form_skips_disabled_fields_and_maps_names PASSED [ 81%]
 tests/test_routes_forms.py::test_dynamic_message_form_unknown_field_type_raises PASSED [ 81%]
 tests/test_routes_forms.py::test_dynamic_message_form_choice_fields_select_and_multicheckbox PASSED [ 81%]
 tests/test_routes_forms.py::test_onboarding_profile_form_rejects_disallowed_language PASSED [ 81%]
@@ -2120,13 +2359,13 @@ tests/test_safe_template.py::test_missing_var PASSED                     [ 81%]
 tests/test_safe_template.py::test_invalid_var_syntax PASSED              [ 81%]
 tests/test_safe_template.py::test_unclosed_var PASSED                    [ 81%]
 tests/test_safe_template.py::test_unopened_var PASSED                    [ 81%]
-tests/test_safe_template.py::test_invalid_var_value PASSED               [ 81%]
-tests/test_safe_template.py::test_single_var PASSED                      [ 81%]
-tests/test_safe_template.py::test_multiple_vars PASSED                   [ 81%]
-tests/test_secure_session.py::TestSessionEnabled::test_get_set PASSED    [ 81%]
-tests/test_secure_session.py::TestSessionEnabled::test_key_only_session_access_sets_vary_cookie PASSED [ 81%]
-tests/test_secure_session.py::TestNoSessionEnabled::test_no_session PASSED [ 81%]
-tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_missing_seed_file PASSED [ 81%]
+tests/test_safe_template.py::test_invalid_var_value PASSED               [ 82%]
+tests/test_safe_template.py::test_single_var PASSED                      [ 82%]
+tests/test_safe_template.py::test_multiple_vars PASSED                   [ 82%]
+tests/test_secure_session.py::TestSessionEnabled::test_get_set PASSED    [ 82%]
+tests/test_secure_session.py::TestSessionEnabled::test_key_only_session_access_sets_vary_cookie PASSED [ 82%]
+tests/test_secure_session.py::TestNoSessionEnabled::test_no_session PASSED [ 82%]
+tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_missing_seed_file PASSED [ 82%]
 tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_non_list_seed_json PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_is_deterministic_and_schema_compatible PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_normalize_string_list_filters_invalid_blank_and_duplicate_values PASSED [ 82%]
@@ -2139,13 +2378,13 @@ tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_ro
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows1-Duplicate SecureDrop listing id: securedrop-one] PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows2-Normalized row slug must be a string] PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows3-Duplicate SecureDrop listing slug: securedrop~shared] PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_requests_expected_shape PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_list_payload PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_object_payload_items PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_render_securedrop_refresh_summary PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_summary_row_label_falls_back_to_name_id_or_unnamed_listing PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_append_summary_section_skips_empty_entries PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows3-Duplicate SecureDrop listing slug: securedrop~shared] PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_requests_expected_shape PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_list_payload PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_object_payload_items PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_render_securedrop_refresh_summary PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_summary_row_label_falls_back_to_name_id_or_unnamed_listing PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_append_summary_section_skips_empty_entries PASSED [ 83%]
 tests/test_security_headers.py::test_csp PASSED                          [ 83%]
 tests/test_security_headers.py::test_csp_script_src_elem_disallows_inline_scripts PASSED [ 83%]
 tests/test_security_headers.py::test_custom_splash_logo_keeps_csp_enforced PASSED [ 83%]
@@ -2158,13 +2397,13 @@ tests/test_security_headers.py::test_base_template_uses_external_no_js_bootstrap
 tests/test_security_headers.py::test_x_frame_options PASSED              [ 83%]
 tests/test_security_headers.py::test_x_content_type_options PASSED       [ 83%]
 tests/test_security_headers.py::test_permissions_policy PASSED           [ 83%]
-tests/test_security_headers.py::test_referrer_policy PASSED              [ 83%]
-tests/test_security_headers.py::test_x_xss_protection PASSED             [ 83%]
-tests/test_security_headers.py::test_strict_transport_security PASSED    [ 83%]
-tests/test_security_headers.py::test_no_strict_transport_security_onion PASSED [ 83%]
-tests/test_settings.py::test_user_account_category_persists PASSED       [ 83%]
-tests/test_settings.py::test_user_location_persists PASSED               [ 83%]
-tests/test_settings.py::test_notification_recipient_shadow_persists_from_legacy_fields PASSED [ 83%]
+tests/test_security_headers.py::test_referrer_policy PASSED              [ 84%]
+tests/test_security_headers.py::test_x_xss_protection PASSED             [ 84%]
+tests/test_security_headers.py::test_strict_transport_security PASSED    [ 84%]
+tests/test_security_headers.py::test_no_strict_transport_security_onion PASSED [ 84%]
+tests/test_settings.py::test_user_account_category_persists PASSED       [ 84%]
+tests/test_settings.py::test_user_location_persists PASSED               [ 84%]
+tests/test_settings.py::test_notification_recipient_shadow_persists_from_legacy_fields PASSED [ 84%]
 tests/test_settings.py::test_user_ensure_primary_notification_recipient_returns_existing_recipient PASSED [ 84%]
 tests/test_settings.py::test_settings_page_loads PASSED                  [ 84%]
 tests/test_settings.py::test_settings_profile_page_renders_updated_profile_copy PASSED [ 84%]
@@ -2177,12 +2416,12 @@ tests/test_settings.py::test_invalid_password_post_shows_only_password_errors_an
 tests/test_settings.py::test_username_post_does_not_trigger_password_form_validation PASSED [ 84%]
 tests/test_settings.py::test_password_post_does_not_trigger_username_form_validation PASSED [ 84%]
 tests/test_settings.py::test_change_password PASSED                      [ 84%]
-tests/test_settings.py::test_change_password_revokes_sibling_session PASSED [ 84%]
-tests/test_settings.py::test_change_password_from_native_werkzeug_scrypt_hash PASSED [ 84%]
-tests/test_settings.py::test_change_password_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 84%]
-tests/test_settings.py::test_add_pgp_key PASSED                          [ 84%]
-tests/test_settings.py::test_add_invalid_pgp_key PASSED                  [ 84%]
-tests/test_settings.py::test_encryption_invalid_manual_key_form_shows_only_manual_key_errors PASSED [ 84%]
+tests/test_settings.py::test_change_password_revokes_sibling_session PASSED [ 85%]
+tests/test_settings.py::test_change_password_from_native_werkzeug_scrypt_hash PASSED [ 85%]
+tests/test_settings.py::test_change_password_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 85%]
+tests/test_settings.py::test_add_pgp_key PASSED                          [ 85%]
+tests/test_settings.py::test_add_invalid_pgp_key PASSED                  [ 85%]
+tests/test_settings.py::test_encryption_invalid_manual_key_form_shows_only_manual_key_errors PASSED [ 85%]
 tests/test_settings.py::test_add_pgp_key_without_encryption_subkey PASSED [ 85%]
 tests/test_settings.py::test_add_pgp_key_proton_redirects_to_encryption PASSED [ 85%]
 tests/test_settings.py::test_add_pgp_key_proton_invalid_form_redirects_index PASSED [ 85%]
@@ -2196,12 +2435,12 @@ tests/test_settings.py::test_update_smtp_settings_reject_private_host PASSED [ 8
 tests/test_settings.py::test_notifications_invalid_email_forwarding_post_shows_only_forwarding_errors PASSED [ 85%]
 tests/test_settings.py::test_add_notification_recipient PASSED           [ 85%]
 tests/test_settings.py::test_free_user_cannot_add_second_notification_recipient PASSED [ 85%]
-tests/test_settings.py::test_business_user_can_add_second_notification_recipient PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_page_renders_proton_lookup PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_proton_lookup_prefills_form PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_proton_lookup_invalid_email_returns_400 PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_proton_lookup_error_returns_400 PASSED [ 85%]
-tests/test_settings.py::test_add_notification_recipient_rejects_invalid_pgp_key PASSED [ 85%]
+tests/test_settings.py::test_business_user_can_add_second_notification_recipient PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_page_renders_proton_lookup PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_prefills_form PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_invalid_email_returns_400 PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_error_returns_400 PASSED [ 86%]
+tests/test_settings.py::test_add_notification_recipient_rejects_invalid_pgp_key PASSED [ 86%]
 tests/test_settings.py::test_add_notification_recipient_rejects_non_encryptable_pgp_key PASSED [ 86%]
 tests/test_settings.py::test_edit_notification_recipient PASSED          [ 86%]
 tests/test_settings.py::test_notification_recipient_page_missing_recipient_redirects_to_notifications PASSED [ 86%]
@@ -2215,11 +2454,11 @@ tests/test_settings.py::test_enabled_recipient_requires_key_when_content_include
 tests/test_settings.py::test_notifications_page_rejects_content_toggle_without_encryptable_recipient PASSED [ 86%]
 tests/test_settings.py::test_notifications_page_lists_recipient_drill_ins_for_business_user PASSED [ 86%]
 tests/test_settings.py::test_notifications_page_uses_any_message_recipient_key_for_message_capable_warning PASSED [ 86%]
-tests/test_settings.py::test_notifications_page_shows_upgrade_when_free_user_reaches_recipient_limit PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_page_renders_edit_form PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_page_groups_toggles_together PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_toggle_enabled_rejects_unencryptable_recipient PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_toggle_enabled_can_enable_recipient PASSED [ 86%]
+tests/test_settings.py::test_notifications_page_shows_upgrade_when_free_user_reaches_recipient_limit PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_page_renders_edit_form PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_page_groups_toggles_together PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_toggle_enabled_rejects_unencryptable_recipient PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_toggle_enabled_can_enable_recipient PASSED [ 87%]
 tests/test_settings.py::test_notification_recipient_page_rejects_content_toggle_without_encryptable_recipient PASSED [ 87%]
 tests/test_settings.py::test_notification_recipient_page_toggle_include_content_enables PASSED [ 87%]
 tests/test_settings.py::test_notification_recipient_page_toggle_include_content_disables PASSED [ 87%]
@@ -2234,11 +2473,11 @@ tests/test_settings.py::test_toggle_notifications_setting PASSED         [ 87%]
 tests/test_settings.py::test_toggle_include_content_setting PASSED       [ 87%]
 tests/test_settings.py::test_toggle_encrypt_entire_body_setting PASSED   [ 87%]
 tests/test_settings.py::test_toggle_recipient_enabled_setting PASSED     [ 87%]
-tests/test_settings.py::test_notifications_invalid_post_returns_400 PASSED [ 87%]
-tests/test_settings.py::test_add_alias PASSED                            [ 87%]
-tests/test_settings.py::test_add_alias_fails_when_alias_mode_is_never PASSED [ 87%]
-tests/test_settings.py::test_add_alias_not_exceed_max PASSED             [ 87%]
-tests/test_settings.py::test_add_alias_duplicate PASSED                  [ 87%]
+tests/test_settings.py::test_notifications_invalid_post_returns_400 PASSED [ 88%]
+tests/test_settings.py::test_add_alias PASSED                            [ 88%]
+tests/test_settings.py::test_add_alias_fails_when_alias_mode_is_never PASSED [ 88%]
+tests/test_settings.py::test_add_alias_not_exceed_max PASSED             [ 88%]
+tests/test_settings.py::test_add_alias_duplicate PASSED                  [ 88%]
 tests/test_settings.py::test_add_alias_duplicate_case_insensitive PASSED [ 88%]
 tests/test_settings.py::test_alias_page_loads PASSED                     [ 88%]
 tests/test_settings.py::test_delete_alias PASSED                         [ 88%]
@@ -2253,11 +2492,11 @@ tests/test_settings.py::test_change_profile_location PASSED              [ 88%]
 tests/test_settings.py::test_change_profile_location_clears_incomplete_dependency_chain PASSED [ 88%]
 tests/test_settings.py::test_change_profile_location_clears_city_when_city_field_is_omitted PASSED [ 88%]
 tests/test_settings.py::test_profile_states_endpoint_returns_country_scoped_options PASSED [ 88%]
-tests/test_settings.py::test_profile_cities_endpoint_returns_state_scoped_options PASSED [ 88%]
-tests/test_settings.py::test_alias_change_bio PASSED                     [ 88%]
-tests/test_settings.py::test_alias_change_bio_invalid_post_renders_error_and_preserves_submitted_bio PASSED [ 88%]
-tests/test_settings.py::test_alias_change_bio_preserves_account_category PASSED [ 88%]
-tests/test_settings.py::test_alias_change_bio_preserves_account_location PASSED [ 88%]
+tests/test_settings.py::test_profile_cities_endpoint_returns_state_scoped_options PASSED [ 89%]
+tests/test_settings.py::test_alias_change_bio PASSED                     [ 89%]
+tests/test_settings.py::test_alias_change_bio_invalid_post_renders_error_and_preserves_submitted_bio PASSED [ 89%]
+tests/test_settings.py::test_alias_change_bio_preserves_account_category PASSED [ 89%]
+tests/test_settings.py::test_alias_change_bio_preserves_account_location PASSED [ 89%]
 tests/test_settings.py::test_change_directory_visibility PASSED          [ 89%]
 tests/test_settings.py::test_alias_change_directory_visibility PASSED    [ 89%]
 tests/test_settings.py::test_update_brand_primary_color PASSED           [ 89%]
@@ -2272,10 +2511,10 @@ tests/test_settings.py::test_update_guidance_emergency_exit PASSED       [ 89%]
 tests/test_settings.py::test_update_guidance_emergency_exit_requires_url PASSED [ 89%]
 tests/test_settings.py::test_update_guidance_prompts PASSED              [ 89%]
 tests/test_settings.py::test_update_guidance_prompt_accepts_expanded_length PASSED [ 89%]
-tests/test_settings.py::test_update_guidance_prompt_rejects_text_over_expanded_length PASSED [ 89%]
-tests/test_settings.py::test_diretory_intro_text PASSED                  [ 89%]
-tests/test_settings.py::test_directory_intro_text_reset_to_default PASSED [ 89%]
-tests/test_settings.py::test_directory_intro_text_reset_aborts_when_multiple_rows_would_delete PASSED [ 89%]
+tests/test_settings.py::test_update_guidance_prompt_rejects_text_over_expanded_length PASSED [ 90%]
+tests/test_settings.py::test_diretory_intro_text PASSED                  [ 90%]
+tests/test_settings.py::test_directory_intro_text_reset_to_default PASSED [ 90%]
+tests/test_settings.py::test_directory_intro_text_reset_aborts_when_multiple_rows_would_delete PASSED [ 90%]
 tests/test_settings.py::test_homepage_user PASSED                        [ 90%]
 tests/test_settings.py::test_homepage_reset_when_already_default PASSED  [ 90%]
 tests/test_settings.py::test_homepage_reset_multiple_rows_error PASSED   [ 90%]
@@ -2291,10 +2530,10 @@ tests/test_settings.py::test_alias_fields_enabled PASSED                 [ 90%]
 tests/test_settings.py::test_alias_fields_disabled PASSED                [ 90%]
 tests/test_settings.py::test_hide_donate_button PASSED                   [ 90%]
 tests/test_settings.py::test_encryption_post_invalid_form_returns_400 PASSED [ 90%]
-tests/test_settings.py::test_alias_route_missing_alias_returns_404 PASSED [ 90%]
-tests/test_settings.py::test_delete_alias_missing_alias_returns_404 PASSED [ 90%]
-tests/test_settings.py::test_alias_fields_missing_alias_redirects_index PASSED [ 90%]
-tests/test_settings.py::test_alias_route_invalid_post_returns_400 PASSED [ 90%]
+tests/test_settings.py::test_alias_route_missing_alias_returns_404 PASSED [ 91%]
+tests/test_settings.py::test_delete_alias_missing_alias_returns_404 PASSED [ 91%]
+tests/test_settings.py::test_alias_fields_missing_alias_redirects_index PASSED [ 91%]
+tests/test_settings.py::test_alias_route_invalid_post_returns_400 PASSED [ 91%]
 tests/test_settings.py::test_alias_fields_post_uses_handle_field_post_result PASSED [ 91%]
 tests/test_settings.py::test_profile_route_raises_if_primary_username_missing PASSED [ 91%]
 tests/test_settings.py::test_profile_fields_raises_if_primary_username_missing PASSED [ 91%]
@@ -2310,10 +2549,10 @@ tests/test_settings.py::test_alias_fields_invalid_add_post_renders_errors_withou
 tests/test_settings_common.py::test_set_and_unset_field_attribute PASSED [ 91%]
 tests/test_settings_common.py::test_set_input_disabled_toggle PASSED     [ 91%]
 tests/test_settings_common.py::test_settings_forms_reject_disallowed_language PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_account_category PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_country PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_subdivision_for_country PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_city_for_subdivision PASSED [ 91%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_account_category PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_country PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_subdivision_for_country PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_city_for_subdivision PASSED [ 92%]
 tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[] PASSED [ 92%]
 tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[   ] PASSED [ 92%]
 tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[Atlantis] PASSED [ 92%]
@@ -2329,9 +2568,9 @@ tests/test_settings_common.py::test_normalize_city_name_returns_none_for_unresol
 tests/test_settings_common.py::test_normalize_subdivision_name_returns_trimmed_value_for_unknown_country PASSED [ 92%]
 tests/test_settings_common.py::test_profile_form_allows_empty_city_without_normalizing PASSED [ 92%]
 tests/test_settings_common.py::test_profile_form_validate_city_returns_early_for_blank_field PASSED [ 92%]
-tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_country_choice PASSED [ 92%]
-tests/test_settings_common.py::test_strip_whitespace_leaves_non_string_values_unchanged PASSED [ 92%]
-tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_subdivision_and_city_labels PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_country_choice PASSED [ 93%]
+tests/test_settings_common.py::test_strip_whitespace_leaves_non_string_values_unchanged PASSED [ 93%]
+tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_subdivision_and_city_labels PASSED [ 93%]
 tests/test_settings_common.py::test_city_choice_label_returns_raw_value_when_lookup_is_ambiguous PASSED [ 93%]
 tests/test_settings_common.py::test_profile_form_account_category_choices_are_split PASSED [ 93%]
 tests/test_settings_common.py::test_create_profile_forms_disables_location_inputs_until_dependencies PASSED [ 93%]
@@ -2348,9 +2587,9 @@ tests/test_settings_common.py::test_is_safe_verification_url_resolved_public_all
 tests/test_settings_common.py::test_resolve_safe_verification_url_returns_pinned_addresses PASSED [ 93%]
 tests/test_settings_common.py::test_static_verification_resolver_refuses_unvalidated_hosts PASSED [ 93%]
 tests/test_settings_common.py::test_resolve_safe_verification_url_rejects_when_no_usable_addresses PASSED [ 93%]
-tests/test_settings_common.py::test_fetch_verification_html_disables_redirects PASSED [ 93%]
-tests/test_settings_common.py::test_fetch_verification_html_uses_pinned_address_connector PASSED [ 93%]
-tests/test_settings_common.py::test_is_safe_verification_url_direct_private_ip_rejected PASSED [ 93%]
+tests/test_settings_common.py::test_fetch_verification_html_disables_redirects PASSED [ 94%]
+tests/test_settings_common.py::test_fetch_verification_html_uses_pinned_address_connector PASSED [ 94%]
+tests/test_settings_common.py::test_is_safe_verification_url_direct_private_ip_rejected PASSED [ 94%]
 tests/test_settings_common.py::test_is_safe_verification_url_resolved_blocked_ip_rejected PASSED [ 94%]
 tests/test_settings_common.py::test_verify_url_handles_client_error PASSED [ 94%]
 tests/test_settings_common.py::test_verify_url_returns_early_when_url_is_not_safe PASSED [ 94%]
@@ -2367,8 +2606,8 @@ tests/test_settings_common.py::test_handle_change_username_form_internal_error_f
 tests/test_settings_common.py::test_handle_change_password_form_rejects_wrong_old_password PASSED [ 94%]
 tests/test_settings_common.py::test_handle_pgp_key_form_empty_value_clears_only_public_key PASSED [ 94%]
 tests/test_settings_common.py::test_handle_profile_post_invalid_form_returns_none PASSED [ 94%]
-tests/test_settings_common.py::test_handle_profile_post_updates_directory_visibility PASSED [ 94%]
-tests/test_settings_common.py::test_handle_field_post_add_branch PASSED  [ 94%]
+tests/test_settings_common.py::test_handle_profile_post_updates_directory_visibility PASSED [ 95%]
+tests/test_settings_common.py::test_handle_field_post_add_branch PASSED  [ 95%]
 tests/test_settings_common.py::test_handle_field_post_update_branch PASSED [ 95%]
 tests/test_settings_common.py::test_handle_field_post_delete_branch PASSED [ 95%]
 tests/test_settings_common.py::test_handle_field_post_move_up_and_down_branches PASSED [ 95%]
@@ -2386,8 +2625,8 @@ tests/test_settings_registration.py::test_registration_create_invite_code PASSED
 tests/test_settings_registration.py::test_registration_delete_invite_code PASSED [ 95%]
 tests/test_settings_registration.py::test_registration_delete_invite_code_not_found PASSED [ 95%]
 tests/test_settings_registration.py::test_registration_invalid_form_submission PASSED [ 95%]
-tests/test_settings_registration.py::test_registration_invalid_delete_submission_preserves_redirect_and_flash PASSED [ 95%]
-tests/test_settings_registration.py::test_registration_missing_csrf_redirects_with_invalid_submission_flash PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_invalid_delete_submission_preserves_redirect_and_flash PASSED [ 96%]
+tests/test_settings_registration.py::test_registration_missing_csrf_redirects_with_invalid_submission_flash PASSED [ 96%]
 tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_enable_when_not_configured PASSED [ 96%]
 tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_disable_when_already_configured PASSED [ 96%]
 tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_login_without_user_id PASSED [ 96%]
@@ -2405,8 +2644,8 @@ tests/test_splash_screen.py::test_first_load_splash_duration_uses_runtime_config
 tests/test_splash_screen.py::test_first_load_splash_uses_brand_logo_fallback PASSED [ 96%]
 tests/test_splash_screen.py::test_first_load_splash_uses_custom_splash_logo PASSED [ 96%]
 tests/test_splash_screen.py::test_first_load_splash_uses_versioned_custom_splash_logo PASSED [ 96%]
-tests/test_splash_screen.py::test_first_load_splash_defaults_to_disabled PASSED [ 96%]
-tests/test_splash_screen.py::test_first_load_splash_can_be_disabled PASSED [ 96%]
+tests/test_splash_screen.py::test_first_load_splash_defaults_to_disabled PASSED [ 97%]
+tests/test_splash_screen.py::test_first_load_splash_can_be_disabled PASSED [ 97%]
 tests/test_static_typing_config.py::test_mypy_targets_python_313_semantics PASSED [ 97%]
 tests/test_storage.py::TestFsDriver::test_put_and_serve PASSED           [ 97%]
 tests/test_storage.py::TestFsDriver::test_put_and_delete PASSED          [ 97%]
@@ -2424,7 +2663,7 @@ tests/test_storage.py::test_blob_storage_abort_when_driver_not_configured PASSED
 tests/test_user_profile_location.py::test_user_new_session_id_returns_distinct_tokens PASSED [ 97%]
 tests/test_user_profile_location.py::test_profile_location_returns_country_when_us_geography_only_has_country PASSED [ 97%]
 tests/test_user_profile_location.py::test_profile_location_spells_out_state_when_city_missing PASSED [ 97%]
-tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_state_missing PASSED [ 97%]
+tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_state_missing PASSED [ 98%]
 tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_it_is_the_only_field PASSED [ 98%]
 tests/test_user_profile_location.py::test_profile_location_returns_none_for_inconsistent_empty_us_geography PASSED [ 98%]
 tests/test_utils.py::test_redirect_to_self_uses_current_endpoint_and_view_args PASSED [ 98%]
@@ -2443,7 +2682,7 @@ tests/test_vision.py::test_vision_redirects_to_login_when_session_user_missing P
 tests/test_vision.py::test_vision_redirects_with_flash_when_user_missing_after_auth PASSED [ 98%]
 tests/test_vision.py::test_vision_renders_for_free_user PASSED           [ 98%]
 tests/test_vision.py::test_vision_renders_for_paid_user PASSED           [ 98%]
-tests/test_weekly_agent_report_runner.py::test_report_addresses_and_title_are_fixed PASSED [ 98%]
+tests/test_weekly_agent_report_runner.py::test_report_addresses_and_title_are_fixed PASSED [ 99%]
 tests/test_weekly_agent_report_runner.py::test_default_sources_match_monitored_logs PASSED [ 99%]
 tests/test_weekly_agent_report_runner.py::test_collect_events_from_hushline_runner_log PASSED [ 99%]
 tests/test_weekly_agent_report_runner.py::test_parse_log_timestamp_uses_timezone_abbreviation_during_fallback PASSED [ 99%]
@@ -2465,44 +2704,93 @@ tests/test_workflow_pr_head_qualification.py::test_tests_workflow_lint_job_uses_
 tests/test_workflow_pr_head_qualification.py::test_dependency_audit_workflow_only_runs_python_audit_when_poetry_lock_changes PASSED [100%]
 
 =================================== FAILURES ===================================
-_______ test_encrypted_field_migration_runbook_locks_security_guardrails _______
+______ test_downgrade_preserves_mixed_ciphertexts_readable_by_dual_reader ______
 
-    def test_encrypted_field_migration_runbook_locks_security_guardrails() -> None:
-        content = _runbook_text().lower()
+app = <Flask 'hushline'>
+monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0xffffa00ea0b0>
+
+    def test_downgrade_preserves_mixed_ciphertexts_readable_by_dual_reader(
+        app: Flask,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cfg = typing.cast(alembic.config.Config, migrate.get_config())
+        command.upgrade(cfg, "b2039e7c0a1d")
+        monkeypatch.setenv("ENCRYPTION_KEY", LEGACY_FERNET_KEY)
+        app.config[ENCRYPTED_FIELD_WRITE_FORMAT] = EncryptedFieldWriteFormat.ENVELOPE_FERNET
     
-        required_phrases = (
-            "keep the dual reader deployed",
-            "keep legacy fernet read support enabled",
-            "must not edit historical alembic",
-            "do not drop, blank, truncate, or overwrite source ciphertext",
-            "do not assume a maintenance window",
-            "stop before live mode if any non-empty row cannot be classified or decrypted",
-            "dry-run mode must execute the same selection, classification, decryption",
-            "skip rows already in the target envelope format after verifying",
-            "the replacement plaintext exactly matches the source plaintext",
-            "backups without matching encrypted-field key material are not complete",
-            "must not include plaintext or full ciphertext",
-            "rollback must preserve the old reader",
+        mod = __import__(
+            "tests.migrations.revision_b2039e7c0a1d",
+            fromlist=["RollbackReadabilityTester"],
         )
+        rollback_tester = mod.RollbackReadabilityTester()
+        rollback_tester.load_data()
+        db.session.close()
     
-        for phrase in required_phrases:
->           assert phrase in content
-E           assert 'must not include plaintext or full ciphertext' in "# encrypted field migration runbook\n\ndate: 2026-05-26\n\nstatus: draft for rehearsal before production use\n\n## scope\n\nthis runbook defines the required operating plan for a future migration that\nrewrites existing encrypted database fields from legacy fernet ciphertext to a\nnew encrypted-field envelope. it covers local, staging, and production\nexecution, but it does not introduce migration helper code and must not be used\nuntil maintainers approve the specific helper, target format, and rollout\nconfiguration.\n\nthe encrypted-field inventory is the code-owned contract in\n`hushline.crypto.encrypted_field_contracts` and the protected-field table in\n[`encrypted-field-modernization-adr.md`](encrypted-field-modernization-adr.md).\nthe migration must remain forward-only and must not edit historical alembic\nmigrations.\n\n## operator guardrails\n\n- keep the dual reader deployed before, during, and after the migration.\n- keep legacy fernet read support enabled until migration completion and the\n  rollback window are explicitly closed.\n- do not drop, blank, truncate, or overwrite source ciphertext before the\n  replacement value has been decrypted and verified for that row.\n- do not assume a maintenance window. run in small batches while normal reads\n  and writes continue unless maintainers explicitly approve downtime.\n- do not log plaintext, private keys, raw encrypted-field secrets, or full\n  ciphertext values.\n- do not combine this migration with password hashing, flask session secret,\n  application secret management, or unrelated schema changes.\n\n## environments\n\n### local\n\nuse local execution to prove the helper mechanics against seeded and synthetic\nrecords before staging data is touched.\n\n1. run the helper in dry-run mode against local data.\n2. confirm every inventory entry reports row counts, legacy-format counts,\n   target-format counts, and decryptability results.\n3. run a small live batch against disposable local data.\n4. stop the helper mid-run, then resume it with the same target format and batch\n   size.\n5. confirm already migrated rows are skipped and remaining rows continue.\n\n### staging\n\nuse staging as the production rehearsal. staging must use production-like\nconfiguration, data volume, and key-management procedures without exposing\nproduction plaintext.\n\n1. confirm the deployed application reads both legacy fernet and target envelope\n   values.\n2. capture preflight row counts and decryptability checks.\n3. rehearse backup creation and restore into a separate staging database.\n4. run dry-run mode and review the progress and failure report.\n5. run live migration in small batches, including at least one intentional\n   interruption and resume.\n6. verify application reads, settings updates, notification recipient updates,\n   inbox reads, resend behavior, and data export for migrated rows.\n7. rehearse rollback with the old reader still deployed.\n\n### production\n\nproduction execution requires maintainer approval after staging evidence is\nreviewed. use the same helper version, target format, batch size ceiling, and\nrollback plan proven in staging.\n\n1. confirm the current release includes the dual reader and that legacy fernet\n   reads are still enabled.\n2. confirm recent backups exist and a restore rehearsal has succeeded for the\n   same database version and key material.\n3. run preflight checks and dry-run mode.\n4. start with a small live batch. increase batch size only after error-free\n   progress and normal application health are observed.\n5. pause between batches when needed; do not hold long transactions across the\n   full inventory.\n6. keep the old reader deployed after completion until post-migration\n   verification and rollback criteria have passed.\n\n## preflight checks\n\npreflight must be read-only and must fail closed before any write occurs.\n\n- confirm the deployed code can read legacy fernet and the target envelope\n  format.\n- confirm `encryption_key` and any future encrypted-field key material are\n  present through the approved secret path for the environment.\n- confirm the target write format is explicitly configured for the planned\n  migration.\n- confirm the database revision is the expected forward-only revision.\n- count rows for each encrypted-field contract:\n  - total rows in the table\n  - rows with null or empty encrypted values\n  - rows with legacy fernet ciphertext\n  - rows with target envelope ciphertext\n  - rows with unknown or malformed ciphertext\n- decrypt every non-empty encrypted value, or sample only if maintainers approve\n  a documented sampling plan for very large production tables.\n- report counts by contract id, table, column, and ciphertext format.\n- stop before live mode if any non-empty row cannot be classified or decrypted.\n\n## dry-run behavior\n\ndry-run mode must execute the same selection, classification, decryption,\nreencryption, and verification path as live mode, except for database writes.\n\nfor each candidate row, dry-run mode must:\n\n1. load the row using the same ordering used by live batches.\n2. classify the existing ciphertext format.\n3. decrypt the existing ciphertext through the production reader.\n4. build the replacement ciphertext using the target writer.\n5. decrypt the replacement ciphertext through the production reader.\n6. compare replacement plaintext with source plaintext in memory.\n7. emit counters and row identifiers only, never plaintext or full ciphertext.\n\ndry-run output must include eligible rows, skipped rows, already migrated rows,\nverification failures, decrypt failures, and the next resume position that live\nmode would use.\n\n## small-batch execution\n\nlive migration must process bounded batches. the default batch size should be\nsmall enough to avoid long locks, large transactions, and operational surprise;\nproduction batch-size increases require operator review of staging timing and\nproduction health.\n\nfor each batch:\n\n1. select rows in stable primary-key order for one encrypted-field contract.\n2. lock only the rows being processed when the helper needs write consistency.\n3. decrypt the source ciphertext.\n4. create the replacement ciphertext without mutating the source value.\n5. decrypt and verify the replacement ciphertext.\n6. write the replacement only after verification succeeds.\n7. commit the batch.\n8. emit progress for the contract, last processed primary key, rows migrated,\n   rows skipped, and failures.\n\nif any row fails decryption, reencryption, verification, or update, the helper\nmust leave that row's original ciphertext intact, record the failure, and stop\nor quarantine according to maintainer-approved helper behavior.\n\n## idempotent resume\n\nresume behavior must be safe after process crashes, deploy restarts, database\nfailover, and operator cancellation.\n\n- classify each row by its current stored format on every run.\n- skip rows already in the target envelope format after verifying they still\n  decrypt.\n- reprocess legacy-format rows even if their primary key is lower than the last\n  reported resume position when the operator explicitly requests a full scan.\n- store or print a resume token containing only contract id, last processed\n  primary key, target format, helper version, and batch size.\n- reject resume when the helper version, target format, or encrypted-field\n  contract set differs from the dry-run or prior live execution unless\n  maintainers approve a new dry run.\n- treat rerunning the helper from the beginning as valid and non-destructive.\n\n## per-row verification\n\nevery rewritten row must be verified before source ciphertext is replaced.\n\nverification must prove:\n\n- the source ciphertext decrypts through the old reader.\n- the candidate replacement decrypts through the deployed reader.\n- the replacement plaintext exactly matches the source plaintext.\n- the replacement uses the expected contract id, domain, table, column, and aad\n  values for the row.\n- the database update affects exactly one expected row.\n- a post-update read decrypts to the same plaintext before the batch is counted\n  as migrated.\n\nverification failures are migration blockers. do not continue to later batches\nuntil maintainers have reviewed the failure class and decided whether to fix\nhelper code, repair data, restore from backup, or retry.\n\n## backup and restore rehearsal\n\nbefore production live mode, operators must complete and document a restore\nrehearsal.\n\nthe rehearsal must confirm:\n\n- a database backup can be restored into an isolated environment.\n- the restored environment has the matching encrypted-field key material.\n- legacy fernet rows decrypt after restore.\n- target envelope rows decrypt after restore.\n- the migration helper can dry-run against the restored database.\n- rollback can run on restored data while the old reader remains deployed.\n\nbackups without matching encrypted-field key material are not complete recovery\nartifacts for this migration.\n\n## progress and failure reporting\n\nmigration output must be observable without exposing sensitive values.\n\nrequired progress fields:\n\n- helper version\n- environment name\n- dry-run or live mode\n- contract id\n- table and column\n- batch size\n- last processed primary key\n- total candidate rows\n- already migrated rows\n- migrated rows\n- skipped rows\n- decrypt failures\n- verification failures\n- update failures\n- elapsed time\n- next resume token\n\nfailure reports must include the contract id, primary key, failure phase, error\nclass, and whether the source ciphertext was left unchanged. they must not\ninclude plaintext or full ciphertext.\n\n## rollback\n\nrollback must preserve the old reader. the safest rollback for application code\nis to redeploy a release that still reads both legacy fernet and target envelope\nvalues, then set new writes back to the previously approved format while\noperators investigate.\n\nrollback requirements:\n\n1. do not remove legacy fernet read support.\n2. do not run a destructive down migration against encrypted-field data.\n3. if live migration has started, keep migrated target-envelope rows readable by\n   the deployed dual reader.\n4. if helper code supports reverse rewriting, run it only after a restore\n   rehearsal proves target-envelope values can be converted back to legacy\n   fernet and per-row verified.\n5. if helper behavior is suspected, stop the helper, keep the dual reader\n   deployed, and restore from the rehearsed backup only if maintainers decide\n   the mixed-format database is unsafe to keep serving.\n6. after rollback, rerun preflight decryptability checks across all encrypted\n   field contracts and verify normal application reads.\n\nrollback is not complete until both legacy-format and target-format rows that\nremain in the database are readable by the deployed application.\n\n## completion criteria\n\nthe migration can be considered complete only after:\n\n- all encrypted-field contracts have zero unexpected-format rows\n- every non-empty encrypted value decrypts through the deployed reader\n- dry-run mode reports no remaining live changes\n- application flows that read encrypted fields pass manual review in production\n- backups taken after migration have been restored and decryptability checked\n- maintainers explicitly approve closing the rollback window\n\nlegacy fernet read support may be removed only in a later issue after the\nrollback window is closed and a separate removal plan is approved.\n"
+        command.downgrade(cfg, "-1")
+        app.config[ENCRYPTED_FIELD_WRITE_FORMAT] = EncryptedFieldWriteFormat.LEGACY_FERNET
+    
+        for encrypted_value in rollback_tester.encrypted_values():
+            decrypted_value = crypto.decrypt_field(encrypted_value)
+            assert decrypted_value is not None
+>           assert decrypted_value.startswith(("legacy", "recipient", "safe"))
+E           AssertionError: assert False
+E            +  where False = <built-in method startswith of str object at 0xffffa09ce9b0>(('legacy', 'recipient', 'safe'))
+E            +    where <built-in method startswith of str object at 0xffffa09ce9b0> = 'smtp.legacy.example'.startswith
 
-tests/test_encrypted_field_migration_runbook.py:59: AssertionError
+tests/test_migrations.py:265: AssertionError
+---------------------------- Captured stdout setup -----------------------------
+Postgres DB: griziigfdozplvqp, template: app_db_template
+----------------------------- Captured stderr call -----------------------------
+INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
+INFO  [alembic.runtime.migration] Will assume transactional DDL.
+INFO  [alembic.runtime.migration] Running upgrade  -> 691dba936e64, Initial migration
+INFO  [alembic.runtime.migration] Running upgrade 691dba936e64 -> ff59dfd3bdf6, add AuthenticationLog
+INFO  [alembic.runtime.migration] Running upgrade ff59dfd3bdf6 -> 568f77aefcb4, add timecode to AuthenticationLog
+INFO  [alembic.runtime.migration] Running upgrade 568f77aefcb4 -> 6e53eac9ea14, smtp encryption protocol
+INFO  [alembic.runtime.migration] Running upgrade 6e53eac9ea14 -> 166a3402c391, add extra fields to user
+INFO  [alembic.runtime.migration] Running upgrade 166a3402c391 -> 83a6b3b09eca, add verified fields
+INFO  [alembic.runtime.migration] Running upgrade 83a6b3b09eca -> 62551ed63cbf, make boolean fields required
+INFO  [alembic.runtime.migration] Running upgrade 62551ed63cbf -> 46aedec8fd9b, create alias tables
+INFO  [alembic.runtime.migration] Running upgrade 46aedec8fd9b -> 5ffe5a5c8e9a, update entities to match metadata
+INFO  [alembic.runtime.migration] Running upgrade 5ffe5a5c8e9a -> 5410668e15ad, add host_organization table
+INFO  [alembic.runtime.migration] Running upgrade 5410668e15ad -> be0744a5679f, add stripe tables
+INFO  [alembic.runtime.migration] Running upgrade be0744a5679f -> 0b1321c8de13, host org to settings kv table
+INFO  [alembic.runtime.migration] Running upgrade 0b1321c8de13 -> 06b343c38386, rename index
+INFO  [alembic.runtime.migration] Running upgrade 06b343c38386 -> cf2a880aff10, add message status text table
+INFO  [alembic.runtime.migration] Running upgrade cf2a880aff10 -> 4a53667aff6e, add FieldDefinition and FieldValue
+INFO  [alembic.runtime.migration] Running upgrade 4a53667aff6e -> 6071f1eea074, add user email settings
+INFO  [alembic.runtime.migration] Running upgrade 6071f1eea074 -> f32aa741ddc4, add user.email_encrypt_entire_body
+INFO  [alembic.runtime.migration] Running upgrade f32aa741ddc4 -> b6a1e3f5a2b1, add message public id
+INFO  [alembic.runtime.migration] Running upgrade b6a1e3f5a2b1 -> 7d6a9f2f8c1a, Add onboarding complete flag to users.
+INFO  [alembic.runtime.migration] Running upgrade 7d6a9f2f8c1a -> 2e3e5b1f2b3c, fix field definition nullability and field value fk
+INFO  [alembic.runtime.migration] Running upgrade 2e3e5b1f2b3c -> 9f7c4c3ea9a1, add user session_id
+INFO  [alembic.runtime.migration] Running upgrade 9f7c4c3ea9a1 -> 3c1b2a4d5e6f, add case-insensitive username index
+INFO  [alembic.runtime.migration] Running upgrade 3c1b2a4d5e6f -> 8f3f1f0a1b2c, add user account category
+INFO  [alembic.runtime.migration] Running upgrade 8f3f1f0a1b2c -> 1a2b3c4d5e6a, add user location fields
+INFO  [alembic.runtime.migration] Running upgrade 1a2b3c4d5e6a -> c4f8e2a1b6d9, add user cautious flag
+INFO  [alembic.runtime.migration] Running upgrade c4f8e2a1b6d9 -> 84f1d3b2c6e7, add user suspended flag
+INFO  [alembic.runtime.migration] Running upgrade 84f1d3b2c6e7 -> d1f0e9c2b7aa, add notification recipients
+INFO  [alembic.runtime.migration] Running upgrade d1f0e9c2b7aa -> 2d8a1f7c9b41, add password reset tables
+INFO  [alembic.runtime.migration] Running upgrade 2d8a1f7c9b41 -> 7b9c2d1e4f60, add embeddable form policy fields
+INFO  [alembic.runtime.migration] Running upgrade 7b9c2d1e4f60 -> a4c8f2d9e713, add embed rate limit attempts
+INFO  [alembic.runtime.migration] Running upgrade a4c8f2d9e713 -> b2039e7c0a1d, widen encrypted columns for envelopes
+INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
+INFO  [alembic.runtime.migration] Will assume transactional DDL.
+INFO  [alembic.runtime.migration] Running downgrade b2039e7c0a1d -> a4c8f2d9e713, widen encrypted columns for envelopes
 
 ---------- coverage: platform linux, python 3.13.13-final-0 ----------
 Name                                             Stmts   Miss  Cover
 --------------------------------------------------------------------
-hushline/__init__.py                               160      0   100%
+hushline/__init__.py                               162      0   100%
 hushline/admin.py                                  187      0   100%
 hushline/auth.py                                    73      0   100%
+hushline/cli_encrypted_field.py                    400     65    84%
 hushline/cli_password_hash.py                       56      0   100%
 hushline/cli_reg.py                                 47      0   100%
 hushline/cli_stripe.py                              32      0   100%
 hushline/config.py                                 144      0   100%
 hushline/content_safety.py                          40      0   100%
-hushline/crypto.py                                 235     17    93%
+hushline/crypto.py                                 271     23    92%
 hushline/db.py                                       6      0   100%
 hushline/email.py                                  109      0   100%
 hushline/email_headers.py                          353      0   100%
@@ -2580,12 +2868,14 @@ hushline/user_deletion.py                           18      0   100%
 hushline/utils.py                                   21      0   100%
 hushline/version.py                                  1      0   100%
 --------------------------------------------------------------------
-TOTAL                                             9042     17    99%
+TOTAL                                             9480     88    99%
 Coverage HTML written to dir /tmp/hushline-htmlcov
 
 =========================== short test summary info ============================
-FAILED tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_locks_security_guardrails - assert 'must not include plaintext or full ciphertext' in "# encrypted field migration runbook\n\ndate: 2026-05-26\n\nstatus: draft for rehearsal before production use\n\n## scope\n\nthis runbook defines the required operating plan for a future migration that\nrewrites existing encrypted database fields from legacy fernet ciphertext to a\nnew encrypted-field envelope. it covers local, staging, and production\nexecution, but it does not introduce migration helper code and must not be used\nuntil maintainers approve the specific helper, target format, and rollout\nconfiguration.\n\nthe encrypted-field inventory is the code-owned contract in\n`hushline.crypto.encrypted_field_contracts` and the protected-field table in\n[`encrypted-field-modernization-adr.md`](encrypted-field-modernization-adr.md).\nthe migration must remain forward-only and must not edit historical alembic\nmigrations.\n\n## operator guardrails\n\n- keep the dual reader deployed before, during, and after the migration.\n- keep legacy fernet read support enabled until migration completion and the\n  rollback window are explicitly closed.\n- do not drop, blank, truncate, or overwrite source ciphertext before the\n  replacement value has been decrypted and verified for that row.\n- do not assume a maintenance window. run in small batches while normal reads\n  and writes continue unless maintainers explicitly approve downtime.\n- do not log plaintext, private keys, raw encrypted-field secrets, or full\n  ciphertext values.\n- do not combine this migration with password hashing, flask session secret,\n  application secret management, or unrelated schema changes.\n\n## environments\n\n### local\n\nuse local execution to prove the helper mechanics against seeded and synthetic\nrecords before staging data is touched.\n\n1. run the helper in dry-run mode against local data.\n2. confirm every inventory entry reports row counts, legacy-format counts,\n   target-format counts, and decryptability results.\n3. run a small live batch against disposable local data.\n4. stop the helper mid-run, then resume it with the same target format and batch\n   size.\n5. confirm already migrated rows are skipped and remaining rows continue.\n\n### staging\n\nuse staging as the production rehearsal. staging must use production-like\nconfiguration, data volume, and key-management procedures without exposing\nproduction plaintext.\n\n1. confirm the deployed application reads both legacy fernet and target envelope\n   values.\n2. capture preflight row counts and decryptability checks.\n3. rehearse backup creation and restore into a separate staging database.\n4. run dry-run mode and review the progress and failure report.\n5. run live migration in small batches, including at least one intentional\n   interruption and resume.\n6. verify application reads, settings updates, notification recipient updates,\n   inbox reads, resend behavior, and data export for migrated rows.\n7. rehearse rollback with the old reader still deployed.\n\n### production\n\nproduction execution requires maintainer approval after staging evidence is\nreviewed. use the same helper version, target format, batch size ceiling, and\nrollback plan proven in staging.\n\n1. confirm the current release includes the dual reader and that legacy fernet\n   reads are still enabled.\n2. confirm recent backups exist and a restore rehearsal has succeeded for the\n   same database version and key material.\n3. run preflight checks and dry-run mode.\n4. start with a small live batch. increase batch size only after error-free\n   progress and normal application health are observed.\n5. pause between batches when needed; do not hold long transactions across the\n   full inventory.\n6. keep the old reader deployed after completion until post-migration\n   verification and rollback criteria have passed.\n\n## preflight checks\n\npreflight must be read-only and must fail closed before any write occurs.\n\n- confirm the deployed code can read legacy fernet and the target envelope\n  format.\n- confirm `encryption_key` and any future encrypted-field key material are\n  present through the approved secret path for the environment.\n- confirm the target write format is explicitly configured for the planned\n  migration.\n- confirm the database revision is the expected forward-only revision.\n- count rows for each encrypted-field contract:\n  - total rows in the table\n  - rows with null or empty encrypted values\n  - rows with legacy fernet ciphertext\n  - rows with target envelope ciphertext\n  - rows with unknown or malformed ciphertext\n- decrypt every non-empty encrypted value, or sample only if maintainers approve\n  a documented sampling plan for very large production tables.\n- report counts by contract id, table, column, and ciphertext format.\n- stop before live mode if any non-empty row cannot be classified or decrypted.\n\n## dry-run behavior\n\ndry-run mode must execute the same selection, classification, decryption,\nreencryption, and verification path as live mode, except for database writes.\n\nfor each candidate row, dry-run mode must:\n\n1. load the row using the same ordering used by live batches.\n2. classify the existing ciphertext format.\n3. decrypt the existing ciphertext through the production reader.\n4. build the replacement ciphertext using the target writer.\n5. decrypt the replacement ciphertext through the production reader.\n6. compare replacement plaintext with source plaintext in memory.\n7. emit counters and row identifiers only, never plaintext or full ciphertext.\n\ndry-run output must include eligible rows, skipped rows, already migrated rows,\nverification failures, decrypt failures, and the next resume position that live\nmode would use.\n\n## small-batch execution\n\nlive migration must process bounded batches. the default batch size should be\nsmall enough to avoid long locks, large transactions, and operational surprise;\nproduction batch-size increases require operator review of staging timing and\nproduction health.\n\nfor each batch:\n\n1. select rows in stable primary-key order for one encrypted-field contract.\n2. lock only the rows being processed when the helper needs write consistency.\n3. decrypt the source ciphertext.\n4. create the replacement ciphertext without mutating the source value.\n5. decrypt and verify the replacement ciphertext.\n6. write the replacement only after verification succeeds.\n7. commit the batch.\n8. emit progress for the contract, last processed primary key, rows migrated,\n   rows skipped, and failures.\n\nif any row fails decryption, reencryption, verification, or update, the helper\nmust leave that row's original ciphertext intact, record the failure, and stop\nor quarantine according to maintainer-approved helper behavior.\n\n## idempotent resume\n\nresume behavior must be safe after process crashes, deploy restarts, database\nfailover, and operator cancellation.\n\n- classify each row by its current stored format on every run.\n- skip rows already in the target envelope format after verifying they still\n  decrypt.\n- reprocess legacy-format rows even if their primary key is lower than the last\n  reported resume position when the operator explicitly requests a full scan.\n- store or print a resume token containing only contract id, last processed\n  primary key, target format, helper version, and batch size.\n- reject resume when the helper version, target format, or encrypted-field\n  contract set differs from the dry-run or prior live execution unless\n  maintainers approve a new dry run.\n- treat rerunning the helper from the beginning as valid and non-destructive.\n\n## per-row verification\n\nevery rewritten row must be verified before source ciphertext is replaced.\n\nverification must prove:\n\n- the source ciphertext decrypts through the old reader.\n- the candidate replacement decrypts through the deployed reader.\n- the replacement plaintext exactly matches the source plaintext.\n- the replacement uses the expected contract id, domain, table, column, and aad\n  values for the row.\n- the database update affects exactly one expected row.\n- a post-update read decrypts to the same plaintext before the batch is counted\n  as migrated.\n\nverification failures are migration blockers. do not continue to later batches\nuntil maintainers have reviewed the failure class and decided whether to fix\nhelper code, repair data, restore from backup, or retry.\n\n## backup and restore rehearsal\n\nbefore production live mode, operators must complete and document a restore\nrehearsal.\n\nthe rehearsal must confirm:\n\n- a database backup can be restored into an isolated environment.\n- the restored environment has the matching encrypted-field key material.\n- legacy fernet rows decrypt after restore.\n- target envelope rows decrypt after restore.\n- the migration helper can dry-run against the restored database.\n- rollback can run on restored data while the old reader remains deployed.\n\nbackups without matching encrypted-field key material are not complete recovery\nartifacts for this migration.\n\n## progress and failure reporting\n\nmigration output must be observable without exposing sensitive values.\n\nrequired progress fields:\n\n- helper version\n- environment name\n- dry-run or live mode\n- contract id\n- table and column\n- batch size\n- last processed primary key\n- total candidate rows\n- already migrated rows\n- migrated rows\n- skipped rows\n- decrypt failures\n- verification failures\n- update failures\n- elapsed time\n- next resume token\n\nfailure reports must include the contract id, primary key, failure phase, error\nclass, and whether the source ciphertext was left unchanged. they must not\ninclude plaintext or full ciphertext.\n\n## rollback\n\nrollback must preserve the old reader. the safest rollback for application code\nis to redeploy a release that still reads both legacy fernet and target envelope\nvalues, then set new writes back to the previously approved format while\noperators investigate.\n\nrollback requirements:\n\n1. do not remove legacy fernet read support.\n2. do not run a destructive down migration against encrypted-field data.\n3. if live migration has started, keep migrated target-envelope rows readable by\n   the deployed dual reader.\n4. if helper code supports reverse rewriting, run it only after a restore\n   rehearsal proves target-envelope values can be converted back to legacy\n   fernet and per-row verified.\n5. if helper behavior is suspected, stop the helper, keep the dual reader\n   deployed, and restore from the rehearsed backup only if maintainers decide\n   the mixed-format database is unsafe to keep serving.\n6. after rollback, rerun preflight decryptability checks across all encrypted\n   field contracts and verify normal application reads.\n\nrollback is not complete until both legacy-format and target-format rows that\nremain in the database are readable by the deployed application.\n\n## completion criteria\n\nthe migration can be considered complete only after:\n\n- all encrypted-field contracts have zero unexpected-format rows\n- every non-empty encrypted value decrypts through the deployed reader\n- dry-run mode reports no remaining live changes\n- application flows that read encrypted fields pass manual review in production\n- backups taken after migration have been restored and decryptability checked\n- maintainers explicitly approve closing the rollback window\n\nlegacy fernet read support may be removed only in a later issue after the\nrollback window is closed and a separate removal plan is approved.\n"
-===== 1 failed, 1860 passed, 1 deselected, 1 xfailed in 409.10s (0:06:49) ======
+FAILED tests/test_migrations.py::test_downgrade_preserves_mixed_ciphertexts_readable_by_dual_reader - AssertionError: assert False
+ +  where False = <built-in method startswith of str object at 0xffffa09ce9b0>(('legacy', 'recipient', 'safe'))
+ +    where <built-in method startswith of str object at 0xffffa09ce9b0> = 'smtp.legacy.example'.startswith
+===== 1 failed, 1902 passed, 1 deselected, 1 xfailed in 435.84s (0:07:15) ======
 
 make: *** [test] Error 1
 Self-heal: restarting local runtime stack and reseeding dev data.
@@ -2594,17 +2884,17 @@ Self-heal: restarting local runtime stack and reseeding dev data.
  Network hushline_default Created 
  Container hushline-blob-storage-1 Creating 
  Container hushline-postgres-1 Creating 
- Container hushline-blob-storage-1 Created 
  Container hushline-postgres-1 Created 
+ Container hushline-blob-storage-1 Created 
  Container hushline-dev_data-1 Creating 
  Container hushline-dev_data-1 Created 
  Container hushline-app-1 Creating 
  Container hushline-app-1 Created 
  Container hushline-blob-storage-1 Starting 
  Container hushline-postgres-1 Starting 
+ Container hushline-blob-storage-1 Started 
  Container hushline-postgres-1 Started 
  Container hushline-postgres-1 Waiting 
- Container hushline-blob-storage-1 Started 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
@@ -2620,31 +2910,31 @@ Self-heal: restarting local runtime stack and reseeding dev data.
  Container hushline-postgres-1 Running 
  Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
- Container hushline-dev_data-run-e8e6725d520a Creating 
- Container hushline-dev_data-run-e8e6725d520a Created 
+ Container hushline-dev_data-run-d2d7d410dafa Creating 
+ Container hushline-dev_data-run-d2d7d410dafa Created 
 poetry run ./scripts/dev_migrations.py
 Creating database tables
 Database tables created
 poetry run ./scripts/dev_data.py
-2026-05-26 06:09:12,757:INFO:Password hash counter
-2026-05-26 06:09:12,943:INFO:Password hash counter
-2026-05-26 06:09:13,123:INFO:Password hash counter
-2026-05-26 06:09:13,301:INFO:Password hash counter
-2026-05-26 06:09:13,508:INFO:Password hash counter
-2026-05-26 06:09:13,685:INFO:Password hash counter
-2026-05-26 06:09:13,862:INFO:Password hash counter
-2026-05-26 06:09:14,043:INFO:Password hash counter
-2026-05-26 06:09:14,220:INFO:Password hash counter
-2026-05-26 06:09:14,395:INFO:Password hash counter
-2026-05-26 06:09:14,599:INFO:Password hash counter
-2026-05-26 06:09:14,774:INFO:Password hash counter
-2026-05-26 06:09:14,949:INFO:Password hash counter
-2026-05-26 06:09:15,126:INFO:Password hash counter
-2026-05-26 06:09:15,302:INFO:Password hash counter
-2026-05-26 06:09:15,477:INFO:Password hash counter
-2026-05-26 06:09:15,681:INFO:Password hash counter
-2026-05-26 06:09:15,857:INFO:Password hash counter
-2026-05-26 06:09:16,032:INFO:Password hash counter
+2026-05-27 10:04:48,863:INFO:Password hash counter
+2026-05-27 10:04:49,046:INFO:Password hash counter
+2026-05-27 10:04:49,226:INFO:Password hash counter
+2026-05-27 10:04:49,408:INFO:Password hash counter
+2026-05-27 10:04:49,613:INFO:Password hash counter
+2026-05-27 10:04:49,797:INFO:Password hash counter
+2026-05-27 10:04:49,979:INFO:Password hash counter
+2026-05-27 10:04:50,161:INFO:Password hash counter
+2026-05-27 10:04:50,340:INFO:Password hash counter
+2026-05-27 10:04:50,521:INFO:Password hash counter
+2026-05-27 10:04:50,725:INFO:Password hash counter
+2026-05-27 10:04:50,903:INFO:Password hash counter
+2026-05-27 10:04:51,087:INFO:Password hash counter
+2026-05-27 10:04:51,268:INFO:Password hash counter
+2026-05-27 10:04:51,450:INFO:Password hash counter
+2026-05-27 10:04:51,631:INFO:Password hash counter
+2026-05-27 10:04:51,839:INFO:Password hash counter
+2026-05-27 10:04:52,023:INFO:Password hash counter
+2026-05-27 10:04:52,206:INFO:Password hash counter
 Adding dev data
 Tier:
   name = Free
@@ -2700,20 +2990,20 @@ Still running after 240s: Run test (full suite) (self-heal retry after runtime r
 Still running after 300s: Run test (full suite) (self-heal retry after runtime reset)
 Still running after 360s: Run test (full suite) (self-heal retry after runtime reset)
 docker compose run --rm app poetry run pytest --cov hushline --cov-report term --cov-report html:/tmp/hushline-htmlcov -vv -m "not external_network"  ./tests/
- Container hushline-postgres-1 Running 
  Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Running 
  Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
- Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
  Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-325c288e53cd Creating 
- Container hushline-app-run-325c288e53cd Created 
+ Container hushline-app-run-fecf846483c7 Creating 
+ Container hushline-app-run-fecf846483c7 Created 
 ============================= test session starts ==============================
 platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.5.0 -- /root/.cache/pypoetry/virtualenvs/hushline-9TtSrW0h-py3.13/bin/python
 cachedir: .pytest_cache
@@ -2721,7 +3011,7 @@ rootdir: /app
 configfile: pyproject.toml
 plugins: cov-5.0.0, asyncio-1.3.0, mock-3.14.0
 asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
-collecting ... collected 1863 items / 1 deselected / 1862 selected
+collecting ... collected 1905 items / 1 deselected / 1904 selected
 
 tests/test_2fa.py::test_enable_2fa PASSED                                [  0%]
 tests/test_2fa.py::test_valid_2fa_should_login PASSED                    [  0%]
@@ -2741,7 +3031,7 @@ tests/test_admin.py::test_admin_settings_clamps_invalid_page_requests PASSED [  
 tests/test_admin.py::test_admin_settings_searches_all_usernames_before_paginating PASSED [  0%]
 tests/test_admin.py::test_admin_settings_hides_verified_on_nonmanaged_service PASSED [  0%]
 tests/test_admin.py::test_toggle_verified_on_managed_service PASSED      [  0%]
-tests/test_admin.py::test_toggle_verified_on_nonmanaged_service PASSED   [  1%]
+tests/test_admin.py::test_toggle_verified_on_nonmanaged_service PASSED   [  0%]
 tests/test_admin.py::test_toggle_admin_only_admin PASSED                 [  1%]
 tests/test_admin.py::test_toggle_admin_multiple_admins PASSED            [  1%]
 tests/test_admin.py::test_toggle_verified_alias_on_managed_service PASSED [  1%]
@@ -2760,7 +3050,7 @@ tests/test_admin.py::test_toggle_cautious_updates_user PASSED            [  1%]
 tests/test_admin.py::test_toggle_suspended_updates_user PASSED           [  1%]
 tests/test_admin.py::test_toggle_suspended_clears_user_state PASSED      [  1%]
 tests/test_admin.py::test_update_account_category_validates_and_updates_user PASSED [  1%]
-tests/test_admin.py::test_update_account_category_rejects_missing_field_and_unknown_user PASSED [  2%]
+tests/test_admin.py::test_update_account_category_rejects_missing_field_and_unknown_user PASSED [  1%]
 tests/test_admin.py::test_toggle_cautious_user_not_found PASSED          [  2%]
 tests/test_admin.py::test_toggle_suspended_forbidden_for_non_admin PASSED [  2%]
 tests/test_admin.py::test_toggle_suspended_user_not_found PASSED         [  2%]
@@ -2778,8 +3068,8 @@ tests/test_agent_daily_issue_runner.py::test_runner_defaults_to_approved_codex_m
 tests/test_agent_daily_issue_runner.py::test_runner_defaults_to_ten_minute_idle_polling PASSED [  2%]
 tests/test_agent_daily_issue_runner.py::test_runner_defaults_idle_status_state_file_outside_lock_dir PASSED [  2%]
 tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_proceeds_when_5h_has_capacity PASSED [  2%]
-tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_sleeps_until_low_5h_quota_resets PASSED [  3%]
-tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_backs_off_when_reset_is_stale PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_sleeps_until_low_5h_quota_resets PASSED [  2%]
+tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_backs_off_when_reset_is_stale PASSED [  2%]
 tests/test_agent_daily_issue_runner.py::test_idle_codex_status_check_skips_when_recent PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_idle_codex_status_check_runs_when_due PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_count_open_bot_prs_excluding_heads_fails_closed_when_pr_query_fails PASSED [  3%]
@@ -2797,8 +3087,8 @@ tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap
 tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap_when_human_pr_exists PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_main_resumes_in_progress_issue_before_selecting_new_work PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap_when_no_issue_is_available PASSED [  3%]
-tests/test_agent_daily_issue_runner.py::test_runner_status_prefixes_lines_with_local_timestamp PASSED [  4%]
-tests/test_agent_daily_issue_runner.py::test_main_bootstrap_does_not_prune_docker_system PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_runner_status_prefixes_lines_with_local_timestamp PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_main_bootstrap_does_not_prune_docker_system PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_build_pr_title_omits_codex_daily_prefix PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_build_pr_title_uses_diagnostic_title_for_diagnostic_pr PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_build_branch_name_uses_issue_prefix PASSED [  4%]
@@ -2816,8 +3106,8 @@ tests/test_agent_daily_issue_runner.py::test_add_issue_to_project_status_warns_w
 tests/test_agent_daily_issue_runner.py::test_coverage_gap_snapshot_from_log_reports_latest_missed_rows PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_open_coverage_gap_issue_after_pr_creates_agent_eligible_issue PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_filters_open_issues_in_target_status PASSED [  4%]
-tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_paginates_before_filtering PASSED [  5%]
-tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_supports_custom_status_name PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_paginates_before_filtering PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_supports_custom_status_name PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_main_allows_existing_epic_pr_before_runtime_bootstrap PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_main_marks_issue_in_progress_before_runtime_bootstrap PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_main_uses_fetched_origin_epic_ref_for_child_pr_uniqueness_check PASSED [  5%]
@@ -2834,9 +3124,9 @@ tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_adds_plain_
 tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_explains_log_only_run PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_explains_diagnostic_pr PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_matches_network_errors PASSED [  5%]
-tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_rejects_tls_vulnerability_text PASSED [  6%]
-tests/test_agent_daily_issue_runner.py::test_runtime_schema_files_changed_detects_branch_schema_diff_from_runtime_base PASSED [  6%]
-tests/test_agent_daily_issue_runner.py::test_restore_runtime_generated_static_artifacts_cleans_bootstrap_noise PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_rejects_tls_vulnerability_text PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_runtime_schema_files_changed_detects_branch_schema_diff_from_runtime_base PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_restore_runtime_generated_static_artifacts_cleans_bootstrap_noise PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_restore_non_log_worktree_changes_uses_staged_and_worktree_restore PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_run_check_capture_times_out_stuck_check PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_runtime_bootstrap_retries_retryable_registry_failure PASSED [  6%]
@@ -2853,9 +3143,9 @@ tests/test_agent_daily_issue_runner.py::test_failure_signature_from_text_falls_b
 tests/test_agent_daily_issue_runner.py::test_build_fix_prompt_withholds_raw_check_output PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_recent_failure_block_from_text_extracts_recent_actionable_context PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_recent_failure_block_from_text_redacts_secret_like_values PASSED [  6%]
-tests/test_agent_daily_issue_runner.py::test_recent_failure_block_keeps_traceback_when_coverage_table_follows PASSED [  7%]
-tests/test_agent_daily_issue_runner.py::test_failure_excerpt_from_text_redacts_sensitive_values PASSED [  7%]
-tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_stops_after_max_attempts PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_recent_failure_block_keeps_traceback_when_coverage_table_follows PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_failure_excerpt_from_text_redacts_sensitive_values PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_stops_after_max_attempts PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_retries_when_post_fix_changes_collapse_to_log_only PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_has_non_log_changes_ignores_preexisting_branch_commits PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_summarize_pr_feedback_reports_unresolved_threads_and_comments PASSED [  7%]
@@ -2871,10 +3161,10 @@ tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_repor
 tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_polls_until_pr_closes PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_pr_feedback_action_waits_for_pending_checks PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_pr_feedback_action_key_ignores_pending_count_changes PASSED [  7%]
-tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_addresses_actionable_feedback_once PASSED [  8%]
-tests/test_agent_daily_issue_runner.py::test_address_pr_feedback_replies_and_resolves_review_threads PASSED [  8%]
-tests/test_agent_daily_issue_runner.py::test_pr_feedback_thread_targets_only_include_team_members_or_codex PASSED [  8%]
-tests/test_agent_daily_issue_runner.py::test_resolve_pr_number_from_ref_prefers_pr_url_without_gh_lookup PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_addresses_actionable_feedback_once PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_address_pr_feedback_replies_and_resolves_review_threads PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_pr_feedback_thread_targets_only_include_team_members_or_codex PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_resolve_pr_number_from_ref_prefers_pr_url_without_gh_lookup PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_main_refuses_review_pr_when_issue_loop_fails PASSED [  8%]
 tests/test_agent_daily_issue_runner.py::test_main_continues_after_pr_create_when_pr_number_lookup_fails PASSED [  8%]
 tests/test_agent_daily_issue_runner.py::test_main_keeps_pr_branch_checked_out_until_feedback_monitor_returns PASSED [  8%]
@@ -2890,10 +3180,10 @@ tests/test_behavior_contracts.py::test_contract_notifications_field_content_mode
 tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_prefers_client_encrypted_body PASSED [  8%]
 tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_falls_back_to_server_encrypt PASSED [  8%]
 tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_uses_client_body_for_all_enabled_recipients PASSED [  8%]
-tests/test_behavior_contracts.py::test_contract_2fa_enable_then_disable_round_trip PASSED [  9%]
-tests/test_behavior_contracts.py::test_contract_onboarding_notifications_and_directory_persist_expected_state PASSED [  9%]
-tests/test_behavior_contracts.py::test_contract_directory_users_surface_verified_and_unverified_accounts PASSED [  9%]
-tests/test_behavior_contracts.py::test_contract_whistleblower_message_flow_defaults_and_actions PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_2fa_enable_then_disable_round_trip PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_onboarding_notifications_and_directory_persist_expected_state PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_directory_users_surface_verified_and_unverified_accounts PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_whistleblower_message_flow_defaults_and_actions PASSED [  8%]
 tests/test_behavior_contracts.py::test_contract_message_actions_do_not_cross_user_boundaries PASSED [  9%]
 tests/test_behavior_contracts.py::test_contract_authenticated_settings_profile_and_auth_round_trip PASSED [  9%]
 tests/test_behavior_contracts.py::test_contract_authenticated_encryption_and_data_export_flow PASSED [  9%]
@@ -2904,11 +3194,19 @@ tests/test_cli_commands.py::test_reg_settings_command_outputs_current_values PAS
 tests/test_cli_commands.py::test_reg_toggle_commands_update_org_settings PASSED [  9%]
 tests/test_cli_commands.py::test_reg_code_commands_create_list_and_delete PASSED [  9%]
 tests/test_cli_commands.py::test_reg_code_create_avoids_dash_prefixed_codes PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_reports_ready_without_sensitive_values PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_blocks_malformed_ciphertext PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_blocks_schema_that_is_not_envelope_ready PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_blocks_missing_schema_without_crashing PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_dry_run_reports_without_writing PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_live_rewrites_and_verifies_post_write PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_live_resumes_after_interruption PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_failure_report_omits_sensitive_values PASSED [  9%]
 tests/test_cli_commands.py::test_password_hash_report_outputs_legacy_count_and_removal_gate PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_report_blocks_when_measured_legacy_successes_non_zero PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_can_remove_passlib_blocks_when_legacy_rows_remain PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_can_remove_passlib_succeeds_when_legacy_rows_and_volume_are_zero PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_can_remove_passlib_accepts_reviewed_in_repo_legacy_verifier_path PASSED [  9%]
+tests/test_cli_commands.py::test_password_hash_report_blocks_when_measured_legacy_successes_non_zero PASSED [ 10%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_blocks_when_legacy_rows_remain PASSED [ 10%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_succeeds_when_legacy_rows_and_volume_are_zero PASSED [ 10%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_accepts_reviewed_in_repo_legacy_verifier_path PASSED [ 10%]
 tests/test_cli_commands.py::test_stripe_configure_skips_when_secret_missing PASSED [ 10%]
 tests/test_cli_commands.py::test_stripe_configure_creates_missing_tiers_when_lookup_returns_none PASSED [ 10%]
 tests/test_cli_commands.py::test_stripe_configure_runs_premium_setup_when_secret_present PASSED [ 10%]
@@ -2924,9 +3222,9 @@ tests/test_config.py::test_preferred_url_scheme_invalid_value PASSED     [ 10%]
 tests/test_config.py::test_public_base_url_loads PASSED                  [ 10%]
 tests/test_config.py::test_public_base_url_invalid[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 10%]
 tests/test_config.py::test_public_base_url_invalid[https://example.com/path-PUBLIC_BASE_URL must not include a path] PASSED [ 10%]
-tests/test_config.py::test_public_base_url_invalid[https://example.com/?q=1-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 10%]
-tests/test_config.py::test_public_base_url_invalid[https://example.com/#frag-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 10%]
-tests/test_config.py::test_smtp_notification_reply_to_loads PASSED       [ 10%]
+tests/test_config.py::test_public_base_url_invalid[https://example.com/?q=1-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 11%]
+tests/test_config.py::test_public_base_url_invalid[https://example.com/#frag-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 11%]
+tests/test_config.py::test_smtp_notification_reply_to_loads PASSED       [ 11%]
 tests/test_config.py::test_password_hash_write_use_werkzeug_scrypt_flag_defaults_false_and_parses_true PASSED [ 11%]
 tests/test_config.py::test_password_hash_rehash_on_auth_flag_defaults_false_and_parses_true PASSED [ 11%]
 tests/test_config.py::test_encrypted_field_write_format_defaults_legacy_and_parses_envelope PASSED [ 11%]
@@ -2943,9 +3241,9 @@ tests/test_coverage_push.py::test_custom_validators_negative_paths PASSED [ 11%]
 tests/test_coverage_push.py::test_email_forwarding_form_requires_smtp_fields PASSED [ 11%]
 tests/test_coverage_push.py::test_email_forwarding_form_validate_short_circuits_when_base_invalid PASSED [ 11%]
 tests/test_coverage_push.py::test_set_homepage_username_form_rejects_unknown_user PASSED [ 11%]
-tests/test_coverage_push.py::test_base_smtp_config_not_implemented PASSED [ 11%]
-tests/test_coverage_push.py::test_is_safe_smtp_host_rejects_invalid_ip PASSED [ 11%]
-tests/test_coverage_push.py::test_send_email_decodes_bytes_and_returns_false_when_no_attempts PASSED [ 11%]
+tests/test_coverage_push.py::test_base_smtp_config_not_implemented PASSED [ 12%]
+tests/test_coverage_push.py::test_is_safe_smtp_host_rejects_invalid_ip PASSED [ 12%]
+tests/test_coverage_push.py::test_send_email_decodes_bytes_and_returns_false_when_no_attempts PASSED [ 12%]
 tests/test_coverage_push.py::test_message_status_text_upsert_delete_paths PASSED [ 12%]
 tests/test_coverage_push.py::test_encrypted_session_invalid_token_invalid_json_and_missing_key PASSED [ 12%]
 tests/test_coverage_push.py::test_data_export_invalid_form_returns_400 PASSED [ 12%]
@@ -2962,9 +3260,9 @@ tests/test_coverage_push.py::test_load_config_additional_branches PASSED [ 12%]
 tests/test_coverage_push.py::test_registration_toggle_false_paths PASSED [ 12%]
 tests/test_coverage_push.py::test_blob_storage_none_driver_when_missing_config PASSED [ 12%]
 tests/test_coverage_push.py::test_encrypt_helpers_branch_types PASSED    [ 12%]
-tests/test_coverage_push.py::test_handle_email_forwarding_form_smtp_validation_exception PASSED [ 12%]
-tests/test_coverage_push.py::test_notifications_toggle_false_flash_paths PASSED [ 12%]
-tests/test_coverage_push.py::test_notifications_toggle_include_content_true_path PASSED [ 12%]
+tests/test_coverage_push.py::test_handle_email_forwarding_form_smtp_validation_exception PASSED [ 13%]
+tests/test_coverage_push.py::test_notifications_toggle_false_flash_paths PASSED [ 13%]
+tests/test_coverage_push.py::test_notifications_toggle_include_content_true_path PASSED [ 13%]
 tests/test_coverage_push.py::test_authentication_required_redirects_to_2fa_when_not_authenticated PASSED [ 13%]
 tests/test_coverage_push.py::test_authentication_required_clears_session_on_session_id_mismatch PASSED [ 13%]
 tests/test_coverage_push.py::test_authentication_required_clears_session_when_user_id_missing PASSED [ 13%]
@@ -2981,8 +3279,8 @@ tests/test_coverage_push_remaining.py::test_hushline_init_remaining_paths PASSED
 tests/test_coverage_push_remaining.py::test_crypto_encrypt_message_string_branch PASSED [ 13%]
 tests/test_coverage_push_remaining.py::test_stripe_invoice_remaining_paths PASSED [ 13%]
 tests/test_coverage_push_remaining.py::test_alias_route_delete_button_path PASSED [ 13%]
-tests/test_coverage_push_remaining.py::test_branding_delete_logo_multirow_safety PASSED [ 13%]
-tests/test_coverage_push_remaining.py::test_branding_delete_splash_logo_multirow_safety PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_branding_delete_logo_multirow_safety PASSED [ 14%]
+tests/test_coverage_push_remaining.py::test_branding_delete_splash_logo_multirow_safety PASSED [ 14%]
 tests/test_coverage_push_remaining.py::test_guidance_none_prompts_default_path PASSED [ 14%]
 tests/test_coverage_push_remaining.py::test_settings_common_remaining_paths PASSED [ 14%]
 tests/test_coverage_push_remaining.py::test_enable_2fa_invalid_code_path PASSED [ 14%]
@@ -2992,6 +3290,7 @@ tests/test_crypto.py::test_scoped_key_derivation_changes_key PASSED      [ 14%]
 tests/test_crypto.py::test_encrypt_and_decrypt_field PASSED              [ 14%]
 tests/test_crypto.py::test_encrypt_field_defaults_to_legacy_fernet_write_format PASSED [ 14%]
 tests/test_crypto.py::test_encrypt_field_can_write_versioned_fernet_envelope PASSED [ 14%]
+tests/test_crypto.py::test_encrypt_field_envelope_write_requires_schema_check_context PASSED [ 14%]
 tests/test_crypto.py::test_encrypt_field_transition_reads_legacy_and_envelope_formats PASSED [ 14%]
 tests/test_crypto.py::test_encrypt_field_uses_app_configured_write_format PASSED [ 14%]
 tests/test_crypto.py::test_encrypted_field_envelope_roundtrips_wrapped_fernet PASSED [ 14%]
@@ -2999,9 +3298,9 @@ tests/test_crypto.py::test_encrypted_field_aad_is_canonical_and_stable PASSED [ 
 tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values0] PASSED [ 14%]
 tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values1] PASSED [ 14%]
 tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values2] PASSED [ 14%]
-tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values3] PASSED [ 14%]
-tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values4] PASSED [ 14%]
-tests/test_crypto.py::test_encrypted_field_aead_prototype_requires_expected_domain_and_aad PASSED [ 14%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values3] PASSED [ 15%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values4] PASSED [ 15%]
+tests/test_crypto.py::test_encrypted_field_aead_prototype_requires_expected_domain_and_aad PASSED [ 15%]
 tests/test_crypto.py::test_legacy_fernet_token_has_no_envelope PASSED    [ 15%]
 tests/test_crypto.py::test_unknown_encrypted_field_envelope_version_fails_closed PASSED [ 15%]
 tests/test_crypto.py::test_malformed_encrypted_field_envelopes_fail_closed[hlfield:] PASSED [ 15%]
@@ -3018,8 +3317,8 @@ tests/test_crypto.py::test_pgp_helpers_invalid_key PASSED                [ 15%]
 tests/test_crypto.py::test_encrypt_message_uses_all_recipient_keys PASSED [ 15%]
 tests/test_crypto.py::test_load_recipient_certs_requires_at_least_one_key PASSED [ 15%]
 tests/test_crypto.py::test_gen_reply_slug_uses_diceware_words PASSED     [ 15%]
-tests/test_data_export.py::test_data_export_requires_auth PASSED         [ 15%]
-tests/test_data_export.py::test_data_export_zip_contains_csv_and_pgp PASSED [ 15%]
+tests/test_data_export.py::test_data_export_requires_auth PASSED         [ 16%]
+tests/test_data_export.py::test_data_export_zip_contains_csv_and_pgp PASSED [ 16%]
 tests/test_data_export.py::test_data_export_encrypted_export PASSED      [ 16%]
 tests/test_data_export.py::test_data_export_only_includes_current_user PASSED [ 16%]
 tests/test_delete_account.py::test_delete_account PASSED                 [ 16%]
@@ -3037,8 +3336,8 @@ tests/test_directory.py::test_globaleaks_seed_has_rows PASSED            [ 16%]
 tests/test_directory.py::test_directory_accessible PASSED                [ 16%]
 tests/test_directory.py::test_directory_public_record_banner_links_to_admin PASSED [ 16%]
 tests/test_directory.py::test_directory_securedrop_banner_links_to_admin_without_tor_copy PASSED [ 16%]
-tests/test_directory.py::test_directory_globaleaks_banner_links_to_admin_without_tor_copy PASSED [ 16%]
-tests/test_directory.py::test_directory_newsrooms_banner_links_to_admin PASSED [ 16%]
+tests/test_directory.py::test_directory_globaleaks_banner_links_to_admin_without_tor_copy PASSED [ 17%]
+tests/test_directory.py::test_directory_newsrooms_banner_links_to_admin PASSED [ 17%]
 tests/test_directory.py::test_directory_all_tab_banner_links_to_admin PASSED [ 17%]
 tests/test_directory.py::test_directory_hides_tab_bar_when_verified_tabs_disabled PASSED [ 17%]
 tests/test_directory.py::test_directory_users_json_excludes_public_records_when_verified_tabs_disabled PASSED [ 17%]
@@ -3056,8 +3355,8 @@ tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified
 tests/test_directory.py::test_directory_users_json_does_not_flag_verified_or_admin_suspicious_display_names PASSED [ 17%]
 tests/test_directory.py::test_directory_users_json_flags_suspicious_username_when_display_name_missing PASSED [ 17%]
 tests/test_directory.py::test_directory_users_json_includes_unverified_info_only_korean_account PASSED [ 17%]
-tests/test_directory.py::test_directory_users_json_marks_recipient_key_only_account_as_message_capable PASSED [ 17%]
-tests/test_directory.py::test_directory_users_json_includes_account_category PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_marks_recipient_key_only_account_as_message_capable PASSED [ 18%]
+tests/test_directory.py::test_directory_users_json_includes_account_category PASSED [ 18%]
 tests/test_directory.py::test_directory_users_json_includes_normalized_user_location PASSED [ 18%]
 tests/test_directory.py::test_directory_users_json_includes_legacy_account_category_label PASSED [ 18%]
 tests/test_directory.py::test_directory_self_reported_attorneys_render_in_attorneys_tab PASSED [ 18%]
@@ -3075,7 +3374,7 @@ tests/test_directory.py::test_directory_users_json_excludes_verified_tab_sources
 tests/test_directory.py::test_directory_card_bio_uses_bio_length_limit_with_ascii_ellipsis PASSED [ 18%]
 tests/test_directory.py::test_directory_users_json_truncates_long_automated_listing_bios PASSED [ 18%]
 tests/test_directory.py::test_directory_public_record_cards_truncate_long_automated_listing_bios PASSED [ 18%]
-tests/test_directory.py::test_directory_public_record_cards_do_not_show_location PASSED [ 18%]
+tests/test_directory.py::test_directory_public_record_cards_do_not_show_location PASSED [ 19%]
 tests/test_directory.py::test_directory_users_json_includes_legacy_public_record_rows PASSED [ 19%]
 tests/test_directory.py::test_directory_filters_public_records_by_country_and_region_query_params PASSED [ 19%]
 tests/test_directory.py::test_directory_attorney_filter_panel_hidden_by_default PASSED [ 19%]
@@ -3094,7 +3393,7 @@ tests/test_directory.py::test_directory_attorney_filters_json_reflects_active_qu
 tests/test_directory.py::test_directory_attorney_filters_json_includes_self_reported_attorneys PASSED [ 19%]
 tests/test_directory.py::test_directory_newsroom_filters_json_includes_self_reported_newsrooms PASSED [ 19%]
 tests/test_directory.py::test_directory_newsroom_filters_json_includes_automated_newsroom_listings PASSED [ 19%]
-tests/test_directory.py::test_directory_all_filters_json_reflects_active_query_filters PASSED [ 19%]
+tests/test_directory.py::test_directory_all_filters_json_reflects_active_query_filters PASSED [ 20%]
 tests/test_directory.py::test_directory_all_filters_json_updates_country_counts_for_verified_listing_type PASSED [ 20%]
 tests/test_directory.py::test_directory_all_filters_json_is_empty_when_verified_tabs_disabled PASSED [ 20%]
 tests/test_directory.py::test_listing_matches_attorney_filters_wrapper_uses_listing_geography PASSED [ 20%]
@@ -3113,7 +3412,7 @@ tests/test_directory.py::test_directory_newsroom_filters_include_normalized_coun
 tests/test_directory.py::test_directory_attorney_filters_support_non_us_subdivisions PASSED [ 20%]
 tests/test_directory.py::test_directory_newsroom_filters_support_non_us_subdivisions PASSED [ 20%]
 tests/test_directory.py::test_directory_attorney_filters_json_ignores_untrusted_query_values PASSED [ 20%]
-tests/test_directory.py::test_directory_newsroom_filters_json_ignores_untrusted_query_values PASSED [ 20%]
+tests/test_directory.py::test_directory_newsroom_filters_json_ignores_untrusted_query_values PASSED [ 21%]
 tests/test_directory.py::test_directory_attorney_filters_json_returns_empty_metadata_when_verified_tabs_disabled PASSED [ 21%]
 tests/test_directory.py::test_directory_newsroom_filters_json_returns_empty_metadata_when_verified_tabs_disabled PASSED [ 21%]
 tests/test_directory.py::test_directory_securedrop_render_only_in_securedrop_and_all PASSED [ 21%]
@@ -3169,7 +3468,7 @@ tests/test_directory_listing_geography.py::test_directory_listing_geography_loca
 tests/test_directory_listing_geography.py::test_directory_listing_geography_location_variants[geography3-All countries, USA] PASSED [ 23%]
 tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_state_as_subdivision_when_country_present PASSED [ 23%]
 tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_us_state_code_when_country_missing PASSED [ 23%]
-tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_non_us_state_value_as_country_when_missing PASSED [ 24%]
+tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_non_us_state_value_as_country_when_missing PASSED [ 23%]
 tests/test_directory_listing_geography.py::test_build_directory_geography_keeps_non_us_subdivision_strings PASSED [ 24%]
 tests/test_docker_runtime_images.py::test_dev_and_prod_dockerfiles_use_the_same_python_313_bookworm_runtime_image PASSED [ 24%]
 tests/test_docs_library_mirror.py::test_library_docs_mirror_contains_required_pages PASSED [ 24%]
@@ -3188,7 +3487,7 @@ tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_guest_ar
 tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_marks_state_preparation_scenes_always_visit PASSED [ 24%]
 tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_artvandelay_profile_cleanup_accepts_delete_confirmations PASSED [ 24%]
 tests/test_email.py::test_create_smtp_config_variants PASSED             [ 24%]
-tests/test_email.py::test_create_smtp_config_invalid_encryption PASSED   [ 25%]
+tests/test_email.py::test_create_smtp_config_invalid_encryption PASSED   [ 24%]
 tests/test_email.py::test_ssl_smtp_login_authenticates_over_ssl PASSED   [ 25%]
 tests/test_email.py::test_starttls_smtp_login_upgrades_with_default_tls_context PASSED [ 25%]
 tests/test_email.py::test_is_safe_smtp_host_validation PASSED            [ 25%]
@@ -3207,8 +3506,8 @@ tests/test_email_headers.py::test_email_headers_page_renders PASSED      [ 25%]
 tests/test_email_headers.py::test_email_headers_export_requires_authentication PASSED [ 25%]
 tests/test_email_headers.py::test_email_headers_page_renders_authenticated PASSED [ 25%]
 tests/test_email_headers.py::test_email_headers_post_without_dkim_still_reports_auth_results PASSED [ 25%]
-tests/test_email_headers.py::test_analyze_raw_email_headers_marks_likely_forged_on_triple_fail PASSED [ 26%]
-tests/test_email_headers.py::test_analyze_raw_email_headers_marks_valid_on_spf_dmarc_pass_without_dkim PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_marks_likely_forged_on_triple_fail PASSED [ 25%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_marks_valid_on_spf_dmarc_pass_without_dkim PASSED [ 25%]
 tests/test_email_headers.py::test_analyze_raw_email_headers_marks_appears_inauthentic PASSED [ 26%]
 tests/test_email_headers.py::test_analyze_raw_email_headers_rejects_empty_input PASSED [ 26%]
 tests/test_email_headers.py::test_analyze_raw_email_headers_with_header_body_mix_parses_headers_only PASSED [ 26%]
@@ -3225,9 +3524,9 @@ tests/test_email_headers.py::test_email_headers_post_value_error_shows_flash PAS
 tests/test_email_headers.py::test_email_headers_missing_csrf_preserves_invalid_post_behavior PASSED [ 26%]
 tests/test_email_headers.py::test_email_headers_export_invalid_form_redirects_with_flash PASSED [ 26%]
 tests/test_email_headers.py::test_email_headers_export_missing_csrf_redirects_with_flash PASSED [ 26%]
-tests/test_email_headers.py::test_email_headers_export_value_error_redirects_with_flash PASSED [ 27%]
-tests/test_email_headers.py::test_parse_tag_value_pairs_ignores_invalid_parts_and_empty_keys PASSED [ 27%]
-tests/test_email_headers.py::test_build_interpretation_includes_strong_chain_multiple_signatures_and_strong_keys PASSED [ 27%]
+tests/test_email_headers.py::test_email_headers_export_value_error_redirects_with_flash PASSED [ 26%]
+tests/test_email_headers.py::test_parse_tag_value_pairs_ignores_invalid_parts_and_empty_keys PASSED [ 26%]
+tests/test_email_headers.py::test_build_interpretation_includes_strong_chain_multiple_signatures_and_strong_keys PASSED [ 26%]
 tests/test_email_headers.py::test_render_minimal_pdf_renders_when_no_lines_provided PASSED [ 27%]
 tests/test_email_headers.py::test_render_report_pdf_includes_none_sections_and_warnings_block PASSED [ 27%]
 tests/test_email_headers.py::test_create_evidence_zip_includes_lookup_error_details PASSED [ 27%]
@@ -3244,9 +3543,9 @@ tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example?campaign=1] PASSED [ 27%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example#fragment] PASSED [ 27%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://user:[redacted-email]] PASSED [ 27%]
-tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example:] PASSED [ 28%]
-tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example;.onion] PASSED [ 28%]
-tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example .onion] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example:] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example;.onion] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example .onion] PASSED [ 27%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\t.onion] PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\n.onion] PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\x0c.onion] PASSED [ 28%]
@@ -3262,10 +3561,10 @@ tests/test_embeddable_forms_model.py::test_embed_requires_at_least_one_exact_all
 tests/test_embeddable_forms_model.py::test_embed_admin_disablement_blocks_profile PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_embed_preserves_missing_key_and_suspension_rejection PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_alias_embed_requires_owner_eligibility PASSED [ 28%]
-tests/test_embeddable_forms_settings.py::test_admin_embeddable_forms_default_disabled PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_route_is_disabled_by_default PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_profile_opted_out PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_origin_allowlist PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_admin_embeddable_forms_default_disabled PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_is_disabled_by_default PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_profile_opted_out PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_origin_allowlist PASSED [ 28%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_recipient_key PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_suspended_target PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_unknown_target PASSED [ 29%]
@@ -3281,10 +3580,10 @@ tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_handles_u
 tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_evicts_stale_global_state PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_requires_embed_form_token PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_invalid_csrf_token PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_owner_guard_mismatch PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_captcha_failure PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_missing_required_field PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_suspension PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_owner_guard_mismatch PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_captcha_failure PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_missing_required_field PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_suspension PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_recipient_key_removed PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_uses_same_enabled_custom_fields PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_malformed_recipient_ciphertexts_use_generic_notification_body PASSED [ 30%]
@@ -3300,10 +3599,10 @@ tests/test_embeddable_forms_settings.py::test_admin_non_super_user_can_access_de
 tests/test_embeddable_forms_settings.py::test_admin_non_super_user_cannot_update_profile_embed_settings PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_developer_embed_settings_require_usable_recipient_key PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_admin_can_toggle_embeddable_forms PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_non_admin_cannot_toggle_embeddable_forms PASSED [ 31%]
-tests/test_embeddable_forms_settings.py::test_primary_embed_settings_update_origins_and_render_iframe_snippet PASSED [ 31%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_template_has_compact_trust_chrome_and_form PASSED [ 31%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_non_admin_cannot_toggle_embeddable_forms PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_primary_embed_settings_update_origins_and_render_iframe_snippet PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_template_has_compact_trust_chrome_and_form PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_renders_additional_profile_fields_like_full_profile PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_keyboard_flow_and_mobile_accessibility_chrome PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_required_chrome_survives_recipient_branding_settings PASSED [ 31%]
@@ -3314,12 +3613,15 @@ tests/test_embeddable_forms_settings.py::test_embed_settings_require_message_cap
 tests/test_embeddable_forms_settings.py::test_alias_embed_settings_are_independent PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_alias_embed_settings_reject_invalid_origin PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_alias_embed_settings_require_alias_owner PASSED [ 31%]
+tests/test_encrypted_field_aead_evaluation.py::test_encrypted_field_aead_evaluation_exists_and_is_linked PASSED [ 31%]
+tests/test_encrypted_field_aead_evaluation.py::test_encrypted_field_aead_evaluation_covers_required_options PASSED [ 31%]
+tests/test_encrypted_field_aead_evaluation.py::test_encrypted_field_aead_evaluation_locks_recommendation_and_guardrails PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_encrypted_field_property_inventory_is_complete PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_encrypted_field_inventory_columns_match_models PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_encrypted_field_domain_contract_covers_inventory PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_user_encrypted_properties_store_fernet_ciphertext PASSED [ 31%]
-tests/test_encrypted_field_inventory.py::test_notification_recipient_properties_store_fernet_ciphertext PASSED [ 32%]
-tests/test_encrypted_field_inventory.py::test_field_value_stores_encrypted_custom_message_value_as_fernet_ciphertext PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_notification_recipient_properties_store_fernet_ciphertext PASSED [ 31%]
+tests/test_encrypted_field_inventory.py::test_field_value_stores_encrypted_custom_message_value_as_fernet_ciphertext PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_legacy_fernet_user_fields_decrypt_through_properties PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_legacy_fernet_notification_recipient_fields_decrypt PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_legacy_fernet_field_value_decrypts_encrypted_custom_message_value PASSED [ 32%]
@@ -3337,10 +3639,19 @@ tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_s
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.smtp_server] PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.smtp_username] PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.smtp_password] PASSED [ 32%]
-tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.pgp_key] PASSED [ 33%]
-tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[NotificationRecipient.email] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.pgp_key] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[NotificationRecipient.email] PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[NotificationRecipient.pgp_key] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[FieldValue.value] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.totp_secret] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.email] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.smtp_server] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.smtp_username] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.smtp_password] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.pgp_key] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[NotificationRecipient.email] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[NotificationRecipient.pgp_key] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[FieldValue.value] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.totp_secret] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.email] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.smtp_server] PASSED [ 33%]
@@ -3349,13 +3660,13 @@ tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_cipherte
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.pgp_key] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[NotificationRecipient.email] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[NotificationRecipient.pgp_key] PASSED [ 33%]
-tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[FieldValue.value] PASSED [ 33%]
-tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_exists_and_is_linked PASSED [ 33%]
-tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_covers_required_execution_paths PASSED [ 33%]
-tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_locks_security_guardrails FAILED [ 33%]
-tests/test_external_urls.py::test_normalize_public_base_url_strips_trailing_slash PASSED [ 33%]
-tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 33%]
-tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://-PUBLIC_BASE_URL must include a host] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[FieldValue.value] PASSED [ 34%]
+tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_exists_and_is_linked PASSED [ 34%]
+tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_covers_required_execution_paths PASSED [ 34%]
+tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_locks_security_guardrails PASSED [ 34%]
+tests/test_external_urls.py::test_normalize_public_base_url_strips_trailing_slash PASSED [ 34%]
+tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 34%]
+tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://-PUBLIC_BASE_URL must include a host] PASSED [ 34%]
 tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://example.com/path-PUBLIC_BASE_URL must not include a path] PASSED [ 34%]
 tests/test_external_urls.py::test_canonical_external_url_prefers_public_base_url PASSED [ 34%]
 tests/test_external_urls.py::test_canonical_external_url_falls_back_to_request_derived_url_in_dev_and_testing[config_overrides0] PASSED [ 34%]
@@ -3368,12 +3679,12 @@ tests/test_fields.py::test_field_value_encryption PASSED                 [ 34%]
 tests/test_fields.py::test_field_value_unencryption PASSED               [ 34%]
 tests/test_fields.py::test_field_value_encryption_uses_all_enabled_recipient_keys PASSED [ 34%]
 tests/test_first_user.py::test_no_users_redirect_to_register PASSED      [ 34%]
-tests/test_first_user.py::test_no_users_register_should_show_alert PASSED [ 34%]
-tests/test_first_user.py::test_some_users_register_should_hide_alert PASSED [ 34%]
-tests/test_first_user.py::test_first_user_is_admin PASSED                [ 34%]
-tests/test_first_user.py::test_registration_does_not_grant_admin_after_stale_first_user_check PASSED [ 34%]
-tests/test_first_user.py::test_second_user_is_not_admin PASSED           [ 34%]
-tests/test_frontend_compat.py::test_package_json_declares_node_20_plus PASSED [ 34%]
+tests/test_first_user.py::test_no_users_register_should_show_alert PASSED [ 35%]
+tests/test_first_user.py::test_some_users_register_should_hide_alert PASSED [ 35%]
+tests/test_first_user.py::test_first_user_is_admin PASSED                [ 35%]
+tests/test_first_user.py::test_registration_does_not_grant_admin_after_stale_first_user_check PASSED [ 35%]
+tests/test_first_user.py::test_second_user_is_not_admin PASSED           [ 35%]
+tests/test_frontend_compat.py::test_package_json_declares_node_20_plus PASSED [ 35%]
 tests/test_frontend_compat.py::test_webpack_compose_services_use_lockfile_guard_script PASSED [ 35%]
 tests/test_frontend_compat.py::test_static_js_bundles_avoid_eval_wrappers PASSED [ 35%]
 tests/test_frontend_compat.py::test_client_side_encryption_has_platform_guards PASSED [ 35%]
@@ -3387,12 +3698,12 @@ tests/test_frontend_compat.py::test_directory_search_accessibility_hooks_exist P
 tests/test_frontend_compat.py::test_directory_sticky_active_tab_scroll_to_top_hook_exists PASSED [ 35%]
 tests/test_frontend_compat.py::test_directory_tab_scroll_buttons_clamp_to_valid_bounds PASSED [ 35%]
 tests/test_frontend_compat.py::test_inbox_sticky_nav_hooks_exist PASSED  [ 35%]
-tests/test_frontend_compat.py::test_settings_field_delete_confirmation_blocks_submit_on_cancel PASSED [ 35%]
-tests/test_frontend_compat.py::test_settings_sticky_nav_hooks_exist PASSED [ 35%]
-tests/test_frontend_compat.py::test_profile_location_settings_use_country_select_and_dependency_script PASSED [ 35%]
-tests/test_frontend_compat.py::test_profile_settings_template_contains_updated_ui_copy PASSED [ 35%]
-tests/test_frontend_compat.py::test_settings_field_builder_select_hooks_are_wrapper_safe PASSED [ 35%]
-tests/test_gdpr_compliance.py::test_gdpr_compliance_evidence_policy_and_functionality PASSED [ 35%]
+tests/test_frontend_compat.py::test_settings_field_delete_confirmation_blocks_submit_on_cancel PASSED [ 36%]
+tests/test_frontend_compat.py::test_settings_sticky_nav_hooks_exist PASSED [ 36%]
+tests/test_frontend_compat.py::test_profile_location_settings_use_country_select_and_dependency_script PASSED [ 36%]
+tests/test_frontend_compat.py::test_profile_settings_template_contains_updated_ui_copy PASSED [ 36%]
+tests/test_frontend_compat.py::test_settings_field_builder_select_hooks_are_wrapper_safe PASSED [ 36%]
+tests/test_gdpr_compliance.py::test_gdpr_compliance_evidence_policy_and_functionality PASSED [ 36%]
 tests/test_globaleaks_directory_listing_model.py::test_globaleaks_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 36%]
 tests/test_globaleaks_directory_listing_model.py::test_globaleaks_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 36%]
 tests/test_globaleaks_directory_listing_model.py::test_get_globaleaks_directory_listing_matches_slug_case_insensitively PASSED [ 36%]
@@ -3406,11 +3717,11 @@ tests/test_globaleaks_directory_refresh.py::test_choose_submission_url_uses_webs
 tests/test_globaleaks_directory_refresh.py::test_choose_host_falls_back_to_candidate_hosts_or_errors PASSED [ 36%]
 tests/test_globaleaks_directory_refresh.py::test_candidate_hosts_normalizes_and_skips_blank_or_duplicate_values PASSED [ 36%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_rejects_empty_slug_after_normalization PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows1-Normalized row slug must be a string] PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows2-Duplicate GlobaLeaks listing slug: globaleaks~shared] PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_index_known_rows_by_host_ignores_blank_url_fields PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_extract_discovery_links_filters_excluded_duplicate_and_non_candidate_hosts PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows1-Normalized row slug must be a string] PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows2-Duplicate GlobaLeaks listing slug: globaleaks~shared] PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_index_known_rows_by_host_ignores_blank_url_fields PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_extract_discovery_links_filters_excluded_duplicate_and_non_candidate_hosts PASSED [ 37%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_is_deterministic_and_schema_compatible PASSED [ 37%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_rejects_duplicates PASSED [ 37%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_requires_submission_host_or_url PASSED [ 37%]
@@ -3425,11 +3736,11 @@ tests/test_helpers.py::test_form_to_data_targets_only_selected_submit_button PAS
 tests/test_helpers.py::test_form_to_data_flattens_fieldlist_subforms PASSED [ 37%]
 tests/test_inbox.py::test_delete_own_message PASSED                      [ 37%]
 tests/test_inbox.py::test_cannot_delete_other_user_message PASSED        [ 37%]
-tests/test_inbox.py::test_filter_on_status PASSED                        [ 37%]
-tests/test_inbox.py::test_inbox_invalid_status_returns_bad_request PASSED [ 37%]
-tests/test_inbox.py::test_inbox_missing_user_row_returns_not_found PASSED [ 37%]
-tests/test_info.py::test_info_available PASSED                           [ 37%]
-tests/test_info.py::test_site_webmanifest_reflects_branding PASSED       [ 37%]
+tests/test_inbox.py::test_filter_on_status PASSED                        [ 38%]
+tests/test_inbox.py::test_inbox_invalid_status_returns_bad_request PASSED [ 38%]
+tests/test_inbox.py::test_inbox_missing_user_row_returns_not_found PASSED [ 38%]
+tests/test_info.py::test_info_available PASSED                           [ 38%]
+tests/test_info.py::test_site_webmanifest_reflects_branding PASSED       [ 38%]
 tests/test_info.py::test_site_webmanifest_includes_uploaded_logo_icon PASSED [ 38%]
 tests/test_invite_code_model.py::test_invite_code_repr_includes_code PASSED [ 38%]
 tests/test_make_admin.py::test_toggle_admin_prints_when_user_missing PASSED [ 38%]
@@ -3444,11 +3755,11 @@ tests/test_md.py::test_md_to_html_returns_markup_input_unchanged PASSED  [ 38%]
 tests/test_md.py::test_md_to_html_sanitizes_disallowed_tags_and_keeps_links PASSED [ 38%]
 tests/test_migrations.py::test_linear_revision_history PASSED            [ 38%]
 tests/test_migrations.py::test_upgrade_with_data[46aedec8fd9b] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[5410668e15ad] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[be0744a5679f] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[0b1321c8de13] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[cf2a880aff10] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[4a53667aff6e] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[5410668e15ad] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[be0744a5679f] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[0b1321c8de13] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[cf2a880aff10] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[4a53667aff6e] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[b6a1e3f5a2b1] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[7d6a9f2f8c1a] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[2e3e5b1f2b3c] PASSED    [ 39%]
@@ -3460,13 +3771,14 @@ tests/test_migrations.py::test_upgrade_with_data[c4f8e2a1b6d9] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[84f1d3b2c6e7] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[d1f0e9c2b7aa] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[2d8a1f7c9b41] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[b2039e7c0a1d] PASSED    [ 39%]
 tests/test_migrations.py::test_downgrade_with_data[46aedec8fd9b] PASSED  [ 39%]
 tests/test_migrations.py::test_downgrade_with_data[5410668e15ad] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[be0744a5679f] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[0b1321c8de13] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[cf2a880aff10] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[4a53667aff6e] XFAIL   [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[b6a1e3f5a2b1] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[be0744a5679f] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[0b1321c8de13] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[cf2a880aff10] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[4a53667aff6e] XFAIL   [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[b6a1e3f5a2b1] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[7d6a9f2f8c1a] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[2e3e5b1f2b3c] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[9f7c4c3ea9a1] PASSED  [ 40%]
@@ -3477,15 +3789,16 @@ tests/test_migrations.py::test_downgrade_with_data[c4f8e2a1b6d9] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[84f1d3b2c6e7] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[d1f0e9c2b7aa] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[2d8a1f7c9b41] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[b2039e7c0a1d] PASSED  [ 40%]
 tests/test_migrations.py::test_double_upgrade[46aedec8fd9b] PASSED       [ 40%]
 tests/test_migrations.py::test_double_upgrade[5410668e15ad] PASSED       [ 40%]
 tests/test_migrations.py::test_double_upgrade[be0744a5679f] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[0b1321c8de13] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[cf2a880aff10] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[4a53667aff6e] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[b6a1e3f5a2b1] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[7d6a9f2f8c1a] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[2e3e5b1f2b3c] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[0b1321c8de13] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[cf2a880aff10] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[4a53667aff6e] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[b6a1e3f5a2b1] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[7d6a9f2f8c1a] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[2e3e5b1f2b3c] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[9f7c4c3ea9a1] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[3c1b2a4d5e6f] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[8f3f1f0a1b2c] PASSED       [ 41%]
@@ -3494,575 +3807,594 @@ tests/test_migrations.py::test_double_upgrade[c4f8e2a1b6d9] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[84f1d3b2c6e7] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[d1f0e9c2b7aa] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[2d8a1f7c9b41] PASSED       [ 41%]
-tests/test_native_dependencies.py::test_cryptography_fernet_and_scrypt_runtime PASSED [ 41%]
-tests/test_native_dependencies.py::test_pysequoia_cert_parse_and_encrypt_runtime PASSED [ 41%]
-tests/test_native_dependencies.py::test_psycopg_connects_and_executes_query PASSED [ 41%]
-tests/test_native_dependencies.py::test_greenlet_switch_runtime PASSED   [ 41%]
-tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_get_newsroom_directory_listing_matches_slug_case_insensitively PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_build_newsroom_listing_exposes_geography_properties PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_newsroom_seed_path_points_to_committed_dataset PASSED [ 41%]
-tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_non_retryable_http_error_immediately PASSED [ 41%]
-tests/test_newsroom_directory_refresh.py::test_get_with_retries_reraises_last_error_from_post_loop_fallback PASSED [ 41%]
-tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_fallback_error_when_no_attempts_run PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_should_retry_request_error_returns_false_for_non_retryable_errors PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_string_list_handles_split_deduping_and_invalid_inputs PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_http_url_validates_required_and_optional_fields PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_http_url_covers_optional_and_required_error_edges PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_country_subdivision_and_listing_slug_handle_blank_and_fallback_values PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_extract_organization_urls_filters_duplicates_and_non_listing_links PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_extract_european_network_urls_filters_duplicates_and_non_listing_links PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_extract_source_browse_page_urls_for_european_networks_follows_public_pages PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_text_and_core_detail_extractors_skip_incomplete_nodes_and_plain_text_lists PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_location_handles_blank_city_country_and_single_part_inputs PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_location_normalizes_united_states_and_state_abbreviations PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_normalizes_baseline_fields PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_newsroom_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_european_network_helper_extractors_cover_missing_sections_and_mixed_children PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_normalized_row_shapes PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row0-Missing required newsroom id] PASSED [ 42%]
+tests/test_migrations.py::test_double_upgrade[b2039e7c0a1d] PASSED       [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-totp_secret] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-email] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-smtp_server] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-smtp_username] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-smtp_password] PASSED [ 42%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[notification_recipients-email] PASSED [ 42%]
+tests/test_migrations.py::test_envelope_schema_readiness_columns_match_widening_migration PASSED [ 42%]
+tests/test_migrations.py::test_encrypted_field_preflight_tracks_widening_migration_readiness PASSED [ 42%]
+tests/test_migrations.py::test_legacy_encrypted_field_writes_do_not_require_envelope_schema PASSED [ 42%]
+tests/test_migrations.py::test_envelope_encrypted_field_writes_reject_pre_migration_schema PASSED [ 42%]
+tests/test_migrations.py::test_envelope_encrypted_field_writes_accept_widened_schema PASSED [ 42%]
+tests/test_migrations.py::test_downgrade_preserves_mixed_ciphertexts_readable_by_dual_reader FAILED [ 42%]
+tests/test_native_dependencies.py::test_cryptography_fernet_and_scrypt_runtime PASSED [ 42%]
+tests/test_native_dependencies.py::test_pysequoia_cert_parse_and_encrypt_runtime PASSED [ 42%]
+tests/test_native_dependencies.py::test_psycopg_connects_and_executes_query PASSED [ 42%]
+tests/test_native_dependencies.py::test_greenlet_switch_runtime PASSED   [ 42%]
+tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_get_newsroom_directory_listing_matches_slug_case_insensitively PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_build_newsroom_listing_exposes_geography_properties PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_newsroom_seed_path_points_to_committed_dataset PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_non_retryable_http_error_immediately PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_reraises_last_error_from_post_loop_fallback PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_fallback_error_when_no_attempts_run PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_should_retry_request_error_returns_false_for_non_retryable_errors PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_string_list_handles_split_deduping_and_invalid_inputs PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_http_url_validates_required_and_optional_fields PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_http_url_covers_optional_and_required_error_edges PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_country_subdivision_and_listing_slug_handle_blank_and_fallback_values PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_extract_organization_urls_filters_duplicates_and_non_listing_links PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_extract_european_network_urls_filters_duplicates_and_non_listing_links PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_extract_source_browse_page_urls_for_european_networks_follows_public_pages PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_text_and_core_detail_extractors_skip_incomplete_nodes_and_plain_text_lists PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_location_handles_blank_city_country_and_single_part_inputs PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_location_normalizes_united_states_and_state_abbreviations PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_normalizes_baseline_fields PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_newsroom_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_european_network_helper_extractors_cover_missing_sections_and_mixed_children PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_normalized_row_shapes PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row0-Missing required newsroom id] PASSED [ 43%]
 tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row1-Missing required newsroom slug] PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row2-Missing required newsroom name] PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_non_string_and_duplicate_slugs PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_rejects_duplicate_ids_and_slugs PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_is_deterministic_and_schema_compatible PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_seen_browse_and_detail_urls PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_raises_when_no_listings_are_discovered PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_wraps_detail_request_failures PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_browse_urls_seen_after_queueing PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_uses_public_explore_urls_only PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_discovers_european_networks_across_public_browse_pages PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_wraps_request_errors PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_retries_transient_gateway_timeout PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_render_newsroom_refresh_summary_includes_counts PASSED [ 43%]
-tests/test_notifications.py::test_notifications_disabled PASSED          [ 43%]
-tests/test_notifications.py::test_notifications_enabled_no_content PASSED [ 43%]
-tests/test_notifications.py::test_notifications_enabled_no_content_delivers_to_all_enabled_recipients PASSED [ 43%]
-tests/test_notifications.py::test_message_submission_deduplicates_notification_recipient_email_addresses PASSED [ 43%]
-tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row2-Missing required newsroom name] PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_non_string_and_duplicate_slugs PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_rejects_duplicate_ids_and_slugs PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_is_deterministic_and_schema_compatible PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_seen_browse_and_detail_urls PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_raises_when_no_listings_are_discovered PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_wraps_detail_request_failures PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_browse_urls_seen_after_queueing PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_uses_public_explore_urls_only PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_discovers_european_networks_across_public_browse_pages PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_wraps_request_errors PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_retries_transient_gateway_timeout PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_render_newsroom_refresh_summary_includes_counts PASSED [ 44%]
+tests/test_notifications.py::test_notifications_disabled PASSED          [ 44%]
+tests/test_notifications.py::test_notifications_enabled_no_content PASSED [ 44%]
+tests/test_notifications.py::test_notifications_enabled_no_content_delivers_to_all_enabled_recipients PASSED [ 44%]
+tests/test_notifications.py::test_message_submission_deduplicates_notification_recipient_email_addresses PASSED [ 44%]
+tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body PASSED [ 44%]
 tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body_delivers_to_all_enabled_recipients PASSED [ 44%]
-tests/test_notifications.py::test_notifications_multi_recipient_missing_field_ciphertext_uses_generic_body PASSED [ 44%]
-tests/test_notifications.py::test_notifications_multi_recipient_non_object_field_ciphertext_payload_uses_generic_body PASSED [ 44%]
-tests/test_notifications.py::test_notifications_multi_recipient_uses_recipient_specific_field_ciphertext PASSED [ 44%]
-tests/test_notifications.py::test_notifications_enabled_yes_content_yes_encrypted_body PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_embedded_markers_use_server_fallback PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_uses_client_body_for_all_enabled_recipients PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_multi_recipient_does_not_wrap_encrypted_fields PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_server_fallback PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_fallback_uses_all_enabled_recipient_keys PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_flow PASSED                    [ 44%]
-tests/test_onboarding.py::test_onboarding_directory_opt_out_persists_false PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_directory_opt_out_overrides_prepopulated_true PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_skip PASSED                    [ 44%]
-tests/test_onboarding.py::test_onboarding_proton_search_prefills_manual_key PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[display_name] PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[bio] PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[pgp_key] PASSED [ 44%]
+tests/test_notifications.py::test_notifications_multi_recipient_missing_field_ciphertext_uses_generic_body PASSED [ 45%]
+tests/test_notifications.py::test_notifications_multi_recipient_non_object_field_ciphertext_payload_uses_generic_body PASSED [ 45%]
+tests/test_notifications.py::test_notifications_multi_recipient_uses_recipient_specific_field_ciphertext PASSED [ 45%]
+tests/test_notifications.py::test_notifications_enabled_yes_content_yes_encrypted_body PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_embedded_markers_use_server_fallback PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_uses_client_body_for_all_enabled_recipients PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_multi_recipient_does_not_wrap_encrypted_fields PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_server_fallback PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_fallback_uses_all_enabled_recipient_keys PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_flow PASSED                    [ 45%]
+tests/test_onboarding.py::test_onboarding_directory_opt_out_persists_false PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_directory_opt_out_overrides_prepopulated_true PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_skip PASSED                    [ 45%]
+tests/test_onboarding.py::test_onboarding_proton_search_prefills_manual_key PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[display_name] PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[bio] PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[pgp_key] PASSED [ 45%]
 tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[enable_email_notifications] PASSED [ 45%]
 tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_include_message_content] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_encrypt_entire_body] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[show_in_directory] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_redirects_to_inbox_when_already_complete PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_allows_non_profile_step_when_already_complete PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_handles_missing_primary_username PASSED [ 45%]
-tests/test_onboarding.py::test_submitted_onboarding_form_selects_expected_step_form PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_encryption_unknown_method_returns_bad_request PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_key_shows_error PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_proton_fetch_failure_shows_error PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_notifications_requires_pgp_key PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_missing_user_redirects_login PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_invalid_step_defaults_to_profile PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_post_invalid_step_defaults_to_profile PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_profile_invalid_form_returns_400 PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_profile_invalid_form_preserves_submitted_values PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_encrypt_entire_body] PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email] PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[show_in_directory] PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_redirects_to_inbox_when_already_complete PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_allows_non_profile_step_when_already_complete PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_handles_missing_primary_username PASSED [ 46%]
+tests/test_onboarding.py::test_submitted_onboarding_form_selects_expected_step_form PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_encryption_unknown_method_returns_bad_request PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_key_shows_error PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_proton_fetch_failure_shows_error PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_notifications_requires_pgp_key PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_missing_user_redirects_login PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_invalid_step_defaults_to_profile PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_post_invalid_step_defaults_to_profile PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_profile_invalid_form_returns_400 PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_profile_invalid_form_preserves_submitted_values PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_returns_400 PASSED [ 46%]
 tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_preserves_submitted_email PASSED [ 46%]
 tests/test_onboarding.py::test_onboarding_proton_key_without_encryption_subkey_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_proton_no_key_found_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_proton_non_200_response_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_missing_key_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_whitespace_key_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_form_returns_400_with_csrf PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_non_encryptable_key_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_notifications_invalid_form_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_profile_requires_csrf_token PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_notifications_requires_csrf_token PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_directory_invalid_form_returns_400_with_csrf PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_unknown_step_post_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_directory_redirects_to_select_tier_when_stripe_enabled PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_skip_missing_user_redirects_login PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_skip_invalid_form_redirects_onboarding_with_csrf PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_skip_redirects_to_select_tier_when_enabled PASSED [ 46%]
-tests/test_onboarding.py::test_webpack_build_includes_onboarding_bundle PASSED [ 46%]
-tests/test_password_hasher.py::test_verify_password_uses_legacy_passlib_scrypt_fixture_and_logs_success PASSED [ 46%]
-tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_legacy_passlib_scrypt_fixture PASSED [ 47%]
-tests/test_password_hasher.py::test_legacy_passlib_scrypt_fixture_documents_prefix_and_cost_baseline PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_uses_native_werkzeug_scrypt_hash_and_logs_success PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_native_werkzeug_scrypt_hash PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_routes_non_scrypt_native_prefixes_to_primary_verifier PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_primary_password_hash_rejects_non_scrypt_native_prefix PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_unknown_prefix_fails_closed_without_mutating_user PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_malformed_legacy_hash_fails_closed PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_without_app_context PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_skips_non_legacy_hashes PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_when_disabled PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_rehashes_legacy_hash_when_enabled PASSED [ 47%]
-tests/test_password_hasher.py::test_get_password_hash_prefix_returns_unknown_for_plaintext_like_values PASSED [ 47%]
-tests/test_password_hasher.py::test_hash_password_logs_write_counter_without_sensitive_data PASSED [ 47%]
-tests/test_password_hasher.py::test_hash_password_uses_pinned_werkzeug_scrypt_method_when_enabled PASSED [ 47%]
-tests/test_password_hasher.py::test_pinned_werkzeug_scrypt_method_matches_legacy_passlib_cost_baseline PASSED [ 47%]
-tests/test_password_hasher.py::test_password_hash_telemetry_helpers_noop_without_app_context PASSED [ 47%]
-tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[True-password_hash_rehash_on_auth_success_total] PASSED [ 47%]
-tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[False-password_hash_rehash_on_auth_failure_total] PASSED [ 48%]
-tests/test_premium.py::test_create_products_and_prices PASSED            [ 48%]
-tests/test_premium.py::test_update_price_existing PASSED                 [ 48%]
-tests/test_premium.py::test_update_price_new PASSED                      [ 48%]
-tests/test_premium.py::test_create_customer PASSED                       [ 48%]
-tests/test_premium.py::test_create_customer_updates_existing_customer PASSED [ 48%]
-tests/test_premium.py::test_create_customer_recreates_when_modify_fails PASSED [ 48%]
-tests/test_premium.py::test_get_subscription PASSED                      [ 48%]
-tests/test_premium.py::test_get_business_price_string_formats PASSED     [ 48%]
-tests/test_premium.py::test_get_business_price_string_missing_tier PASSED [ 48%]
-tests/test_premium.py::test_create_products_and_prices_missing_business_tier PASSED [ 48%]
-tests/test_premium.py::test_update_price_without_product_id_logs_and_returns PASSED [ 48%]
-tests/test_premium.py::test_get_subscription_none_when_missing_subscription_id PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_created PASSED           [ 48%]
-tests/test_premium.py::test_handle_subscription_created_raises_for_missing_user PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_updated_upgrade PASSED   [ 48%]
-tests/test_premium.py::test_handle_subscription_updated_downgrade PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_updated_raises_for_missing_subscription PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_deleted PASSED           [ 48%]
-tests/test_premium.py::test_handle_subscription_deleted_raises_for_missing_subscription PASSED [ 49%]
-tests/test_premium.py::test_handle_invoice_created PASSED                [ 49%]
-tests/test_premium.py::test_handle_invoice_created_value_error_is_handled PASSED [ 49%]
-tests/test_premium.py::test_handle_invoice_updated PASSED                [ 49%]
-tests/test_premium.py::test_handle_invoice_updated_refreshes_receipt_url PASSED [ 49%]
-tests/test_premium.py::test_premium_index_links_receipts_through_authenticated_route PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_refreshes_stale_url_before_redirect PASSED [ 49%]
-tests/test_premium.py::test_receipt_url_from_invoice_prefers_pdf_when_hosted_url_missing PASSED [ 49%]
-tests/test_premium.py::test_receipt_url_from_invoice_returns_none_without_hosted_url_or_pdf PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_redirects_to_stale_url_when_stripe_refresh_fails PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_flashes_when_no_receipt_url_available PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_redirects_to_login_when_user_missing_inside_route PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_returns_404_for_missing_invoice PASSED [ 49%]
-tests/test_premium.py::test_handle_invoice_updated_raises_for_missing_invoice PASSED [ 49%]
-tests/test_premium.py::test_upgrade_post_user_already_on_business_tier PASSED [ 49%]
-tests/test_premium.py::test_upgrade_process PASSED                       [ 49%]
-tests/test_premium.py::test_upgrade_process_uses_public_base_url_for_success_url PASSED [ 49%]
-tests/test_premium.py::test_update_payment_method_creates_billing_portal_session PASSED [ 49%]
-tests/test_premium.py::test_update_payment_method_requires_active_subscription PASSED [ 50%]
-tests/test_premium.py::test_update_payment_method_stripe_error PASSED    [ 50%]
-tests/test_premium.py::test_update_payment_method_aborts_when_portal_session_has_no_url PASSED [ 50%]
-tests/test_premium.py::test_disable_autorenew_no_user_in_session PASSED  [ 50%]
-tests/test_premium.py::test_disable_autorenew_no_subscription PASSED     [ 50%]
-tests/test_premium.py::test_disable_autorenew_success PASSED             [ 50%]
-tests/test_premium.py::test_disable_autorenew_stripe_error PASSED        [ 50%]
-tests/test_premium.py::test_enable_autorenew_no_user_in_session PASSED   [ 50%]
-tests/test_premium.py::test_enable_autorenew_no_subscription PASSED      [ 50%]
-tests/test_premium.py::test_enable_autorenew_success PASSED              [ 50%]
-tests/test_premium.py::test_enable_autorenew_stripe_error PASSED         [ 50%]
-tests/test_premium.py::test_cancel_no_user_in_session PASSED             [ 50%]
-tests/test_premium.py::test_cancel_no_subscription PASSED                [ 50%]
-tests/test_premium.py::test_cancel_success PASSED                        [ 50%]
-tests/test_premium.py::test_cancel_stripe_error PASSED                   [ 50%]
-tests/test_premium.py::test_premium_select_tier_redirects_when_onboarding_incomplete PASSED [ 50%]
-tests/test_premium.py::test_premium_select_free_sets_free_tier_when_unset PASSED [ 50%]
-tests/test_premium.py::test_premium_status_business_user_flashes_success PASSED [ 50%]
-tests/test_premium.py::test_premium_index_warns_on_incomplete_subscription PASSED [ 50%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.index-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_tier-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_free-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.upgrade-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.update_payment_method-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.disable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.enable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.cancel-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.status-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.index-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_tier-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_free-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.upgrade-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.update_payment_method-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.disable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.enable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.cancel-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.status-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_select_tier_renders_for_complete_user PASSED [ 51%]
-tests/test_premium.py::test_premium_waiting_page_renders PASSED          [ 52%]
-tests/test_premium.py::test_upgrade_missing_business_tier PASSED         [ 52%]
-tests/test_premium.py::test_upgrade_missing_business_price_id PASSED     [ 52%]
-tests/test_premium.py::test_upgrade_create_customer_failure PASSED       [ 52%]
-tests/test_premium.py::test_upgrade_checkout_creation_failure PASSED     [ 52%]
-tests/test_premium.py::test_upgrade_checkout_session_without_url_returns_500 PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_rejects_invalid_payload PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_rejects_invalid_signature PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_ignores_duplicate_event PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_stores_new_event PASSED      [ 52%]
-tests/test_premium.py::test_worker_processes_subscription_created_event PASSED [ 52%]
-tests/test_premium.py::test_worker_marks_event_error_when_handler_raises PASSED [ 52%]
-tests/test_premium.py::test_worker_waits_for_tables_before_starting PASSED [ 52%]
-tests/test_premium.py::test_worker_processes_subscription_updated_and_deleted_events PASSED [ 52%]
-tests/test_premium.py::test_worker_processes_invoice_created_event PASSED [ 52%]
-tests/test_premium.py::test_worker_processes_invoice_payment_succeeded_event PASSED [ 52%]
-tests/test_profile.py::test_profile_header PASSED                        [ 52%]
-tests/test_profile.py::test_profile_accepts_case_insensitive_username PASSED [ 52%]
-tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_non_admin_display_name PASSED [ 53%]
-tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_username_when_display_name_missing PASSED [ 53%]
-tests/test_profile.py::test_profile_404_for_unknown_username PASSED      [ 53%]
-tests/test_profile.py::test_profile_404s_when_case_insensitive_lookup_is_ambiguous PASSED [ 53%]
-tests/test_profile.py::test_profile_does_not_expose_owner_user_id PASSED [ 53%]
-tests/test_profile.py::test_profile_submit_message PASSED                [ 53%]
-tests/test_profile.py::test_profile_submit_message_to_alias PASSED       [ 53%]
-tests/test_profile.py::test_profile_failed_submit_preserves_input PASSED [ 53%]
-tests/test_profile.py::test_profile_rejects_owner_guard_mismatch PASSED  [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_non_numeric_captcha PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_expired_captcha_token PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_bad_captcha_token PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_captcha_token_for_different_profile PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_post_404s_if_account_is_suspended_after_render PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_if_account_is_suspended_during_submission PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_if_recipient_keys_are_removed_during_submission PASSED [ 53%]
-tests/test_profile.py::test_profile_pgp_required PASSED                  [ 53%]
-tests/test_profile.py::test_profile_allows_submission_with_recipient_key_when_legacy_user_key_missing PASSED [ 53%]
-tests/test_profile.py::test_profile_allows_submission_with_legacy_key_when_primary_recipient_lacks_key PASSED [ 53%]
-tests/test_profile.py::test_profile_submit_message_with_recipient_key_when_legacy_user_key_missing PASSED [ 54%]
-tests/test_profile.py::test_profile_submit_message_ignores_enabled_recipient_without_key PASSED [ 54%]
-tests/test_profile.py::test_profile_suspended_state_disables_message_form_with_pgp_key PASSED [ 54%]
-tests/test_profile.py::test_profile_post_rejects_when_target_has_no_pgp_key PASSED [ 54%]
-tests/test_profile.py::test_profile_post_rejects_when_target_is_suspended PASSED [ 54%]
-tests/test_profile.py::test_profile_post_rejects_alias_when_owner_is_suspended PASSED [ 54%]
-tests/test_profile.py::test_profile_post_form_validation_errors_are_rendered PASSED [ 54%]
-tests/test_profile.py::test_profile_requires_csrf_token PASSED           [ 54%]
-tests/test_profile.py::test_profile_full_body_encryption_fallback_to_generic_when_no_fields PASSED [ 54%]
-tests/test_profile.py::test_profile_full_body_encryption_exception_falls_back_to_generic PASSED [ 54%]
-tests/test_profile.py::test_profile_full_body_encryption_uses_server_fallback_when_client_body_missing PASSED [ 54%]
-tests/test_profile.py::test_profile_notification_without_message_content_sends_generic_body PASSED [ 54%]
-tests/test_profile.py::test_profile_single_recipient_notification_can_include_stored_message_content PASSED [ 54%]
-tests/test_profile.py::test_profile_extra_fields PASSED                  [ 54%]
-tests/test_profile.py::test_profile_field_encryption_labels PASSED       [ 54%]
-tests/test_profile.py::test_profile_account_category_renders_first_extra_field PASSED [ 54%]
-tests/test_profile.py::test_profile_location_renders_as_single_extra_field PASSED [ 54%]
-tests/test_profile.py::test_profile_location_keeps_full_names_outside_us PASSED [ 54%]
-tests/test_profile.py::test_redirect_submit_message_route PASSED         [ 54%]
-tests/test_profile.py::test_submission_success_without_reply_slug_redirects_directory PASSED [ 55%]
-tests/test_profile.py::test_submission_success_404_when_message_missing PASSED [ 55%]
-tests/test_profile.py::test_submission_success_uses_public_base_url_for_reply_link PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_build_snapshot_filters_to_public_hushline_users PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_build_markdown_report_reports_added_and_removed_usernames PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_build_readme_report_renders_natural_language_and_history_table PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_resolve_history_baselines_uses_latest_sync_and_week_old_snapshot PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_load_summary_history_includes_current_summary_and_sorts_descending PASSED [ 55%]
-tests/test_public_record_refresh.py::test_default_us_region_state_map_includes_all_50_states PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_is_deterministic_and_schema_compatible PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_preserves_existing_identifiers PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_duplicate_id_or_slug PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_enforces_region_targets PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_above_region_targets PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_flags_and_drops_link_failures PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_on_transient_link_failures PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_legacy_self_reported_source_label PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_source_matching_website PASSED [ 55%]
+tests/test_onboarding.py::test_onboarding_proton_no_key_found_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_proton_non_200_response_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_missing_key_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_whitespace_key_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_form_returns_400_with_csrf PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_non_encryptable_key_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_notifications_invalid_form_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_profile_requires_csrf_token PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_notifications_requires_csrf_token PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_directory_invalid_form_returns_400_with_csrf PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_unknown_step_post_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_directory_redirects_to_select_tier_when_stripe_enabled PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_skip_missing_user_redirects_login PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_skip_invalid_form_redirects_onboarding_with_csrf PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_skip_redirects_to_select_tier_when_enabled PASSED [ 47%]
+tests/test_onboarding.py::test_webpack_build_includes_onboarding_bundle PASSED [ 47%]
+tests/test_operational_key_management_design.py::test_operational_key_management_design_exists_and_is_linked PASSED [ 47%]
+tests/test_operational_key_management_design.py::test_operational_key_management_design_covers_required_topics PASSED [ 47%]
+tests/test_operational_key_management_design.py::test_operational_key_management_design_locks_recommendation_and_guardrails PASSED [ 47%]
+tests/test_password_hash_modernization_evaluation.py::test_password_hash_modernization_evaluation_exists_and_is_linked PASSED [ 48%]
+tests/test_password_hash_modernization_evaluation.py::test_password_hash_modernization_evaluation_covers_required_decision_points PASSED [ 48%]
+tests/test_password_hash_modernization_evaluation.py::test_password_hash_modernization_evaluation_locks_guardrails PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_uses_legacy_passlib_scrypt_fixture_and_logs_success PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_legacy_passlib_scrypt_fixture PASSED [ 48%]
+tests/test_password_hasher.py::test_legacy_passlib_scrypt_fixture_documents_prefix_and_cost_baseline PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_uses_native_werkzeug_scrypt_hash_and_logs_success PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_native_werkzeug_scrypt_hash PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_routes_non_scrypt_native_prefixes_to_primary_verifier PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_primary_password_hash_rejects_non_scrypt_native_prefix PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_unknown_prefix_fails_closed_without_mutating_user PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_malformed_legacy_hash_fails_closed PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_without_app_context PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_skips_non_legacy_hashes PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_when_disabled PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_rehashes_legacy_hash_when_enabled PASSED [ 48%]
+tests/test_password_hasher.py::test_get_password_hash_prefix_returns_unknown_for_plaintext_like_values PASSED [ 48%]
+tests/test_password_hasher.py::test_hash_password_logs_write_counter_without_sensitive_data PASSED [ 48%]
+tests/test_password_hasher.py::test_hash_password_uses_pinned_werkzeug_scrypt_method_when_enabled PASSED [ 48%]
+tests/test_password_hasher.py::test_pinned_werkzeug_scrypt_method_matches_legacy_passlib_cost_baseline PASSED [ 49%]
+tests/test_password_hasher.py::test_password_hash_telemetry_helpers_noop_without_app_context PASSED [ 49%]
+tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[True-password_hash_rehash_on_auth_success_total] PASSED [ 49%]
+tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[False-password_hash_rehash_on_auth_failure_total] PASSED [ 49%]
+tests/test_premium.py::test_create_products_and_prices PASSED            [ 49%]
+tests/test_premium.py::test_update_price_existing PASSED                 [ 49%]
+tests/test_premium.py::test_update_price_new PASSED                      [ 49%]
+tests/test_premium.py::test_create_customer PASSED                       [ 49%]
+tests/test_premium.py::test_create_customer_updates_existing_customer PASSED [ 49%]
+tests/test_premium.py::test_create_customer_recreates_when_modify_fails PASSED [ 49%]
+tests/test_premium.py::test_get_subscription PASSED                      [ 49%]
+tests/test_premium.py::test_get_business_price_string_formats PASSED     [ 49%]
+tests/test_premium.py::test_get_business_price_string_missing_tier PASSED [ 49%]
+tests/test_premium.py::test_create_products_and_prices_missing_business_tier PASSED [ 49%]
+tests/test_premium.py::test_update_price_without_product_id_logs_and_returns PASSED [ 49%]
+tests/test_premium.py::test_get_subscription_none_when_missing_subscription_id PASSED [ 49%]
+tests/test_premium.py::test_handle_subscription_created PASSED           [ 49%]
+tests/test_premium.py::test_handle_subscription_created_raises_for_missing_user PASSED [ 49%]
+tests/test_premium.py::test_handle_subscription_updated_upgrade PASSED   [ 49%]
+tests/test_premium.py::test_handle_subscription_updated_downgrade PASSED [ 50%]
+tests/test_premium.py::test_handle_subscription_updated_raises_for_missing_subscription PASSED [ 50%]
+tests/test_premium.py::test_handle_subscription_deleted PASSED           [ 50%]
+tests/test_premium.py::test_handle_subscription_deleted_raises_for_missing_subscription PASSED [ 50%]
+tests/test_premium.py::test_handle_invoice_created PASSED                [ 50%]
+tests/test_premium.py::test_handle_invoice_created_value_error_is_handled PASSED [ 50%]
+tests/test_premium.py::test_handle_invoice_updated PASSED                [ 50%]
+tests/test_premium.py::test_handle_invoice_updated_refreshes_receipt_url PASSED [ 50%]
+tests/test_premium.py::test_premium_index_links_receipts_through_authenticated_route PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_refreshes_stale_url_before_redirect PASSED [ 50%]
+tests/test_premium.py::test_receipt_url_from_invoice_prefers_pdf_when_hosted_url_missing PASSED [ 50%]
+tests/test_premium.py::test_receipt_url_from_invoice_returns_none_without_hosted_url_or_pdf PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_redirects_to_stale_url_when_stripe_refresh_fails PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_flashes_when_no_receipt_url_available PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_redirects_to_login_when_user_missing_inside_route PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_returns_404_for_missing_invoice PASSED [ 50%]
+tests/test_premium.py::test_handle_invoice_updated_raises_for_missing_invoice PASSED [ 50%]
+tests/test_premium.py::test_upgrade_post_user_already_on_business_tier PASSED [ 50%]
+tests/test_premium.py::test_upgrade_process PASSED                       [ 50%]
+tests/test_premium.py::test_upgrade_process_uses_public_base_url_for_success_url PASSED [ 50%]
+tests/test_premium.py::test_update_payment_method_creates_billing_portal_session PASSED [ 51%]
+tests/test_premium.py::test_update_payment_method_requires_active_subscription PASSED [ 51%]
+tests/test_premium.py::test_update_payment_method_stripe_error PASSED    [ 51%]
+tests/test_premium.py::test_update_payment_method_aborts_when_portal_session_has_no_url PASSED [ 51%]
+tests/test_premium.py::test_disable_autorenew_no_user_in_session PASSED  [ 51%]
+tests/test_premium.py::test_disable_autorenew_no_subscription PASSED     [ 51%]
+tests/test_premium.py::test_disable_autorenew_success PASSED             [ 51%]
+tests/test_premium.py::test_disable_autorenew_stripe_error PASSED        [ 51%]
+tests/test_premium.py::test_enable_autorenew_no_user_in_session PASSED   [ 51%]
+tests/test_premium.py::test_enable_autorenew_no_subscription PASSED      [ 51%]
+tests/test_premium.py::test_enable_autorenew_success PASSED              [ 51%]
+tests/test_premium.py::test_enable_autorenew_stripe_error PASSED         [ 51%]
+tests/test_premium.py::test_cancel_no_user_in_session PASSED             [ 51%]
+tests/test_premium.py::test_cancel_no_subscription PASSED                [ 51%]
+tests/test_premium.py::test_cancel_success PASSED                        [ 51%]
+tests/test_premium.py::test_cancel_stripe_error PASSED                   [ 51%]
+tests/test_premium.py::test_premium_select_tier_redirects_when_onboarding_incomplete PASSED [ 51%]
+tests/test_premium.py::test_premium_select_free_sets_free_tier_when_unset PASSED [ 51%]
+tests/test_premium.py::test_premium_status_business_user_flashes_success PASSED [ 51%]
+tests/test_premium.py::test_premium_index_warns_on_incomplete_subscription PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.index-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_tier-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_free-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.upgrade-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.update_payment_method-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.disable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.enable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.cancel-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.status-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.index-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_tier-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_free-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.upgrade-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.update_payment_method-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.disable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.enable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.cancel-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.status-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_select_tier_renders_for_complete_user PASSED [ 53%]
+tests/test_premium.py::test_premium_waiting_page_renders PASSED          [ 53%]
+tests/test_premium.py::test_upgrade_missing_business_tier PASSED         [ 53%]
+tests/test_premium.py::test_upgrade_missing_business_price_id PASSED     [ 53%]
+tests/test_premium.py::test_upgrade_create_customer_failure PASSED       [ 53%]
+tests/test_premium.py::test_upgrade_checkout_creation_failure PASSED     [ 53%]
+tests/test_premium.py::test_upgrade_checkout_session_without_url_returns_500 PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_rejects_invalid_payload PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_rejects_invalid_signature PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_ignores_duplicate_event PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_stores_new_event PASSED      [ 53%]
+tests/test_premium.py::test_worker_processes_subscription_created_event PASSED [ 53%]
+tests/test_premium.py::test_worker_marks_event_error_when_handler_raises PASSED [ 53%]
+tests/test_premium.py::test_worker_waits_for_tables_before_starting PASSED [ 53%]
+tests/test_premium.py::test_worker_processes_subscription_updated_and_deleted_events PASSED [ 53%]
+tests/test_premium.py::test_worker_processes_invoice_created_event PASSED [ 53%]
+tests/test_premium.py::test_worker_processes_invoice_payment_succeeded_event PASSED [ 53%]
+tests/test_profile.py::test_profile_header PASSED                        [ 53%]
+tests/test_profile.py::test_profile_accepts_case_insensitive_username PASSED [ 53%]
+tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_non_admin_display_name PASSED [ 54%]
+tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_username_when_display_name_missing PASSED [ 54%]
+tests/test_profile.py::test_profile_404_for_unknown_username PASSED      [ 54%]
+tests/test_profile.py::test_profile_404s_when_case_insensitive_lookup_is_ambiguous PASSED [ 54%]
+tests/test_profile.py::test_profile_does_not_expose_owner_user_id PASSED [ 54%]
+tests/test_profile.py::test_profile_submit_message PASSED                [ 54%]
+tests/test_profile.py::test_profile_submit_message_to_alias PASSED       [ 54%]
+tests/test_profile.py::test_profile_failed_submit_preserves_input PASSED [ 54%]
+tests/test_profile.py::test_profile_rejects_owner_guard_mismatch PASSED  [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_non_numeric_captcha PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_expired_captcha_token PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_bad_captcha_token PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_captcha_token_for_different_profile PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_post_404s_if_account_is_suspended_after_render PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_if_account_is_suspended_during_submission PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_if_recipient_keys_are_removed_during_submission PASSED [ 54%]
+tests/test_profile.py::test_profile_pgp_required PASSED                  [ 54%]
+tests/test_profile.py::test_profile_allows_submission_with_recipient_key_when_legacy_user_key_missing PASSED [ 54%]
+tests/test_profile.py::test_profile_allows_submission_with_legacy_key_when_primary_recipient_lacks_key PASSED [ 54%]
+tests/test_profile.py::test_profile_submit_message_with_recipient_key_when_legacy_user_key_missing PASSED [ 55%]
+tests/test_profile.py::test_profile_submit_message_ignores_enabled_recipient_without_key PASSED [ 55%]
+tests/test_profile.py::test_profile_suspended_state_disables_message_form_with_pgp_key PASSED [ 55%]
+tests/test_profile.py::test_profile_post_rejects_when_target_has_no_pgp_key PASSED [ 55%]
+tests/test_profile.py::test_profile_post_rejects_when_target_is_suspended PASSED [ 55%]
+tests/test_profile.py::test_profile_post_rejects_alias_when_owner_is_suspended PASSED [ 55%]
+tests/test_profile.py::test_profile_post_form_validation_errors_are_rendered PASSED [ 55%]
+tests/test_profile.py::test_profile_requires_csrf_token PASSED           [ 55%]
+tests/test_profile.py::test_profile_full_body_encryption_fallback_to_generic_when_no_fields PASSED [ 55%]
+tests/test_profile.py::test_profile_full_body_encryption_exception_falls_back_to_generic PASSED [ 55%]
+tests/test_profile.py::test_profile_full_body_encryption_uses_server_fallback_when_client_body_missing PASSED [ 55%]
+tests/test_profile.py::test_profile_notification_without_message_content_sends_generic_body PASSED [ 55%]
+tests/test_profile.py::test_profile_single_recipient_notification_can_include_stored_message_content PASSED [ 55%]
+tests/test_profile.py::test_profile_extra_fields PASSED                  [ 55%]
+tests/test_profile.py::test_profile_field_encryption_labels PASSED       [ 55%]
+tests/test_profile.py::test_profile_account_category_renders_first_extra_field PASSED [ 55%]
+tests/test_profile.py::test_profile_location_renders_as_single_extra_field PASSED [ 55%]
+tests/test_profile.py::test_profile_location_keeps_full_names_outside_us PASSED [ 55%]
+tests/test_profile.py::test_redirect_submit_message_route PASSED         [ 55%]
+tests/test_profile.py::test_submission_success_without_reply_slug_redirects_directory PASSED [ 56%]
+tests/test_profile.py::test_submission_success_404_when_message_missing PASSED [ 56%]
+tests/test_profile.py::test_submission_success_uses_public_base_url_for_reply_link PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_build_snapshot_filters_to_public_hushline_users PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_build_markdown_report_reports_added_and_removed_usernames PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_build_readme_report_renders_natural_language_and_history_table PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_resolve_history_baselines_uses_latest_sync_and_week_old_snapshot PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_load_summary_history_includes_current_summary_and_sorts_descending PASSED [ 56%]
+tests/test_public_record_refresh.py::test_default_us_region_state_map_includes_all_50_states PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_is_deterministic_and_schema_compatible PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_preserves_existing_identifiers PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_duplicate_id_or_slug PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_enforces_region_targets PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_above_region_targets PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_flags_and_drops_link_failures PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_on_transient_link_failures PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_legacy_self_reported_source_label PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_source_matching_website PASSED [ 56%]
 tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_missing_us_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_cross_state_source_policy PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_generic_us_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_ohio_record_fragment_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_ohio_generic_home_fragment_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_synthetic_listing_marker PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_search_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_non_chambers_hosts_with_chambers_substrings PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_retries_then_succeeds PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_marks_404_as_definitive_failure PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_rejects_invalid_arguments PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_server_error_after_retries PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_request_exception_reason PASSED [ 56%]
-tests/test_public_record_refresh.py::test_render_refresh_summary_includes_dropped_ids_and_link_failures PASSED [ 56%]
-tests/test_public_record_refresh.py::test_parse_chambers_index_entries_skips_invalid_rows_and_sorts PASSED [ 56%]
-tests/test_public_record_refresh.py::test_fetch_json_payload_handles_non_200_and_successful_json PASSED [ 56%]
-tests/test_public_record_refresh.py::test_discovered_description_handles_tag_list_shapes PASSED [ 56%]
-tests/test_public_record_refresh.py::test_validate_regions_rejects_unknown_region PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_cross_state_source_policy PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_generic_us_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_ohio_record_fragment_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_ohio_generic_home_fragment_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_synthetic_listing_marker PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_search_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_non_chambers_hosts_with_chambers_substrings PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_retries_then_succeeds PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_marks_404_as_definitive_failure PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_rejects_invalid_arguments PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_server_error_after_retries PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_request_exception_reason PASSED [ 57%]
+tests/test_public_record_refresh.py::test_render_refresh_summary_includes_dropped_ids_and_link_failures PASSED [ 57%]
+tests/test_public_record_refresh.py::test_parse_chambers_index_entries_skips_invalid_rows_and_sorts PASSED [ 57%]
+tests/test_public_record_refresh.py::test_fetch_json_payload_handles_non_200_and_successful_json PASSED [ 57%]
+tests/test_public_record_refresh.py::test_discovered_description_handles_tag_list_shapes PASSED [ 57%]
+tests/test_public_record_refresh.py::test_validate_regions_rejects_unknown_region PASSED [ 57%]
 tests/test_public_record_refresh.py::test_chambers_public_profile_url_helpers_cover_supported_and_invalid_inputs PASSED [ 57%]
-tests/test_public_record_refresh.py::test_apply_region_targets_handles_none_and_invalid_target_configurations PASSED [ 57%]
-tests/test_public_record_refresh.py::test_normalization_helpers_validate_and_filter_values PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_seed_rows_respects_zero_limit_and_maximum PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_noop_official_public_record_rows_returns_empty_list PASSED [ 57%]
-tests/test_public_record_refresh.py::test_parse_chambers_index_entries_returns_empty_for_non_list_payload PASSED [ 57%]
-tests/test_public_record_refresh.py::test_fetch_json_payload_handles_exceptions_and_invalid_json PASSED [ 57%]
-tests/test_public_record_refresh.py::test_chambers_discovery_helpers_cover_locations_tags_and_url_normalization PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_validates_arguments_and_missing_adapters PASSED [ 57%]
-tests/test_public_record_refresh.py::test_authoritative_source_and_url_helper_branches PASSED [ 57%]
-tests/test_public_record_refresh.py::test_validate_links_skips_empty_fields_and_region_lookup_requires_mapping PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_chambers_public_record_rows_is_disabled PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_strict_accepts_full_coverage PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_covers_current_implemented_states PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AK] PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AL] PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AR] PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AZ] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_apply_region_targets_handles_none_and_invalid_target_configurations PASSED [ 58%]
+tests/test_public_record_refresh.py::test_normalization_helpers_validate_and_filter_values PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_seed_rows_respects_zero_limit_and_maximum PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_noop_official_public_record_rows_returns_empty_list PASSED [ 58%]
+tests/test_public_record_refresh.py::test_parse_chambers_index_entries_returns_empty_for_non_list_payload PASSED [ 58%]
+tests/test_public_record_refresh.py::test_fetch_json_payload_handles_exceptions_and_invalid_json PASSED [ 58%]
+tests/test_public_record_refresh.py::test_chambers_discovery_helpers_cover_locations_tags_and_url_normalization PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_validates_arguments_and_missing_adapters PASSED [ 58%]
+tests/test_public_record_refresh.py::test_authoritative_source_and_url_helper_branches PASSED [ 58%]
+tests/test_public_record_refresh.py::test_validate_links_skips_empty_fields_and_region_lookup_requires_mapping PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_chambers_public_record_rows_is_disabled PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_strict_accepts_full_coverage PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_covers_current_implemented_states PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AK] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AL] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AR] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AZ] PASSED [ 58%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CA] PASSED [ 58%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CO] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CT] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[DE] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[FL] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[GA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[HI] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ID] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IL] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IN] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KS] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KY] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[LA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MD] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ME] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MI] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MN] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CT] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[DE] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[FL] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[GA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[HI] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ID] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IL] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IN] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KS] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KY] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[LA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MD] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ME] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MI] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MN] PASSED [ 59%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MO] PASSED [ 59%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MS] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MT] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NC] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ND] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NE] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NH] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NJ] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NM] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NV] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NY] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OH] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OK] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OR] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[PA] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[RI] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SC] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SD] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TN] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MT] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NC] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ND] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NE] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NH] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NJ] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NM] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NV] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NY] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OH] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OK] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OR] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[PA] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[RI] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SC] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SD] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TN] PASSED [ 60%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TX] PASSED [ 60%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[UT] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VA] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VT] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WA] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WI] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WV] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WY] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AK] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AL] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AR] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AZ] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CA] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CO] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CT] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-DE] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-FL] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-GA] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VT] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WI] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WV] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WY] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AK] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AL] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AR] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AZ] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CO] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CT] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-DE] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-FL] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-GA] PASSED [ 61%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-HI] PASSED [ 61%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IA] PASSED [ 61%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ID] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IL] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IN] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KS] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KY] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-LA] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MA] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MD] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ME] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MI] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MN] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MO] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MS] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MT] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NC] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ND] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NE] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IL] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IN] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KS] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KY] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-LA] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MA] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MD] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ME] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MI] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MN] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MO] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MS] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MT] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NC] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ND] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NE] PASSED [ 62%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NH] PASSED [ 62%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NJ] PASSED [ 62%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NM] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NV] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NY] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OH] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OK] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OR] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-PA] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-RI] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SC] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SD] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TN] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TX] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-UT] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VA] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VT] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WA] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WI] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NV] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NY] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OH] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OK] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OR] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-PA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-RI] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SC] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SD] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TN] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TX] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-UT] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VT] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WI] PASSED [ 63%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WV] PASSED [ 63%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WY] PASSED [ 63%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AK] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AL] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AR] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AZ] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CA] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CO] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CT] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-DE] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-FL] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-GA] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-HI] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IA] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ID] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IL] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IN] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KS] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AL] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AR] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AZ] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CA] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CO] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CT] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-DE] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-FL] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-GA] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-HI] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IA] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ID] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IL] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IN] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KS] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KY] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-LA] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MA] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MD] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ME] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MI] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MN] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MO] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MS] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MT] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NC] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ND] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NE] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NH] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NJ] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NM] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NV] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NY] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OH] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ME] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MI] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MN] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MO] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MS] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MT] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NC] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ND] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NE] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NH] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NJ] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NM] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NV] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NY] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OH] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OK] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OR] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-PA] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-RI] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SC] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SD] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TN] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TX] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-UT] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VA] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VT] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WA] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WI] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WV] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WY] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AK] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AL] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AR] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SC] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SD] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TN] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TX] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-UT] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VA] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VT] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WA] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WI] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WV] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WY] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AK] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AL] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AR] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AZ] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CA] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CO] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CT] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-DE] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-FL] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-GA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-HI] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ID] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IL] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IN] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KS] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KY] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-LA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MD] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ME] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MI] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-FL] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-GA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-HI] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ID] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IL] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IN] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KS] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KY] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-LA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MD] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ME] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MI] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MN] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MO] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MS] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MT] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NC] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ND] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NE] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NH] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NJ] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NM] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NV] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NY] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OH] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OK] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OR] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-PA] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-RI] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SC] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SD] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ND] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NE] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NH] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NJ] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NM] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NV] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NY] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OH] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OK] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OR] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-PA] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-RI] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SC] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SD] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-TN] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-TX] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-UT] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-VA] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-VT] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WA] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WI] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WV] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WY] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_california_seeds PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen-Alaska Bar Association public directory-https://member.alaskabar.org/cv5/cgi-bin/memberdll.dll/Info?CUSTOMERCD=8744&WRP=Customer_Profile.htm] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers-Alabama State Bar public directory-https://members.alabar.org/Member_Portal/Member_Portal/Sections/AP.aspx] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik-Arkansas Bar Association public directory-https://www.arkbar.com/?pg=board-of-trustees] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali-State Bar of Arizona public directory-https://www.azbar.org/for-legal-professionals/practice-tools-management/member-directory/?m=Anthony-Cali-177781] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock-Colorado Bar Association public directory-https://community.cobar.org/profile/contributions/contributions-achievements?UserKey=330f70ad-afc9-44f0-b8b1-6b55108bc275] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown-Connecticut Bar Association public directory-https://members.ctbar.org/member/thelaborlawyer] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott-Delaware Courts published opinion-https://courts.delaware.gov/Opinions/Download.aspx?id=342050] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.-The Florida Bar public directory-https://www.floridabar.org/directories/find-mbr/profile/?num=123000] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WA] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WI] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WV] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WY] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_california_seeds PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen-Alaska Bar Association public directory-https://member.alaskabar.org/cv5/cgi-bin/memberdll.dll/Info?CUSTOMERCD=8744&WRP=Customer_Profile.htm] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers-Alabama State Bar public directory-https://members.alabar.org/Member_Portal/Member_Portal/Sections/AP.aspx] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik-Arkansas Bar Association public directory-https://www.arkbar.com/?pg=board-of-trustees] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali-State Bar of Arizona public directory-https://www.azbar.org/for-legal-professionals/practice-tools-management/member-directory/?m=Anthony-Cali-177781] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock-Colorado Bar Association public directory-https://community.cobar.org/profile/contributions/contributions-achievements?UserKey=330f70ad-afc9-44f0-b8b1-6b55108bc275] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown-Connecticut Bar Association public directory-https://members.ctbar.org/member/thelaborlawyer] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott-Delaware Courts published opinion-https://courts.delaware.gov/Opinions/Download.aspx?id=342050] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.-The Florida Bar public directory-https://www.floridabar.org/directories/find-mbr/profile/?num=123000] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton-State Bar of Georgia speaker profile-https://icle.gabar.org/speaker/todd-stanton-1261014] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz-Hawaii State Bar Association attorney recognition record-https://hsba.org/HSBA_2020/About_Us/Living_Legend_Lawyers_.aspx] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin-Iowa State Bar Association jury verdict record-https://services.iowabar.org/IB/JuryVerdicts.nsf/b96238336212630c85258ca1000240fd/e71fe5f6f6d3242d872589900011edc5!OpenDocument] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser-Idaho State Bar attorney profile-https://isb.idaho.gov/blog/trudy-hanson-fouser/] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler-Indiana State Bar public directory-https://www.inbar.org/members/?id=30400364] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady-Kansas Judicial Branch published opinion-https://kscourts.gov/Cases-Decisions/Decisions/Published/Brown-v-Ford-Storage-and-Moving-Co-Inc] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks-Kentucky Bar Association public directory-https://www.kybar.org/members/?id=42347567] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer-Louisiana Attorney Disciplinary Board attorney records-https://www.ladb.org/DR/Document.cfm?docket=24-DB-014] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey-Massachusetts BBO attorney records-https://bbopublic.massbbo.org/web/f/SJC_WellBeing_Cmte_Report.pdf] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker-Maryland Courts attorney discipline records-https://www.courts.state.md.us/attygrievance/sanctions07] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher-Maine Board of Overseers of the Bar public directory-https://mebarconnect.mainebar.org/people/daniel-eccher] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese-State Bar of Michigan public directory-https://connect.michbar.org/laborlaw[redacted-path] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman-Minnesota Courts attorney records-https://mncourts.gov/help-topics/Legal-Paraprofessional-Program/standing-committee] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips-The Missouri Bar public directory-https://news.mobar.org/jerina-d-phillips-receives-2025-diversity-champion-award/] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MS-seed-joel-frank-dillard-public-record~joel-frank-dillard-Joel Frank Dillard-The Mississippi Bar public directory-https://www.msbar.org/inside-the-bar/sections/labor-employment-law/] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm-State Bar of Montana public directory-https://www.montanabar.org/About-Us/Sections-and-Committees] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams-North Carolina State Bar public directory-https://www.ncbar.gov/for-lawyers/directories/leadership/state-bar-officers/] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson-North Dakota Court System attorney directory-https://www.ndcourts.gov/lawyers/06402] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau-Nebraska Judicial Branch case record-https://supremecourt.nebraska.gov/courts/supreme-court/supreme-court-call/city-omaha-v-professional-firefighters-association-omaha] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks-Kentucky Bar Association public directory-https://www.kybar.org/members/?id=42347567] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer-Louisiana Attorney Disciplinary Board attorney records-https://www.ladb.org/DR/Document.cfm?docket=24-DB-014] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey-Massachusetts BBO attorney records-https://bbopublic.massbbo.org/web/f/SJC_WellBeing_Cmte_Report.pdf] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker-Maryland Courts attorney discipline records-https://www.courts.state.md.us/attygrievance/sanctions07] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher-Maine Board of Overseers of the Bar public directory-https://mebarconnect.mainebar.org/people/daniel-eccher] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese-State Bar of Michigan public directory-https://connect.michbar.org/laborlaw[redacted-path] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman-Minnesota Courts attorney records-https://mncourts.gov/help-topics/Legal-Paraprofessional-Program/standing-committee] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips-The Missouri Bar public directory-https://news.mobar.org/jerina-d-phillips-receives-2025-diversity-champion-award/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MS-seed-joel-frank-dillard-public-record~joel-frank-dillard-Joel Frank Dillard-The Mississippi Bar public directory-https://www.msbar.org/inside-the-bar/sections/labor-employment-law/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm-State Bar of Montana public directory-https://www.montanabar.org/About-Us/Sections-and-Committees] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams-North Carolina State Bar public directory-https://www.ncbar.gov/for-lawyers/directories/leadership/state-bar-officers/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson-North Dakota Court System attorney directory-https://www.ndcourts.gov/lawyers/06402] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau-Nebraska Judicial Branch case record-https://supremecourt.nebraska.gov/courts/supreme-court/supreme-court-call/city-omaha-v-professional-firefighters-association-omaha] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns-New Hampshire Bar Association CLE speaker profile-https://member.nhbar.org/calendar/event/34th-annual-labor-and-employment-law-update] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins-NJ Courts attorney certification records-https://www.njcourts.gov/notices/order-board-attorney-certification-new-chair-and-vice-chair-designations-certification] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy-State Bar of New Mexico public directory-https://www.sbnm.org/cvweb/cgi-bin/Utilities.dll?View=INMEMBERDETAILS&RECORDNO=1&CUSTOMERNO=11321] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck-State Bar of Nevada public directory-https://nvbar.org/for-lawyers/bar-service-opportunities/join-a-section/labor-and-employment-law-section/] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone-New York Courts attorney directory-https://decisions.courts.state.ny.us/ad3/Decisions/2023/CV-22-1940.pdf] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough-Oklahoma Bar Association public directory-https://ams.okbar.org/eweb/DynamicPage.aspx?Action=Add&DoNotSave=yes&ObjectKeyFrom=1A83491A-9853-4C87-86A4-F7D95601C2E2&ParentDataObject=Invoice+Detail&ParentObject=CentralizedOrderEntry&WebCode=ProdDetailAdd&ivd_cst_key=00000000-0000-0000-0000-000000000000&ivd_cst_ship_key=00000000-0000-0000-0000-000000000000&ivd_formkey=69202792-63d7-4ba2-bf4e-a0da41270555&ivd_prc_prd_key=F5FDCC21-BBDF-4D41-944F-5351AD775A80] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland-Oregon State Bar public directory-https://www.osbar.org/sections/labor.html] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson-Pennsylvania Disciplinary Board attorney directory-https://www.padisciplinaryboard.org/for-the-public/find-attorney/attorney-detail/85957] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof-Rhode Island Judiciary attorney records-https://www.courts.ri.gov/attorney-resources/Pages/Board-of-Bar-Examiners-default.aspx] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe-South Carolina Bar public directory-https://www.scbar.org/for-lawyers/networking/sections/employment-and-labor-law-section/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger-State Bar of South Dakota public directory-https://www.statebarofsouthdakota.com/project-rural-practice/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez-State Bar of Texas public directory-https://www.texasbar.com/AM/Template.cfm?ContactID=157597&template=%2FCustomsource%2FMemberDirectory%2FMemberDirectoryDetail.cfm] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen-Utah Courts public legal directory-https://www.utcourts.gov/en/about/administration/committees/ethics-advisory-committee.html] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt-Virginia State Bar public directory-https://virginialawyer.vsb.org/articles/professional-notices?article_id=5100257&i=859839] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VT-seed-jeremy-s-grant-public-record~jeremy-s-grant-Jeremy S. Grant-Vermont Bar Association public directory-https://www.vtbar.org/2025-annual-meeting-in-review/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus-State Bar of Wisconsin public directory-https://www.wisbar.org/NewsPublications/WisconsinLawyer/WisconsinLawyerPDFs/97/01/20_24.pdf] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess-West Virginia State Bar public directory-https://wvbar.org/wp-content/uploads/2024/04/24-25-Active-List-UPDATED.pdf] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke-Wyoming State Bar public directory-https://www.wyomingbar.org/about-us/bar-leadership/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland-Oregon State Bar public directory-https://www.osbar.org/sections/labor.html] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson-Pennsylvania Disciplinary Board attorney directory-https://www.padisciplinaryboard.org/for-the-public/find-attorney/attorney-detail/85957] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof-Rhode Island Judiciary attorney records-https://www.courts.ri.gov/attorney-resources/Pages/Board-of-Bar-Examiners-default.aspx] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe-South Carolina Bar public directory-https://www.scbar.org/for-lawyers/networking/sections/employment-and-labor-law-section/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger-State Bar of South Dakota public directory-https://www.statebarofsouthdakota.com/project-rural-practice/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez-State Bar of Texas public directory-https://www.texasbar.com/AM/Template.cfm?ContactID=157597&template=%2FCustomsource%2FMemberDirectory%2FMemberDirectoryDetail.cfm] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen-Utah Courts public legal directory-https://www.utcourts.gov/en/about/administration/committees/ethics-advisory-committee.html] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt-Virginia State Bar public directory-https://virginialawyer.vsb.org/articles/professional-notices?article_id=5100257&i=859839] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VT-seed-jeremy-s-grant-public-record~jeremy-s-grant-Jeremy S. Grant-Vermont Bar Association public directory-https://www.vtbar.org/2025-annual-meeting-in-review/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus-State Bar of Wisconsin public directory-https://www.wisbar.org/NewsPublications/WisconsinLawyer/WisconsinLawyerPDFs/97/01/20_24.pdf] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess-West Virginia State Bar public directory-https://wvbar.org/wp-content/uploads/2024/04/24-25-Active-List-UPDATED.pdf] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke-Wyoming State Bar public directory-https://www.wyomingbar.org/about-us/bar-leadership/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips] PASSED [ 72%]
@@ -4070,18 +4402,18 @@ tests/test_public_record_refresh.py::test_discover_official_us_state_public_reco
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt] PASSED [ 73%]
@@ -4089,17 +4421,17 @@ tests/test_public_record_refresh.py::test_discover_official_us_state_public_reco
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke] PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_washington_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_washington_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_ohio_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_ohio_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_tennessee_seeds PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_tennessee_seeds PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_illinois_seeds PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_illinois_seeds PASSED [ 73%]
-tests/test_public_record_refresh_workflow.py::test_public_record_quarterly_refresh_workflow_uses_correction_pr_flow PASSED [ 73%]
-tests/test_public_record_refresh_workflow.py::test_refresh_public_record_corrections_make_target_matches_workflow_semantics PASSED [ 73%]
-tests/test_public_record_refresh_workflow.py::test_refresh_report_matches_structured_values PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_washington_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_washington_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_ohio_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_ohio_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_tennessee_seeds PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_tennessee_seeds PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_illinois_seeds PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_illinois_seeds PASSED [ 74%]
+tests/test_public_record_refresh_workflow.py::test_public_record_quarterly_refresh_workflow_uses_correction_pr_flow PASSED [ 74%]
+tests/test_public_record_refresh_workflow.py::test_refresh_public_record_corrections_make_target_matches_workflow_semantics PASSED [ 74%]
+tests/test_public_record_refresh_workflow.py::test_refresh_report_matches_structured_values PASSED [ 74%]
 tests/test_public_record_refresh_workflow.py::test_sync_provenance_roadmap_updates_baseline_and_adapter_count PASSED [ 74%]
 tests/test_public_record_refresh_workflow.py::test_sync_provenance_roadmap_preserves_eu_planning_section PASSED [ 74%]
 tests/test_public_record_refresh_workflow.py::test_public_record_provenance_roadmap_documents_eu_phase_0b_policy PASSED [ 74%]
@@ -4108,17 +4440,17 @@ tests/test_public_record_refresh_workflow.py::test_public_record_provenance_road
 tests/test_public_record_refresh_workflow.py::test_public_record_provenance_roadmap_documents_eu_phase_0e_rollout_backlog PASSED [ 74%]
 tests/test_refresh_newsroom_directory_listings_script.py::test_serialize_rows_is_deterministic_without_node_tooling PASSED [ 74%]
 tests/test_registration_and_login.py::test_user_registration_disabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_disabled_first_user PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_with_invite_code_disabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_with_invite_code_enabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_rejects_case_insensitive_duplicate PASSED [ 74%]
-tests/test_registration_and_login.py::test_username_db_constraint_rejects_case_insensitive_duplicate PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_handles_case_insensitive_race_integrity_error PASSED [ 74%]
-tests/test_registration_and_login.py::test_register_page_loads PASSED    [ 74%]
-tests/test_registration_and_login.py::test_register_requires_csrf_token PASSED [ 74%]
-tests/test_registration_and_login.py::test_login_page_loads PASSED       [ 74%]
-tests/test_registration_and_login.py::test_login_invalid_post_shows_errors_and_preserves_username PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_registration_disabled_first_user PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_with_invite_code_disabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_with_invite_code_enabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_rejects_case_insensitive_duplicate PASSED [ 75%]
+tests/test_registration_and_login.py::test_username_db_constraint_rejects_case_insensitive_duplicate PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_handles_case_insensitive_race_integrity_error PASSED [ 75%]
+tests/test_registration_and_login.py::test_register_page_loads PASSED    [ 75%]
+tests/test_registration_and_login.py::test_register_requires_csrf_token PASSED [ 75%]
+tests/test_registration_and_login.py::test_login_page_loads PASSED       [ 75%]
+tests/test_registration_and_login.py::test_login_invalid_post_shows_errors_and_preserves_username PASSED [ 75%]
 tests/test_registration_and_login.py::test_login_requires_csrf_token PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_after_registration PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_case_insensitive PASSED [ 75%]
@@ -4128,16 +4460,16 @@ tests/test_registration_and_login.py::test_user_login_rehashes_legacy_passlib_ha
 tests/test_registration_and_login.py::test_user_login_does_not_rehash_legacy_passlib_hash_when_disabled PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_rehash_failure_preserves_legacy_passlib_hash PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_handles_case_insensitive_duplicate_rows PASSED [ 75%]
-tests/test_replies.py::test_message_reply_404_for_unknown_slug PASSED    [ 75%]
-tests/test_replies.py::test_default_replies PASSED                       [ 75%]
-tests/test_replies.py::test_custom_replies PASSED                        [ 75%]
-tests/test_replies.py::test_set_custom_replies PASSED                    [ 75%]
-tests/test_replies.py::test_settings_replies_prefills_default_status_text PASSED [ 75%]
-tests/test_replies.py::test_settings_replies_prefills_custom_status_text_when_present PASSED [ 75%]
-tests/test_replies.py::test_set_custom_replies_redirects_back_with_success_flash PASSED [ 75%]
-tests/test_replies.py::test_set_default_replies_keeps_builtin_default_without_persisting_override PASSED [ 75%]
-tests/test_replies.py::test_message_page PASSED                          [ 75%]
-tests/test_replies.py::test_message_page_wrong_user PASSED               [ 75%]
+tests/test_replies.py::test_message_reply_404_for_unknown_slug PASSED    [ 76%]
+tests/test_replies.py::test_default_replies PASSED                       [ 76%]
+tests/test_replies.py::test_custom_replies PASSED                        [ 76%]
+tests/test_replies.py::test_set_custom_replies PASSED                    [ 76%]
+tests/test_replies.py::test_settings_replies_prefills_default_status_text PASSED [ 76%]
+tests/test_replies.py::test_settings_replies_prefills_custom_status_text_when_present PASSED [ 76%]
+tests/test_replies.py::test_set_custom_replies_redirects_back_with_success_flash PASSED [ 76%]
+tests/test_replies.py::test_set_default_replies_keeps_builtin_default_without_persisting_override PASSED [ 76%]
+tests/test_replies.py::test_message_page PASSED                          [ 76%]
+tests/test_replies.py::test_message_page_wrong_user PASSED               [ 76%]
 tests/test_replies.py::test_set_message_status_success PASSED            [ 76%]
 tests/test_replies.py::test_set_message_status_invalid_form PASSED       [ 76%]
 tests/test_replies.py::test_set_message_status_message_not_found PASSED  [ 76%]
@@ -4147,15 +4479,15 @@ tests/test_replies.py::test_settings_replies_invalid_status_renders_field_error_
 tests/test_replies.py::test_settings_replies_missing_csrf_renders_error_on_submitted_form PASSED [ 76%]
 tests/test_resend_message.py::test_resend_message_sends_per_field PASSED [ 76%]
 tests/test_resend_message.py::test_resend_message_sends_per_field_to_all_enabled_recipients PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_blocks_other_users_messages PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_requires_email_notifications PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_requires_csrf_token PASSED [ 76%]
-tests/test_resend_message.py::test_resend_button_visible_with_required_settings PASSED [ 76%]
-tests/test_resend_message.py::test_resend_button_hidden_without_notifications_or_content PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_uses_existing_armored_value_without_reencryption PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_reuses_armored_value_for_duplicate_shared_recipient_key PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_encrypts_value_with_embedded_pgp_header_substring PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_blocks_other_users_messages PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_requires_email_notifications PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_requires_csrf_token PASSED [ 77%]
+tests/test_resend_message.py::test_resend_button_visible_with_required_settings PASSED [ 77%]
+tests/test_resend_message.py::test_resend_button_hidden_without_notifications_or_content PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_uses_existing_armored_value_without_reencryption PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_reuses_armored_value_for_duplicate_shared_recipient_key PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_encrypts_value_with_embedded_pgp_header_substring PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value PASSED [ 77%]
 tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value_for_all_enabled_recipients PASSED [ 77%]
 tests/test_resend_message.py::test_resend_message_full_body_encryption_failure_falls_back_to_generic PASSED [ 77%]
 tests/test_resend_message.py::test_resend_message_full_body_multi_recipient_armored_value_falls_back_to_generic PASSED [ 77%]
@@ -4166,15 +4498,15 @@ tests/test_routes_auth.py::test_register_redirects_when_already_logged_in PASSED
 tests/test_routes_auth.py::test_register_rejects_incorrect_captcha PASSED [ 77%]
 tests/test_routes_auth.py::test_register_rejects_invalid_invite_code PASSED [ 77%]
 tests/test_routes_auth.py::test_register_rejects_expired_invite_code PASSED [ 77%]
-tests/test_routes_auth.py::test_register_requires_invite_code_by_default_for_first_user PASSED [ 77%]
-tests/test_routes_auth.py::test_register_valid_invite_code_deletes_code PASSED [ 77%]
-tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_invalid_session_state PASSED [ 77%]
-tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_non_legacy_source_hash PASSED [ 77%]
-tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_mismatched_source_digest PASSED [ 77%]
-tests/test_routes_auth.py::test_register_handles_unexpected_integrity_error PASSED [ 77%]
-tests/test_routes_auth.py::test_login_redirects_when_already_logged_in PASSED [ 77%]
-tests/test_routes_auth.py::test_login_redirects_to_select_tier_when_premium_enabled PASSED [ 77%]
-tests/test_routes_auth.py::test_login_redirects_to_original_protected_page PASSED [ 77%]
+tests/test_routes_auth.py::test_register_requires_invite_code_by_default_for_first_user PASSED [ 78%]
+tests/test_routes_auth.py::test_register_valid_invite_code_deletes_code PASSED [ 78%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_invalid_session_state PASSED [ 78%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_non_legacy_source_hash PASSED [ 78%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_mismatched_source_digest PASSED [ 78%]
+tests/test_routes_auth.py::test_register_handles_unexpected_integrity_error PASSED [ 78%]
+tests/test_routes_auth.py::test_login_redirects_when_already_logged_in PASSED [ 78%]
+tests/test_routes_auth.py::test_login_redirects_to_select_tier_when_premium_enabled PASSED [ 78%]
+tests/test_routes_auth.py::test_login_redirects_to_original_protected_page PASSED [ 78%]
 tests/test_routes_auth.py::test_password_reset_request_is_generic_and_sends_only_for_eligible_account PASSED [ 78%]
 tests/test_routes_auth.py::test_find_primary_username_returns_none_and_logs_when_query_is_ambiguous PASSED [ 78%]
 tests/test_routes_auth.py::test_password_reset_sets_new_password_and_consumes_token PASSED [ 78%]
@@ -4185,14 +4517,14 @@ tests/test_routes_auth.py::test_password_reset_request_rejects_incorrect_captcha
 tests/test_routes_auth.py::test_stash_post_auth_redirect_skips_logout_and_preserves_session PASSED [ 78%]
 tests/test_routes_auth.py::test_stash_post_auth_redirect_rejects_unsafe_target_and_preserves_session PASSED [ 78%]
 tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[None] PASSED [ 78%]
-tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[bind1] PASSED [ 78%]
-tests/test_routes_auth.py::test_register_rejects_when_first_user_recheck_finds_existing_user PASSED [ 78%]
-tests/test_routes_auth.py::test_login_clears_auth_session_when_2fa_commit_fails PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_login_and_clears_session_for_missing_user PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_inbox_when_already_authenticated PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_rejects_when_user_has_no_totp_secret PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_requires_csrf_token PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_onboarding PASSED [ 78%]
+tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[bind1] PASSED [ 79%]
+tests/test_routes_auth.py::test_register_rejects_when_first_user_recheck_finds_existing_user PASSED [ 79%]
+tests/test_routes_auth.py::test_login_clears_auth_session_when_2fa_commit_fails PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_login_and_clears_session_for_missing_user PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_inbox_when_already_authenticated PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_rejects_when_user_has_no_totp_secret PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_requires_csrf_token PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_onboarding PASSED [ 79%]
 tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_select_tier_when_enabled PASSED [ 79%]
 tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_original_protected_page PASSED [ 79%]
 tests/test_routes_auth.py::test_verify_2fa_login_failed_rehash_commit_clears_auth_session PASSED [ 79%]
@@ -4204,14 +4536,14 @@ tests/test_routes_common.py::test_get_ip_address_fallback PASSED         [ 79%]
 tests/test_routes_common.py::test_show_directory_caution_badge_honors_explicit_cautious_override PASSED [ 79%]
 tests/test_routes_common.py::test_do_send_email_returns_early_without_enabled_notifications PASSED [ 79%]
 tests/test_routes_common.py::test_do_send_email_uses_user_custom_smtp PASSED [ 79%]
-tests/test_routes_common.py::test_do_send_email_sends_to_each_enabled_recipient PASSED [ 79%]
-tests/test_routes_common.py::test_do_send_email_deduplicates_recipient_email_addresses PASSED [ 79%]
-tests/test_routes_common.py::test_do_send_email_retries_duplicate_address_after_false_result PASSED [ 79%]
-tests/test_routes_common.py::test_send_email_to_user_recipients_accepts_recipient_body_factory PASSED [ 79%]
-tests/test_routes_common.py::test_send_email_to_user_recipients_skips_empty_recipient_body PASSED [ 79%]
-tests/test_routes_common.py::test_notification_email_encryption_target_returns_all_enabled_keys PASSED [ 79%]
-tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_without_primary_row PASSED [ 79%]
-tests/test_routes_common.py::test_notification_email_encryption_target_falls_back_to_legacy_user_key PASSED [ 79%]
+tests/test_routes_common.py::test_do_send_email_sends_to_each_enabled_recipient PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_deduplicates_recipient_email_addresses PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_retries_duplicate_address_after_false_result PASSED [ 80%]
+tests/test_routes_common.py::test_send_email_to_user_recipients_accepts_recipient_body_factory PASSED [ 80%]
+tests/test_routes_common.py::test_send_email_to_user_recipients_skips_empty_recipient_body PASSED [ 80%]
+tests/test_routes_common.py::test_notification_email_encryption_target_returns_all_enabled_keys PASSED [ 80%]
+tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_without_primary_row PASSED [ 80%]
+tests/test_routes_common.py::test_notification_email_encryption_target_falls_back_to_legacy_user_key PASSED [ 80%]
 tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_when_primary_row_lacks_key PASSED [ 80%]
 tests/test_routes_common.py::test_notification_email_encryption_target_uses_non_primary_recipient_without_legacy_key PASSED [ 80%]
 tests/test_routes_common.py::test_notification_email_encryption_target_ignores_enabled_recipient_without_key PASSED [ 80%]
@@ -4223,14 +4555,14 @@ tests/test_routes_common.py::test_notification_recipient_encryption_target_uses_
 tests/test_routes_common.py::test_notification_recipient_encryption_target_returns_none_without_key PASSED [ 80%]
 tests/test_routes_common.py::test_do_send_email_continues_after_single_recipient_failure PASSED [ 80%]
 tests/test_routes_common.py::test_do_send_email_uses_default_smtp PASSED [ 80%]
-tests/test_routes_common.py::test_do_send_email_uses_notifications_address_as_reply_to_fallback PASSED [ 80%]
-tests/test_routes_common.py::test_do_send_email_skips_recipient_without_email PASSED [ 80%]
-tests/test_routes_common.py::test_do_send_email_catches_errors PASSED    [ 80%]
-tests/test_routes_common.py::test_do_send_email_skips_when_default_smtp_incomplete PASSED [ 80%]
-tests/test_routes_common.py::test_formatters PASSED                      [ 80%]
-tests/test_routes_forms.py::test_login_password_max_matches_registration PASSED [ 80%]
-tests/test_routes_forms.py::test_login_username_max_matches_registration PASSED [ 80%]
-tests/test_routes_forms.py::test_dynamic_message_form_skips_disabled_fields_and_maps_names PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_uses_notifications_address_as_reply_to_fallback PASSED [ 81%]
+tests/test_routes_common.py::test_do_send_email_skips_recipient_without_email PASSED [ 81%]
+tests/test_routes_common.py::test_do_send_email_catches_errors PASSED    [ 81%]
+tests/test_routes_common.py::test_do_send_email_skips_when_default_smtp_incomplete PASSED [ 81%]
+tests/test_routes_common.py::test_formatters PASSED                      [ 81%]
+tests/test_routes_forms.py::test_login_password_max_matches_registration PASSED [ 81%]
+tests/test_routes_forms.py::test_login_username_max_matches_registration PASSED [ 81%]
+tests/test_routes_forms.py::test_dynamic_message_form_skips_disabled_fields_and_maps_names PASSED [ 81%]
 tests/test_routes_forms.py::test_dynamic_message_form_unknown_field_type_raises PASSED [ 81%]
 tests/test_routes_forms.py::test_dynamic_message_form_choice_fields_select_and_multicheckbox PASSED [ 81%]
 tests/test_routes_forms.py::test_onboarding_profile_form_rejects_disallowed_language PASSED [ 81%]
@@ -4242,13 +4574,13 @@ tests/test_safe_template.py::test_missing_var PASSED                     [ 81%]
 tests/test_safe_template.py::test_invalid_var_syntax PASSED              [ 81%]
 tests/test_safe_template.py::test_unclosed_var PASSED                    [ 81%]
 tests/test_safe_template.py::test_unopened_var PASSED                    [ 81%]
-tests/test_safe_template.py::test_invalid_var_value PASSED               [ 81%]
-tests/test_safe_template.py::test_single_var PASSED                      [ 81%]
-tests/test_safe_template.py::test_multiple_vars PASSED                   [ 81%]
-tests/test_secure_session.py::TestSessionEnabled::test_get_set PASSED    [ 81%]
-tests/test_secure_session.py::TestSessionEnabled::test_key_only_session_access_sets_vary_cookie PASSED [ 81%]
-tests/test_secure_session.py::TestNoSessionEnabled::test_no_session PASSED [ 81%]
-tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_missing_seed_file PASSED [ 81%]
+tests/test_safe_template.py::test_invalid_var_value PASSED               [ 82%]
+tests/test_safe_template.py::test_single_var PASSED                      [ 82%]
+tests/test_safe_template.py::test_multiple_vars PASSED                   [ 82%]
+tests/test_secure_session.py::TestSessionEnabled::test_get_set PASSED    [ 82%]
+tests/test_secure_session.py::TestSessionEnabled::test_key_only_session_access_sets_vary_cookie PASSED [ 82%]
+tests/test_secure_session.py::TestNoSessionEnabled::test_no_session PASSED [ 82%]
+tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_missing_seed_file PASSED [ 82%]
 tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_non_list_seed_json PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_is_deterministic_and_schema_compatible PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_normalize_string_list_filters_invalid_blank_and_duplicate_values PASSED [ 82%]
@@ -4261,13 +4593,13 @@ tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_ro
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows1-Duplicate SecureDrop listing id: securedrop-one] PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows2-Normalized row slug must be a string] PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows3-Duplicate SecureDrop listing slug: securedrop~shared] PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_requests_expected_shape PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_list_payload PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_object_payload_items PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_render_securedrop_refresh_summary PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_summary_row_label_falls_back_to_name_id_or_unnamed_listing PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_append_summary_section_skips_empty_entries PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows3-Duplicate SecureDrop listing slug: securedrop~shared] PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_requests_expected_shape PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_list_payload PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_object_payload_items PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_render_securedrop_refresh_summary PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_summary_row_label_falls_back_to_name_id_or_unnamed_listing PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_append_summary_section_skips_empty_entries PASSED [ 83%]
 tests/test_security_headers.py::test_csp PASSED                          [ 83%]
 tests/test_security_headers.py::test_csp_script_src_elem_disallows_inline_scripts PASSED [ 83%]
 tests/test_security_headers.py::test_custom_splash_logo_keeps_csp_enforced PASSED [ 83%]
@@ -4280,13 +4612,13 @@ tests/test_security_headers.py::test_base_template_uses_external_no_js_bootstrap
 tests/test_security_headers.py::test_x_frame_options PASSED              [ 83%]
 tests/test_security_headers.py::test_x_content_type_options PASSED       [ 83%]
 tests/test_security_headers.py::test_permissions_policy PASSED           [ 83%]
-tests/test_security_headers.py::test_referrer_policy PASSED              [ 83%]
-tests/test_security_headers.py::test_x_xss_protection PASSED             [ 83%]
-tests/test_security_headers.py::test_strict_transport_security PASSED    [ 83%]
-tests/test_security_headers.py::test_no_strict_transport_security_onion PASSED [ 83%]
-tests/test_settings.py::test_user_account_category_persists PASSED       [ 83%]
-tests/test_settings.py::test_user_location_persists PASSED               [ 83%]
-tests/test_settings.py::test_notification_recipient_shadow_persists_from_legacy_fields PASSED [ 83%]
+tests/test_security_headers.py::test_referrer_policy PASSED              [ 84%]
+tests/test_security_headers.py::test_x_xss_protection PASSED             [ 84%]
+tests/test_security_headers.py::test_strict_transport_security PASSED    [ 84%]
+tests/test_security_headers.py::test_no_strict_transport_security_onion PASSED [ 84%]
+tests/test_settings.py::test_user_account_category_persists PASSED       [ 84%]
+tests/test_settings.py::test_user_location_persists PASSED               [ 84%]
+tests/test_settings.py::test_notification_recipient_shadow_persists_from_legacy_fields PASSED [ 84%]
 tests/test_settings.py::test_user_ensure_primary_notification_recipient_returns_existing_recipient PASSED [ 84%]
 tests/test_settings.py::test_settings_page_loads PASSED                  [ 84%]
 tests/test_settings.py::test_settings_profile_page_renders_updated_profile_copy PASSED [ 84%]
@@ -4299,12 +4631,12 @@ tests/test_settings.py::test_invalid_password_post_shows_only_password_errors_an
 tests/test_settings.py::test_username_post_does_not_trigger_password_form_validation PASSED [ 84%]
 tests/test_settings.py::test_password_post_does_not_trigger_username_form_validation PASSED [ 84%]
 tests/test_settings.py::test_change_password PASSED                      [ 84%]
-tests/test_settings.py::test_change_password_revokes_sibling_session PASSED [ 84%]
-tests/test_settings.py::test_change_password_from_native_werkzeug_scrypt_hash PASSED [ 84%]
-tests/test_settings.py::test_change_password_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 84%]
-tests/test_settings.py::test_add_pgp_key PASSED                          [ 84%]
-tests/test_settings.py::test_add_invalid_pgp_key PASSED                  [ 84%]
-tests/test_settings.py::test_encryption_invalid_manual_key_form_shows_only_manual_key_errors PASSED [ 84%]
+tests/test_settings.py::test_change_password_revokes_sibling_session PASSED [ 85%]
+tests/test_settings.py::test_change_password_from_native_werkzeug_scrypt_hash PASSED [ 85%]
+tests/test_settings.py::test_change_password_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 85%]
+tests/test_settings.py::test_add_pgp_key PASSED                          [ 85%]
+tests/test_settings.py::test_add_invalid_pgp_key PASSED                  [ 85%]
+tests/test_settings.py::test_encryption_invalid_manual_key_form_shows_only_manual_key_errors PASSED [ 85%]
 tests/test_settings.py::test_add_pgp_key_without_encryption_subkey PASSED [ 85%]
 tests/test_settings.py::test_add_pgp_key_proton_redirects_to_encryption PASSED [ 85%]
 tests/test_settings.py::test_add_pgp_key_proton_invalid_form_redirects_index PASSED [ 85%]
@@ -4318,12 +4650,12 @@ tests/test_settings.py::test_update_smtp_settings_reject_private_host PASSED [ 8
 tests/test_settings.py::test_notifications_invalid_email_forwarding_post_shows_only_forwarding_errors PASSED [ 85%]
 tests/test_settings.py::test_add_notification_recipient PASSED           [ 85%]
 tests/test_settings.py::test_free_user_cannot_add_second_notification_recipient PASSED [ 85%]
-tests/test_settings.py::test_business_user_can_add_second_notification_recipient PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_page_renders_proton_lookup PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_proton_lookup_prefills_form PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_proton_lookup_invalid_email_returns_400 PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_proton_lookup_error_returns_400 PASSED [ 85%]
-tests/test_settings.py::test_add_notification_recipient_rejects_invalid_pgp_key PASSED [ 85%]
+tests/test_settings.py::test_business_user_can_add_second_notification_recipient PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_page_renders_proton_lookup PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_prefills_form PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_invalid_email_returns_400 PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_error_returns_400 PASSED [ 86%]
+tests/test_settings.py::test_add_notification_recipient_rejects_invalid_pgp_key PASSED [ 86%]
 tests/test_settings.py::test_add_notification_recipient_rejects_non_encryptable_pgp_key PASSED [ 86%]
 tests/test_settings.py::test_edit_notification_recipient PASSED          [ 86%]
 tests/test_settings.py::test_notification_recipient_page_missing_recipient_redirects_to_notifications PASSED [ 86%]
@@ -4337,11 +4669,11 @@ tests/test_settings.py::test_enabled_recipient_requires_key_when_content_include
 tests/test_settings.py::test_notifications_page_rejects_content_toggle_without_encryptable_recipient PASSED [ 86%]
 tests/test_settings.py::test_notifications_page_lists_recipient_drill_ins_for_business_user PASSED [ 86%]
 tests/test_settings.py::test_notifications_page_uses_any_message_recipient_key_for_message_capable_warning PASSED [ 86%]
-tests/test_settings.py::test_notifications_page_shows_upgrade_when_free_user_reaches_recipient_limit PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_page_renders_edit_form PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_page_groups_toggles_together PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_toggle_enabled_rejects_unencryptable_recipient PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_toggle_enabled_can_enable_recipient PASSED [ 86%]
+tests/test_settings.py::test_notifications_page_shows_upgrade_when_free_user_reaches_recipient_limit PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_page_renders_edit_form PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_page_groups_toggles_together PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_toggle_enabled_rejects_unencryptable_recipient PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_toggle_enabled_can_enable_recipient PASSED [ 87%]
 tests/test_settings.py::test_notification_recipient_page_rejects_content_toggle_without_encryptable_recipient PASSED [ 87%]
 tests/test_settings.py::test_notification_recipient_page_toggle_include_content_enables PASSED [ 87%]
 tests/test_settings.py::test_notification_recipient_page_toggle_include_content_disables PASSED [ 87%]
@@ -4356,11 +4688,11 @@ tests/test_settings.py::test_toggle_notifications_setting PASSED         [ 87%]
 tests/test_settings.py::test_toggle_include_content_setting PASSED       [ 87%]
 tests/test_settings.py::test_toggle_encrypt_entire_body_setting PASSED   [ 87%]
 tests/test_settings.py::test_toggle_recipient_enabled_setting PASSED     [ 87%]
-tests/test_settings.py::test_notifications_invalid_post_returns_400 PASSED [ 87%]
-tests/test_settings.py::test_add_alias PASSED                            [ 87%]
-tests/test_settings.py::test_add_alias_fails_when_alias_mode_is_never PASSED [ 87%]
-tests/test_settings.py::test_add_alias_not_exceed_max PASSED             [ 87%]
-tests/test_settings.py::test_add_alias_duplicate PASSED                  [ 87%]
+tests/test_settings.py::test_notifications_invalid_post_returns_400 PASSED [ 88%]
+tests/test_settings.py::test_add_alias PASSED                            [ 88%]
+tests/test_settings.py::test_add_alias_fails_when_alias_mode_is_never PASSED [ 88%]
+tests/test_settings.py::test_add_alias_not_exceed_max PASSED             [ 88%]
+tests/test_settings.py::test_add_alias_duplicate PASSED                  [ 88%]
 tests/test_settings.py::test_add_alias_duplicate_case_insensitive PASSED [ 88%]
 tests/test_settings.py::test_alias_page_loads PASSED                     [ 88%]
 tests/test_settings.py::test_delete_alias PASSED                         [ 88%]
@@ -4375,11 +4707,11 @@ tests/test_settings.py::test_change_profile_location PASSED              [ 88%]
 tests/test_settings.py::test_change_profile_location_clears_incomplete_dependency_chain PASSED [ 88%]
 tests/test_settings.py::test_change_profile_location_clears_city_when_city_field_is_omitted PASSED [ 88%]
 tests/test_settings.py::test_profile_states_endpoint_returns_country_scoped_options PASSED [ 88%]
-tests/test_settings.py::test_profile_cities_endpoint_returns_state_scoped_options PASSED [ 88%]
-tests/test_settings.py::test_alias_change_bio PASSED                     [ 88%]
-tests/test_settings.py::test_alias_change_bio_invalid_post_renders_error_and_preserves_submitted_bio PASSED [ 88%]
-tests/test_settings.py::test_alias_change_bio_preserves_account_category PASSED [ 88%]
-tests/test_settings.py::test_alias_change_bio_preserves_account_location PASSED [ 88%]
+tests/test_settings.py::test_profile_cities_endpoint_returns_state_scoped_options PASSED [ 89%]
+tests/test_settings.py::test_alias_change_bio PASSED                     [ 89%]
+tests/test_settings.py::test_alias_change_bio_invalid_post_renders_error_and_preserves_submitted_bio PASSED [ 89%]
+tests/test_settings.py::test_alias_change_bio_preserves_account_category PASSED [ 89%]
+tests/test_settings.py::test_alias_change_bio_preserves_account_location PASSED [ 89%]
 tests/test_settings.py::test_change_directory_visibility PASSED          [ 89%]
 tests/test_settings.py::test_alias_change_directory_visibility PASSED    [ 89%]
 tests/test_settings.py::test_update_brand_primary_color PASSED           [ 89%]
@@ -4394,10 +4726,10 @@ tests/test_settings.py::test_update_guidance_emergency_exit PASSED       [ 89%]
 tests/test_settings.py::test_update_guidance_emergency_exit_requires_url PASSED [ 89%]
 tests/test_settings.py::test_update_guidance_prompts PASSED              [ 89%]
 tests/test_settings.py::test_update_guidance_prompt_accepts_expanded_length PASSED [ 89%]
-tests/test_settings.py::test_update_guidance_prompt_rejects_text_over_expanded_length PASSED [ 89%]
-tests/test_settings.py::test_diretory_intro_text PASSED                  [ 89%]
-tests/test_settings.py::test_directory_intro_text_reset_to_default PASSED [ 89%]
-tests/test_settings.py::test_directory_intro_text_reset_aborts_when_multiple_rows_would_delete PASSED [ 89%]
+tests/test_settings.py::test_update_guidance_prompt_rejects_text_over_expanded_length PASSED [ 90%]
+tests/test_settings.py::test_diretory_intro_text PASSED                  [ 90%]
+tests/test_settings.py::test_directory_intro_text_reset_to_default PASSED [ 90%]
+tests/test_settings.py::test_directory_intro_text_reset_aborts_when_multiple_rows_would_delete PASSED [ 90%]
 tests/test_settings.py::test_homepage_user PASSED                        [ 90%]
 tests/test_settings.py::test_homepage_reset_when_already_default PASSED  [ 90%]
 tests/test_settings.py::test_homepage_reset_multiple_rows_error PASSED   [ 90%]
@@ -4413,10 +4745,10 @@ tests/test_settings.py::test_alias_fields_enabled PASSED                 [ 90%]
 tests/test_settings.py::test_alias_fields_disabled PASSED                [ 90%]
 tests/test_settings.py::test_hide_donate_button PASSED                   [ 90%]
 tests/test_settings.py::test_encryption_post_invalid_form_returns_400 PASSED [ 90%]
-tests/test_settings.py::test_alias_route_missing_alias_returns_404 PASSED [ 90%]
-tests/test_settings.py::test_delete_alias_missing_alias_returns_404 PASSED [ 90%]
-tests/test_settings.py::test_alias_fields_missing_alias_redirects_index PASSED [ 90%]
-tests/test_settings.py::test_alias_route_invalid_post_returns_400 PASSED [ 90%]
+tests/test_settings.py::test_alias_route_missing_alias_returns_404 PASSED [ 91%]
+tests/test_settings.py::test_delete_alias_missing_alias_returns_404 PASSED [ 91%]
+tests/test_settings.py::test_alias_fields_missing_alias_redirects_index PASSED [ 91%]
+tests/test_settings.py::test_alias_route_invalid_post_returns_400 PASSED [ 91%]
 tests/test_settings.py::test_alias_fields_post_uses_handle_field_post_result PASSED [ 91%]
 tests/test_settings.py::test_profile_route_raises_if_primary_username_missing PASSED [ 91%]
 tests/test_settings.py::test_profile_fields_raises_if_primary_username_missing PASSED [ 91%]
@@ -4432,10 +4764,10 @@ tests/test_settings.py::test_alias_fields_invalid_add_post_renders_errors_withou
 tests/test_settings_common.py::test_set_and_unset_field_attribute PASSED [ 91%]
 tests/test_settings_common.py::test_set_input_disabled_toggle PASSED     [ 91%]
 tests/test_settings_common.py::test_settings_forms_reject_disallowed_language PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_account_category PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_country PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_subdivision_for_country PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_city_for_subdivision PASSED [ 91%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_account_category PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_country PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_subdivision_for_country PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_city_for_subdivision PASSED [ 92%]
 tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[] PASSED [ 92%]
 tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[   ] PASSED [ 92%]
 tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[Atlantis] PASSED [ 92%]
@@ -4451,9 +4783,9 @@ tests/test_settings_common.py::test_normalize_city_name_returns_none_for_unresol
 tests/test_settings_common.py::test_normalize_subdivision_name_returns_trimmed_value_for_unknown_country PASSED [ 92%]
 tests/test_settings_common.py::test_profile_form_allows_empty_city_without_normalizing PASSED [ 92%]
 tests/test_settings_common.py::test_profile_form_validate_city_returns_early_for_blank_field PASSED [ 92%]
-tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_country_choice PASSED [ 92%]
-tests/test_settings_common.py::test_strip_whitespace_leaves_non_string_values_unchanged PASSED [ 92%]
-tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_subdivision_and_city_labels PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_country_choice PASSED [ 93%]
+tests/test_settings_common.py::test_strip_whitespace_leaves_non_string_values_unchanged PASSED [ 93%]
+tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_subdivision_and_city_labels PASSED [ 93%]
 tests/test_settings_common.py::test_city_choice_label_returns_raw_value_when_lookup_is_ambiguous PASSED [ 93%]
 tests/test_settings_common.py::test_profile_form_account_category_choices_are_split PASSED [ 93%]
 tests/test_settings_common.py::test_create_profile_forms_disables_location_inputs_until_dependencies PASSED [ 93%]
@@ -4470,9 +4802,9 @@ tests/test_settings_common.py::test_is_safe_verification_url_resolved_public_all
 tests/test_settings_common.py::test_resolve_safe_verification_url_returns_pinned_addresses PASSED [ 93%]
 tests/test_settings_common.py::test_static_verification_resolver_refuses_unvalidated_hosts PASSED [ 93%]
 tests/test_settings_common.py::test_resolve_safe_verification_url_rejects_when_no_usable_addresses PASSED [ 93%]
-tests/test_settings_common.py::test_fetch_verification_html_disables_redirects PASSED [ 93%]
-tests/test_settings_common.py::test_fetch_verification_html_uses_pinned_address_connector PASSED [ 93%]
-tests/test_settings_common.py::test_is_safe_verification_url_direct_private_ip_rejected PASSED [ 93%]
+tests/test_settings_common.py::test_fetch_verification_html_disables_redirects PASSED [ 94%]
+tests/test_settings_common.py::test_fetch_verification_html_uses_pinned_address_connector PASSED [ 94%]
+tests/test_settings_common.py::test_is_safe_verification_url_direct_private_ip_rejected PASSED [ 94%]
 tests/test_settings_common.py::test_is_safe_verification_url_resolved_blocked_ip_rejected PASSED [ 94%]
 tests/test_settings_common.py::test_verify_url_handles_client_error PASSED [ 94%]
 tests/test_settings_common.py::test_verify_url_returns_early_when_url_is_not_safe PASSED [ 94%]
@@ -4489,8 +4821,8 @@ tests/test_settings_common.py::test_handle_change_username_form_internal_error_f
 tests/test_settings_common.py::test_handle_change_password_form_rejects_wrong_old_password PASSED [ 94%]
 tests/test_settings_common.py::test_handle_pgp_key_form_empty_value_clears_only_public_key PASSED [ 94%]
 tests/test_settings_common.py::test_handle_profile_post_invalid_form_returns_none PASSED [ 94%]
-tests/test_settings_common.py::test_handle_profile_post_updates_directory_visibility PASSED [ 94%]
-tests/test_settings_common.py::test_handle_field_post_add_branch PASSED  [ 94%]
+tests/test_settings_common.py::test_handle_profile_post_updates_directory_visibility PASSED [ 95%]
+tests/test_settings_common.py::test_handle_field_post_add_branch PASSED  [ 95%]
 tests/test_settings_common.py::test_handle_field_post_update_branch PASSED [ 95%]
 tests/test_settings_common.py::test_handle_field_post_delete_branch PASSED [ 95%]
 tests/test_settings_common.py::test_handle_field_post_move_up_and_down_branches PASSED [ 95%]
@@ -4508,8 +4840,8 @@ tests/test_settings_registration.py::test_registration_create_invite_code PASSED
 tests/test_settings_registration.py::test_registration_delete_invite_code PASSED [ 95%]
 tests/test_settings_registration.py::test_registration_delete_invite_code_not_found PASSED [ 95%]
 tests/test_settings_registration.py::test_registration_invalid_form_submission PASSED [ 95%]
-tests/test_settings_registration.py::test_registration_invalid_delete_submission_preserves_redirect_and_flash PASSED [ 95%]
-tests/test_settings_registration.py::test_registration_missing_csrf_redirects_with_invalid_submission_flash PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_invalid_delete_submission_preserves_redirect_and_flash PASSED [ 96%]
+tests/test_settings_registration.py::test_registration_missing_csrf_redirects_with_invalid_submission_flash PASSED [ 96%]
 tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_enable_when_not_configured PASSED [ 96%]
 tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_disable_when_already_configured PASSED [ 96%]
 tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_login_without_user_id PASSED [ 96%]
@@ -4527,8 +4859,8 @@ tests/test_splash_screen.py::test_first_load_splash_duration_uses_runtime_config
 tests/test_splash_screen.py::test_first_load_splash_uses_brand_logo_fallback PASSED [ 96%]
 tests/test_splash_screen.py::test_first_load_splash_uses_custom_splash_logo PASSED [ 96%]
 tests/test_splash_screen.py::test_first_load_splash_uses_versioned_custom_splash_logo PASSED [ 96%]
-tests/test_splash_screen.py::test_first_load_splash_defaults_to_disabled PASSED [ 96%]
-tests/test_splash_screen.py::test_first_load_splash_can_be_disabled PASSED [ 96%]
+tests/test_splash_screen.py::test_first_load_splash_defaults_to_disabled PASSED [ 97%]
+tests/test_splash_screen.py::test_first_load_splash_can_be_disabled PASSED [ 97%]
 tests/test_static_typing_config.py::test_mypy_targets_python_313_semantics PASSED [ 97%]
 tests/test_storage.py::TestFsDriver::test_put_and_serve PASSED           [ 97%]
 tests/test_storage.py::TestFsDriver::test_put_and_delete PASSED          [ 97%]
@@ -4546,7 +4878,7 @@ tests/test_storage.py::test_blob_storage_abort_when_driver_not_configured PASSED
 tests/test_user_profile_location.py::test_user_new_session_id_returns_distinct_tokens PASSED [ 97%]
 tests/test_user_profile_location.py::test_profile_location_returns_country_when_us_geography_only_has_country PASSED [ 97%]
 tests/test_user_profile_location.py::test_profile_location_spells_out_state_when_city_missing PASSED [ 97%]
-tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_state_missing PASSED [ 97%]
+tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_state_missing PASSED [ 98%]
 tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_it_is_the_only_field PASSED [ 98%]
 tests/test_user_profile_location.py::test_profile_location_returns_none_for_inconsistent_empty_us_geography PASSED [ 98%]
 tests/test_utils.py::test_redirect_to_self_uses_current_endpoint_and_view_args PASSED [ 98%]
@@ -4565,7 +4897,7 @@ tests/test_vision.py::test_vision_redirects_to_login_when_session_user_missing P
 tests/test_vision.py::test_vision_redirects_with_flash_when_user_missing_after_auth PASSED [ 98%]
 tests/test_vision.py::test_vision_renders_for_free_user PASSED           [ 98%]
 tests/test_vision.py::test_vision_renders_for_paid_user PASSED           [ 98%]
-tests/test_weekly_agent_report_runner.py::test_report_addresses_and_title_are_fixed PASSED [ 98%]
+tests/test_weekly_agent_report_runner.py::test_report_addresses_and_title_are_fixed PASSED [ 99%]
 tests/test_weekly_agent_report_runner.py::test_default_sources_match_monitored_logs PASSED [ 99%]
 tests/test_weekly_agent_report_runner.py::test_collect_events_from_hushline_runner_log PASSED [ 99%]
 tests/test_weekly_agent_report_runner.py::test_parse_log_timestamp_uses_timezone_abbreviation_during_fallback PASSED [ 99%]
@@ -4587,44 +4919,93 @@ tests/test_workflow_pr_head_qualification.py::test_tests_workflow_lint_job_uses_
 tests/test_workflow_pr_head_qualification.py::test_dependency_audit_workflow_only_runs_python_audit_when_poetry_lock_changes PASSED [100%]
 
 =================================== FAILURES ===================================
-_______ test_encrypted_field_migration_runbook_locks_security_guardrails _______
+______ test_downgrade_preserves_mixed_ciphertexts_readable_by_dual_reader ______
 
-    def test_encrypted_field_migration_runbook_locks_security_guardrails() -> None:
-        content = _runbook_text().lower()
+app = <Flask 'hushline'>
+monkeypatch = <_pytest.monkeypatch.MonkeyPatch object at 0xffff67866890>
+
+    def test_downgrade_preserves_mixed_ciphertexts_readable_by_dual_reader(
+        app: Flask,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        cfg = typing.cast(alembic.config.Config, migrate.get_config())
+        command.upgrade(cfg, "b2039e7c0a1d")
+        monkeypatch.setenv("ENCRYPTION_KEY", LEGACY_FERNET_KEY)
+        app.config[ENCRYPTED_FIELD_WRITE_FORMAT] = EncryptedFieldWriteFormat.ENVELOPE_FERNET
     
-        required_phrases = (
-            "keep the dual reader deployed",
-            "keep legacy fernet read support enabled",
-            "must not edit historical alembic",
-            "do not drop, blank, truncate, or overwrite source ciphertext",
-            "do not assume a maintenance window",
-            "stop before live mode if any non-empty row cannot be classified or decrypted",
-            "dry-run mode must execute the same selection, classification, decryption",
-            "skip rows already in the target envelope format after verifying",
-            "the replacement plaintext exactly matches the source plaintext",
-            "backups without matching encrypted-field key material are not complete",
-            "must not include plaintext or full ciphertext",
-            "rollback must preserve the old reader",
+        mod = __import__(
+            "tests.migrations.revision_b2039e7c0a1d",
+            fromlist=["RollbackReadabilityTester"],
         )
+        rollback_tester = mod.RollbackReadabilityTester()
+        rollback_tester.load_data()
+        db.session.close()
     
-        for phrase in required_phrases:
->           assert phrase in content
-E           assert 'must not include plaintext or full ciphertext' in "# encrypted field migration runbook\n\ndate: 2026-05-26\n\nstatus: draft for rehearsal before production use\n\n## scope\n\nthis runbook defines the required operating plan for a future migration that\nrewrites existing encrypted database fields from legacy fernet ciphertext to a\nnew encrypted-field envelope. it covers local, staging, and production\nexecution, but it does not introduce migration helper code and must not be used\nuntil maintainers approve the specific helper, target format, and rollout\nconfiguration.\n\nthe encrypted-field inventory is the code-owned contract in\n`hushline.crypto.encrypted_field_contracts` and the protected-field table in\n[`encrypted-field-modernization-adr.md`](encrypted-field-modernization-adr.md).\nthe migration must remain forward-only and must not edit historical alembic\nmigrations.\n\n## operator guardrails\n\n- keep the dual reader deployed before, during, and after the migration.\n- keep legacy fernet read support enabled until migration completion and the\n  rollback window are explicitly closed.\n- do not drop, blank, truncate, or overwrite source ciphertext before the\n  replacement value has been decrypted and verified for that row.\n- do not assume a maintenance window. run in small batches while normal reads\n  and writes continue unless maintainers explicitly approve downtime.\n- do not log plaintext, private keys, raw encrypted-field secrets, or full\n  ciphertext values.\n- do not combine this migration with password hashing, flask session secret,\n  application secret management, or unrelated schema changes.\n\n## environments\n\n### local\n\nuse local execution to prove the helper mechanics against seeded and synthetic\nrecords before staging data is touched.\n\n1. run the helper in dry-run mode against local data.\n2. confirm every inventory entry reports row counts, legacy-format counts,\n   target-format counts, and decryptability results.\n3. run a small live batch against disposable local data.\n4. stop the helper mid-run, then resume it with the same target format and batch\n   size.\n5. confirm already migrated rows are skipped and remaining rows continue.\n\n### staging\n\nuse staging as the production rehearsal. staging must use production-like\nconfiguration, data volume, and key-management procedures without exposing\nproduction plaintext.\n\n1. confirm the deployed application reads both legacy fernet and target envelope\n   values.\n2. capture preflight row counts and decryptability checks.\n3. rehearse backup creation and restore into a separate staging database.\n4. run dry-run mode and review the progress and failure report.\n5. run live migration in small batches, including at least one intentional\n   interruption and resume.\n6. verify application reads, settings updates, notification recipient updates,\n   inbox reads, resend behavior, and data export for migrated rows.\n7. rehearse rollback with the old reader still deployed.\n\n### production\n\nproduction execution requires maintainer approval after staging evidence is\nreviewed. use the same helper version, target format, batch size ceiling, and\nrollback plan proven in staging.\n\n1. confirm the current release includes the dual reader and that legacy fernet\n   reads are still enabled.\n2. confirm recent backups exist and a restore rehearsal has succeeded for the\n   same database version and key material.\n3. run preflight checks and dry-run mode.\n4. start with a small live batch. increase batch size only after error-free\n   progress and normal application health are observed.\n5. pause between batches when needed; do not hold long transactions across the\n   full inventory.\n6. keep the old reader deployed after completion until post-migration\n   verification and rollback criteria have passed.\n\n## preflight checks\n\npreflight must be read-only and must fail closed before any write occurs.\n\n- confirm the deployed code can read legacy fernet and the target envelope\n  format.\n- confirm `encryption_key` and any future encrypted-field key material are\n  present through the approved secret path for the environment.\n- confirm the target write format is explicitly configured for the planned\n  migration.\n- confirm the database revision is the expected forward-only revision.\n- count rows for each encrypted-field contract:\n  - total rows in the table\n  - rows with null or empty encrypted values\n  - rows with legacy fernet ciphertext\n  - rows with target envelope ciphertext\n  - rows with unknown or malformed ciphertext\n- decrypt every non-empty encrypted value, or sample only if maintainers approve\n  a documented sampling plan for very large production tables.\n- report counts by contract id, table, column, and ciphertext format.\n- stop before live mode if any non-empty row cannot be classified or decrypted.\n\n## dry-run behavior\n\ndry-run mode must execute the same selection, classification, decryption,\nreencryption, and verification path as live mode, except for database writes.\n\nfor each candidate row, dry-run mode must:\n\n1. load the row using the same ordering used by live batches.\n2. classify the existing ciphertext format.\n3. decrypt the existing ciphertext through the production reader.\n4. build the replacement ciphertext using the target writer.\n5. decrypt the replacement ciphertext through the production reader.\n6. compare replacement plaintext with source plaintext in memory.\n7. emit counters and row identifiers only, never plaintext or full ciphertext.\n\ndry-run output must include eligible rows, skipped rows, already migrated rows,\nverification failures, decrypt failures, and the next resume position that live\nmode would use.\n\n## small-batch execution\n\nlive migration must process bounded batches. the default batch size should be\nsmall enough to avoid long locks, large transactions, and operational surprise;\nproduction batch-size increases require operator review of staging timing and\nproduction health.\n\nfor each batch:\n\n1. select rows in stable primary-key order for one encrypted-field contract.\n2. lock only the rows being processed when the helper needs write consistency.\n3. decrypt the source ciphertext.\n4. create the replacement ciphertext without mutating the source value.\n5. decrypt and verify the replacement ciphertext.\n6. write the replacement only after verification succeeds.\n7. commit the batch.\n8. emit progress for the contract, last processed primary key, rows migrated,\n   rows skipped, and failures.\n\nif any row fails decryption, reencryption, verification, or update, the helper\nmust leave that row's original ciphertext intact, record the failure, and stop\nor quarantine according to maintainer-approved helper behavior.\n\n## idempotent resume\n\nresume behavior must be safe after process crashes, deploy restarts, database\nfailover, and operator cancellation.\n\n- classify each row by its current stored format on every run.\n- skip rows already in the target envelope format after verifying they still\n  decrypt.\n- reprocess legacy-format rows even if their primary key is lower than the last\n  reported resume position when the operator explicitly requests a full scan.\n- store or print a resume token containing only contract id, last processed\n  primary key, target format, helper version, and batch size.\n- reject resume when the helper version, target format, or encrypted-field\n  contract set differs from the dry-run or prior live execution unless\n  maintainers approve a new dry run.\n- treat rerunning the helper from the beginning as valid and non-destructive.\n\n## per-row verification\n\nevery rewritten row must be verified before source ciphertext is replaced.\n\nverification must prove:\n\n- the source ciphertext decrypts through the old reader.\n- the candidate replacement decrypts through the deployed reader.\n- the replacement plaintext exactly matches the source plaintext.\n- the replacement uses the expected contract id, domain, table, column, and aad\n  values for the row.\n- the database update affects exactly one expected row.\n- a post-update read decrypts to the same plaintext before the batch is counted\n  as migrated.\n\nverification failures are migration blockers. do not continue to later batches\nuntil maintainers have reviewed the failure class and decided whether to fix\nhelper code, repair data, restore from backup, or retry.\n\n## backup and restore rehearsal\n\nbefore production live mode, operators must complete and document a restore\nrehearsal.\n\nthe rehearsal must confirm:\n\n- a database backup can be restored into an isolated environment.\n- the restored environment has the matching encrypted-field key material.\n- legacy fernet rows decrypt after restore.\n- target envelope rows decrypt after restore.\n- the migration helper can dry-run against the restored database.\n- rollback can run on restored data while the old reader remains deployed.\n\nbackups without matching encrypted-field key material are not complete recovery\nartifacts for this migration.\n\n## progress and failure reporting\n\nmigration output must be observable without exposing sensitive values.\n\nrequired progress fields:\n\n- helper version\n- environment name\n- dry-run or live mode\n- contract id\n- table and column\n- batch size\n- last processed primary key\n- total candidate rows\n- already migrated rows\n- migrated rows\n- skipped rows\n- decrypt failures\n- verification failures\n- update failures\n- elapsed time\n- next resume token\n\nfailure reports must include the contract id, primary key, failure phase, error\nclass, and whether the source ciphertext was left unchanged. they must not\ninclude plaintext or full ciphertext.\n\n## rollback\n\nrollback must preserve the old reader. the safest rollback for application code\nis to redeploy a release that still reads both legacy fernet and target envelope\nvalues, then set new writes back to the previously approved format while\noperators investigate.\n\nrollback requirements:\n\n1. do not remove legacy fernet read support.\n2. do not run a destructive down migration against encrypted-field data.\n3. if live migration has started, keep migrated target-envelope rows readable by\n   the deployed dual reader.\n4. if helper code supports reverse rewriting, run it only after a restore\n   rehearsal proves target-envelope values can be converted back to legacy\n   fernet and per-row verified.\n5. if helper behavior is suspected, stop the helper, keep the dual reader\n   deployed, and restore from the rehearsed backup only if maintainers decide\n   the mixed-format database is unsafe to keep serving.\n6. after rollback, rerun preflight decryptability checks across all encrypted\n   field contracts and verify normal application reads.\n\nrollback is not complete until both legacy-format and target-format rows that\nremain in the database are readable by the deployed application.\n\n## completion criteria\n\nthe migration can be considered complete only after:\n\n- all encrypted-field contracts have zero unexpected-format rows\n- every non-empty encrypted value decrypts through the deployed reader\n- dry-run mode reports no remaining live changes\n- application flows that read encrypted fields pass manual review in production\n- backups taken after migration have been restored and decryptability checked\n- maintainers explicitly approve closing the rollback window\n\nlegacy fernet read support may be removed only in a later issue after the\nrollback window is closed and a separate removal plan is approved.\n"
+        command.downgrade(cfg, "-1")
+        app.config[ENCRYPTED_FIELD_WRITE_FORMAT] = EncryptedFieldWriteFormat.LEGACY_FERNET
+    
+        for encrypted_value in rollback_tester.encrypted_values():
+            decrypted_value = crypto.decrypt_field(encrypted_value)
+            assert decrypted_value is not None
+>           assert decrypted_value.startswith(("legacy", "recipient", "safe"))
+E           AssertionError: assert False
+E            +  where False = <built-in method startswith of str object at 0xffff69e831f0>(('legacy', 'recipient', 'safe'))
+E            +    where <built-in method startswith of str object at 0xffff69e831f0> = 'smtp.legacy.example'.startswith
 
-tests/test_encrypted_field_migration_runbook.py:59: AssertionError
+tests/test_migrations.py:265: AssertionError
+---------------------------- Captured stdout setup -----------------------------
+Postgres DB: veeaflwbritgbceo, template: app_db_template
+----------------------------- Captured stderr call -----------------------------
+INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
+INFO  [alembic.runtime.migration] Will assume transactional DDL.
+INFO  [alembic.runtime.migration] Running upgrade  -> 691dba936e64, Initial migration
+INFO  [alembic.runtime.migration] Running upgrade 691dba936e64 -> ff59dfd3bdf6, add AuthenticationLog
+INFO  [alembic.runtime.migration] Running upgrade ff59dfd3bdf6 -> 568f77aefcb4, add timecode to AuthenticationLog
+INFO  [alembic.runtime.migration] Running upgrade 568f77aefcb4 -> 6e53eac9ea14, smtp encryption protocol
+INFO  [alembic.runtime.migration] Running upgrade 6e53eac9ea14 -> 166a3402c391, add extra fields to user
+INFO  [alembic.runtime.migration] Running upgrade 166a3402c391 -> 83a6b3b09eca, add verified fields
+INFO  [alembic.runtime.migration] Running upgrade 83a6b3b09eca -> 62551ed63cbf, make boolean fields required
+INFO  [alembic.runtime.migration] Running upgrade 62551ed63cbf -> 46aedec8fd9b, create alias tables
+INFO  [alembic.runtime.migration] Running upgrade 46aedec8fd9b -> 5ffe5a5c8e9a, update entities to match metadata
+INFO  [alembic.runtime.migration] Running upgrade 5ffe5a5c8e9a -> 5410668e15ad, add host_organization table
+INFO  [alembic.runtime.migration] Running upgrade 5410668e15ad -> be0744a5679f, add stripe tables
+INFO  [alembic.runtime.migration] Running upgrade be0744a5679f -> 0b1321c8de13, host org to settings kv table
+INFO  [alembic.runtime.migration] Running upgrade 0b1321c8de13 -> 06b343c38386, rename index
+INFO  [alembic.runtime.migration] Running upgrade 06b343c38386 -> cf2a880aff10, add message status text table
+INFO  [alembic.runtime.migration] Running upgrade cf2a880aff10 -> 4a53667aff6e, add FieldDefinition and FieldValue
+INFO  [alembic.runtime.migration] Running upgrade 4a53667aff6e -> 6071f1eea074, add user email settings
+INFO  [alembic.runtime.migration] Running upgrade 6071f1eea074 -> f32aa741ddc4, add user.email_encrypt_entire_body
+INFO  [alembic.runtime.migration] Running upgrade f32aa741ddc4 -> b6a1e3f5a2b1, add message public id
+INFO  [alembic.runtime.migration] Running upgrade b6a1e3f5a2b1 -> 7d6a9f2f8c1a, Add onboarding complete flag to users.
+INFO  [alembic.runtime.migration] Running upgrade 7d6a9f2f8c1a -> 2e3e5b1f2b3c, fix field definition nullability and field value fk
+INFO  [alembic.runtime.migration] Running upgrade 2e3e5b1f2b3c -> 9f7c4c3ea9a1, add user session_id
+INFO  [alembic.runtime.migration] Running upgrade 9f7c4c3ea9a1 -> 3c1b2a4d5e6f, add case-insensitive username index
+INFO  [alembic.runtime.migration] Running upgrade 3c1b2a4d5e6f -> 8f3f1f0a1b2c, add user account category
+INFO  [alembic.runtime.migration] Running upgrade 8f3f1f0a1b2c -> 1a2b3c4d5e6a, add user location fields
+INFO  [alembic.runtime.migration] Running upgrade 1a2b3c4d5e6a -> c4f8e2a1b6d9, add user cautious flag
+INFO  [alembic.runtime.migration] Running upgrade c4f8e2a1b6d9 -> 84f1d3b2c6e7, add user suspended flag
+INFO  [alembic.runtime.migration] Running upgrade 84f1d3b2c6e7 -> d1f0e9c2b7aa, add notification recipients
+INFO  [alembic.runtime.migration] Running upgrade d1f0e9c2b7aa -> 2d8a1f7c9b41, add password reset tables
+INFO  [alembic.runtime.migration] Running upgrade 2d8a1f7c9b41 -> 7b9c2d1e4f60, add embeddable form policy fields
+INFO  [alembic.runtime.migration] Running upgrade 7b9c2d1e4f60 -> a4c8f2d9e713, add embed rate limit attempts
+INFO  [alembic.runtime.migration] Running upgrade a4c8f2d9e713 -> b2039e7c0a1d, widen encrypted columns for envelopes
+INFO  [alembic.runtime.migration] Context impl PostgresqlImpl.
+INFO  [alembic.runtime.migration] Will assume transactional DDL.
+INFO  [alembic.runtime.migration] Running downgrade b2039e7c0a1d -> a4c8f2d9e713, widen encrypted columns for envelopes
 
 ---------- coverage: platform linux, python 3.13.13-final-0 ----------
 Name                                             Stmts   Miss  Cover
 --------------------------------------------------------------------
-hushline/__init__.py                               160      0   100%
+hushline/__init__.py                               162      0   100%
 hushline/admin.py                                  187      0   100%
 hushline/auth.py                                    73      0   100%
+hushline/cli_encrypted_field.py                    400     65    84%
 hushline/cli_password_hash.py                       56      0   100%
 hushline/cli_reg.py                                 47      0   100%
 hushline/cli_stripe.py                              32      0   100%
 hushline/config.py                                 144      0   100%
 hushline/content_safety.py                          40      0   100%
-hushline/crypto.py                                 235     17    93%
+hushline/crypto.py                                 271     23    92%
 hushline/db.py                                       6      0   100%
 hushline/email.py                                  109      0   100%
 hushline/email_headers.py                          353      0   100%
@@ -4702,46 +5083,142 @@ hushline/user_deletion.py                           18      0   100%
 hushline/utils.py                                   21      0   100%
 hushline/version.py                                  1      0   100%
 --------------------------------------------------------------------
-TOTAL                                             9042     17    99%
+TOTAL                                             9480     88    99%
 Coverage HTML written to dir /tmp/hushline-htmlcov
 
 =========================== short test summary info ============================
-FAILED tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_locks_security_guardrails - assert 'must not include plaintext or full ciphertext' in "# encrypted field migration runbook\n\ndate: 2026-05-26\n\nstatus: draft for rehearsal before production use\n\n## scope\n\nthis runbook defines the required operating plan for a future migration that\nrewrites existing encrypted database fields from legacy fernet ciphertext to a\nnew encrypted-field envelope. it covers local, staging, and production\nexecution, but it does not introduce migration helper code and must not be used\nuntil maintainers approve the specific helper, target format, and rollout\nconfiguration.\n\nthe encrypted-field inventory is the code-owned contract in\n`hushline.crypto.encrypted_field_contracts` and the protected-field table in\n[`encrypted-field-modernization-adr.md`](encrypted-field-modernization-adr.md).\nthe migration must remain forward-only and must not edit historical alembic\nmigrations.\n\n## operator guardrails\n\n- keep the dual reader deployed before, during, and after the migration.\n- keep legacy fernet read support enabled until migration completion and the\n  rollback window are explicitly closed.\n- do not drop, blank, truncate, or overwrite source ciphertext before the\n  replacement value has been decrypted and verified for that row.\n- do not assume a maintenance window. run in small batches while normal reads\n  and writes continue unless maintainers explicitly approve downtime.\n- do not log plaintext, private keys, raw encrypted-field secrets, or full\n  ciphertext values.\n- do not combine this migration with password hashing, flask session secret,\n  application secret management, or unrelated schema changes.\n\n## environments\n\n### local\n\nuse local execution to prove the helper mechanics against seeded and synthetic\nrecords before staging data is touched.\n\n1. run the helper in dry-run mode against local data.\n2. confirm every inventory entry reports row counts, legacy-format counts,\n   target-format counts, and decryptability results.\n3. run a small live batch against disposable local data.\n4. stop the helper mid-run, then resume it with the same target format and batch\n   size.\n5. confirm already migrated rows are skipped and remaining rows continue.\n\n### staging\n\nuse staging as the production rehearsal. staging must use production-like\nconfiguration, data volume, and key-management procedures without exposing\nproduction plaintext.\n\n1. confirm the deployed application reads both legacy fernet and target envelope\n   values.\n2. capture preflight row counts and decryptability checks.\n3. rehearse backup creation and restore into a separate staging database.\n4. run dry-run mode and review the progress and failure report.\n5. run live migration in small batches, including at least one intentional\n   interruption and resume.\n6. verify application reads, settings updates, notification recipient updates,\n   inbox reads, resend behavior, and data export for migrated rows.\n7. rehearse rollback with the old reader still deployed.\n\n### production\n\nproduction execution requires maintainer approval after staging evidence is\nreviewed. use the same helper version, target format, batch size ceiling, and\nrollback plan proven in staging.\n\n1. confirm the current release includes the dual reader and that legacy fernet\n   reads are still enabled.\n2. confirm recent backups exist and a restore rehearsal has succeeded for the\n   same database version and key material.\n3. run preflight checks and dry-run mode.\n4. start with a small live batch. increase batch size only after error-free\n   progress and normal application health are observed.\n5. pause between batches when needed; do not hold long transactions across the\n   full inventory.\n6. keep the old reader deployed after completion until post-migration\n   verification and rollback criteria have passed.\n\n## preflight checks\n\npreflight must be read-only and must fail closed before any write occurs.\n\n- confirm the deployed code can read legacy fernet and the target envelope\n  format.\n- confirm `encryption_key` and any future encrypted-field key material are\n  present through the approved secret path for the environment.\n- confirm the target write format is explicitly configured for the planned\n  migration.\n- confirm the database revision is the expected forward-only revision.\n- count rows for each encrypted-field contract:\n  - total rows in the table\n  - rows with null or empty encrypted values\n  - rows with legacy fernet ciphertext\n  - rows with target envelope ciphertext\n  - rows with unknown or malformed ciphertext\n- decrypt every non-empty encrypted value, or sample only if maintainers approve\n  a documented sampling plan for very large production tables.\n- report counts by contract id, table, column, and ciphertext format.\n- stop before live mode if any non-empty row cannot be classified or decrypted.\n\n## dry-run behavior\n\ndry-run mode must execute the same selection, classification, decryption,\nreencryption, and verification path as live mode, except for database writes.\n\nfor each candidate row, dry-run mode must:\n\n1. load the row using the same ordering used by live batches.\n2. classify the existing ciphertext format.\n3. decrypt the existing ciphertext through the production reader.\n4. build the replacement ciphertext using the target writer.\n5. decrypt the replacement ciphertext through the production reader.\n6. compare replacement plaintext with source plaintext in memory.\n7. emit counters and row identifiers only, never plaintext or full ciphertext.\n\ndry-run output must include eligible rows, skipped rows, already migrated rows,\nverification failures, decrypt failures, and the next resume position that live\nmode would use.\n\n## small-batch execution\n\nlive migration must process bounded batches. the default batch size should be\nsmall enough to avoid long locks, large transactions, and operational surprise;\nproduction batch-size increases require operator review of staging timing and\nproduction health.\n\nfor each batch:\n\n1. select rows in stable primary-key order for one encrypted-field contract.\n2. lock only the rows being processed when the helper needs write consistency.\n3. decrypt the source ciphertext.\n4. create the replacement ciphertext without mutating the source value.\n5. decrypt and verify the replacement ciphertext.\n6. write the replacement only after verification succeeds.\n7. commit the batch.\n8. emit progress for the contract, last processed primary key, rows migrated,\n   rows skipped, and failures.\n\nif any row fails decryption, reencryption, verification, or update, the helper\nmust leave that row's original ciphertext intact, record the failure, and stop\nor quarantine according to maintainer-approved helper behavior.\n\n## idempotent resume\n\nresume behavior must be safe after process crashes, deploy restarts, database\nfailover, and operator cancellation.\n\n- classify each row by its current stored format on every run.\n- skip rows already in the target envelope format after verifying they still\n  decrypt.\n- reprocess legacy-format rows even if their primary key is lower than the last\n  reported resume position when the operator explicitly requests a full scan.\n- store or print a resume token containing only contract id, last processed\n  primary key, target format, helper version, and batch size.\n- reject resume when the helper version, target format, or encrypted-field\n  contract set differs from the dry-run or prior live execution unless\n  maintainers approve a new dry run.\n- treat rerunning the helper from the beginning as valid and non-destructive.\n\n## per-row verification\n\nevery rewritten row must be verified before source ciphertext is replaced.\n\nverification must prove:\n\n- the source ciphertext decrypts through the old reader.\n- the candidate replacement decrypts through the deployed reader.\n- the replacement plaintext exactly matches the source plaintext.\n- the replacement uses the expected contract id, domain, table, column, and aad\n  values for the row.\n- the database update affects exactly one expected row.\n- a post-update read decrypts to the same plaintext before the batch is counted\n  as migrated.\n\nverification failures are migration blockers. do not continue to later batches\nuntil maintainers have reviewed the failure class and decided whether to fix\nhelper code, repair data, restore from backup, or retry.\n\n## backup and restore rehearsal\n\nbefore production live mode, operators must complete and document a restore\nrehearsal.\n\nthe rehearsal must confirm:\n\n- a database backup can be restored into an isolated environment.\n- the restored environment has the matching encrypted-field key material.\n- legacy fernet rows decrypt after restore.\n- target envelope rows decrypt after restore.\n- the migration helper can dry-run against the restored database.\n- rollback can run on restored data while the old reader remains deployed.\n\nbackups without matching encrypted-field key material are not complete recovery\nartifacts for this migration.\n\n## progress and failure reporting\n\nmigration output must be observable without exposing sensitive values.\n\nrequired progress fields:\n\n- helper version\n- environment name\n- dry-run or live mode\n- contract id\n- table and column\n- batch size\n- last processed primary key\n- total candidate rows\n- already migrated rows\n- migrated rows\n- skipped rows\n- decrypt failures\n- verification failures\n- update failures\n- elapsed time\n- next resume token\n\nfailure reports must include the contract id, primary key, failure phase, error\nclass, and whether the source ciphertext was left unchanged. they must not\ninclude plaintext or full ciphertext.\n\n## rollback\n\nrollback must preserve the old reader. the safest rollback for application code\nis to redeploy a release that still reads both legacy fernet and target envelope\nvalues, then set new writes back to the previously approved format while\noperators investigate.\n\nrollback requirements:\n\n1. do not remove legacy fernet read support.\n2. do not run a destructive down migration against encrypted-field data.\n3. if live migration has started, keep migrated target-envelope rows readable by\n   the deployed dual reader.\n4. if helper code supports reverse rewriting, run it only after a restore\n   rehearsal proves target-envelope values can be converted back to legacy\n   fernet and per-row verified.\n5. if helper behavior is suspected, stop the helper, keep the dual reader\n   deployed, and restore from the rehearsed backup only if maintainers decide\n   the mixed-format database is unsafe to keep serving.\n6. after rollback, rerun preflight decryptability checks across all encrypted\n   field contracts and verify normal application reads.\n\nrollback is not complete until both legacy-format and target-format rows that\nremain in the database are readable by the deployed application.\n\n## completion criteria\n\nthe migration can be considered complete only after:\n\n- all encrypted-field contracts have zero unexpected-format rows\n- every non-empty encrypted value decrypts through the deployed reader\n- dry-run mode reports no remaining live changes\n- application flows that read encrypted fields pass manual review in production\n- backups taken after migration have been restored and decryptability checked\n- maintainers explicitly approve closing the rollback window\n\nlegacy fernet read support may be removed only in a later issue after the\nrollback window is closed and a separate removal plan is approved.\n"
-===== 1 failed, 1860 passed, 1 deselected, 1 xfailed in 410.16s (0:06:50) ======
+FAILED tests/test_migrations.py::test_downgrade_preserves_mixed_ciphertexts_readable_by_dual_reader - AssertionError: assert False
+ +  where False = <built-in method startswith of str object at 0xffff69e831f0>(('legacy', 'recipient', 'safe'))
+ +    where <built-in method startswith of str object at 0xffff69e831f0> = 'smtp.legacy.example'.startswith
+===== 1 failed, 1902 passed, 1 deselected, 1 xfailed in 427.93s (0:07:07) ======
 
 make: *** [test] Error 1
-Workflow checks failed; Codex self-heal attempt 1.
+Workflow checks failed; Codex self-heal attempt 2.
 Codex execution started; transcript output is excluded from persisted run logs.
-Prompt stats: bytes=28778 lines=88 words=3622
+Prompt stats: bytes=7755 lines=99 words=884
 Pre-Codex worktree snapshot:
 git status --short:
- M docs/ISSUE-411-SYMMETRIC-CRYPTO-FEASIBILITY.md
- M docs/README.md
-?? docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
-?? tests/test_encrypted_field_migration_runbook.py
+ M tests/migrations/revision_b2039e7c0a1d.py
+ M tests/test_migrations.py
 Non-log changed files:
-docs/ISSUE-411-SYMMETRIC-CRYPTO-FEASIBILITY.md
-docs/README.md
-docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
-tests/test_encrypted_field_migration_runbook.py
+tests/migrations/revision_b2039e7c0a1d.py
+tests/test_migrations.py
 Codex execution completed.
 Post-Codex worktree snapshot:
 git status --short:
- M docs/ISSUE-411-SYMMETRIC-CRYPTO-FEASIBILITY.md
- M docs/README.md
-?? docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
-?? tests/test_encrypted_field_migration_runbook.py
+ M tests/migrations/revision_b2039e7c0a1d.py
+ M tests/test_migrations.py
 Non-log changed files:
-docs/ISSUE-411-SYMMETRIC-CRYPTO-FEASIBILITY.md
-docs/README.md
-docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
-tests/test_encrypted_field_migration_runbook.py
+tests/migrations/revision_b2039e7c0a1d.py
+tests/test_migrations.py
 Codex final message:
-Updated [docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md]([redacted-path] so the locked guardrail phrase appears verbatim: `must not include plaintext or full ciphertext`.
+Fixed the failing rollback readability assertion in [tests/test_migrations.py]([redacted-path] The decrypted fixture value `smtp.legacy.example` is valid legacy ciphertext content, so the test now accepts the known SMTP legacy plaintext prefix.
 
-Validation: confirmed the phrase with `rg`. I did not run `make lint` or `make test`; the runner will handle those.
+I did not run local validation; the runner should rerun `make lint` and `make test`.
 ==> Refresh local runtime after schema changes
-Skipped: no schema-affecting files changed.
+==> Start Docker stack
+ Network hushline_default Creating 
+ Network hushline_default Created 
+ Container hushline-postgres-1 Creating 
+ Container hushline-blob-storage-1 Creating 
+ Container hushline-blob-storage-1 Created 
+ Container hushline-postgres-1 Created 
+ Container hushline-dev_data-1 Creating 
+ Container hushline-dev_data-1 Created 
+ Container hushline-app-1 Creating 
+ Container hushline-app-1 Created 
+ Container hushline-postgres-1 Starting 
+ Container hushline-blob-storage-1 Starting 
+ Container hushline-postgres-1 Started 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Started 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Starting 
+ Container hushline-dev_data-1 Started 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-blob-storage-1 Waiting 
+ Container hushline-dev_data-1 Waiting 
+ Container hushline-blob-storage-1 Healthy 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-1 Exited 
+ Container hushline-app-1 Starting 
+ Container hushline-app-1 Started 
+==> Seed development data
+ Container hushline-postgres-1 Running 
+ Container hushline-postgres-1 Waiting 
+ Container hushline-postgres-1 Healthy 
+ Container hushline-dev_data-run-3b5d6e8b8052 Creating 
+ Container hushline-dev_data-run-3b5d6e8b8052 Created 
+poetry run ./scripts/dev_migrations.py
+Creating database tables
+Database tables created
+poetry run ./scripts/dev_data.py
+2026-05-27 10:13:37,591:INFO:Password hash counter
+2026-05-27 10:13:37,772:INFO:Password hash counter
+2026-05-27 10:13:37,951:INFO:Password hash counter
+2026-05-27 10:13:38,127:INFO:Password hash counter
+2026-05-27 10:13:38,325:INFO:Password hash counter
+2026-05-27 10:13:38,503:INFO:Password hash counter
+2026-05-27 10:13:38,679:INFO:Password hash counter
+2026-05-27 10:13:38,854:INFO:Password hash counter
+2026-05-27 10:13:39,030:INFO:Password hash counter
+2026-05-27 10:13:39,205:INFO:Password hash counter
+2026-05-27 10:13:39,392:INFO:Password hash counter
+2026-05-27 10:13:39,579:INFO:Password hash counter
+2026-05-27 10:13:39,755:INFO:Password hash counter
+2026-05-27 10:13:39,930:INFO:Password hash counter
+2026-05-27 10:13:40,106:INFO:Password hash counter
+2026-05-27 10:13:40,281:INFO:Password hash counter
+2026-05-27 10:13:40,459:INFO:Password hash counter
+2026-05-27 10:13:40,656:INFO:Password hash counter
+2026-05-27 10:13:40,832:INFO:Password hash counter
+Adding dev data
+Tier:
+  name = Free
+  monthly_amount = 0
+Tier:
+  name = Super User
+  monthly_amount = 500
+Dev data added
+User updated:
+  username = admin
+User updated:
+  username = artvandelay
+User updated:
+  username = jerryseinfeld
+User updated:
+  username = georgecostanza
+User updated:
+  username = elainebenes
+User updated:
+  username = cosmokramer
+User updated:
+  username = newman
+User updated:
+  username = frankcostanza
+User updated:
+  username = michaelbluth
+User updated:
+  username = gobbluth
+User updated:
+  username = busterbluth
+User updated:
+  username = lucillebluth
+User updated:
+  username = tobiasfunke
+User updated:
+  username = larrydavid
+User updated:
+  username = jeffgreene
+User updated:
+  username = leonblack
+User updated:
+  username = dwightschrute
+User updated:
+  username = martymcfly
+User updated:
+  username = georgecostanzakr
+Public storage bucket: public
 ==> Run lint
 docker compose run --rm app poetry run ruff format --check && \
 	docker compose run --rm app poetry run ruff check --output-format full && \
@@ -4753,32 +5230,32 @@ docker compose run --rm app poetry run ruff format --check && \
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
- Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
  Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-6ca5fc907a07 Creating 
- Container hushline-app-run-6ca5fc907a07 Created 
-229 files already formatted
+ Container hushline-app-run-278b13fec4be Creating 
+ Container hushline-app-run-278b13fec4be Created 
+235 files already formatted
  Container hushline-blob-storage-1 Running 
  Container hushline-postgres-1 Running 
  Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
- Container hushline-dev_data-1 Waiting 
  Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
- Container hushline-blob-storage-1 Healthy 
+ Container hushline-dev_data-1 Waiting 
  Container hushline-postgres-1 Healthy 
+ Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-0d75d4ec903d Creating 
- Container hushline-app-run-0d75d4ec903d Created 
+ Container hushline-app-run-912b6d2301ba Creating 
+ Container hushline-app-run-912b6d2301ba Created 
 All checks passed!
- Container hushline-postgres-1 Running 
  Container hushline-blob-storage-1 Running 
+ Container hushline-postgres-1 Running 
  Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
@@ -4786,12 +5263,12 @@ All checks passed!
  Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
  Container hushline-dev_data-1 Waiting 
- Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
+ Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-8555472d768f Creating 
- Container hushline-app-run-8555472d768f Created 
-Success: no issues found in 228 source files
+ Container hushline-app-run-60acabe01fef Creating 
+ Container hushline-app-run-60acabe01fef Created 
+Success: no issues found in 234 source files
  Container hushline-postgres-1 Running 
  Container hushline-blob-storage-1 Running 
  Container hushline-postgres-1 Waiting 
@@ -4804,8 +5281,8 @@ Success: no issues found in 228 source files
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-6c49dcd10037 Creating 
- Container hushline-app-run-6c49dcd10037 Created 
+ Container hushline-app-run-00ef4ce7ea1c Creating 
+ Container hushline-app-run-00ef4ce7ea1c Created 
 Checking formatting...
 All matched files use Prettier code style!
 ==> Run test (full suite)
@@ -4816,20 +5293,20 @@ Still running after 240s: Run test (full suite)
 Still running after 300s: Run test (full suite)
 Still running after 360s: Run test (full suite)
 docker compose run --rm app poetry run pytest --cov hushline --cov-report term --cov-report html:/tmp/hushline-htmlcov -vv -m "not external_network"  ./tests/
- Container hushline-blob-storage-1 Running 
  Container hushline-postgres-1 Running 
+ Container hushline-blob-storage-1 Running 
  Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-dev_data-1 Starting 
  Container hushline-dev_data-1 Started 
- Container hushline-postgres-1 Waiting 
  Container hushline-blob-storage-1 Waiting 
  Container hushline-dev_data-1 Waiting 
+ Container hushline-postgres-1 Waiting 
  Container hushline-postgres-1 Healthy 
  Container hushline-blob-storage-1 Healthy 
  Container hushline-dev_data-1 Exited 
- Container hushline-app-run-7de3b5d01d39 Creating 
- Container hushline-app-run-7de3b5d01d39 Created 
+ Container hushline-app-run-8e63c5ebce6f Creating 
+ Container hushline-app-run-8e63c5ebce6f Created 
 ============================= test session starts ==============================
 platform linux -- Python 3.13.13, pytest-9.0.3, pluggy-1.5.0 -- /root/.cache/pypoetry/virtualenvs/hushline-9TtSrW0h-py3.13/bin/python
 cachedir: .pytest_cache
@@ -4837,7 +5314,7 @@ rootdir: /app
 configfile: pyproject.toml
 plugins: cov-5.0.0, asyncio-1.3.0, mock-3.14.0
 asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
-collecting ... collected 1863 items / 1 deselected / 1862 selected
+collecting ... collected 1905 items / 1 deselected / 1904 selected
 
 tests/test_2fa.py::test_enable_2fa PASSED                                [  0%]
 tests/test_2fa.py::test_valid_2fa_should_login PASSED                    [  0%]
@@ -4857,7 +5334,7 @@ tests/test_admin.py::test_admin_settings_clamps_invalid_page_requests PASSED [  
 tests/test_admin.py::test_admin_settings_searches_all_usernames_before_paginating PASSED [  0%]
 tests/test_admin.py::test_admin_settings_hides_verified_on_nonmanaged_service PASSED [  0%]
 tests/test_admin.py::test_toggle_verified_on_managed_service PASSED      [  0%]
-tests/test_admin.py::test_toggle_verified_on_nonmanaged_service PASSED   [  1%]
+tests/test_admin.py::test_toggle_verified_on_nonmanaged_service PASSED   [  0%]
 tests/test_admin.py::test_toggle_admin_only_admin PASSED                 [  1%]
 tests/test_admin.py::test_toggle_admin_multiple_admins PASSED            [  1%]
 tests/test_admin.py::test_toggle_verified_alias_on_managed_service PASSED [  1%]
@@ -4876,7 +5353,7 @@ tests/test_admin.py::test_toggle_cautious_updates_user PASSED            [  1%]
 tests/test_admin.py::test_toggle_suspended_updates_user PASSED           [  1%]
 tests/test_admin.py::test_toggle_suspended_clears_user_state PASSED      [  1%]
 tests/test_admin.py::test_update_account_category_validates_and_updates_user PASSED [  1%]
-tests/test_admin.py::test_update_account_category_rejects_missing_field_and_unknown_user PASSED [  2%]
+tests/test_admin.py::test_update_account_category_rejects_missing_field_and_unknown_user PASSED [  1%]
 tests/test_admin.py::test_toggle_cautious_user_not_found PASSED          [  2%]
 tests/test_admin.py::test_toggle_suspended_forbidden_for_non_admin PASSED [  2%]
 tests/test_admin.py::test_toggle_suspended_user_not_found PASSED         [  2%]
@@ -4894,8 +5371,8 @@ tests/test_agent_daily_issue_runner.py::test_runner_defaults_to_approved_codex_m
 tests/test_agent_daily_issue_runner.py::test_runner_defaults_to_ten_minute_idle_polling PASSED [  2%]
 tests/test_agent_daily_issue_runner.py::test_runner_defaults_idle_status_state_file_outside_lock_dir PASSED [  2%]
 tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_proceeds_when_5h_has_capacity PASSED [  2%]
-tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_sleeps_until_low_5h_quota_resets PASSED [  3%]
-tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_backs_off_when_reset_is_stale PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_sleeps_until_low_5h_quota_resets PASSED [  2%]
+tests/test_agent_daily_issue_runner.py::test_wait_for_codex_status_credit_window_backs_off_when_reset_is_stale PASSED [  2%]
 tests/test_agent_daily_issue_runner.py::test_idle_codex_status_check_skips_when_recent PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_idle_codex_status_check_runs_when_due PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_count_open_bot_prs_excluding_heads_fails_closed_when_pr_query_fails PASSED [  3%]
@@ -4913,8 +5390,8 @@ tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap
 tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap_when_human_pr_exists PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_main_resumes_in_progress_issue_before_selecting_new_work PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_main_exits_before_runtime_bootstrap_when_no_issue_is_available PASSED [  3%]
-tests/test_agent_daily_issue_runner.py::test_runner_status_prefixes_lines_with_local_timestamp PASSED [  4%]
-tests/test_agent_daily_issue_runner.py::test_main_bootstrap_does_not_prune_docker_system PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_runner_status_prefixes_lines_with_local_timestamp PASSED [  3%]
+tests/test_agent_daily_issue_runner.py::test_main_bootstrap_does_not_prune_docker_system PASSED [  3%]
 tests/test_agent_daily_issue_runner.py::test_build_pr_title_omits_codex_daily_prefix PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_build_pr_title_uses_diagnostic_title_for_diagnostic_pr PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_build_branch_name_uses_issue_prefix PASSED [  4%]
@@ -4932,8 +5409,8 @@ tests/test_agent_daily_issue_runner.py::test_add_issue_to_project_status_warns_w
 tests/test_agent_daily_issue_runner.py::test_coverage_gap_snapshot_from_log_reports_latest_missed_rows PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_open_coverage_gap_issue_after_pr_creates_agent_eligible_issue PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_filters_open_issues_in_target_status PASSED [  4%]
-tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_paginates_before_filtering PASSED [  5%]
-tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_supports_custom_status_name PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_paginates_before_filtering PASSED [  4%]
+tests/test_agent_daily_issue_runner.py::test_collect_issue_candidates_from_project_supports_custom_status_name PASSED [  4%]
 tests/test_agent_daily_issue_runner.py::test_main_allows_existing_epic_pr_before_runtime_bootstrap PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_main_marks_issue_in_progress_before_runtime_bootstrap PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_main_uses_fetched_origin_epic_ref_for_child_pr_uniqueness_check PASSED [  5%]
@@ -4950,9 +5427,9 @@ tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_adds_plain_
 tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_explains_log_only_run PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_write_pr_narrative_lead_explains_diagnostic_pr PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_matches_network_errors PASSED [  5%]
-tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_rejects_tls_vulnerability_text PASSED [  6%]
-tests/test_agent_daily_issue_runner.py::test_runtime_schema_files_changed_detects_branch_schema_diff_from_runtime_base PASSED [  6%]
-tests/test_agent_daily_issue_runner.py::test_restore_runtime_generated_static_artifacts_cleans_bootstrap_noise PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_audit_failure_environmental_classifier_rejects_tls_vulnerability_text PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_runtime_schema_files_changed_detects_branch_schema_diff_from_runtime_base PASSED [  5%]
+tests/test_agent_daily_issue_runner.py::test_restore_runtime_generated_static_artifacts_cleans_bootstrap_noise PASSED [  5%]
 tests/test_agent_daily_issue_runner.py::test_restore_non_log_worktree_changes_uses_staged_and_worktree_restore PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_run_check_capture_times_out_stuck_check PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_runtime_bootstrap_retries_retryable_registry_failure PASSED [  6%]
@@ -4969,9 +5446,9 @@ tests/test_agent_daily_issue_runner.py::test_failure_signature_from_text_falls_b
 tests/test_agent_daily_issue_runner.py::test_build_fix_prompt_withholds_raw_check_output PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_recent_failure_block_from_text_extracts_recent_actionable_context PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_recent_failure_block_from_text_redacts_secret_like_values PASSED [  6%]
-tests/test_agent_daily_issue_runner.py::test_recent_failure_block_keeps_traceback_when_coverage_table_follows PASSED [  7%]
-tests/test_agent_daily_issue_runner.py::test_failure_excerpt_from_text_redacts_sensitive_values PASSED [  7%]
-tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_stops_after_max_attempts PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_recent_failure_block_keeps_traceback_when_coverage_table_follows PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_failure_excerpt_from_text_redacts_sensitive_values PASSED [  6%]
+tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_stops_after_max_attempts PASSED [  6%]
 tests/test_agent_daily_issue_runner.py::test_issue_attempt_loop_retries_when_post_fix_changes_collapse_to_log_only PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_has_non_log_changes_ignores_preexisting_branch_commits PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_summarize_pr_feedback_reports_unresolved_threads_and_comments PASSED [  7%]
@@ -4987,10 +5464,10 @@ tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_repor
 tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_polls_until_pr_closes PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_pr_feedback_action_waits_for_pending_checks PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_pr_feedback_action_key_ignores_pending_count_changes PASSED [  7%]
-tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_addresses_actionable_feedback_once PASSED [  8%]
-tests/test_agent_daily_issue_runner.py::test_address_pr_feedback_replies_and_resolves_review_threads PASSED [  8%]
-tests/test_agent_daily_issue_runner.py::test_pr_feedback_thread_targets_only_include_team_members_or_codex PASSED [  8%]
-tests/test_agent_daily_issue_runner.py::test_resolve_pr_number_from_ref_prefers_pr_url_without_gh_lookup PASSED [  8%]
+tests/test_agent_daily_issue_runner.py::test_check_pr_feedback_after_delay_addresses_actionable_feedback_once PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_address_pr_feedback_replies_and_resolves_review_threads PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_pr_feedback_thread_targets_only_include_team_members_or_codex PASSED [  7%]
+tests/test_agent_daily_issue_runner.py::test_resolve_pr_number_from_ref_prefers_pr_url_without_gh_lookup PASSED [  7%]
 tests/test_agent_daily_issue_runner.py::test_main_refuses_review_pr_when_issue_loop_fails PASSED [  8%]
 tests/test_agent_daily_issue_runner.py::test_main_continues_after_pr_create_when_pr_number_lookup_fails PASSED [  8%]
 tests/test_agent_daily_issue_runner.py::test_main_keeps_pr_branch_checked_out_until_feedback_monitor_returns PASSED [  8%]
@@ -5006,10 +5483,10 @@ tests/test_behavior_contracts.py::test_contract_notifications_field_content_mode
 tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_prefers_client_encrypted_body PASSED [  8%]
 tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_falls_back_to_server_encrypt PASSED [  8%]
 tests/test_behavior_contracts.py::test_contract_notifications_full_body_mode_uses_client_body_for_all_enabled_recipients PASSED [  8%]
-tests/test_behavior_contracts.py::test_contract_2fa_enable_then_disable_round_trip PASSED [  9%]
-tests/test_behavior_contracts.py::test_contract_onboarding_notifications_and_directory_persist_expected_state PASSED [  9%]
-tests/test_behavior_contracts.py::test_contract_directory_users_surface_verified_and_unverified_accounts PASSED [  9%]
-tests/test_behavior_contracts.py::test_contract_whistleblower_message_flow_defaults_and_actions PASSED [  9%]
+tests/test_behavior_contracts.py::test_contract_2fa_enable_then_disable_round_trip PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_onboarding_notifications_and_directory_persist_expected_state PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_directory_users_surface_verified_and_unverified_accounts PASSED [  8%]
+tests/test_behavior_contracts.py::test_contract_whistleblower_message_flow_defaults_and_actions PASSED [  8%]
 tests/test_behavior_contracts.py::test_contract_message_actions_do_not_cross_user_boundaries PASSED [  9%]
 tests/test_behavior_contracts.py::test_contract_authenticated_settings_profile_and_auth_round_trip PASSED [  9%]
 tests/test_behavior_contracts.py::test_contract_authenticated_encryption_and_data_export_flow PASSED [  9%]
@@ -5020,11 +5497,19 @@ tests/test_cli_commands.py::test_reg_settings_command_outputs_current_values PAS
 tests/test_cli_commands.py::test_reg_toggle_commands_update_org_settings PASSED [  9%]
 tests/test_cli_commands.py::test_reg_code_commands_create_list_and_delete PASSED [  9%]
 tests/test_cli_commands.py::test_reg_code_create_avoids_dash_prefixed_codes PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_reports_ready_without_sensitive_values PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_blocks_malformed_ciphertext PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_blocks_schema_that_is_not_envelope_ready PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_preflight_blocks_missing_schema_without_crashing PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_dry_run_reports_without_writing PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_live_rewrites_and_verifies_post_write PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_live_resumes_after_interruption PASSED [  9%]
+tests/test_cli_commands.py::test_encrypted_field_migrate_failure_report_omits_sensitive_values PASSED [  9%]
 tests/test_cli_commands.py::test_password_hash_report_outputs_legacy_count_and_removal_gate PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_report_blocks_when_measured_legacy_successes_non_zero PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_can_remove_passlib_blocks_when_legacy_rows_remain PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_can_remove_passlib_succeeds_when_legacy_rows_and_volume_are_zero PASSED [  9%]
-tests/test_cli_commands.py::test_password_hash_can_remove_passlib_accepts_reviewed_in_repo_legacy_verifier_path PASSED [  9%]
+tests/test_cli_commands.py::test_password_hash_report_blocks_when_measured_legacy_successes_non_zero PASSED [ 10%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_blocks_when_legacy_rows_remain PASSED [ 10%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_succeeds_when_legacy_rows_and_volume_are_zero PASSED [ 10%]
+tests/test_cli_commands.py::test_password_hash_can_remove_passlib_accepts_reviewed_in_repo_legacy_verifier_path PASSED [ 10%]
 tests/test_cli_commands.py::test_stripe_configure_skips_when_secret_missing PASSED [ 10%]
 tests/test_cli_commands.py::test_stripe_configure_creates_missing_tiers_when_lookup_returns_none PASSED [ 10%]
 tests/test_cli_commands.py::test_stripe_configure_runs_premium_setup_when_secret_present PASSED [ 10%]
@@ -5040,9 +5525,9 @@ tests/test_config.py::test_preferred_url_scheme_invalid_value PASSED     [ 10%]
 tests/test_config.py::test_public_base_url_loads PASSED                  [ 10%]
 tests/test_config.py::test_public_base_url_invalid[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 10%]
 tests/test_config.py::test_public_base_url_invalid[https://example.com/path-PUBLIC_BASE_URL must not include a path] PASSED [ 10%]
-tests/test_config.py::test_public_base_url_invalid[https://example.com/?q=1-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 10%]
-tests/test_config.py::test_public_base_url_invalid[https://example.com/#frag-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 10%]
-tests/test_config.py::test_smtp_notification_reply_to_loads PASSED       [ 10%]
+tests/test_config.py::test_public_base_url_invalid[https://example.com/?q=1-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 11%]
+tests/test_config.py::test_public_base_url_invalid[https://example.com/#frag-PUBLIC_BASE_URL must not include query or fragment] PASSED [ 11%]
+tests/test_config.py::test_smtp_notification_reply_to_loads PASSED       [ 11%]
 tests/test_config.py::test_password_hash_write_use_werkzeug_scrypt_flag_defaults_false_and_parses_true PASSED [ 11%]
 tests/test_config.py::test_password_hash_rehash_on_auth_flag_defaults_false_and_parses_true PASSED [ 11%]
 tests/test_config.py::test_encrypted_field_write_format_defaults_legacy_and_parses_envelope PASSED [ 11%]
@@ -5059,9 +5544,9 @@ tests/test_coverage_push.py::test_custom_validators_negative_paths PASSED [ 11%]
 tests/test_coverage_push.py::test_email_forwarding_form_requires_smtp_fields PASSED [ 11%]
 tests/test_coverage_push.py::test_email_forwarding_form_validate_short_circuits_when_base_invalid PASSED [ 11%]
 tests/test_coverage_push.py::test_set_homepage_username_form_rejects_unknown_user PASSED [ 11%]
-tests/test_coverage_push.py::test_base_smtp_config_not_implemented PASSED [ 11%]
-tests/test_coverage_push.py::test_is_safe_smtp_host_rejects_invalid_ip PASSED [ 11%]
-tests/test_coverage_push.py::test_send_email_decodes_bytes_and_returns_false_when_no_attempts PASSED [ 11%]
+tests/test_coverage_push.py::test_base_smtp_config_not_implemented PASSED [ 12%]
+tests/test_coverage_push.py::test_is_safe_smtp_host_rejects_invalid_ip PASSED [ 12%]
+tests/test_coverage_push.py::test_send_email_decodes_bytes_and_returns_false_when_no_attempts PASSED [ 12%]
 tests/test_coverage_push.py::test_message_status_text_upsert_delete_paths PASSED [ 12%]
 tests/test_coverage_push.py::test_encrypted_session_invalid_token_invalid_json_and_missing_key PASSED [ 12%]
 tests/test_coverage_push.py::test_data_export_invalid_form_returns_400 PASSED [ 12%]
@@ -5078,9 +5563,9 @@ tests/test_coverage_push.py::test_load_config_additional_branches PASSED [ 12%]
 tests/test_coverage_push.py::test_registration_toggle_false_paths PASSED [ 12%]
 tests/test_coverage_push.py::test_blob_storage_none_driver_when_missing_config PASSED [ 12%]
 tests/test_coverage_push.py::test_encrypt_helpers_branch_types PASSED    [ 12%]
-tests/test_coverage_push.py::test_handle_email_forwarding_form_smtp_validation_exception PASSED [ 12%]
-tests/test_coverage_push.py::test_notifications_toggle_false_flash_paths PASSED [ 12%]
-tests/test_coverage_push.py::test_notifications_toggle_include_content_true_path PASSED [ 12%]
+tests/test_coverage_push.py::test_handle_email_forwarding_form_smtp_validation_exception PASSED [ 13%]
+tests/test_coverage_push.py::test_notifications_toggle_false_flash_paths PASSED [ 13%]
+tests/test_coverage_push.py::test_notifications_toggle_include_content_true_path PASSED [ 13%]
 tests/test_coverage_push.py::test_authentication_required_redirects_to_2fa_when_not_authenticated PASSED [ 13%]
 tests/test_coverage_push.py::test_authentication_required_clears_session_on_session_id_mismatch PASSED [ 13%]
 tests/test_coverage_push.py::test_authentication_required_clears_session_when_user_id_missing PASSED [ 13%]
@@ -5097,8 +5582,8 @@ tests/test_coverage_push_remaining.py::test_hushline_init_remaining_paths PASSED
 tests/test_coverage_push_remaining.py::test_crypto_encrypt_message_string_branch PASSED [ 13%]
 tests/test_coverage_push_remaining.py::test_stripe_invoice_remaining_paths PASSED [ 13%]
 tests/test_coverage_push_remaining.py::test_alias_route_delete_button_path PASSED [ 13%]
-tests/test_coverage_push_remaining.py::test_branding_delete_logo_multirow_safety PASSED [ 13%]
-tests/test_coverage_push_remaining.py::test_branding_delete_splash_logo_multirow_safety PASSED [ 13%]
+tests/test_coverage_push_remaining.py::test_branding_delete_logo_multirow_safety PASSED [ 14%]
+tests/test_coverage_push_remaining.py::test_branding_delete_splash_logo_multirow_safety PASSED [ 14%]
 tests/test_coverage_push_remaining.py::test_guidance_none_prompts_default_path PASSED [ 14%]
 tests/test_coverage_push_remaining.py::test_settings_common_remaining_paths PASSED [ 14%]
 tests/test_coverage_push_remaining.py::test_enable_2fa_invalid_code_path PASSED [ 14%]
@@ -5108,6 +5593,7 @@ tests/test_crypto.py::test_scoped_key_derivation_changes_key PASSED      [ 14%]
 tests/test_crypto.py::test_encrypt_and_decrypt_field PASSED              [ 14%]
 tests/test_crypto.py::test_encrypt_field_defaults_to_legacy_fernet_write_format PASSED [ 14%]
 tests/test_crypto.py::test_encrypt_field_can_write_versioned_fernet_envelope PASSED [ 14%]
+tests/test_crypto.py::test_encrypt_field_envelope_write_requires_schema_check_context PASSED [ 14%]
 tests/test_crypto.py::test_encrypt_field_transition_reads_legacy_and_envelope_formats PASSED [ 14%]
 tests/test_crypto.py::test_encrypt_field_uses_app_configured_write_format PASSED [ 14%]
 tests/test_crypto.py::test_encrypted_field_envelope_roundtrips_wrapped_fernet PASSED [ 14%]
@@ -5115,9 +5601,9 @@ tests/test_crypto.py::test_encrypted_field_aad_is_canonical_and_stable PASSED [ 
 tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values0] PASSED [ 14%]
 tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values1] PASSED [ 14%]
 tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values2] PASSED [ 14%]
-tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values3] PASSED [ 14%]
-tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values4] PASSED [ 14%]
-tests/test_crypto.py::test_encrypted_field_aead_prototype_requires_expected_domain_and_aad PASSED [ 14%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values3] PASSED [ 15%]
+tests/test_crypto.py::test_encrypted_field_aad_rejects_mutable_context[values4] PASSED [ 15%]
+tests/test_crypto.py::test_encrypted_field_aead_prototype_requires_expected_domain_and_aad PASSED [ 15%]
 tests/test_crypto.py::test_legacy_fernet_token_has_no_envelope PASSED    [ 15%]
 tests/test_crypto.py::test_unknown_encrypted_field_envelope_version_fails_closed PASSED [ 15%]
 tests/test_crypto.py::test_malformed_encrypted_field_envelopes_fail_closed[hlfield:] PASSED [ 15%]
@@ -5134,8 +5620,8 @@ tests/test_crypto.py::test_pgp_helpers_invalid_key PASSED                [ 15%]
 tests/test_crypto.py::test_encrypt_message_uses_all_recipient_keys PASSED [ 15%]
 tests/test_crypto.py::test_load_recipient_certs_requires_at_least_one_key PASSED [ 15%]
 tests/test_crypto.py::test_gen_reply_slug_uses_diceware_words PASSED     [ 15%]
-tests/test_data_export.py::test_data_export_requires_auth PASSED         [ 15%]
-tests/test_data_export.py::test_data_export_zip_contains_csv_and_pgp PASSED [ 15%]
+tests/test_data_export.py::test_data_export_requires_auth PASSED         [ 16%]
+tests/test_data_export.py::test_data_export_zip_contains_csv_and_pgp PASSED [ 16%]
 tests/test_data_export.py::test_data_export_encrypted_export PASSED      [ 16%]
 tests/test_data_export.py::test_data_export_only_includes_current_user PASSED [ 16%]
 tests/test_delete_account.py::test_delete_account PASSED                 [ 16%]
@@ -5153,8 +5639,8 @@ tests/test_directory.py::test_globaleaks_seed_has_rows PASSED            [ 16%]
 tests/test_directory.py::test_directory_accessible PASSED                [ 16%]
 tests/test_directory.py::test_directory_public_record_banner_links_to_admin PASSED [ 16%]
 tests/test_directory.py::test_directory_securedrop_banner_links_to_admin_without_tor_copy PASSED [ 16%]
-tests/test_directory.py::test_directory_globaleaks_banner_links_to_admin_without_tor_copy PASSED [ 16%]
-tests/test_directory.py::test_directory_newsrooms_banner_links_to_admin PASSED [ 16%]
+tests/test_directory.py::test_directory_globaleaks_banner_links_to_admin_without_tor_copy PASSED [ 17%]
+tests/test_directory.py::test_directory_newsrooms_banner_links_to_admin PASSED [ 17%]
 tests/test_directory.py::test_directory_all_tab_banner_links_to_admin PASSED [ 17%]
 tests/test_directory.py::test_directory_hides_tab_bar_when_verified_tabs_disabled PASSED [ 17%]
 tests/test_directory.py::test_directory_users_json_excludes_public_records_when_verified_tabs_disabled PASSED [ 17%]
@@ -5172,8 +5658,8 @@ tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified
 tests/test_directory.py::test_directory_users_json_does_not_flag_verified_or_admin_suspicious_display_names PASSED [ 17%]
 tests/test_directory.py::test_directory_users_json_flags_suspicious_username_when_display_name_missing PASSED [ 17%]
 tests/test_directory.py::test_directory_users_json_includes_unverified_info_only_korean_account PASSED [ 17%]
-tests/test_directory.py::test_directory_users_json_marks_recipient_key_only_account_as_message_capable PASSED [ 17%]
-tests/test_directory.py::test_directory_users_json_includes_account_category PASSED [ 17%]
+tests/test_directory.py::test_directory_users_json_marks_recipient_key_only_account_as_message_capable PASSED [ 18%]
+tests/test_directory.py::test_directory_users_json_includes_account_category PASSED [ 18%]
 tests/test_directory.py::test_directory_users_json_includes_normalized_user_location PASSED [ 18%]
 tests/test_directory.py::test_directory_users_json_includes_legacy_account_category_label PASSED [ 18%]
 tests/test_directory.py::test_directory_self_reported_attorneys_render_in_attorneys_tab PASSED [ 18%]
@@ -5191,7 +5677,7 @@ tests/test_directory.py::test_directory_users_json_excludes_verified_tab_sources
 tests/test_directory.py::test_directory_card_bio_uses_bio_length_limit_with_ascii_ellipsis PASSED [ 18%]
 tests/test_directory.py::test_directory_users_json_truncates_long_automated_listing_bios PASSED [ 18%]
 tests/test_directory.py::test_directory_public_record_cards_truncate_long_automated_listing_bios PASSED [ 18%]
-tests/test_directory.py::test_directory_public_record_cards_do_not_show_location PASSED [ 18%]
+tests/test_directory.py::test_directory_public_record_cards_do_not_show_location PASSED [ 19%]
 tests/test_directory.py::test_directory_users_json_includes_legacy_public_record_rows PASSED [ 19%]
 tests/test_directory.py::test_directory_filters_public_records_by_country_and_region_query_params PASSED [ 19%]
 tests/test_directory.py::test_directory_attorney_filter_panel_hidden_by_default PASSED [ 19%]
@@ -5210,7 +5696,7 @@ tests/test_directory.py::test_directory_attorney_filters_json_reflects_active_qu
 tests/test_directory.py::test_directory_attorney_filters_json_includes_self_reported_attorneys PASSED [ 19%]
 tests/test_directory.py::test_directory_newsroom_filters_json_includes_self_reported_newsrooms PASSED [ 19%]
 tests/test_directory.py::test_directory_newsroom_filters_json_includes_automated_newsroom_listings PASSED [ 19%]
-tests/test_directory.py::test_directory_all_filters_json_reflects_active_query_filters PASSED [ 19%]
+tests/test_directory.py::test_directory_all_filters_json_reflects_active_query_filters PASSED [ 20%]
 tests/test_directory.py::test_directory_all_filters_json_updates_country_counts_for_verified_listing_type PASSED [ 20%]
 tests/test_directory.py::test_directory_all_filters_json_is_empty_when_verified_tabs_disabled PASSED [ 20%]
 tests/test_directory.py::test_listing_matches_attorney_filters_wrapper_uses_listing_geography PASSED [ 20%]
@@ -5229,7 +5715,7 @@ tests/test_directory.py::test_directory_newsroom_filters_include_normalized_coun
 tests/test_directory.py::test_directory_attorney_filters_support_non_us_subdivisions PASSED [ 20%]
 tests/test_directory.py::test_directory_newsroom_filters_support_non_us_subdivisions PASSED [ 20%]
 tests/test_directory.py::test_directory_attorney_filters_json_ignores_untrusted_query_values PASSED [ 20%]
-tests/test_directory.py::test_directory_newsroom_filters_json_ignores_untrusted_query_values PASSED [ 20%]
+tests/test_directory.py::test_directory_newsroom_filters_json_ignores_untrusted_query_values PASSED [ 21%]
 tests/test_directory.py::test_directory_attorney_filters_json_returns_empty_metadata_when_verified_tabs_disabled PASSED [ 21%]
 tests/test_directory.py::test_directory_newsroom_filters_json_returns_empty_metadata_when_verified_tabs_disabled PASSED [ 21%]
 tests/test_directory.py::test_directory_securedrop_render_only_in_securedrop_and_all PASSED [ 21%]
@@ -5285,7 +5771,7 @@ tests/test_directory_listing_geography.py::test_directory_listing_geography_loca
 tests/test_directory_listing_geography.py::test_directory_listing_geography_location_variants[geography3-All countries, USA] PASSED [ 23%]
 tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_state_as_subdivision_when_country_present PASSED [ 23%]
 tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_us_state_code_when_country_missing PASSED [ 23%]
-tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_non_us_state_value_as_country_when_missing PASSED [ 24%]
+tests/test_directory_listing_geography.py::test_build_public_record_geography_uses_non_us_state_value_as_country_when_missing PASSED [ 23%]
 tests/test_directory_listing_geography.py::test_build_directory_geography_keeps_non_us_subdivision_strings PASSED [ 24%]
 tests/test_docker_runtime_images.py::test_dev_and_prod_dockerfiles_use_the_same_python_313_bookworm_runtime_image PASSED [ 24%]
 tests/test_docs_library_mirror.py::test_library_docs_mirror_contains_required_pages PASSED [ 24%]
@@ -5304,7 +5790,7 @@ tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_guest_ar
 tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_marks_state_preparation_scenes_always_visit PASSED [ 24%]
 tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_artvandelay_profile_cleanup_accepts_delete_confirmations PASSED [ 24%]
 tests/test_email.py::test_create_smtp_config_variants PASSED             [ 24%]
-tests/test_email.py::test_create_smtp_config_invalid_encryption PASSED   [ 25%]
+tests/test_email.py::test_create_smtp_config_invalid_encryption PASSED   [ 24%]
 tests/test_email.py::test_ssl_smtp_login_authenticates_over_ssl PASSED   [ 25%]
 tests/test_email.py::test_starttls_smtp_login_upgrades_with_default_tls_context PASSED [ 25%]
 tests/test_email.py::test_is_safe_smtp_host_validation PASSED            [ 25%]
@@ -5323,8 +5809,8 @@ tests/test_email_headers.py::test_email_headers_page_renders PASSED      [ 25%]
 tests/test_email_headers.py::test_email_headers_export_requires_authentication PASSED [ 25%]
 tests/test_email_headers.py::test_email_headers_page_renders_authenticated PASSED [ 25%]
 tests/test_email_headers.py::test_email_headers_post_without_dkim_still_reports_auth_results PASSED [ 25%]
-tests/test_email_headers.py::test_analyze_raw_email_headers_marks_likely_forged_on_triple_fail PASSED [ 26%]
-tests/test_email_headers.py::test_analyze_raw_email_headers_marks_valid_on_spf_dmarc_pass_without_dkim PASSED [ 26%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_marks_likely_forged_on_triple_fail PASSED [ 25%]
+tests/test_email_headers.py::test_analyze_raw_email_headers_marks_valid_on_spf_dmarc_pass_without_dkim PASSED [ 25%]
 tests/test_email_headers.py::test_analyze_raw_email_headers_marks_appears_inauthentic PASSED [ 26%]
 tests/test_email_headers.py::test_analyze_raw_email_headers_rejects_empty_input PASSED [ 26%]
 tests/test_email_headers.py::test_analyze_raw_email_headers_with_header_body_mix_parses_headers_only PASSED [ 26%]
@@ -5341,9 +5827,9 @@ tests/test_email_headers.py::test_email_headers_post_value_error_shows_flash PAS
 tests/test_email_headers.py::test_email_headers_missing_csrf_preserves_invalid_post_behavior PASSED [ 26%]
 tests/test_email_headers.py::test_email_headers_export_invalid_form_redirects_with_flash PASSED [ 26%]
 tests/test_email_headers.py::test_email_headers_export_missing_csrf_redirects_with_flash PASSED [ 26%]
-tests/test_email_headers.py::test_email_headers_export_value_error_redirects_with_flash PASSED [ 27%]
-tests/test_email_headers.py::test_parse_tag_value_pairs_ignores_invalid_parts_and_empty_keys PASSED [ 27%]
-tests/test_email_headers.py::test_build_interpretation_includes_strong_chain_multiple_signatures_and_strong_keys PASSED [ 27%]
+tests/test_email_headers.py::test_email_headers_export_value_error_redirects_with_flash PASSED [ 26%]
+tests/test_email_headers.py::test_parse_tag_value_pairs_ignores_invalid_parts_and_empty_keys PASSED [ 26%]
+tests/test_email_headers.py::test_build_interpretation_includes_strong_chain_multiple_signatures_and_strong_keys PASSED [ 26%]
 tests/test_email_headers.py::test_render_minimal_pdf_renders_when_no_lines_provided PASSED [ 27%]
 tests/test_email_headers.py::test_render_report_pdf_includes_none_sections_and_warnings_block PASSED [ 27%]
 tests/test_email_headers.py::test_create_evidence_zip_includes_lookup_error_details PASSED [ 27%]
@@ -5360,9 +5846,9 @@ tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example?campaign=1] PASSED [ 27%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example#fragment] PASSED [ 27%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://user:[redacted-email]] PASSED [ 27%]
-tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example:] PASSED [ 28%]
-tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example;.onion] PASSED [ 28%]
-tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example .onion] PASSED [ 28%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[https://tips.example:] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example;.onion] PASSED [ 27%]
+tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example .onion] PASSED [ 27%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\t.onion] PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\n.onion] PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_embed_allowed_origins_reject_invalid_origin_rules[http://tips.example\x0c.onion] PASSED [ 28%]
@@ -5378,10 +5864,10 @@ tests/test_embeddable_forms_model.py::test_embed_requires_at_least_one_exact_all
 tests/test_embeddable_forms_model.py::test_embed_admin_disablement_blocks_profile PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_embed_preserves_missing_key_and_suspension_rejection PASSED [ 28%]
 tests/test_embeddable_forms_model.py::test_alias_embed_requires_owner_eligibility PASSED [ 28%]
-tests/test_embeddable_forms_settings.py::test_admin_embeddable_forms_default_disabled PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_route_is_disabled_by_default PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_profile_opted_out PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_origin_allowlist PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_admin_embeddable_forms_default_disabled PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_is_disabled_by_default PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_profile_opted_out PASSED [ 28%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_origin_allowlist PASSED [ 28%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_missing_recipient_key PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_suspended_target PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_route_denies_unknown_target PASSED [ 29%]
@@ -5397,10 +5883,10 @@ tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_handles_u
 tests/test_embeddable_forms_settings.py::test_embed_profile_rate_limit_evicts_stale_global_state PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_requires_embed_form_token PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_invalid_csrf_token PASSED [ 29%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_owner_guard_mismatch PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_captcha_failure PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_missing_required_field PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_suspension PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_owner_guard_mismatch PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_captcha_failure PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_missing_required_field PASSED [ 29%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_suspension PASSED [ 29%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_stale_form_after_recipient_key_removed PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_submission_uses_same_enabled_custom_fields PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_malformed_recipient_ciphertexts_use_generic_notification_body PASSED [ 30%]
@@ -5416,10 +5902,10 @@ tests/test_embeddable_forms_settings.py::test_admin_non_super_user_can_access_de
 tests/test_embeddable_forms_settings.py::test_admin_non_super_user_cannot_update_profile_embed_settings PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_developer_embed_settings_require_usable_recipient_key PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_admin_can_toggle_embeddable_forms PASSED [ 30%]
-tests/test_embeddable_forms_settings.py::test_non_admin_cannot_toggle_embeddable_forms PASSED [ 31%]
-tests/test_embeddable_forms_settings.py::test_primary_embed_settings_update_origins_and_render_iframe_snippet PASSED [ 31%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_template_has_compact_trust_chrome_and_form PASSED [ 31%]
-tests/test_embeddable_forms_settings.py::test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source PASSED [ 31%]
+tests/test_embeddable_forms_settings.py::test_non_admin_cannot_toggle_embeddable_forms PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_primary_embed_settings_update_origins_and_render_iframe_snippet PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_template_has_compact_trust_chrome_and_form PASSED [ 30%]
+tests/test_embeddable_forms_settings.py::test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source PASSED [ 30%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_renders_additional_profile_fields_like_full_profile PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_keyboard_flow_and_mobile_accessibility_chrome PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_embed_profile_required_chrome_survives_recipient_branding_settings PASSED [ 31%]
@@ -5430,12 +5916,15 @@ tests/test_embeddable_forms_settings.py::test_embed_settings_require_message_cap
 tests/test_embeddable_forms_settings.py::test_alias_embed_settings_are_independent PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_alias_embed_settings_reject_invalid_origin PASSED [ 31%]
 tests/test_embeddable_forms_settings.py::test_alias_embed_settings_require_alias_owner PASSED [ 31%]
+tests/test_encrypted_field_aead_evaluation.py::test_encrypted_field_aead_evaluation_exists_and_is_linked PASSED [ 31%]
+tests/test_encrypted_field_aead_evaluation.py::test_encrypted_field_aead_evaluation_covers_required_options PASSED [ 31%]
+tests/test_encrypted_field_aead_evaluation.py::test_encrypted_field_aead_evaluation_locks_recommendation_and_guardrails PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_encrypted_field_property_inventory_is_complete PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_encrypted_field_inventory_columns_match_models PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_encrypted_field_domain_contract_covers_inventory PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_user_encrypted_properties_store_fernet_ciphertext PASSED [ 31%]
-tests/test_encrypted_field_inventory.py::test_notification_recipient_properties_store_fernet_ciphertext PASSED [ 32%]
-tests/test_encrypted_field_inventory.py::test_field_value_stores_encrypted_custom_message_value_as_fernet_ciphertext PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_notification_recipient_properties_store_fernet_ciphertext PASSED [ 31%]
+tests/test_encrypted_field_inventory.py::test_field_value_stores_encrypted_custom_message_value_as_fernet_ciphertext PASSED [ 31%]
 tests/test_encrypted_field_inventory.py::test_legacy_fernet_user_fields_decrypt_through_properties PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_legacy_fernet_notification_recipient_fields_decrypt PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_legacy_fernet_field_value_decrypts_encrypted_custom_message_value PASSED [ 32%]
@@ -5453,10 +5942,19 @@ tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_s
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.smtp_server] PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.smtp_username] PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.smtp_password] PASSED [ 32%]
-tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.pgp_key] PASSED [ 33%]
-tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[NotificationRecipient.email] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[User.pgp_key] PASSED [ 32%]
+tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[NotificationRecipient.email] PASSED [ 32%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[NotificationRecipient.pgp_key] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_configured_envelope_write_format_stores_one_envelope_through_properties[FieldValue.value] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.totp_secret] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.email] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.smtp_server] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.smtp_username] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.smtp_password] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[User.pgp_key] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[NotificationRecipient.email] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[NotificationRecipient.pgp_key] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_envelope_write_round_trips_long_values_that_exceed_legacy_capacity[FieldValue.value] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.totp_secret] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.email] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.smtp_server] PASSED [ 33%]
@@ -5465,13 +5963,13 @@ tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_cipherte
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[User.pgp_key] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[NotificationRecipient.email] PASSED [ 33%]
 tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[NotificationRecipient.pgp_key] PASSED [ 33%]
-tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[FieldValue.value] PASSED [ 33%]
-tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_exists_and_is_linked PASSED [ 33%]
-tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_covers_required_execution_paths PASSED [ 33%]
-tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_locks_security_guardrails PASSED [ 33%]
-tests/test_external_urls.py::test_normalize_public_base_url_strips_trailing_slash PASSED [ 33%]
-tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 33%]
-tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://-PUBLIC_BASE_URL must include a host] PASSED [ 33%]
+tests/test_encrypted_field_inventory.py::test_malformed_encrypted_field_ciphertext_fails_closed[FieldValue.value] PASSED [ 34%]
+tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_exists_and_is_linked PASSED [ 34%]
+tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_covers_required_execution_paths PASSED [ 34%]
+tests/test_encrypted_field_migration_runbook.py::test_encrypted_field_migration_runbook_locks_security_guardrails PASSED [ 34%]
+tests/test_external_urls.py::test_normalize_public_base_url_strips_trailing_slash PASSED [ 34%]
+tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[ftp://example.com-PUBLIC_BASE_URL must use http or https] PASSED [ 34%]
+tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://-PUBLIC_BASE_URL must include a host] PASSED [ 34%]
 tests/test_external_urls.py::test_normalize_public_base_url_rejects_invalid_values[https://example.com/path-PUBLIC_BASE_URL must not include a path] PASSED [ 34%]
 tests/test_external_urls.py::test_canonical_external_url_prefers_public_base_url PASSED [ 34%]
 tests/test_external_urls.py::test_canonical_external_url_falls_back_to_request_derived_url_in_dev_and_testing[config_overrides0] PASSED [ 34%]
@@ -5484,12 +5982,12 @@ tests/test_fields.py::test_field_value_encryption PASSED                 [ 34%]
 tests/test_fields.py::test_field_value_unencryption PASSED               [ 34%]
 tests/test_fields.py::test_field_value_encryption_uses_all_enabled_recipient_keys PASSED [ 34%]
 tests/test_first_user.py::test_no_users_redirect_to_register PASSED      [ 34%]
-tests/test_first_user.py::test_no_users_register_should_show_alert PASSED [ 34%]
-tests/test_first_user.py::test_some_users_register_should_hide_alert PASSED [ 34%]
-tests/test_first_user.py::test_first_user_is_admin PASSED                [ 34%]
-tests/test_first_user.py::test_registration_does_not_grant_admin_after_stale_first_user_check PASSED [ 34%]
-tests/test_first_user.py::test_second_user_is_not_admin PASSED           [ 34%]
-tests/test_frontend_compat.py::test_package_json_declares_node_20_plus PASSED [ 34%]
+tests/test_first_user.py::test_no_users_register_should_show_alert PASSED [ 35%]
+tests/test_first_user.py::test_some_users_register_should_hide_alert PASSED [ 35%]
+tests/test_first_user.py::test_first_user_is_admin PASSED                [ 35%]
+tests/test_first_user.py::test_registration_does_not_grant_admin_after_stale_first_user_check PASSED [ 35%]
+tests/test_first_user.py::test_second_user_is_not_admin PASSED           [ 35%]
+tests/test_frontend_compat.py::test_package_json_declares_node_20_plus PASSED [ 35%]
 tests/test_frontend_compat.py::test_webpack_compose_services_use_lockfile_guard_script PASSED [ 35%]
 tests/test_frontend_compat.py::test_static_js_bundles_avoid_eval_wrappers PASSED [ 35%]
 tests/test_frontend_compat.py::test_client_side_encryption_has_platform_guards PASSED [ 35%]
@@ -5503,12 +6001,12 @@ tests/test_frontend_compat.py::test_directory_search_accessibility_hooks_exist P
 tests/test_frontend_compat.py::test_directory_sticky_active_tab_scroll_to_top_hook_exists PASSED [ 35%]
 tests/test_frontend_compat.py::test_directory_tab_scroll_buttons_clamp_to_valid_bounds PASSED [ 35%]
 tests/test_frontend_compat.py::test_inbox_sticky_nav_hooks_exist PASSED  [ 35%]
-tests/test_frontend_compat.py::test_settings_field_delete_confirmation_blocks_submit_on_cancel PASSED [ 35%]
-tests/test_frontend_compat.py::test_settings_sticky_nav_hooks_exist PASSED [ 35%]
-tests/test_frontend_compat.py::test_profile_location_settings_use_country_select_and_dependency_script PASSED [ 35%]
-tests/test_frontend_compat.py::test_profile_settings_template_contains_updated_ui_copy PASSED [ 35%]
-tests/test_frontend_compat.py::test_settings_field_builder_select_hooks_are_wrapper_safe PASSED [ 35%]
-tests/test_gdpr_compliance.py::test_gdpr_compliance_evidence_policy_and_functionality PASSED [ 35%]
+tests/test_frontend_compat.py::test_settings_field_delete_confirmation_blocks_submit_on_cancel PASSED [ 36%]
+tests/test_frontend_compat.py::test_settings_sticky_nav_hooks_exist PASSED [ 36%]
+tests/test_frontend_compat.py::test_profile_location_settings_use_country_select_and_dependency_script PASSED [ 36%]
+tests/test_frontend_compat.py::test_profile_settings_template_contains_updated_ui_copy PASSED [ 36%]
+tests/test_frontend_compat.py::test_settings_field_builder_select_hooks_are_wrapper_safe PASSED [ 36%]
+tests/test_gdpr_compliance.py::test_gdpr_compliance_evidence_policy_and_functionality PASSED [ 36%]
 tests/test_globaleaks_directory_listing_model.py::test_globaleaks_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 36%]
 tests/test_globaleaks_directory_listing_model.py::test_globaleaks_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 36%]
 tests/test_globaleaks_directory_listing_model.py::test_get_globaleaks_directory_listing_matches_slug_case_insensitively PASSED [ 36%]
@@ -5522,11 +6020,11 @@ tests/test_globaleaks_directory_refresh.py::test_choose_submission_url_uses_webs
 tests/test_globaleaks_directory_refresh.py::test_choose_host_falls_back_to_candidate_hosts_or_errors PASSED [ 36%]
 tests/test_globaleaks_directory_refresh.py::test_candidate_hosts_normalizes_and_skips_blank_or_duplicate_values PASSED [ 36%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_rejects_empty_slug_after_normalization PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows1-Normalized row slug must be a string] PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows2-Duplicate GlobaLeaks listing slug: globaleaks~shared] PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_index_known_rows_by_host_ignores_blank_url_fields PASSED [ 36%]
-tests/test_globaleaks_directory_refresh.py::test_extract_discovery_links_filters_excluded_duplicate_and_non_candidate_hosts PASSED [ 36%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows1-Normalized row slug must be a string] PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_validates_normalized_row_shapes[normalized_rows2-Duplicate GlobaLeaks listing slug: globaleaks~shared] PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_index_known_rows_by_host_ignores_blank_url_fields PASSED [ 37%]
+tests/test_globaleaks_directory_refresh.py::test_extract_discovery_links_filters_excluded_duplicate_and_non_candidate_hosts PASSED [ 37%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_is_deterministic_and_schema_compatible PASSED [ 37%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_rejects_duplicates PASSED [ 37%]
 tests/test_globaleaks_directory_refresh.py::test_refresh_globaleaks_directory_rows_requires_submission_host_or_url PASSED [ 37%]
@@ -5541,11 +6039,11 @@ tests/test_helpers.py::test_form_to_data_targets_only_selected_submit_button PAS
 tests/test_helpers.py::test_form_to_data_flattens_fieldlist_subforms PASSED [ 37%]
 tests/test_inbox.py::test_delete_own_message PASSED                      [ 37%]
 tests/test_inbox.py::test_cannot_delete_other_user_message PASSED        [ 37%]
-tests/test_inbox.py::test_filter_on_status PASSED                        [ 37%]
-tests/test_inbox.py::test_inbox_invalid_status_returns_bad_request PASSED [ 37%]
-tests/test_inbox.py::test_inbox_missing_user_row_returns_not_found PASSED [ 37%]
-tests/test_info.py::test_info_available PASSED                           [ 37%]
-tests/test_info.py::test_site_webmanifest_reflects_branding PASSED       [ 37%]
+tests/test_inbox.py::test_filter_on_status PASSED                        [ 38%]
+tests/test_inbox.py::test_inbox_invalid_status_returns_bad_request PASSED [ 38%]
+tests/test_inbox.py::test_inbox_missing_user_row_returns_not_found PASSED [ 38%]
+tests/test_info.py::test_info_available PASSED                           [ 38%]
+tests/test_info.py::test_site_webmanifest_reflects_branding PASSED       [ 38%]
 tests/test_info.py::test_site_webmanifest_includes_uploaded_logo_icon PASSED [ 38%]
 tests/test_invite_code_model.py::test_invite_code_repr_includes_code PASSED [ 38%]
 tests/test_make_admin.py::test_toggle_admin_prints_when_user_missing PASSED [ 38%]
@@ -5560,11 +6058,11 @@ tests/test_md.py::test_md_to_html_returns_markup_input_unchanged PASSED  [ 38%]
 tests/test_md.py::test_md_to_html_sanitizes_disallowed_tags_and_keeps_links PASSED [ 38%]
 tests/test_migrations.py::test_linear_revision_history PASSED            [ 38%]
 tests/test_migrations.py::test_upgrade_with_data[46aedec8fd9b] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[5410668e15ad] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[be0744a5679f] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[0b1321c8de13] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[cf2a880aff10] PASSED    [ 38%]
-tests/test_migrations.py::test_upgrade_with_data[4a53667aff6e] PASSED    [ 38%]
+tests/test_migrations.py::test_upgrade_with_data[5410668e15ad] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[be0744a5679f] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[0b1321c8de13] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[cf2a880aff10] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[4a53667aff6e] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[b6a1e3f5a2b1] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[7d6a9f2f8c1a] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[2e3e5b1f2b3c] PASSED    [ 39%]
@@ -5576,13 +6074,14 @@ tests/test_migrations.py::test_upgrade_with_data[c4f8e2a1b6d9] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[84f1d3b2c6e7] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[d1f0e9c2b7aa] PASSED    [ 39%]
 tests/test_migrations.py::test_upgrade_with_data[2d8a1f7c9b41] PASSED    [ 39%]
+tests/test_migrations.py::test_upgrade_with_data[b2039e7c0a1d] PASSED    [ 39%]
 tests/test_migrations.py::test_downgrade_with_data[46aedec8fd9b] PASSED  [ 39%]
 tests/test_migrations.py::test_downgrade_with_data[5410668e15ad] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[be0744a5679f] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[0b1321c8de13] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[cf2a880aff10] PASSED  [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[4a53667aff6e] XFAIL   [ 39%]
-tests/test_migrations.py::test_downgrade_with_data[b6a1e3f5a2b1] PASSED  [ 39%]
+tests/test_migrations.py::test_downgrade_with_data[be0744a5679f] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[0b1321c8de13] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[cf2a880aff10] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[4a53667aff6e] XFAIL   [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[b6a1e3f5a2b1] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[7d6a9f2f8c1a] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[2e3e5b1f2b3c] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[9f7c4c3ea9a1] PASSED  [ 40%]
@@ -5593,15 +6092,16 @@ tests/test_migrations.py::test_downgrade_with_data[c4f8e2a1b6d9] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[84f1d3b2c6e7] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[d1f0e9c2b7aa] PASSED  [ 40%]
 tests/test_migrations.py::test_downgrade_with_data[2d8a1f7c9b41] PASSED  [ 40%]
+tests/test_migrations.py::test_downgrade_with_data[b2039e7c0a1d] PASSED  [ 40%]
 tests/test_migrations.py::test_double_upgrade[46aedec8fd9b] PASSED       [ 40%]
 tests/test_migrations.py::test_double_upgrade[5410668e15ad] PASSED       [ 40%]
 tests/test_migrations.py::test_double_upgrade[be0744a5679f] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[0b1321c8de13] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[cf2a880aff10] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[4a53667aff6e] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[b6a1e3f5a2b1] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[7d6a9f2f8c1a] PASSED       [ 40%]
-tests/test_migrations.py::test_double_upgrade[2e3e5b1f2b3c] PASSED       [ 40%]
+tests/test_migrations.py::test_double_upgrade[0b1321c8de13] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[cf2a880aff10] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[4a53667aff6e] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[b6a1e3f5a2b1] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[7d6a9f2f8c1a] PASSED       [ 41%]
+tests/test_migrations.py::test_double_upgrade[2e3e5b1f2b3c] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[9f7c4c3ea9a1] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[3c1b2a4d5e6f] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[8f3f1f0a1b2c] PASSED       [ 41%]
@@ -5610,575 +6110,594 @@ tests/test_migrations.py::test_double_upgrade[c4f8e2a1b6d9] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[84f1d3b2c6e7] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[d1f0e9c2b7aa] PASSED       [ 41%]
 tests/test_migrations.py::test_double_upgrade[2d8a1f7c9b41] PASSED       [ 41%]
-tests/test_native_dependencies.py::test_cryptography_fernet_and_scrypt_runtime PASSED [ 41%]
-tests/test_native_dependencies.py::test_pysequoia_cert_parse_and_encrypt_runtime PASSED [ 41%]
-tests/test_native_dependencies.py::test_psycopg_connects_and_executes_query PASSED [ 41%]
-tests/test_native_dependencies.py::test_greenlet_switch_runtime PASSED   [ 41%]
-tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_get_newsroom_directory_listing_matches_slug_case_insensitively PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_build_newsroom_listing_exposes_geography_properties PASSED [ 41%]
-tests/test_newsroom_directory_listing.py::test_newsroom_seed_path_points_to_committed_dataset PASSED [ 41%]
-tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_non_retryable_http_error_immediately PASSED [ 41%]
-tests/test_newsroom_directory_refresh.py::test_get_with_retries_reraises_last_error_from_post_loop_fallback PASSED [ 41%]
-tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_fallback_error_when_no_attempts_run PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_should_retry_request_error_returns_false_for_non_retryable_errors PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_string_list_handles_split_deduping_and_invalid_inputs PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_http_url_validates_required_and_optional_fields PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_http_url_covers_optional_and_required_error_edges PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_country_subdivision_and_listing_slug_handle_blank_and_fallback_values PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_extract_organization_urls_filters_duplicates_and_non_listing_links PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_extract_european_network_urls_filters_duplicates_and_non_listing_links PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_extract_source_browse_page_urls_for_european_networks_follows_public_pages PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_text_and_core_detail_extractors_skip_incomplete_nodes_and_plain_text_lists PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_location_handles_blank_city_country_and_single_part_inputs PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_location_normalizes_united_states_and_state_abbreviations PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_normalizes_baseline_fields PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_newsroom_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_european_network_helper_extractors_cover_missing_sections_and_mixed_children PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_normalized_row_shapes PASSED [ 42%]
-tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row0-Missing required newsroom id] PASSED [ 42%]
+tests/test_migrations.py::test_double_upgrade[b2039e7c0a1d] PASSED       [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-totp_secret] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-email] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-smtp_server] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-smtp_username] PASSED [ 41%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[users-smtp_password] PASSED [ 42%]
+tests/test_migrations.py::test_encrypted_column_downgrade_refuses_oversized_ciphertext[notification_recipients-email] PASSED [ 42%]
+tests/test_migrations.py::test_envelope_schema_readiness_columns_match_widening_migration PASSED [ 42%]
+tests/test_migrations.py::test_encrypted_field_preflight_tracks_widening_migration_readiness PASSED [ 42%]
+tests/test_migrations.py::test_legacy_encrypted_field_writes_do_not_require_envelope_schema PASSED [ 42%]
+tests/test_migrations.py::test_envelope_encrypted_field_writes_reject_pre_migration_schema PASSED [ 42%]
+tests/test_migrations.py::test_envelope_encrypted_field_writes_accept_widened_schema PASSED [ 42%]
+tests/test_migrations.py::test_downgrade_preserves_mixed_ciphertexts_readable_by_dual_reader PASSED [ 42%]
+tests/test_native_dependencies.py::test_cryptography_fernet_and_scrypt_runtime PASSED [ 42%]
+tests/test_native_dependencies.py::test_pysequoia_cert_parse_and_encrypt_runtime PASSED [ 42%]
+tests/test_native_dependencies.py::test_psycopg_connects_and_executes_query PASSED [ 42%]
+tests/test_native_dependencies.py::test_greenlet_switch_runtime PASSED   [ 42%]
+tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_when_seed_missing PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_newsroom_directory_listings_returns_empty_tuple_for_non_list_seed PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_get_newsroom_directory_listing_matches_slug_case_insensitively PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_build_newsroom_listing_exposes_geography_properties PASSED [ 42%]
+tests/test_newsroom_directory_listing.py::test_newsroom_seed_path_points_to_committed_dataset PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_non_retryable_http_error_immediately PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_reraises_last_error_from_post_loop_fallback PASSED [ 42%]
+tests/test_newsroom_directory_refresh.py::test_get_with_retries_raises_fallback_error_when_no_attempts_run PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_should_retry_request_error_returns_false_for_non_retryable_errors PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_string_list_handles_split_deduping_and_invalid_inputs PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_http_url_validates_required_and_optional_fields PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_http_url_covers_optional_and_required_error_edges PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_country_subdivision_and_listing_slug_handle_blank_and_fallback_values PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_extract_organization_urls_filters_duplicates_and_non_listing_links PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_extract_european_network_urls_filters_duplicates_and_non_listing_links PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_extract_source_browse_page_urls_for_european_networks_follows_public_pages PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_text_and_core_detail_extractors_skip_incomplete_nodes_and_plain_text_lists PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_location_handles_blank_city_country_and_single_part_inputs PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_location_normalizes_united_states_and_state_abbreviations PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_normalizes_baseline_fields PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_newsroom_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_european_network_helper_extractors_cover_missing_sections_and_mixed_children PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_parse_european_network_detail_html_raises_for_missing_name_and_empty_slug PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_normalized_row_shapes PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row0-Missing required newsroom id] PASSED [ 43%]
 tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row1-Missing required newsroom slug] PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row2-Missing required newsroom name] PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_non_string_and_duplicate_slugs PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_rejects_duplicate_ids_and_slugs PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_is_deterministic_and_schema_compatible PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_seen_browse_and_detail_urls PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_raises_when_no_listings_are_discovered PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_wraps_detail_request_failures PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_browse_urls_seen_after_queueing PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_uses_public_explore_urls_only PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_discovers_european_networks_across_public_browse_pages PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_wraps_request_errors PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_retries_transient_gateway_timeout PASSED [ 43%]
-tests/test_newsroom_directory_refresh.py::test_render_newsroom_refresh_summary_includes_counts PASSED [ 43%]
-tests/test_notifications.py::test_notifications_disabled PASSED          [ 43%]
-tests/test_notifications.py::test_notifications_enabled_no_content PASSED [ 43%]
-tests/test_notifications.py::test_notifications_enabled_no_content_delivers_to_all_enabled_recipients PASSED [ 43%]
-tests/test_notifications.py::test_message_submission_deduplicates_notification_recipient_email_addresses PASSED [ 43%]
-tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body PASSED [ 43%]
+tests/test_newsroom_directory_refresh.py::test_normalize_newsroom_row_validates_required_fields[row2-Missing required newsroom name] PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_validates_non_string_and_duplicate_slugs PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_rejects_duplicate_ids_and_slugs PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_refresh_newsroom_directory_rows_is_deterministic_and_schema_compatible PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_seen_browse_and_detail_urls PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_raises_when_no_listings_are_discovered PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_wraps_detail_request_failures PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_rows_for_source_skips_browse_urls_seen_after_queueing PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_uses_public_explore_urls_only PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_discovers_european_networks_across_public_browse_pages PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_wraps_request_errors PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_fetch_newsroom_directory_rows_retries_transient_gateway_timeout PASSED [ 44%]
+tests/test_newsroom_directory_refresh.py::test_render_newsroom_refresh_summary_includes_counts PASSED [ 44%]
+tests/test_notifications.py::test_notifications_disabled PASSED          [ 44%]
+tests/test_notifications.py::test_notifications_enabled_no_content PASSED [ 44%]
+tests/test_notifications.py::test_notifications_enabled_no_content_delivers_to_all_enabled_recipients PASSED [ 44%]
+tests/test_notifications.py::test_message_submission_deduplicates_notification_recipient_email_addresses PASSED [ 44%]
+tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body PASSED [ 44%]
 tests/test_notifications.py::test_notifications_enabled_yes_content_no_encrypted_body_delivers_to_all_enabled_recipients PASSED [ 44%]
-tests/test_notifications.py::test_notifications_multi_recipient_missing_field_ciphertext_uses_generic_body PASSED [ 44%]
-tests/test_notifications.py::test_notifications_multi_recipient_non_object_field_ciphertext_payload_uses_generic_body PASSED [ 44%]
-tests/test_notifications.py::test_notifications_multi_recipient_uses_recipient_specific_field_ciphertext PASSED [ 44%]
-tests/test_notifications.py::test_notifications_enabled_yes_content_yes_encrypted_body PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_embedded_markers_use_server_fallback PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_uses_client_body_for_all_enabled_recipients PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_multi_recipient_does_not_wrap_encrypted_fields PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_server_fallback PASSED [ 44%]
-tests/test_notifications.py::test_notifications_full_body_encryption_fallback_uses_all_enabled_recipient_keys PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_flow PASSED                    [ 44%]
-tests/test_onboarding.py::test_onboarding_directory_opt_out_persists_false PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_directory_opt_out_overrides_prepopulated_true PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_skip PASSED                    [ 44%]
-tests/test_onboarding.py::test_onboarding_proton_search_prefills_manual_key PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[display_name] PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[bio] PASSED [ 44%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[pgp_key] PASSED [ 44%]
+tests/test_notifications.py::test_notifications_multi_recipient_missing_field_ciphertext_uses_generic_body PASSED [ 45%]
+tests/test_notifications.py::test_notifications_multi_recipient_non_object_field_ciphertext_payload_uses_generic_body PASSED [ 45%]
+tests/test_notifications.py::test_notifications_multi_recipient_uses_recipient_specific_field_ciphertext PASSED [ 45%]
+tests/test_notifications.py::test_notifications_enabled_yes_content_yes_encrypted_body PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_embedded_markers_use_server_fallback PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_uses_client_body_for_all_enabled_recipients PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_multi_recipient_does_not_wrap_encrypted_fields PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_server_fallback PASSED [ 45%]
+tests/test_notifications.py::test_notifications_full_body_encryption_fallback_uses_all_enabled_recipient_keys PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_flow PASSED                    [ 45%]
+tests/test_onboarding.py::test_onboarding_directory_opt_out_persists_false PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_directory_opt_out_overrides_prepopulated_true PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_skip PASSED                    [ 45%]
+tests/test_onboarding.py::test_onboarding_proton_search_prefills_manual_key PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[display_name] PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[bio] PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[pgp_key] PASSED [ 45%]
 tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[enable_email_notifications] PASSED [ 45%]
 tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_include_message_content] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_encrypt_entire_body] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[show_in_directory] PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_redirects_to_inbox_when_already_complete PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_allows_non_profile_step_when_already_complete PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_handles_missing_primary_username PASSED [ 45%]
-tests/test_onboarding.py::test_submitted_onboarding_form_selects_expected_step_form PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_encryption_unknown_method_returns_bad_request PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_key_shows_error PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_proton_fetch_failure_shows_error PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_notifications_requires_pgp_key PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_missing_user_redirects_login PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_invalid_step_defaults_to_profile PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_post_invalid_step_defaults_to_profile PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_profile_invalid_form_returns_400 PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_profile_invalid_form_preserves_submitted_values PASSED [ 45%]
-tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_returns_400 PASSED [ 45%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email_encrypt_entire_body] PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[email] PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_requires_all_steps_when_any_value_incomplete[show_in_directory] PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_redirects_to_inbox_when_already_complete PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_allows_non_profile_step_when_already_complete PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_handles_missing_primary_username PASSED [ 46%]
+tests/test_onboarding.py::test_submitted_onboarding_form_selects_expected_step_form PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_encryption_unknown_method_returns_bad_request PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_key_shows_error PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_proton_fetch_failure_shows_error PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_notifications_requires_pgp_key PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_missing_user_redirects_login PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_invalid_step_defaults_to_profile PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_post_invalid_step_defaults_to_profile PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_profile_invalid_form_returns_400 PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_profile_invalid_form_preserves_submitted_values PASSED [ 46%]
+tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_returns_400 PASSED [ 46%]
 tests/test_onboarding.py::test_onboarding_encryption_proton_invalid_form_preserves_submitted_email PASSED [ 46%]
 tests/test_onboarding.py::test_onboarding_proton_key_without_encryption_subkey_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_proton_no_key_found_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_proton_non_200_response_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_missing_key_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_whitespace_key_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_form_returns_400_with_csrf PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_encryption_manual_non_encryptable_key_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_notifications_invalid_form_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_profile_requires_csrf_token PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_notifications_requires_csrf_token PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_directory_invalid_form_returns_400_with_csrf PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_unknown_step_post_returns_400 PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_directory_redirects_to_select_tier_when_stripe_enabled PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_skip_missing_user_redirects_login PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_skip_invalid_form_redirects_onboarding_with_csrf PASSED [ 46%]
-tests/test_onboarding.py::test_onboarding_skip_redirects_to_select_tier_when_enabled PASSED [ 46%]
-tests/test_onboarding.py::test_webpack_build_includes_onboarding_bundle PASSED [ 46%]
-tests/test_password_hasher.py::test_verify_password_uses_legacy_passlib_scrypt_fixture_and_logs_success PASSED [ 46%]
-tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_legacy_passlib_scrypt_fixture PASSED [ 47%]
-tests/test_password_hasher.py::test_legacy_passlib_scrypt_fixture_documents_prefix_and_cost_baseline PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_uses_native_werkzeug_scrypt_hash_and_logs_success PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_native_werkzeug_scrypt_hash PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_routes_non_scrypt_native_prefixes_to_primary_verifier PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_primary_password_hash_rejects_non_scrypt_native_prefix PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_unknown_prefix_fails_closed_without_mutating_user PASSED [ 47%]
-tests/test_password_hasher.py::test_verify_password_malformed_legacy_hash_fails_closed PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_without_app_context PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_skips_non_legacy_hashes PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_when_disabled PASSED [ 47%]
-tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_rehashes_legacy_hash_when_enabled PASSED [ 47%]
-tests/test_password_hasher.py::test_get_password_hash_prefix_returns_unknown_for_plaintext_like_values PASSED [ 47%]
-tests/test_password_hasher.py::test_hash_password_logs_write_counter_without_sensitive_data PASSED [ 47%]
-tests/test_password_hasher.py::test_hash_password_uses_pinned_werkzeug_scrypt_method_when_enabled PASSED [ 47%]
-tests/test_password_hasher.py::test_pinned_werkzeug_scrypt_method_matches_legacy_passlib_cost_baseline PASSED [ 47%]
-tests/test_password_hasher.py::test_password_hash_telemetry_helpers_noop_without_app_context PASSED [ 47%]
-tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[True-password_hash_rehash_on_auth_success_total] PASSED [ 47%]
-tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[False-password_hash_rehash_on_auth_failure_total] PASSED [ 48%]
-tests/test_premium.py::test_create_products_and_prices PASSED            [ 48%]
-tests/test_premium.py::test_update_price_existing PASSED                 [ 48%]
-tests/test_premium.py::test_update_price_new PASSED                      [ 48%]
-tests/test_premium.py::test_create_customer PASSED                       [ 48%]
-tests/test_premium.py::test_create_customer_updates_existing_customer PASSED [ 48%]
-tests/test_premium.py::test_create_customer_recreates_when_modify_fails PASSED [ 48%]
-tests/test_premium.py::test_get_subscription PASSED                      [ 48%]
-tests/test_premium.py::test_get_business_price_string_formats PASSED     [ 48%]
-tests/test_premium.py::test_get_business_price_string_missing_tier PASSED [ 48%]
-tests/test_premium.py::test_create_products_and_prices_missing_business_tier PASSED [ 48%]
-tests/test_premium.py::test_update_price_without_product_id_logs_and_returns PASSED [ 48%]
-tests/test_premium.py::test_get_subscription_none_when_missing_subscription_id PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_created PASSED           [ 48%]
-tests/test_premium.py::test_handle_subscription_created_raises_for_missing_user PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_updated_upgrade PASSED   [ 48%]
-tests/test_premium.py::test_handle_subscription_updated_downgrade PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_updated_raises_for_missing_subscription PASSED [ 48%]
-tests/test_premium.py::test_handle_subscription_deleted PASSED           [ 48%]
-tests/test_premium.py::test_handle_subscription_deleted_raises_for_missing_subscription PASSED [ 49%]
-tests/test_premium.py::test_handle_invoice_created PASSED                [ 49%]
-tests/test_premium.py::test_handle_invoice_created_value_error_is_handled PASSED [ 49%]
-tests/test_premium.py::test_handle_invoice_updated PASSED                [ 49%]
-tests/test_premium.py::test_handle_invoice_updated_refreshes_receipt_url PASSED [ 49%]
-tests/test_premium.py::test_premium_index_links_receipts_through_authenticated_route PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_refreshes_stale_url_before_redirect PASSED [ 49%]
-tests/test_premium.py::test_receipt_url_from_invoice_prefers_pdf_when_hosted_url_missing PASSED [ 49%]
-tests/test_premium.py::test_receipt_url_from_invoice_returns_none_without_hosted_url_or_pdf PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_redirects_to_stale_url_when_stripe_refresh_fails PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_flashes_when_no_receipt_url_available PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_redirects_to_login_when_user_missing_inside_route PASSED [ 49%]
-tests/test_premium.py::test_receipt_route_returns_404_for_missing_invoice PASSED [ 49%]
-tests/test_premium.py::test_handle_invoice_updated_raises_for_missing_invoice PASSED [ 49%]
-tests/test_premium.py::test_upgrade_post_user_already_on_business_tier PASSED [ 49%]
-tests/test_premium.py::test_upgrade_process PASSED                       [ 49%]
-tests/test_premium.py::test_upgrade_process_uses_public_base_url_for_success_url PASSED [ 49%]
-tests/test_premium.py::test_update_payment_method_creates_billing_portal_session PASSED [ 49%]
-tests/test_premium.py::test_update_payment_method_requires_active_subscription PASSED [ 50%]
-tests/test_premium.py::test_update_payment_method_stripe_error PASSED    [ 50%]
-tests/test_premium.py::test_update_payment_method_aborts_when_portal_session_has_no_url PASSED [ 50%]
-tests/test_premium.py::test_disable_autorenew_no_user_in_session PASSED  [ 50%]
-tests/test_premium.py::test_disable_autorenew_no_subscription PASSED     [ 50%]
-tests/test_premium.py::test_disable_autorenew_success PASSED             [ 50%]
-tests/test_premium.py::test_disable_autorenew_stripe_error PASSED        [ 50%]
-tests/test_premium.py::test_enable_autorenew_no_user_in_session PASSED   [ 50%]
-tests/test_premium.py::test_enable_autorenew_no_subscription PASSED      [ 50%]
-tests/test_premium.py::test_enable_autorenew_success PASSED              [ 50%]
-tests/test_premium.py::test_enable_autorenew_stripe_error PASSED         [ 50%]
-tests/test_premium.py::test_cancel_no_user_in_session PASSED             [ 50%]
-tests/test_premium.py::test_cancel_no_subscription PASSED                [ 50%]
-tests/test_premium.py::test_cancel_success PASSED                        [ 50%]
-tests/test_premium.py::test_cancel_stripe_error PASSED                   [ 50%]
-tests/test_premium.py::test_premium_select_tier_redirects_when_onboarding_incomplete PASSED [ 50%]
-tests/test_premium.py::test_premium_select_free_sets_free_tier_when_unset PASSED [ 50%]
-tests/test_premium.py::test_premium_status_business_user_flashes_success PASSED [ 50%]
-tests/test_premium.py::test_premium_index_warns_on_incomplete_subscription PASSED [ 50%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.index-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_tier-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_free-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.upgrade-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.update_payment_method-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.disable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.enable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.cancel-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.status-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.index-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_tier-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_free-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.upgrade-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.update_payment_method-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.disable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.enable_autorenew-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.cancel-post] PASSED [ 51%]
-tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.status-get] PASSED [ 51%]
-tests/test_premium.py::test_premium_select_tier_renders_for_complete_user PASSED [ 51%]
-tests/test_premium.py::test_premium_waiting_page_renders PASSED          [ 52%]
-tests/test_premium.py::test_upgrade_missing_business_tier PASSED         [ 52%]
-tests/test_premium.py::test_upgrade_missing_business_price_id PASSED     [ 52%]
-tests/test_premium.py::test_upgrade_create_customer_failure PASSED       [ 52%]
-tests/test_premium.py::test_upgrade_checkout_creation_failure PASSED     [ 52%]
-tests/test_premium.py::test_upgrade_checkout_session_without_url_returns_500 PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_rejects_invalid_payload PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_rejects_invalid_signature PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_ignores_duplicate_event PASSED [ 52%]
-tests/test_premium.py::test_premium_webhook_stores_new_event PASSED      [ 52%]
-tests/test_premium.py::test_worker_processes_subscription_created_event PASSED [ 52%]
-tests/test_premium.py::test_worker_marks_event_error_when_handler_raises PASSED [ 52%]
-tests/test_premium.py::test_worker_waits_for_tables_before_starting PASSED [ 52%]
-tests/test_premium.py::test_worker_processes_subscription_updated_and_deleted_events PASSED [ 52%]
-tests/test_premium.py::test_worker_processes_invoice_created_event PASSED [ 52%]
-tests/test_premium.py::test_worker_processes_invoice_payment_succeeded_event PASSED [ 52%]
-tests/test_profile.py::test_profile_header PASSED                        [ 52%]
-tests/test_profile.py::test_profile_accepts_case_insensitive_username PASSED [ 52%]
-tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_non_admin_display_name PASSED [ 53%]
-tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_username_when_display_name_missing PASSED [ 53%]
-tests/test_profile.py::test_profile_404_for_unknown_username PASSED      [ 53%]
-tests/test_profile.py::test_profile_404s_when_case_insensitive_lookup_is_ambiguous PASSED [ 53%]
-tests/test_profile.py::test_profile_does_not_expose_owner_user_id PASSED [ 53%]
-tests/test_profile.py::test_profile_submit_message PASSED                [ 53%]
-tests/test_profile.py::test_profile_submit_message_to_alias PASSED       [ 53%]
-tests/test_profile.py::test_profile_failed_submit_preserves_input PASSED [ 53%]
-tests/test_profile.py::test_profile_rejects_owner_guard_mismatch PASSED  [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_non_numeric_captcha PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_expired_captcha_token PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_bad_captcha_token PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_captcha_token_for_different_profile PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_post_404s_if_account_is_suspended_after_render PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_if_account_is_suspended_during_submission PASSED [ 53%]
-tests/test_profile.py::test_embed_profile_rejects_if_recipient_keys_are_removed_during_submission PASSED [ 53%]
-tests/test_profile.py::test_profile_pgp_required PASSED                  [ 53%]
-tests/test_profile.py::test_profile_allows_submission_with_recipient_key_when_legacy_user_key_missing PASSED [ 53%]
-tests/test_profile.py::test_profile_allows_submission_with_legacy_key_when_primary_recipient_lacks_key PASSED [ 53%]
-tests/test_profile.py::test_profile_submit_message_with_recipient_key_when_legacy_user_key_missing PASSED [ 54%]
-tests/test_profile.py::test_profile_submit_message_ignores_enabled_recipient_without_key PASSED [ 54%]
-tests/test_profile.py::test_profile_suspended_state_disables_message_form_with_pgp_key PASSED [ 54%]
-tests/test_profile.py::test_profile_post_rejects_when_target_has_no_pgp_key PASSED [ 54%]
-tests/test_profile.py::test_profile_post_rejects_when_target_is_suspended PASSED [ 54%]
-tests/test_profile.py::test_profile_post_rejects_alias_when_owner_is_suspended PASSED [ 54%]
-tests/test_profile.py::test_profile_post_form_validation_errors_are_rendered PASSED [ 54%]
-tests/test_profile.py::test_profile_requires_csrf_token PASSED           [ 54%]
-tests/test_profile.py::test_profile_full_body_encryption_fallback_to_generic_when_no_fields PASSED [ 54%]
-tests/test_profile.py::test_profile_full_body_encryption_exception_falls_back_to_generic PASSED [ 54%]
-tests/test_profile.py::test_profile_full_body_encryption_uses_server_fallback_when_client_body_missing PASSED [ 54%]
-tests/test_profile.py::test_profile_notification_without_message_content_sends_generic_body PASSED [ 54%]
-tests/test_profile.py::test_profile_single_recipient_notification_can_include_stored_message_content PASSED [ 54%]
-tests/test_profile.py::test_profile_extra_fields PASSED                  [ 54%]
-tests/test_profile.py::test_profile_field_encryption_labels PASSED       [ 54%]
-tests/test_profile.py::test_profile_account_category_renders_first_extra_field PASSED [ 54%]
-tests/test_profile.py::test_profile_location_renders_as_single_extra_field PASSED [ 54%]
-tests/test_profile.py::test_profile_location_keeps_full_names_outside_us PASSED [ 54%]
-tests/test_profile.py::test_redirect_submit_message_route PASSED         [ 54%]
-tests/test_profile.py::test_submission_success_without_reply_slug_redirects_directory PASSED [ 55%]
-tests/test_profile.py::test_submission_success_404_when_message_missing PASSED [ 55%]
-tests/test_profile.py::test_submission_success_uses_public_base_url_for_reply_link PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_build_snapshot_filters_to_public_hushline_users PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_build_markdown_report_reports_added_and_removed_usernames PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_build_readme_report_renders_natural_language_and_history_table PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_resolve_history_baselines_uses_latest_sync_and_week_old_snapshot PASSED [ 55%]
-tests/test_public_directory_snapshot_report.py::test_load_summary_history_includes_current_summary_and_sorts_descending PASSED [ 55%]
-tests/test_public_record_refresh.py::test_default_us_region_state_map_includes_all_50_states PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_is_deterministic_and_schema_compatible PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_preserves_existing_identifiers PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_duplicate_id_or_slug PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_enforces_region_targets PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_above_region_targets PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_flags_and_drops_link_failures PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_on_transient_link_failures PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_legacy_self_reported_source_label PASSED [ 55%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_source_matching_website PASSED [ 55%]
+tests/test_onboarding.py::test_onboarding_proton_no_key_found_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_proton_non_200_response_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_missing_key_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_whitespace_key_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_invalid_form_returns_400_with_csrf PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_encryption_manual_non_encryptable_key_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_notifications_invalid_form_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_profile_requires_csrf_token PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_notifications_requires_csrf_token PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_directory_invalid_form_returns_400_with_csrf PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_unknown_step_post_returns_400 PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_directory_redirects_to_select_tier_when_stripe_enabled PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_skip_missing_user_redirects_login PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_skip_invalid_form_redirects_onboarding_with_csrf PASSED [ 47%]
+tests/test_onboarding.py::test_onboarding_skip_redirects_to_select_tier_when_enabled PASSED [ 47%]
+tests/test_onboarding.py::test_webpack_build_includes_onboarding_bundle PASSED [ 47%]
+tests/test_operational_key_management_design.py::test_operational_key_management_design_exists_and_is_linked PASSED [ 47%]
+tests/test_operational_key_management_design.py::test_operational_key_management_design_covers_required_topics PASSED [ 47%]
+tests/test_operational_key_management_design.py::test_operational_key_management_design_locks_recommendation_and_guardrails PASSED [ 47%]
+tests/test_password_hash_modernization_evaluation.py::test_password_hash_modernization_evaluation_exists_and_is_linked PASSED [ 48%]
+tests/test_password_hash_modernization_evaluation.py::test_password_hash_modernization_evaluation_covers_required_decision_points PASSED [ 48%]
+tests/test_password_hash_modernization_evaluation.py::test_password_hash_modernization_evaluation_locks_guardrails PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_uses_legacy_passlib_scrypt_fixture_and_logs_success PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_legacy_passlib_scrypt_fixture PASSED [ 48%]
+tests/test_password_hasher.py::test_legacy_passlib_scrypt_fixture_documents_prefix_and_cost_baseline PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_uses_native_werkzeug_scrypt_hash_and_logs_success PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_rejects_wrong_password_for_native_werkzeug_scrypt_hash PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_routes_non_scrypt_native_prefixes_to_primary_verifier PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_primary_password_hash_rejects_non_scrypt_native_prefix PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_unknown_prefix_fails_closed_without_mutating_user PASSED [ 48%]
+tests/test_password_hasher.py::test_verify_password_malformed_legacy_hash_fails_closed PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_without_app_context PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_skips_non_legacy_hashes PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_returns_none_when_disabled PASSED [ 48%]
+tests/test_password_hasher.py::test_prepare_password_rehash_on_auth_rehashes_legacy_hash_when_enabled PASSED [ 48%]
+tests/test_password_hasher.py::test_get_password_hash_prefix_returns_unknown_for_plaintext_like_values PASSED [ 48%]
+tests/test_password_hasher.py::test_hash_password_logs_write_counter_without_sensitive_data PASSED [ 48%]
+tests/test_password_hasher.py::test_hash_password_uses_pinned_werkzeug_scrypt_method_when_enabled PASSED [ 48%]
+tests/test_password_hasher.py::test_pinned_werkzeug_scrypt_method_matches_legacy_passlib_cost_baseline PASSED [ 49%]
+tests/test_password_hasher.py::test_password_hash_telemetry_helpers_noop_without_app_context PASSED [ 49%]
+tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[True-password_hash_rehash_on_auth_success_total] PASSED [ 49%]
+tests/test_password_hasher.py::test_emit_password_rehash_on_auth_telemetry_logs_counter_without_sensitive_data[False-password_hash_rehash_on_auth_failure_total] PASSED [ 49%]
+tests/test_premium.py::test_create_products_and_prices PASSED            [ 49%]
+tests/test_premium.py::test_update_price_existing PASSED                 [ 49%]
+tests/test_premium.py::test_update_price_new PASSED                      [ 49%]
+tests/test_premium.py::test_create_customer PASSED                       [ 49%]
+tests/test_premium.py::test_create_customer_updates_existing_customer PASSED [ 49%]
+tests/test_premium.py::test_create_customer_recreates_when_modify_fails PASSED [ 49%]
+tests/test_premium.py::test_get_subscription PASSED                      [ 49%]
+tests/test_premium.py::test_get_business_price_string_formats PASSED     [ 49%]
+tests/test_premium.py::test_get_business_price_string_missing_tier PASSED [ 49%]
+tests/test_premium.py::test_create_products_and_prices_missing_business_tier PASSED [ 49%]
+tests/test_premium.py::test_update_price_without_product_id_logs_and_returns PASSED [ 49%]
+tests/test_premium.py::test_get_subscription_none_when_missing_subscription_id PASSED [ 49%]
+tests/test_premium.py::test_handle_subscription_created PASSED           [ 49%]
+tests/test_premium.py::test_handle_subscription_created_raises_for_missing_user PASSED [ 49%]
+tests/test_premium.py::test_handle_subscription_updated_upgrade PASSED   [ 49%]
+tests/test_premium.py::test_handle_subscription_updated_downgrade PASSED [ 50%]
+tests/test_premium.py::test_handle_subscription_updated_raises_for_missing_subscription PASSED [ 50%]
+tests/test_premium.py::test_handle_subscription_deleted PASSED           [ 50%]
+tests/test_premium.py::test_handle_subscription_deleted_raises_for_missing_subscription PASSED [ 50%]
+tests/test_premium.py::test_handle_invoice_created PASSED                [ 50%]
+tests/test_premium.py::test_handle_invoice_created_value_error_is_handled PASSED [ 50%]
+tests/test_premium.py::test_handle_invoice_updated PASSED                [ 50%]
+tests/test_premium.py::test_handle_invoice_updated_refreshes_receipt_url PASSED [ 50%]
+tests/test_premium.py::test_premium_index_links_receipts_through_authenticated_route PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_refreshes_stale_url_before_redirect PASSED [ 50%]
+tests/test_premium.py::test_receipt_url_from_invoice_prefers_pdf_when_hosted_url_missing PASSED [ 50%]
+tests/test_premium.py::test_receipt_url_from_invoice_returns_none_without_hosted_url_or_pdf PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_redirects_to_stale_url_when_stripe_refresh_fails PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_flashes_when_no_receipt_url_available PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_redirects_to_login_when_user_missing_inside_route PASSED [ 50%]
+tests/test_premium.py::test_receipt_route_returns_404_for_missing_invoice PASSED [ 50%]
+tests/test_premium.py::test_handle_invoice_updated_raises_for_missing_invoice PASSED [ 50%]
+tests/test_premium.py::test_upgrade_post_user_already_on_business_tier PASSED [ 50%]
+tests/test_premium.py::test_upgrade_process PASSED                       [ 50%]
+tests/test_premium.py::test_upgrade_process_uses_public_base_url_for_success_url PASSED [ 50%]
+tests/test_premium.py::test_update_payment_method_creates_billing_portal_session PASSED [ 51%]
+tests/test_premium.py::test_update_payment_method_requires_active_subscription PASSED [ 51%]
+tests/test_premium.py::test_update_payment_method_stripe_error PASSED    [ 51%]
+tests/test_premium.py::test_update_payment_method_aborts_when_portal_session_has_no_url PASSED [ 51%]
+tests/test_premium.py::test_disable_autorenew_no_user_in_session PASSED  [ 51%]
+tests/test_premium.py::test_disable_autorenew_no_subscription PASSED     [ 51%]
+tests/test_premium.py::test_disable_autorenew_success PASSED             [ 51%]
+tests/test_premium.py::test_disable_autorenew_stripe_error PASSED        [ 51%]
+tests/test_premium.py::test_enable_autorenew_no_user_in_session PASSED   [ 51%]
+tests/test_premium.py::test_enable_autorenew_no_subscription PASSED      [ 51%]
+tests/test_premium.py::test_enable_autorenew_success PASSED              [ 51%]
+tests/test_premium.py::test_enable_autorenew_stripe_error PASSED         [ 51%]
+tests/test_premium.py::test_cancel_no_user_in_session PASSED             [ 51%]
+tests/test_premium.py::test_cancel_no_subscription PASSED                [ 51%]
+tests/test_premium.py::test_cancel_success PASSED                        [ 51%]
+tests/test_premium.py::test_cancel_stripe_error PASSED                   [ 51%]
+tests/test_premium.py::test_premium_select_tier_redirects_when_onboarding_incomplete PASSED [ 51%]
+tests/test_premium.py::test_premium_select_free_sets_free_tier_when_unset PASSED [ 51%]
+tests/test_premium.py::test_premium_status_business_user_flashes_success PASSED [ 51%]
+tests/test_premium.py::test_premium_index_warns_on_incomplete_subscription PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.index-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_tier-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.select_free-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.upgrade-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.update_payment_method-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.disable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.enable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.cancel-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_redirect_to_login_when_user_missing_after_auth[premium.status-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.index-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_tier-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.select_free-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.upgrade-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.update_payment_method-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.disable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.enable_autorenew-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.cancel-post] PASSED [ 52%]
+tests/test_premium.py::test_premium_routes_clear_session_when_user_missing_inside_route[premium.status-get] PASSED [ 52%]
+tests/test_premium.py::test_premium_select_tier_renders_for_complete_user PASSED [ 53%]
+tests/test_premium.py::test_premium_waiting_page_renders PASSED          [ 53%]
+tests/test_premium.py::test_upgrade_missing_business_tier PASSED         [ 53%]
+tests/test_premium.py::test_upgrade_missing_business_price_id PASSED     [ 53%]
+tests/test_premium.py::test_upgrade_create_customer_failure PASSED       [ 53%]
+tests/test_premium.py::test_upgrade_checkout_creation_failure PASSED     [ 53%]
+tests/test_premium.py::test_upgrade_checkout_session_without_url_returns_500 PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_rejects_invalid_payload PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_rejects_invalid_signature PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_ignores_duplicate_event PASSED [ 53%]
+tests/test_premium.py::test_premium_webhook_stores_new_event PASSED      [ 53%]
+tests/test_premium.py::test_worker_processes_subscription_created_event PASSED [ 53%]
+tests/test_premium.py::test_worker_marks_event_error_when_handler_raises PASSED [ 53%]
+tests/test_premium.py::test_worker_waits_for_tables_before_starting PASSED [ 53%]
+tests/test_premium.py::test_worker_processes_subscription_updated_and_deleted_events PASSED [ 53%]
+tests/test_premium.py::test_worker_processes_invoice_created_event PASSED [ 53%]
+tests/test_premium.py::test_worker_processes_invoice_payment_succeeded_event PASSED [ 53%]
+tests/test_profile.py::test_profile_header PASSED                        [ 53%]
+tests/test_profile.py::test_profile_accepts_case_insensitive_username PASSED [ 53%]
+tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_non_admin_display_name PASSED [ 54%]
+tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_username_when_display_name_missing PASSED [ 54%]
+tests/test_profile.py::test_profile_404_for_unknown_username PASSED      [ 54%]
+tests/test_profile.py::test_profile_404s_when_case_insensitive_lookup_is_ambiguous PASSED [ 54%]
+tests/test_profile.py::test_profile_does_not_expose_owner_user_id PASSED [ 54%]
+tests/test_profile.py::test_profile_submit_message PASSED                [ 54%]
+tests/test_profile.py::test_profile_submit_message_to_alias PASSED       [ 54%]
+tests/test_profile.py::test_profile_failed_submit_preserves_input PASSED [ 54%]
+tests/test_profile.py::test_profile_rejects_owner_guard_mismatch PASSED  [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_non_numeric_captcha PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_expired_captcha_token PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_bad_captcha_token PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_captcha_token_for_different_profile PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_post_404s_if_account_is_suspended_after_render PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_if_account_is_suspended_during_submission PASSED [ 54%]
+tests/test_profile.py::test_embed_profile_rejects_if_recipient_keys_are_removed_during_submission PASSED [ 54%]
+tests/test_profile.py::test_profile_pgp_required PASSED                  [ 54%]
+tests/test_profile.py::test_profile_allows_submission_with_recipient_key_when_legacy_user_key_missing PASSED [ 54%]
+tests/test_profile.py::test_profile_allows_submission_with_legacy_key_when_primary_recipient_lacks_key PASSED [ 54%]
+tests/test_profile.py::test_profile_submit_message_with_recipient_key_when_legacy_user_key_missing PASSED [ 55%]
+tests/test_profile.py::test_profile_submit_message_ignores_enabled_recipient_without_key PASSED [ 55%]
+tests/test_profile.py::test_profile_suspended_state_disables_message_form_with_pgp_key PASSED [ 55%]
+tests/test_profile.py::test_profile_post_rejects_when_target_has_no_pgp_key PASSED [ 55%]
+tests/test_profile.py::test_profile_post_rejects_when_target_is_suspended PASSED [ 55%]
+tests/test_profile.py::test_profile_post_rejects_alias_when_owner_is_suspended PASSED [ 55%]
+tests/test_profile.py::test_profile_post_form_validation_errors_are_rendered PASSED [ 55%]
+tests/test_profile.py::test_profile_requires_csrf_token PASSED           [ 55%]
+tests/test_profile.py::test_profile_full_body_encryption_fallback_to_generic_when_no_fields PASSED [ 55%]
+tests/test_profile.py::test_profile_full_body_encryption_exception_falls_back_to_generic PASSED [ 55%]
+tests/test_profile.py::test_profile_full_body_encryption_uses_server_fallback_when_client_body_missing PASSED [ 55%]
+tests/test_profile.py::test_profile_notification_without_message_content_sends_generic_body PASSED [ 55%]
+tests/test_profile.py::test_profile_single_recipient_notification_can_include_stored_message_content PASSED [ 55%]
+tests/test_profile.py::test_profile_extra_fields PASSED                  [ 55%]
+tests/test_profile.py::test_profile_field_encryption_labels PASSED       [ 55%]
+tests/test_profile.py::test_profile_account_category_renders_first_extra_field PASSED [ 55%]
+tests/test_profile.py::test_profile_location_renders_as_single_extra_field PASSED [ 55%]
+tests/test_profile.py::test_profile_location_keeps_full_names_outside_us PASSED [ 55%]
+tests/test_profile.py::test_redirect_submit_message_route PASSED         [ 55%]
+tests/test_profile.py::test_submission_success_without_reply_slug_redirects_directory PASSED [ 56%]
+tests/test_profile.py::test_submission_success_404_when_message_missing PASSED [ 56%]
+tests/test_profile.py::test_submission_success_uses_public_base_url_for_reply_link PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_build_snapshot_filters_to_public_hushline_users PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_build_markdown_report_reports_added_and_removed_usernames PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_build_readme_report_renders_natural_language_and_history_table PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_resolve_history_baselines_uses_latest_sync_and_week_old_snapshot PASSED [ 56%]
+tests/test_public_directory_snapshot_report.py::test_load_summary_history_includes_current_summary_and_sorts_descending PASSED [ 56%]
+tests/test_public_record_refresh.py::test_default_us_region_state_map_includes_all_50_states PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_is_deterministic_and_schema_compatible PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_preserves_existing_identifiers PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_duplicate_id_or_slug PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_enforces_region_targets PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_above_region_targets PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_flags_and_drops_link_failures PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_keeps_rows_on_transient_link_failures PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_legacy_self_reported_source_label PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_source_matching_website PASSED [ 56%]
 tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_missing_us_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_cross_state_source_policy PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_generic_us_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_ohio_record_fragment_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_ohio_generic_home_fragment_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_synthetic_listing_marker PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_search_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_source_url PASSED [ 56%]
-tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_non_chambers_hosts_with_chambers_substrings PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_retries_then_succeeds PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_marks_404_as_definitive_failure PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_rejects_invalid_arguments PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_server_error_after_retries PASSED [ 56%]
-tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_request_exception_reason PASSED [ 56%]
-tests/test_public_record_refresh.py::test_render_refresh_summary_includes_dropped_ids_and_link_failures PASSED [ 56%]
-tests/test_public_record_refresh.py::test_parse_chambers_index_entries_skips_invalid_rows_and_sorts PASSED [ 56%]
-tests/test_public_record_refresh.py::test_fetch_json_payload_handles_non_200_and_successful_json PASSED [ 56%]
-tests/test_public_record_refresh.py::test_discovered_description_handles_tag_list_shapes PASSED [ 56%]
-tests/test_public_record_refresh.py::test_validate_regions_rejects_unknown_region PASSED [ 56%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_cross_state_source_policy PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_generic_us_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_ohio_record_fragment_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_ohio_generic_home_fragment_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_synthetic_listing_marker PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_search_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_rejects_chambers_source_url PASSED [ 57%]
+tests/test_public_record_refresh.py::test_refresh_public_record_rows_allows_non_chambers_hosts_with_chambers_substrings PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_retries_then_succeeds PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_marks_404_as_definitive_failure PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_rejects_invalid_arguments PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_server_error_after_retries PASSED [ 57%]
+tests/test_public_record_refresh.py::test_build_requests_link_checker_returns_last_request_exception_reason PASSED [ 57%]
+tests/test_public_record_refresh.py::test_render_refresh_summary_includes_dropped_ids_and_link_failures PASSED [ 57%]
+tests/test_public_record_refresh.py::test_parse_chambers_index_entries_skips_invalid_rows_and_sorts PASSED [ 57%]
+tests/test_public_record_refresh.py::test_fetch_json_payload_handles_non_200_and_successful_json PASSED [ 57%]
+tests/test_public_record_refresh.py::test_discovered_description_handles_tag_list_shapes PASSED [ 57%]
+tests/test_public_record_refresh.py::test_validate_regions_rejects_unknown_region PASSED [ 57%]
 tests/test_public_record_refresh.py::test_chambers_public_profile_url_helpers_cover_supported_and_invalid_inputs PASSED [ 57%]
-tests/test_public_record_refresh.py::test_apply_region_targets_handles_none_and_invalid_target_configurations PASSED [ 57%]
-tests/test_public_record_refresh.py::test_normalization_helpers_validate_and_filter_values PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_seed_rows_respects_zero_limit_and_maximum PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_noop_official_public_record_rows_returns_empty_list PASSED [ 57%]
-tests/test_public_record_refresh.py::test_parse_chambers_index_entries_returns_empty_for_non_list_payload PASSED [ 57%]
-tests/test_public_record_refresh.py::test_fetch_json_payload_handles_exceptions_and_invalid_json PASSED [ 57%]
-tests/test_public_record_refresh.py::test_chambers_discovery_helpers_cover_locations_tags_and_url_normalization PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_validates_arguments_and_missing_adapters PASSED [ 57%]
-tests/test_public_record_refresh.py::test_authoritative_source_and_url_helper_branches PASSED [ 57%]
-tests/test_public_record_refresh.py::test_validate_links_skips_empty_fields_and_region_lookup_requires_mapping PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_chambers_public_record_rows_is_disabled PASSED [ 57%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_strict_accepts_full_coverage PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_covers_current_implemented_states PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AK] PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AL] PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AR] PASSED [ 57%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AZ] PASSED [ 57%]
+tests/test_public_record_refresh.py::test_apply_region_targets_handles_none_and_invalid_target_configurations PASSED [ 58%]
+tests/test_public_record_refresh.py::test_normalization_helpers_validate_and_filter_values PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_seed_rows_respects_zero_limit_and_maximum PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_noop_official_public_record_rows_returns_empty_list PASSED [ 58%]
+tests/test_public_record_refresh.py::test_parse_chambers_index_entries_returns_empty_for_non_list_payload PASSED [ 58%]
+tests/test_public_record_refresh.py::test_fetch_json_payload_handles_exceptions_and_invalid_json PASSED [ 58%]
+tests/test_public_record_refresh.py::test_chambers_discovery_helpers_cover_locations_tags_and_url_normalization PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_validates_arguments_and_missing_adapters PASSED [ 58%]
+tests/test_public_record_refresh.py::test_authoritative_source_and_url_helper_branches PASSED [ 58%]
+tests/test_public_record_refresh.py::test_validate_links_skips_empty_fields_and_region_lookup_requires_mapping PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_chambers_public_record_rows_is_disabled PASSED [ 58%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_strict_accepts_full_coverage PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_covers_current_implemented_states PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AK] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AL] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AR] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[AZ] PASSED [ 58%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CA] PASSED [ 58%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CO] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CT] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[DE] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[FL] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[GA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[HI] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ID] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IL] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IN] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KS] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KY] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[LA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MA] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MD] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ME] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MI] PASSED [ 58%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MN] PASSED [ 58%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[CT] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[DE] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[FL] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[GA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[HI] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ID] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IL] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[IN] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KS] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[KY] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[LA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MA] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MD] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ME] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MI] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MN] PASSED [ 59%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MO] PASSED [ 59%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MS] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MT] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NC] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ND] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NE] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NH] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NJ] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NM] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NV] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NY] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OH] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OK] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OR] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[PA] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[RI] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SC] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SD] PASSED [ 59%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TN] PASSED [ 59%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[MT] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NC] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[ND] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NE] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NH] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NJ] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NM] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NV] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[NY] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OH] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OK] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[OR] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[PA] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[RI] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SC] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[SD] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TN] PASSED [ 60%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[TX] PASSED [ 60%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[UT] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VA] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VT] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WA] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WI] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WV] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WY] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AK] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AL] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AR] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AZ] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CA] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CO] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CT] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-DE] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-FL] PASSED [ 60%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-GA] PASSED [ 60%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[VT] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WI] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WV] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_validates_state_outputs[WY] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AK] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AL] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AR] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-AZ] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CA] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CO] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-CT] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-DE] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-FL] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-GA] PASSED [ 61%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-HI] PASSED [ 61%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IA] PASSED [ 61%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ID] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IL] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IN] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KS] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KY] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-LA] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MA] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MD] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ME] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MI] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MN] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MO] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MS] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MT] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NC] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ND] PASSED [ 61%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NE] PASSED [ 61%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IL] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-IN] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KS] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-KY] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-LA] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MA] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MD] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ME] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MI] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MN] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MO] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MS] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-MT] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NC] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-ND] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NE] PASSED [ 62%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NH] PASSED [ 62%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NJ] PASSED [ 62%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NM] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NV] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NY] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OH] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OK] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OR] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-PA] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-RI] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SC] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SD] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TN] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TX] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-UT] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VA] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VT] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WA] PASSED [ 62%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WI] PASSED [ 62%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NV] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-NY] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OH] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OK] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-OR] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-PA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-RI] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SC] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-SD] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TN] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-TX] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-UT] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-VT] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WA] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WI] PASSED [ 63%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WV] PASSED [ 63%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[id-WY] PASSED [ 63%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AK] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AL] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AR] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AZ] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CA] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CO] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CT] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-DE] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-FL] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-GA] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-HI] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IA] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ID] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IL] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IN] PASSED [ 63%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KS] PASSED [ 63%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AL] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AR] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-AZ] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CA] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CO] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-CT] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-DE] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-FL] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-GA] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-HI] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IA] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ID] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IL] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-IN] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KS] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-KY] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-LA] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MA] PASSED [ 64%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MD] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ME] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MI] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MN] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MO] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MS] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MT] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NC] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ND] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NE] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NH] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NJ] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NM] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NV] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NY] PASSED [ 64%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OH] PASSED [ 64%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ME] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MI] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MN] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MO] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MS] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-MT] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NC] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-ND] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NE] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NH] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NJ] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NM] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NV] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-NY] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OH] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OK] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-OR] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-PA] PASSED [ 65%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-RI] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SC] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SD] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TN] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TX] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-UT] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VA] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VT] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WA] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WI] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WV] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WY] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AK] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AL] PASSED [ 65%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AR] PASSED [ 65%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SC] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-SD] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TN] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-TX] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-UT] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VA] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-VT] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WA] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WI] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WV] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[slug-WY] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AK] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AL] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AR] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-AZ] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CA] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CO] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-CT] PASSED [ 66%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-DE] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-FL] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-GA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-HI] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ID] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IL] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IN] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KS] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KY] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-LA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MA] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MD] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ME] PASSED [ 66%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MI] PASSED [ 66%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-FL] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-GA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-HI] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ID] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IL] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-IN] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KS] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-KY] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-LA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MA] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MD] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ME] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MI] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MN] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MO] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MS] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-MT] PASSED [ 67%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NC] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ND] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NE] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NH] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NJ] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NM] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NV] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NY] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OH] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OK] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OR] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-PA] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-RI] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SC] PASSED [ 67%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SD] PASSED [ 67%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-ND] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NE] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NH] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NJ] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NM] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NV] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-NY] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OH] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OK] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-OR] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-PA] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-RI] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SC] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-SD] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-TN] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-TX] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-UT] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-VA] PASSED [ 68%]
 tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-VT] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WA] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WI] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WV] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WY] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_california_seeds PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen-Alaska Bar Association public directory-https://member.alaskabar.org/cv5/cgi-bin/memberdll.dll/Info?CUSTOMERCD=8744&WRP=Customer_Profile.htm] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers-Alabama State Bar public directory-https://members.alabar.org/Member_Portal/Member_Portal/Sections/AP.aspx] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik-Arkansas Bar Association public directory-https://www.arkbar.com/?pg=board-of-trustees] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali-State Bar of Arizona public directory-https://www.azbar.org/for-legal-professionals/practice-tools-management/member-directory/?m=Anthony-Cali-177781] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock-Colorado Bar Association public directory-https://community.cobar.org/profile/contributions/contributions-achievements?UserKey=330f70ad-afc9-44f0-b8b1-6b55108bc275] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown-Connecticut Bar Association public directory-https://members.ctbar.org/member/thelaborlawyer] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott-Delaware Courts published opinion-https://courts.delaware.gov/Opinions/Download.aspx?id=342050] PASSED [ 68%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.-The Florida Bar public directory-https://www.floridabar.org/directories/find-mbr/profile/?num=123000] PASSED [ 68%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WA] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WI] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WV] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_official_source_adapter_harness_skips_existing_rows[name-WY] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_california_seeds PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen-Alaska Bar Association public directory-https://member.alaskabar.org/cv5/cgi-bin/memberdll.dll/Info?CUSTOMERCD=8744&WRP=Customer_Profile.htm] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers-Alabama State Bar public directory-https://members.alabar.org/Member_Portal/Member_Portal/Sections/AP.aspx] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik-Arkansas Bar Association public directory-https://www.arkbar.com/?pg=board-of-trustees] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali-State Bar of Arizona public directory-https://www.azbar.org/for-legal-professionals/practice-tools-management/member-directory/?m=Anthony-Cali-177781] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock-Colorado Bar Association public directory-https://community.cobar.org/profile/contributions/contributions-achievements?UserKey=330f70ad-afc9-44f0-b8b1-6b55108bc275] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown-Connecticut Bar Association public directory-https://members.ctbar.org/member/thelaborlawyer] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott-Delaware Courts published opinion-https://courts.delaware.gov/Opinions/Download.aspx?id=342050] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.-The Florida Bar public directory-https://www.floridabar.org/directories/find-mbr/profile/?num=123000] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton-State Bar of Georgia speaker profile-https://icle.gabar.org/speaker/todd-stanton-1261014] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz-Hawaii State Bar Association attorney recognition record-https://hsba.org/HSBA_2020/About_Us/Living_Legend_Lawyers_.aspx] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin-Iowa State Bar Association jury verdict record-https://services.iowabar.org/IB/JuryVerdicts.nsf/b96238336212630c85258ca1000240fd/e71fe5f6f6d3242d872589900011edc5!OpenDocument] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser-Idaho State Bar attorney profile-https://isb.idaho.gov/blog/trudy-hanson-fouser/] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler-Indiana State Bar public directory-https://www.inbar.org/members/?id=30400364] PASSED [ 69%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady-Kansas Judicial Branch published opinion-https://kscourts.gov/Cases-Decisions/Decisions/Published/Brown-v-Ford-Storage-and-Moving-Co-Inc] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks-Kentucky Bar Association public directory-https://www.kybar.org/members/?id=42347567] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer-Louisiana Attorney Disciplinary Board attorney records-https://www.ladb.org/DR/Document.cfm?docket=24-DB-014] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey-Massachusetts BBO attorney records-https://bbopublic.massbbo.org/web/f/SJC_WellBeing_Cmte_Report.pdf] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker-Maryland Courts attorney discipline records-https://www.courts.state.md.us/attygrievance/sanctions07] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher-Maine Board of Overseers of the Bar public directory-https://mebarconnect.mainebar.org/people/daniel-eccher] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese-State Bar of Michigan public directory-https://connect.michbar.org/laborlaw[redacted-path] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman-Minnesota Courts attorney records-https://mncourts.gov/help-topics/Legal-Paraprofessional-Program/standing-committee] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips-The Missouri Bar public directory-https://news.mobar.org/jerina-d-phillips-receives-2025-diversity-champion-award/] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MS-seed-joel-frank-dillard-public-record~joel-frank-dillard-Joel Frank Dillard-The Mississippi Bar public directory-https://www.msbar.org/inside-the-bar/sections/labor-employment-law/] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm-State Bar of Montana public directory-https://www.montanabar.org/About-Us/Sections-and-Committees] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams-North Carolina State Bar public directory-https://www.ncbar.gov/for-lawyers/directories/leadership/state-bar-officers/] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson-North Dakota Court System attorney directory-https://www.ndcourts.gov/lawyers/06402] PASSED [ 69%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau-Nebraska Judicial Branch case record-https://supremecourt.nebraska.gov/courts/supreme-court/supreme-court-call/city-omaha-v-professional-firefighters-association-omaha] PASSED [ 69%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks-Kentucky Bar Association public directory-https://www.kybar.org/members/?id=42347567] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer-Louisiana Attorney Disciplinary Board attorney records-https://www.ladb.org/DR/Document.cfm?docket=24-DB-014] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey-Massachusetts BBO attorney records-https://bbopublic.massbbo.org/web/f/SJC_WellBeing_Cmte_Report.pdf] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker-Maryland Courts attorney discipline records-https://www.courts.state.md.us/attygrievance/sanctions07] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher-Maine Board of Overseers of the Bar public directory-https://mebarconnect.mainebar.org/people/daniel-eccher] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese-State Bar of Michigan public directory-https://connect.michbar.org/laborlaw[redacted-path] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman-Minnesota Courts attorney records-https://mncourts.gov/help-topics/Legal-Paraprofessional-Program/standing-committee] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips-The Missouri Bar public directory-https://news.mobar.org/jerina-d-phillips-receives-2025-diversity-champion-award/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MS-seed-joel-frank-dillard-public-record~joel-frank-dillard-Joel Frank Dillard-The Mississippi Bar public directory-https://www.msbar.org/inside-the-bar/sections/labor-employment-law/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm-State Bar of Montana public directory-https://www.montanabar.org/About-Us/Sections-and-Committees] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams-North Carolina State Bar public directory-https://www.ncbar.gov/for-lawyers/directories/leadership/state-bar-officers/] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson-North Dakota Court System attorney directory-https://www.ndcourts.gov/lawyers/06402] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau-Nebraska Judicial Branch case record-https://supremecourt.nebraska.gov/courts/supreme-court/supreme-court-call/city-omaha-v-professional-firefighters-association-omaha] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns-New Hampshire Bar Association CLE speaker profile-https://member.nhbar.org/calendar/event/34th-annual-labor-and-employment-law-update] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins-NJ Courts attorney certification records-https://www.njcourts.gov/notices/order-board-attorney-certification-new-chair-and-vice-chair-designations-certification] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy-State Bar of New Mexico public directory-https://www.sbnm.org/cvweb/cgi-bin/Utilities.dll?View=INMEMBERDETAILS&RECORDNO=1&CUSTOMERNO=11321] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck-State Bar of Nevada public directory-https://nvbar.org/for-lawyers/bar-service-opportunities/join-a-section/labor-and-employment-law-section/] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone-New York Courts attorney directory-https://decisions.courts.state.ny.us/ad3/Decisions/2023/CV-22-1940.pdf] PASSED [ 70%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough-Oklahoma Bar Association public directory-https://ams.okbar.org/eweb/DynamicPage.aspx?Action=Add&DoNotSave=yes&ObjectKeyFrom=1A83491A-9853-4C87-86A4-F7D95601C2E2&ParentDataObject=Invoice+Detail&ParentObject=CentralizedOrderEntry&WebCode=ProdDetailAdd&ivd_cst_key=00000000-0000-0000-0000-000000000000&ivd_cst_ship_key=00000000-0000-0000-0000-000000000000&ivd_formkey=69202792-63d7-4ba2-bf4e-a0da41270555&ivd_prc_prd_key=F5FDCC21-BBDF-4D41-944F-5351AD775A80] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland-Oregon State Bar public directory-https://www.osbar.org/sections/labor.html] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson-Pennsylvania Disciplinary Board attorney directory-https://www.padisciplinaryboard.org/for-the-public/find-attorney/attorney-detail/85957] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof-Rhode Island Judiciary attorney records-https://www.courts.ri.gov/attorney-resources/Pages/Board-of-Bar-Examiners-default.aspx] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe-South Carolina Bar public directory-https://www.scbar.org/for-lawyers/networking/sections/employment-and-labor-law-section/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger-State Bar of South Dakota public directory-https://www.statebarofsouthdakota.com/project-rural-practice/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez-State Bar of Texas public directory-https://www.texasbar.com/AM/Template.cfm?ContactID=157597&template=%2FCustomsource%2FMemberDirectory%2FMemberDirectoryDetail.cfm] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen-Utah Courts public legal directory-https://www.utcourts.gov/en/about/administration/committees/ethics-advisory-committee.html] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt-Virginia State Bar public directory-https://virginialawyer.vsb.org/articles/professional-notices?article_id=5100257&i=859839] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VT-seed-jeremy-s-grant-public-record~jeremy-s-grant-Jeremy S. Grant-Vermont Bar Association public directory-https://www.vtbar.org/2025-annual-meeting-in-review/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus-State Bar of Wisconsin public directory-https://www.wisbar.org/NewsPublications/WisconsinLawyer/WisconsinLawyerPDFs/97/01/20_24.pdf] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess-West Virginia State Bar public directory-https://wvbar.org/wp-content/uploads/2024/04/24-25-Active-List-UPDATED.pdf] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke-Wyoming State Bar public directory-https://www.wyomingbar.org/about-us/bar-leadership/] PASSED [ 70%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen] PASSED [ 70%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland-Oregon State Bar public directory-https://www.osbar.org/sections/labor.html] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson-Pennsylvania Disciplinary Board attorney directory-https://www.padisciplinaryboard.org/for-the-public/find-attorney/attorney-detail/85957] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof-Rhode Island Judiciary attorney records-https://www.courts.ri.gov/attorney-resources/Pages/Board-of-Bar-Examiners-default.aspx] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe-South Carolina Bar public directory-https://www.scbar.org/for-lawyers/networking/sections/employment-and-labor-law-section/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger-State Bar of South Dakota public directory-https://www.statebarofsouthdakota.com/project-rural-practice/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez-State Bar of Texas public directory-https://www.texasbar.com/AM/Template.cfm?ContactID=157597&template=%2FCustomsource%2FMemberDirectory%2FMemberDirectoryDetail.cfm] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen-Utah Courts public legal directory-https://www.utcourts.gov/en/about/administration/committees/ethics-advisory-committee.html] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt-Virginia State Bar public directory-https://virginialawyer.vsb.org/articles/professional-notices?article_id=5100257&i=859839] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[VT-seed-jeremy-s-grant-public-record~jeremy-s-grant-Jeremy S. Grant-Vermont Bar Association public directory-https://www.vtbar.org/2025-annual-meeting-in-review/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus-State Bar of Wisconsin public directory-https://www.wisbar.org/NewsPublications/WisconsinLawyer/WisconsinLawyerPDFs/97/01/20_24.pdf] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess-West Virginia State Bar public directory-https://wvbar.org/wp-content/uploads/2024/04/24-25-Active-List-UPDATED.pdf] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke-Wyoming State Bar public directory-https://www.wyomingbar.org/about-us/bar-leadership/] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AK-seed-jon-marc-petersen-public-record~jon-marc-petersen-Jon-Marc Petersen] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AL-seed-marc-james-ayers-public-record~marc-james-ayers-Marc James Ayers] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AR-seed-kristin-l-pawlik-public-record~kristin-l-pawlik-Kristin L. Pawlik] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[AZ-seed-anthony-cali-public-record~anthony-cali-Anthony Cali] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seed[CO-seed-rachel-brock-public-record~rachel-brock-Rachel Brock] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[CT-seed-eric-r-brown-public-record~eric-r-brown-Eric R. Brown] PASSED [ 71%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[DE-seed-richard-l-abbott-public-record~richard-l-abbott-Richard L. Abbott] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler] PASSED [ 71%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady] PASSED [ 71%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[FL-seed-jerry-ray-poole-jr-public-record~jerry-ray-poole-jr-Jerry Ray Poole, Jr.] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[GA-seed-todd-h-stanton-public-record~todd-h-stanton-Todd H. Stanton] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_two_seed[HI-seed-eric-seitz-public-record~eric-seitz-Eric Seitz] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[LA-seed-gregory-james-sauzer-public-record~gregory-james-sauzer-Gregory James Sauzer] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MA-seed-hillary-j-massey-public-record~hillary-j-massey-Hillary J. Massey] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MD-seed-sean-w-baker-public-record~sean-w-baker-Sean W. Baker] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[ME-seed-daniel-b-eccher-public-record~daniel-b-eccher-Daniel B. Eccher] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_four_seed[MI-seed-gerard-v-mantese-public-record~gerard-v-mantese-Gerard V. Mantese] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IA-seed-roxanne-barton-conlin-public-record~roxanne-barton-conlin-Roxanne Barton Conlin] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[ID-seed-trudy-hanson-fouser-public-record~trudy-hanson-fouser-Trudy Hanson Fouser] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[IN-seed-georgianna-quinn-tutwiler-public-record~georgianna-quinn-tutwiler-Georgianna Quinn Tutwiler] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KS-seed-michael-f-brady-public-record~michael-f-brady-Michael F. Brady] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_three_seed[KY-seed-andrew-clarke-weeks-public-record~andrew-clarke-weeks-Andrew Clarke Weeks] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MN-seed-landon-j-ascheman-public-record~landon-j-ascheman-Landon J. Ascheman] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MO-seed-jerina-d-phillips-public-record~jerina-d-phillips-Jerina D. Phillips] PASSED [ 72%]
@@ -6186,18 +6705,18 @@ tests/test_public_record_refresh.py::test_discover_official_us_state_public_reco
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[MT-seed-tanis-m-holm-public-record~tanis-m-holm-Tanis M. Holm] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_five_seed[NC-seed-kevin-g-williams-public-record~kevin-g-williams-Kevin G. Williams] PASSED [ 72%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[ND-seed-nathan-c-severson-public-record~nathan-c-severson-Nathan C. Severson] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe] PASSED [ 72%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger] PASSED [ 72%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NE-seed-heidi-a-guttau-public-record~heidi-a-guttau-Heidi A. Guttau] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NH-seed-heather-m-burns-public-record~heather-m-burns-Heather M. Burns] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NJ-seed-rubin-m-sinins-public-record~rubin-m-sinins-Rubin M. Sinins] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_six_seed[NM-seed-elizabeth-a-heaphy-public-record~elizabeth-a-heaphy-Elizabeth A. Heaphy] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NV-seed-luke-w-molleck-public-record~luke-w-molleck-Luke W. Molleck] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[NY-seed-gary-j-malone-public-record~gary-j-malone-Gary J. Malone] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OK-seed-charles-greenough-public-record~charles-greenough-Charles Greenough] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[OR-seed-andrew-toney-noland-public-record~andrew-toney-noland-Andrew Toney-Noland] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_seven_seed[PA-seed-shanon-jude-carson-public-record~shanon-jude-carson-Shanon Jude Carson] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[RI-seed-mark-b-decof-public-record~mark-b-decof-Mark B. Decof] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SC-seed-j-hagood-tighe-public-record~j-hagood-tighe-J. Hagood Tighe] PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[SD-seed-patrick-g-goetzinger-public-record~patrick-g-goetzinger-Patrick G. Goetzinger] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[TX-seed-mark-anthony-sanchez-public-record~mark-anthony-sanchez-Mark Anthony Sanchez] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_eight_seed[UT-seed-lara-a-swensen-public-record~lara-a-swensen-Lara A. Swensen] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[VA-seed-frederick-h-schutt-public-record~frederick-h-schutt-Frederick H. Schutt] PASSED [ 73%]
@@ -6205,17 +6724,17 @@ tests/test_public_record_refresh.py::test_discover_official_us_state_public_reco
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WI-seed-jennifer-s-mirus-public-record~jennifer-s-mirus-Jennifer S. Mirus] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WV-seed-todd-bailess-public-record~todd-bailess-Todd Bailess] PASSED [ 73%]
 tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_batch_nine_seed[WY-seed-scott-e-kolpitcke-public-record~scott-e-kolpitcke-Scott E. Kolpitcke] PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_washington_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_washington_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_ohio_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_ohio_seed PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_tennessee_seeds PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_tennessee_seeds PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_illinois_seeds PASSED [ 73%]
-tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_illinois_seeds PASSED [ 73%]
-tests/test_public_record_refresh_workflow.py::test_public_record_quarterly_refresh_workflow_uses_correction_pr_flow PASSED [ 73%]
-tests/test_public_record_refresh_workflow.py::test_refresh_public_record_corrections_make_target_matches_workflow_semantics PASSED [ 73%]
-tests/test_public_record_refresh_workflow.py::test_refresh_report_matches_structured_values PASSED [ 73%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_washington_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_washington_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_ohio_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_ohio_seed PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_tennessee_seeds PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_tennessee_seeds PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_adds_illinois_seeds PASSED [ 74%]
+tests/test_public_record_refresh.py::test_discover_official_us_state_public_record_rows_skips_existing_illinois_seeds PASSED [ 74%]
+tests/test_public_record_refresh_workflow.py::test_public_record_quarterly_refresh_workflow_uses_correction_pr_flow PASSED [ 74%]
+tests/test_public_record_refresh_workflow.py::test_refresh_public_record_corrections_make_target_matches_workflow_semantics PASSED [ 74%]
+tests/test_public_record_refresh_workflow.py::test_refresh_report_matches_structured_values PASSED [ 74%]
 tests/test_public_record_refresh_workflow.py::test_sync_provenance_roadmap_updates_baseline_and_adapter_count PASSED [ 74%]
 tests/test_public_record_refresh_workflow.py::test_sync_provenance_roadmap_preserves_eu_planning_section PASSED [ 74%]
 tests/test_public_record_refresh_workflow.py::test_public_record_provenance_roadmap_documents_eu_phase_0b_policy PASSED [ 74%]
@@ -6224,17 +6743,17 @@ tests/test_public_record_refresh_workflow.py::test_public_record_provenance_road
 tests/test_public_record_refresh_workflow.py::test_public_record_provenance_roadmap_documents_eu_phase_0e_rollout_backlog PASSED [ 74%]
 tests/test_refresh_newsroom_directory_listings_script.py::test_serialize_rows_is_deterministic_without_node_tooling PASSED [ 74%]
 tests/test_registration_and_login.py::test_user_registration_disabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_disabled_first_user PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_with_invite_code_disabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_with_invite_code_enabled PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_rejects_case_insensitive_duplicate PASSED [ 74%]
-tests/test_registration_and_login.py::test_username_db_constraint_rejects_case_insensitive_duplicate PASSED [ 74%]
-tests/test_registration_and_login.py::test_user_registration_handles_case_insensitive_race_integrity_error PASSED [ 74%]
-tests/test_registration_and_login.py::test_register_page_loads PASSED    [ 74%]
-tests/test_registration_and_login.py::test_register_requires_csrf_token PASSED [ 74%]
-tests/test_registration_and_login.py::test_login_page_loads PASSED       [ 74%]
-tests/test_registration_and_login.py::test_login_invalid_post_shows_errors_and_preserves_username PASSED [ 74%]
+tests/test_registration_and_login.py::test_user_registration_disabled_first_user PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_with_invite_code_disabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_with_invite_code_enabled PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_rejects_case_insensitive_duplicate PASSED [ 75%]
+tests/test_registration_and_login.py::test_username_db_constraint_rejects_case_insensitive_duplicate PASSED [ 75%]
+tests/test_registration_and_login.py::test_user_registration_handles_case_insensitive_race_integrity_error PASSED [ 75%]
+tests/test_registration_and_login.py::test_register_page_loads PASSED    [ 75%]
+tests/test_registration_and_login.py::test_register_requires_csrf_token PASSED [ 75%]
+tests/test_registration_and_login.py::test_login_page_loads PASSED       [ 75%]
+tests/test_registration_and_login.py::test_login_invalid_post_shows_errors_and_preserves_username PASSED [ 75%]
 tests/test_registration_and_login.py::test_login_requires_csrf_token PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_after_registration PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_case_insensitive PASSED [ 75%]
@@ -6244,16 +6763,16 @@ tests/test_registration_and_login.py::test_user_login_rehashes_legacy_passlib_ha
 tests/test_registration_and_login.py::test_user_login_does_not_rehash_legacy_passlib_hash_when_disabled PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_rehash_failure_preserves_legacy_passlib_hash PASSED [ 75%]
 tests/test_registration_and_login.py::test_user_login_handles_case_insensitive_duplicate_rows PASSED [ 75%]
-tests/test_replies.py::test_message_reply_404_for_unknown_slug PASSED    [ 75%]
-tests/test_replies.py::test_default_replies PASSED                       [ 75%]
-tests/test_replies.py::test_custom_replies PASSED                        [ 75%]
-tests/test_replies.py::test_set_custom_replies PASSED                    [ 75%]
-tests/test_replies.py::test_settings_replies_prefills_default_status_text PASSED [ 75%]
-tests/test_replies.py::test_settings_replies_prefills_custom_status_text_when_present PASSED [ 75%]
-tests/test_replies.py::test_set_custom_replies_redirects_back_with_success_flash PASSED [ 75%]
-tests/test_replies.py::test_set_default_replies_keeps_builtin_default_without_persisting_override PASSED [ 75%]
-tests/test_replies.py::test_message_page PASSED                          [ 75%]
-tests/test_replies.py::test_message_page_wrong_user PASSED               [ 75%]
+tests/test_replies.py::test_message_reply_404_for_unknown_slug PASSED    [ 76%]
+tests/test_replies.py::test_default_replies PASSED                       [ 76%]
+tests/test_replies.py::test_custom_replies PASSED                        [ 76%]
+tests/test_replies.py::test_set_custom_replies PASSED                    [ 76%]
+tests/test_replies.py::test_settings_replies_prefills_default_status_text PASSED [ 76%]
+tests/test_replies.py::test_settings_replies_prefills_custom_status_text_when_present PASSED [ 76%]
+tests/test_replies.py::test_set_custom_replies_redirects_back_with_success_flash PASSED [ 76%]
+tests/test_replies.py::test_set_default_replies_keeps_builtin_default_without_persisting_override PASSED [ 76%]
+tests/test_replies.py::test_message_page PASSED                          [ 76%]
+tests/test_replies.py::test_message_page_wrong_user PASSED               [ 76%]
 tests/test_replies.py::test_set_message_status_success PASSED            [ 76%]
 tests/test_replies.py::test_set_message_status_invalid_form PASSED       [ 76%]
 tests/test_replies.py::test_set_message_status_message_not_found PASSED  [ 76%]
@@ -6263,15 +6782,15 @@ tests/test_replies.py::test_settings_replies_invalid_status_renders_field_error_
 tests/test_replies.py::test_settings_replies_missing_csrf_renders_error_on_submitted_form PASSED [ 76%]
 tests/test_resend_message.py::test_resend_message_sends_per_field PASSED [ 76%]
 tests/test_resend_message.py::test_resend_message_sends_per_field_to_all_enabled_recipients PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_blocks_other_users_messages PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_requires_email_notifications PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_requires_csrf_token PASSED [ 76%]
-tests/test_resend_message.py::test_resend_button_visible_with_required_settings PASSED [ 76%]
-tests/test_resend_message.py::test_resend_button_hidden_without_notifications_or_content PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_uses_existing_armored_value_without_reencryption PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_reuses_armored_value_for_duplicate_shared_recipient_key PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_encrypts_value_with_embedded_pgp_header_substring PASSED [ 76%]
-tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value PASSED [ 76%]
+tests/test_resend_message.py::test_resend_message_blocks_other_users_messages PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_requires_email_notifications PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_requires_csrf_token PASSED [ 77%]
+tests/test_resend_message.py::test_resend_button_visible_with_required_settings PASSED [ 77%]
+tests/test_resend_message.py::test_resend_button_hidden_without_notifications_or_content PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_uses_existing_armored_value_without_reencryption PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_reuses_armored_value_for_duplicate_shared_recipient_key PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_encrypts_value_with_embedded_pgp_header_substring PASSED [ 77%]
+tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value PASSED [ 77%]
 tests/test_resend_message.py::test_resend_message_full_body_encrypts_plaintext_value_for_all_enabled_recipients PASSED [ 77%]
 tests/test_resend_message.py::test_resend_message_full_body_encryption_failure_falls_back_to_generic PASSED [ 77%]
 tests/test_resend_message.py::test_resend_message_full_body_multi_recipient_armored_value_falls_back_to_generic PASSED [ 77%]
@@ -6282,15 +6801,15 @@ tests/test_routes_auth.py::test_register_redirects_when_already_logged_in PASSED
 tests/test_routes_auth.py::test_register_rejects_incorrect_captcha PASSED [ 77%]
 tests/test_routes_auth.py::test_register_rejects_invalid_invite_code PASSED [ 77%]
 tests/test_routes_auth.py::test_register_rejects_expired_invite_code PASSED [ 77%]
-tests/test_routes_auth.py::test_register_requires_invite_code_by_default_for_first_user PASSED [ 77%]
-tests/test_routes_auth.py::test_register_valid_invite_code_deletes_code PASSED [ 77%]
-tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_invalid_session_state PASSED [ 77%]
-tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_non_legacy_source_hash PASSED [ 77%]
-tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_mismatched_source_digest PASSED [ 77%]
-tests/test_routes_auth.py::test_register_handles_unexpected_integrity_error PASSED [ 77%]
-tests/test_routes_auth.py::test_login_redirects_when_already_logged_in PASSED [ 77%]
-tests/test_routes_auth.py::test_login_redirects_to_select_tier_when_premium_enabled PASSED [ 77%]
-tests/test_routes_auth.py::test_login_redirects_to_original_protected_page PASSED [ 77%]
+tests/test_routes_auth.py::test_register_requires_invite_code_by_default_for_first_user PASSED [ 78%]
+tests/test_routes_auth.py::test_register_valid_invite_code_deletes_code PASSED [ 78%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_invalid_session_state PASSED [ 78%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_non_legacy_source_hash PASSED [ 78%]
+tests/test_routes_auth.py::test_apply_pending_password_rehash_rejects_mismatched_source_digest PASSED [ 78%]
+tests/test_routes_auth.py::test_register_handles_unexpected_integrity_error PASSED [ 78%]
+tests/test_routes_auth.py::test_login_redirects_when_already_logged_in PASSED [ 78%]
+tests/test_routes_auth.py::test_login_redirects_to_select_tier_when_premium_enabled PASSED [ 78%]
+tests/test_routes_auth.py::test_login_redirects_to_original_protected_page PASSED [ 78%]
 tests/test_routes_auth.py::test_password_reset_request_is_generic_and_sends_only_for_eligible_account PASSED [ 78%]
 tests/test_routes_auth.py::test_find_primary_username_returns_none_and_logs_when_query_is_ambiguous PASSED [ 78%]
 tests/test_routes_auth.py::test_password_reset_sets_new_password_and_consumes_token PASSED [ 78%]
@@ -6301,14 +6820,14 @@ tests/test_routes_auth.py::test_password_reset_request_rejects_incorrect_captcha
 tests/test_routes_auth.py::test_stash_post_auth_redirect_skips_logout_and_preserves_session PASSED [ 78%]
 tests/test_routes_auth.py::test_stash_post_auth_redirect_rejects_unsafe_target_and_preserves_session PASSED [ 78%]
 tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[None] PASSED [ 78%]
-tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[bind1] PASSED [ 78%]
-tests/test_routes_auth.py::test_register_rejects_when_first_user_recheck_finds_existing_user PASSED [ 78%]
-tests/test_routes_auth.py::test_login_clears_auth_session_when_2fa_commit_fails PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_login_and_clears_session_for_missing_user PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_inbox_when_already_authenticated PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_rejects_when_user_has_no_totp_secret PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_requires_csrf_token PASSED [ 78%]
-tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_onboarding PASSED [ 78%]
+tests/test_routes_auth.py::test_lock_first_user_registration_noops_without_postgres_bind[bind1] PASSED [ 79%]
+tests/test_routes_auth.py::test_register_rejects_when_first_user_recheck_finds_existing_user PASSED [ 79%]
+tests/test_routes_auth.py::test_login_clears_auth_session_when_2fa_commit_fails PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_login_and_clears_session_for_missing_user PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_inbox_when_already_authenticated PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_rejects_when_user_has_no_totp_secret PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_requires_csrf_token PASSED [ 79%]
+tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_onboarding PASSED [ 79%]
 tests/test_routes_auth.py::test_verify_2fa_login_success_redirects_to_select_tier_when_enabled PASSED [ 79%]
 tests/test_routes_auth.py::test_verify_2fa_login_redirects_to_original_protected_page PASSED [ 79%]
 tests/test_routes_auth.py::test_verify_2fa_login_failed_rehash_commit_clears_auth_session PASSED [ 79%]
@@ -6320,14 +6839,14 @@ tests/test_routes_common.py::test_get_ip_address_fallback PASSED         [ 79%]
 tests/test_routes_common.py::test_show_directory_caution_badge_honors_explicit_cautious_override PASSED [ 79%]
 tests/test_routes_common.py::test_do_send_email_returns_early_without_enabled_notifications PASSED [ 79%]
 tests/test_routes_common.py::test_do_send_email_uses_user_custom_smtp PASSED [ 79%]
-tests/test_routes_common.py::test_do_send_email_sends_to_each_enabled_recipient PASSED [ 79%]
-tests/test_routes_common.py::test_do_send_email_deduplicates_recipient_email_addresses PASSED [ 79%]
-tests/test_routes_common.py::test_do_send_email_retries_duplicate_address_after_false_result PASSED [ 79%]
-tests/test_routes_common.py::test_send_email_to_user_recipients_accepts_recipient_body_factory PASSED [ 79%]
-tests/test_routes_common.py::test_send_email_to_user_recipients_skips_empty_recipient_body PASSED [ 79%]
-tests/test_routes_common.py::test_notification_email_encryption_target_returns_all_enabled_keys PASSED [ 79%]
-tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_without_primary_row PASSED [ 79%]
-tests/test_routes_common.py::test_notification_email_encryption_target_falls_back_to_legacy_user_key PASSED [ 79%]
+tests/test_routes_common.py::test_do_send_email_sends_to_each_enabled_recipient PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_deduplicates_recipient_email_addresses PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_retries_duplicate_address_after_false_result PASSED [ 80%]
+tests/test_routes_common.py::test_send_email_to_user_recipients_accepts_recipient_body_factory PASSED [ 80%]
+tests/test_routes_common.py::test_send_email_to_user_recipients_skips_empty_recipient_body PASSED [ 80%]
+tests/test_routes_common.py::test_notification_email_encryption_target_returns_all_enabled_keys PASSED [ 80%]
+tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_without_primary_row PASSED [ 80%]
+tests/test_routes_common.py::test_notification_email_encryption_target_falls_back_to_legacy_user_key PASSED [ 80%]
 tests/test_routes_common.py::test_notification_email_encryption_target_uses_legacy_key_when_primary_row_lacks_key PASSED [ 80%]
 tests/test_routes_common.py::test_notification_email_encryption_target_uses_non_primary_recipient_without_legacy_key PASSED [ 80%]
 tests/test_routes_common.py::test_notification_email_encryption_target_ignores_enabled_recipient_without_key PASSED [ 80%]
@@ -6339,14 +6858,14 @@ tests/test_routes_common.py::test_notification_recipient_encryption_target_uses_
 tests/test_routes_common.py::test_notification_recipient_encryption_target_returns_none_without_key PASSED [ 80%]
 tests/test_routes_common.py::test_do_send_email_continues_after_single_recipient_failure PASSED [ 80%]
 tests/test_routes_common.py::test_do_send_email_uses_default_smtp PASSED [ 80%]
-tests/test_routes_common.py::test_do_send_email_uses_notifications_address_as_reply_to_fallback PASSED [ 80%]
-tests/test_routes_common.py::test_do_send_email_skips_recipient_without_email PASSED [ 80%]
-tests/test_routes_common.py::test_do_send_email_catches_errors PASSED    [ 80%]
-tests/test_routes_common.py::test_do_send_email_skips_when_default_smtp_incomplete PASSED [ 80%]
-tests/test_routes_common.py::test_formatters PASSED                      [ 80%]
-tests/test_routes_forms.py::test_login_password_max_matches_registration PASSED [ 80%]
-tests/test_routes_forms.py::test_login_username_max_matches_registration PASSED [ 80%]
-tests/test_routes_forms.py::test_dynamic_message_form_skips_disabled_fields_and_maps_names PASSED [ 80%]
+tests/test_routes_common.py::test_do_send_email_uses_notifications_address_as_reply_to_fallback PASSED [ 81%]
+tests/test_routes_common.py::test_do_send_email_skips_recipient_without_email PASSED [ 81%]
+tests/test_routes_common.py::test_do_send_email_catches_errors PASSED    [ 81%]
+tests/test_routes_common.py::test_do_send_email_skips_when_default_smtp_incomplete PASSED [ 81%]
+tests/test_routes_common.py::test_formatters PASSED                      [ 81%]
+tests/test_routes_forms.py::test_login_password_max_matches_registration PASSED [ 81%]
+tests/test_routes_forms.py::test_login_username_max_matches_registration PASSED [ 81%]
+tests/test_routes_forms.py::test_dynamic_message_form_skips_disabled_fields_and_maps_names PASSED [ 81%]
 tests/test_routes_forms.py::test_dynamic_message_form_unknown_field_type_raises PASSED [ 81%]
 tests/test_routes_forms.py::test_dynamic_message_form_choice_fields_select_and_multicheckbox PASSED [ 81%]
 tests/test_routes_forms.py::test_onboarding_profile_form_rejects_disallowed_language PASSED [ 81%]
@@ -6358,13 +6877,13 @@ tests/test_safe_template.py::test_missing_var PASSED                     [ 81%]
 tests/test_safe_template.py::test_invalid_var_syntax PASSED              [ 81%]
 tests/test_safe_template.py::test_unclosed_var PASSED                    [ 81%]
 tests/test_safe_template.py::test_unopened_var PASSED                    [ 81%]
-tests/test_safe_template.py::test_invalid_var_value PASSED               [ 81%]
-tests/test_safe_template.py::test_single_var PASSED                      [ 81%]
-tests/test_safe_template.py::test_multiple_vars PASSED                   [ 81%]
-tests/test_secure_session.py::TestSessionEnabled::test_get_set PASSED    [ 81%]
-tests/test_secure_session.py::TestSessionEnabled::test_key_only_session_access_sets_vary_cookie PASSED [ 81%]
-tests/test_secure_session.py::TestNoSessionEnabled::test_no_session PASSED [ 81%]
-tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_missing_seed_file PASSED [ 81%]
+tests/test_safe_template.py::test_invalid_var_value PASSED               [ 82%]
+tests/test_safe_template.py::test_single_var PASSED                      [ 82%]
+tests/test_safe_template.py::test_multiple_vars PASSED                   [ 82%]
+tests/test_secure_session.py::TestSessionEnabled::test_get_set PASSED    [ 82%]
+tests/test_secure_session.py::TestSessionEnabled::test_key_only_session_access_sets_vary_cookie PASSED [ 82%]
+tests/test_secure_session.py::TestNoSessionEnabled::test_no_session PASSED [ 82%]
+tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_missing_seed_file PASSED [ 82%]
 tests/test_securedrop_directory_listing.py::test_get_securedrop_directory_listings_returns_empty_tuple_for_non_list_seed_json PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_is_deterministic_and_schema_compatible PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_normalize_string_list_filters_invalid_blank_and_duplicate_values PASSED [ 82%]
@@ -6377,13 +6896,13 @@ tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_ro
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows0-Normalized row id must be a string] PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows1-Duplicate SecureDrop listing id: securedrop-one] PASSED [ 82%]
 tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows2-Normalized row slug must be a string] PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows3-Duplicate SecureDrop listing slug: securedrop~shared] PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_requests_expected_shape PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_list_payload PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_object_payload_items PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_render_securedrop_refresh_summary PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_summary_row_label_falls_back_to_name_id_or_unnamed_listing PASSED [ 82%]
-tests/test_securedrop_directory_refresh.py::test_append_summary_section_skips_empty_entries PASSED [ 82%]
+tests/test_securedrop_directory_refresh.py::test_refresh_securedrop_directory_rows_validates_normalized_row_shapes[normalized_rows3-Duplicate SecureDrop listing slug: securedrop~shared] PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_requests_expected_shape PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_list_payload PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_fetch_securedrop_directory_rows_rejects_non_object_payload_items PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_render_securedrop_refresh_summary PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_summary_row_label_falls_back_to_name_id_or_unnamed_listing PASSED [ 83%]
+tests/test_securedrop_directory_refresh.py::test_append_summary_section_skips_empty_entries PASSED [ 83%]
 tests/test_security_headers.py::test_csp PASSED                          [ 83%]
 tests/test_security_headers.py::test_csp_script_src_elem_disallows_inline_scripts PASSED [ 83%]
 tests/test_security_headers.py::test_custom_splash_logo_keeps_csp_enforced PASSED [ 83%]
@@ -6396,13 +6915,13 @@ tests/test_security_headers.py::test_base_template_uses_external_no_js_bootstrap
 tests/test_security_headers.py::test_x_frame_options PASSED              [ 83%]
 tests/test_security_headers.py::test_x_content_type_options PASSED       [ 83%]
 tests/test_security_headers.py::test_permissions_policy PASSED           [ 83%]
-tests/test_security_headers.py::test_referrer_policy PASSED              [ 83%]
-tests/test_security_headers.py::test_x_xss_protection PASSED             [ 83%]
-tests/test_security_headers.py::test_strict_transport_security PASSED    [ 83%]
-tests/test_security_headers.py::test_no_strict_transport_security_onion PASSED [ 83%]
-tests/test_settings.py::test_user_account_category_persists PASSED       [ 83%]
-tests/test_settings.py::test_user_location_persists PASSED               [ 83%]
-tests/test_settings.py::test_notification_recipient_shadow_persists_from_legacy_fields PASSED [ 83%]
+tests/test_security_headers.py::test_referrer_policy PASSED              [ 84%]
+tests/test_security_headers.py::test_x_xss_protection PASSED             [ 84%]
+tests/test_security_headers.py::test_strict_transport_security PASSED    [ 84%]
+tests/test_security_headers.py::test_no_strict_transport_security_onion PASSED [ 84%]
+tests/test_settings.py::test_user_account_category_persists PASSED       [ 84%]
+tests/test_settings.py::test_user_location_persists PASSED               [ 84%]
+tests/test_settings.py::test_notification_recipient_shadow_persists_from_legacy_fields PASSED [ 84%]
 tests/test_settings.py::test_user_ensure_primary_notification_recipient_returns_existing_recipient PASSED [ 84%]
 tests/test_settings.py::test_settings_page_loads PASSED                  [ 84%]
 tests/test_settings.py::test_settings_profile_page_renders_updated_profile_copy PASSED [ 84%]
@@ -6415,12 +6934,12 @@ tests/test_settings.py::test_invalid_password_post_shows_only_password_errors_an
 tests/test_settings.py::test_username_post_does_not_trigger_password_form_validation PASSED [ 84%]
 tests/test_settings.py::test_password_post_does_not_trigger_username_form_validation PASSED [ 84%]
 tests/test_settings.py::test_change_password PASSED                      [ 84%]
-tests/test_settings.py::test_change_password_revokes_sibling_session PASSED [ 84%]
-tests/test_settings.py::test_change_password_from_native_werkzeug_scrypt_hash PASSED [ 84%]
-tests/test_settings.py::test_change_password_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 84%]
-tests/test_settings.py::test_add_pgp_key PASSED                          [ 84%]
-tests/test_settings.py::test_add_invalid_pgp_key PASSED                  [ 84%]
-tests/test_settings.py::test_encryption_invalid_manual_key_form_shows_only_manual_key_errors PASSED [ 84%]
+tests/test_settings.py::test_change_password_revokes_sibling_session PASSED [ 85%]
+tests/test_settings.py::test_change_password_from_native_werkzeug_scrypt_hash PASSED [ 85%]
+tests/test_settings.py::test_change_password_writes_pinned_werkzeug_scrypt_hash_when_enabled PASSED [ 85%]
+tests/test_settings.py::test_add_pgp_key PASSED                          [ 85%]
+tests/test_settings.py::test_add_invalid_pgp_key PASSED                  [ 85%]
+tests/test_settings.py::test_encryption_invalid_manual_key_form_shows_only_manual_key_errors PASSED [ 85%]
 tests/test_settings.py::test_add_pgp_key_without_encryption_subkey PASSED [ 85%]
 tests/test_settings.py::test_add_pgp_key_proton_redirects_to_encryption PASSED [ 85%]
 tests/test_settings.py::test_add_pgp_key_proton_invalid_form_redirects_index PASSED [ 85%]
@@ -6434,12 +6953,12 @@ tests/test_settings.py::test_update_smtp_settings_reject_private_host PASSED [ 8
 tests/test_settings.py::test_notifications_invalid_email_forwarding_post_shows_only_forwarding_errors PASSED [ 85%]
 tests/test_settings.py::test_add_notification_recipient PASSED           [ 85%]
 tests/test_settings.py::test_free_user_cannot_add_second_notification_recipient PASSED [ 85%]
-tests/test_settings.py::test_business_user_can_add_second_notification_recipient PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_page_renders_proton_lookup PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_proton_lookup_prefills_form PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_proton_lookup_invalid_email_returns_400 PASSED [ 85%]
-tests/test_settings.py::test_new_notification_recipient_proton_lookup_error_returns_400 PASSED [ 85%]
-tests/test_settings.py::test_add_notification_recipient_rejects_invalid_pgp_key PASSED [ 85%]
+tests/test_settings.py::test_business_user_can_add_second_notification_recipient PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_page_renders_proton_lookup PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_prefills_form PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_invalid_email_returns_400 PASSED [ 86%]
+tests/test_settings.py::test_new_notification_recipient_proton_lookup_error_returns_400 PASSED [ 86%]
+tests/test_settings.py::test_add_notification_recipient_rejects_invalid_pgp_key PASSED [ 86%]
 tests/test_settings.py::test_add_notification_recipient_rejects_non_encryptable_pgp_key PASSED [ 86%]
 tests/test_settings.py::test_edit_notification_recipient PASSED          [ 86%]
 tests/test_settings.py::test_notification_recipient_page_missing_recipient_redirects_to_notifications PASSED [ 86%]
@@ -6453,11 +6972,11 @@ tests/test_settings.py::test_enabled_recipient_requires_key_when_content_include
 tests/test_settings.py::test_notifications_page_rejects_content_toggle_without_encryptable_recipient PASSED [ 86%]
 tests/test_settings.py::test_notifications_page_lists_recipient_drill_ins_for_business_user PASSED [ 86%]
 tests/test_settings.py::test_notifications_page_uses_any_message_recipient_key_for_message_capable_warning PASSED [ 86%]
-tests/test_settings.py::test_notifications_page_shows_upgrade_when_free_user_reaches_recipient_limit PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_page_renders_edit_form PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_page_groups_toggles_together PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_toggle_enabled_rejects_unencryptable_recipient PASSED [ 86%]
-tests/test_settings.py::test_notification_recipient_toggle_enabled_can_enable_recipient PASSED [ 86%]
+tests/test_settings.py::test_notifications_page_shows_upgrade_when_free_user_reaches_recipient_limit PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_page_renders_edit_form PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_page_groups_toggles_together PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_toggle_enabled_rejects_unencryptable_recipient PASSED [ 87%]
+tests/test_settings.py::test_notification_recipient_toggle_enabled_can_enable_recipient PASSED [ 87%]
 tests/test_settings.py::test_notification_recipient_page_rejects_content_toggle_without_encryptable_recipient PASSED [ 87%]
 tests/test_settings.py::test_notification_recipient_page_toggle_include_content_enables PASSED [ 87%]
 tests/test_settings.py::test_notification_recipient_page_toggle_include_content_disables PASSED [ 87%]
@@ -6472,11 +6991,11 @@ tests/test_settings.py::test_toggle_notifications_setting PASSED         [ 87%]
 tests/test_settings.py::test_toggle_include_content_setting PASSED       [ 87%]
 tests/test_settings.py::test_toggle_encrypt_entire_body_setting PASSED   [ 87%]
 tests/test_settings.py::test_toggle_recipient_enabled_setting PASSED     [ 87%]
-tests/test_settings.py::test_notifications_invalid_post_returns_400 PASSED [ 87%]
-tests/test_settings.py::test_add_alias PASSED                            [ 87%]
-tests/test_settings.py::test_add_alias_fails_when_alias_mode_is_never PASSED [ 87%]
-tests/test_settings.py::test_add_alias_not_exceed_max PASSED             [ 87%]
-tests/test_settings.py::test_add_alias_duplicate PASSED                  [ 87%]
+tests/test_settings.py::test_notifications_invalid_post_returns_400 PASSED [ 88%]
+tests/test_settings.py::test_add_alias PASSED                            [ 88%]
+tests/test_settings.py::test_add_alias_fails_when_alias_mode_is_never PASSED [ 88%]
+tests/test_settings.py::test_add_alias_not_exceed_max PASSED             [ 88%]
+tests/test_settings.py::test_add_alias_duplicate PASSED                  [ 88%]
 tests/test_settings.py::test_add_alias_duplicate_case_insensitive PASSED [ 88%]
 tests/test_settings.py::test_alias_page_loads PASSED                     [ 88%]
 tests/test_settings.py::test_delete_alias PASSED                         [ 88%]
@@ -6491,11 +7010,11 @@ tests/test_settings.py::test_change_profile_location PASSED              [ 88%]
 tests/test_settings.py::test_change_profile_location_clears_incomplete_dependency_chain PASSED [ 88%]
 tests/test_settings.py::test_change_profile_location_clears_city_when_city_field_is_omitted PASSED [ 88%]
 tests/test_settings.py::test_profile_states_endpoint_returns_country_scoped_options PASSED [ 88%]
-tests/test_settings.py::test_profile_cities_endpoint_returns_state_scoped_options PASSED [ 88%]
-tests/test_settings.py::test_alias_change_bio PASSED                     [ 88%]
-tests/test_settings.py::test_alias_change_bio_invalid_post_renders_error_and_preserves_submitted_bio PASSED [ 88%]
-tests/test_settings.py::test_alias_change_bio_preserves_account_category PASSED [ 88%]
-tests/test_settings.py::test_alias_change_bio_preserves_account_location PASSED [ 88%]
+tests/test_settings.py::test_profile_cities_endpoint_returns_state_scoped_options PASSED [ 89%]
+tests/test_settings.py::test_alias_change_bio PASSED                     [ 89%]
+tests/test_settings.py::test_alias_change_bio_invalid_post_renders_error_and_preserves_submitted_bio PASSED [ 89%]
+tests/test_settings.py::test_alias_change_bio_preserves_account_category PASSED [ 89%]
+tests/test_settings.py::test_alias_change_bio_preserves_account_location PASSED [ 89%]
 tests/test_settings.py::test_change_directory_visibility PASSED          [ 89%]
 tests/test_settings.py::test_alias_change_directory_visibility PASSED    [ 89%]
 tests/test_settings.py::test_update_brand_primary_color PASSED           [ 89%]
@@ -6510,10 +7029,10 @@ tests/test_settings.py::test_update_guidance_emergency_exit PASSED       [ 89%]
 tests/test_settings.py::test_update_guidance_emergency_exit_requires_url PASSED [ 89%]
 tests/test_settings.py::test_update_guidance_prompts PASSED              [ 89%]
 tests/test_settings.py::test_update_guidance_prompt_accepts_expanded_length PASSED [ 89%]
-tests/test_settings.py::test_update_guidance_prompt_rejects_text_over_expanded_length PASSED [ 89%]
-tests/test_settings.py::test_diretory_intro_text PASSED                  [ 89%]
-tests/test_settings.py::test_directory_intro_text_reset_to_default PASSED [ 89%]
-tests/test_settings.py::test_directory_intro_text_reset_aborts_when_multiple_rows_would_delete PASSED [ 89%]
+tests/test_settings.py::test_update_guidance_prompt_rejects_text_over_expanded_length PASSED [ 90%]
+tests/test_settings.py::test_diretory_intro_text PASSED                  [ 90%]
+tests/test_settings.py::test_directory_intro_text_reset_to_default PASSED [ 90%]
+tests/test_settings.py::test_directory_intro_text_reset_aborts_when_multiple_rows_would_delete PASSED [ 90%]
 tests/test_settings.py::test_homepage_user PASSED                        [ 90%]
 tests/test_settings.py::test_homepage_reset_when_already_default PASSED  [ 90%]
 tests/test_settings.py::test_homepage_reset_multiple_rows_error PASSED   [ 90%]
@@ -6529,10 +7048,10 @@ tests/test_settings.py::test_alias_fields_enabled PASSED                 [ 90%]
 tests/test_settings.py::test_alias_fields_disabled PASSED                [ 90%]
 tests/test_settings.py::test_hide_donate_button PASSED                   [ 90%]
 tests/test_settings.py::test_encryption_post_invalid_form_returns_400 PASSED [ 90%]
-tests/test_settings.py::test_alias_route_missing_alias_returns_404 PASSED [ 90%]
-tests/test_settings.py::test_delete_alias_missing_alias_returns_404 PASSED [ 90%]
-tests/test_settings.py::test_alias_fields_missing_alias_redirects_index PASSED [ 90%]
-tests/test_settings.py::test_alias_route_invalid_post_returns_400 PASSED [ 90%]
+tests/test_settings.py::test_alias_route_missing_alias_returns_404 PASSED [ 91%]
+tests/test_settings.py::test_delete_alias_missing_alias_returns_404 PASSED [ 91%]
+tests/test_settings.py::test_alias_fields_missing_alias_redirects_index PASSED [ 91%]
+tests/test_settings.py::test_alias_route_invalid_post_returns_400 PASSED [ 91%]
 tests/test_settings.py::test_alias_fields_post_uses_handle_field_post_result PASSED [ 91%]
 tests/test_settings.py::test_profile_route_raises_if_primary_username_missing PASSED [ 91%]
 tests/test_settings.py::test_profile_fields_raises_if_primary_username_missing PASSED [ 91%]
@@ -6548,10 +7067,10 @@ tests/test_settings.py::test_alias_fields_invalid_add_post_renders_errors_withou
 tests/test_settings_common.py::test_set_and_unset_field_attribute PASSED [ 91%]
 tests/test_settings_common.py::test_set_input_disabled_toggle PASSED     [ 91%]
 tests/test_settings_common.py::test_settings_forms_reject_disallowed_language PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_account_category PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_country PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_subdivision_for_country PASSED [ 91%]
-tests/test_settings_common.py::test_profile_form_rejects_invalid_city_for_subdivision PASSED [ 91%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_account_category PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_country PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_subdivision_for_country PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_rejects_invalid_city_for_subdivision PASSED [ 92%]
 tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[] PASSED [ 92%]
 tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[   ] PASSED [ 92%]
 tests/test_settings_common.py::test_country_iso2_returns_none_for_empty_or_unknown_country[Atlantis] PASSED [ 92%]
@@ -6567,9 +7086,9 @@ tests/test_settings_common.py::test_normalize_city_name_returns_none_for_unresol
 tests/test_settings_common.py::test_normalize_subdivision_name_returns_trimmed_value_for_unknown_country PASSED [ 92%]
 tests/test_settings_common.py::test_profile_form_allows_empty_city_without_normalizing PASSED [ 92%]
 tests/test_settings_common.py::test_profile_form_validate_city_returns_early_for_blank_field PASSED [ 92%]
-tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_country_choice PASSED [ 92%]
-tests/test_settings_common.py::test_strip_whitespace_leaves_non_string_values_unchanged PASSED [ 92%]
-tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_subdivision_and_city_labels PASSED [ 92%]
+tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_country_choice PASSED [ 93%]
+tests/test_settings_common.py::test_strip_whitespace_leaves_non_string_values_unchanged PASSED [ 93%]
+tests/test_settings_common.py::test_profile_form_preserves_unknown_saved_subdivision_and_city_labels PASSED [ 93%]
 tests/test_settings_common.py::test_city_choice_label_returns_raw_value_when_lookup_is_ambiguous PASSED [ 93%]
 tests/test_settings_common.py::test_profile_form_account_category_choices_are_split PASSED [ 93%]
 tests/test_settings_common.py::test_create_profile_forms_disables_location_inputs_until_dependencies PASSED [ 93%]
@@ -6586,9 +7105,9 @@ tests/test_settings_common.py::test_is_safe_verification_url_resolved_public_all
 tests/test_settings_common.py::test_resolve_safe_verification_url_returns_pinned_addresses PASSED [ 93%]
 tests/test_settings_common.py::test_static_verification_resolver_refuses_unvalidated_hosts PASSED [ 93%]
 tests/test_settings_common.py::test_resolve_safe_verification_url_rejects_when_no_usable_addresses PASSED [ 93%]
-tests/test_settings_common.py::test_fetch_verification_html_disables_redirects PASSED [ 93%]
-tests/test_settings_common.py::test_fetch_verification_html_uses_pinned_address_connector PASSED [ 93%]
-tests/test_settings_common.py::test_is_safe_verification_url_direct_private_ip_rejected PASSED [ 93%]
+tests/test_settings_common.py::test_fetch_verification_html_disables_redirects PASSED [ 94%]
+tests/test_settings_common.py::test_fetch_verification_html_uses_pinned_address_connector PASSED [ 94%]
+tests/test_settings_common.py::test_is_safe_verification_url_direct_private_ip_rejected PASSED [ 94%]
 tests/test_settings_common.py::test_is_safe_verification_url_resolved_blocked_ip_rejected PASSED [ 94%]
 tests/test_settings_common.py::test_verify_url_handles_client_error PASSED [ 94%]
 tests/test_settings_common.py::test_verify_url_returns_early_when_url_is_not_safe PASSED [ 94%]
@@ -6605,8 +7124,8 @@ tests/test_settings_common.py::test_handle_change_username_form_internal_error_f
 tests/test_settings_common.py::test_handle_change_password_form_rejects_wrong_old_password PASSED [ 94%]
 tests/test_settings_common.py::test_handle_pgp_key_form_empty_value_clears_only_public_key PASSED [ 94%]
 tests/test_settings_common.py::test_handle_profile_post_invalid_form_returns_none PASSED [ 94%]
-tests/test_settings_common.py::test_handle_profile_post_updates_directory_visibility PASSED [ 94%]
-tests/test_settings_common.py::test_handle_field_post_add_branch PASSED  [ 94%]
+tests/test_settings_common.py::test_handle_profile_post_updates_directory_visibility PASSED [ 95%]
+tests/test_settings_common.py::test_handle_field_post_add_branch PASSED  [ 95%]
 tests/test_settings_common.py::test_handle_field_post_update_branch PASSED [ 95%]
 tests/test_settings_common.py::test_handle_field_post_delete_branch PASSED [ 95%]
 tests/test_settings_common.py::test_handle_field_post_move_up_and_down_branches PASSED [ 95%]
@@ -6624,8 +7143,8 @@ tests/test_settings_registration.py::test_registration_create_invite_code PASSED
 tests/test_settings_registration.py::test_registration_delete_invite_code PASSED [ 95%]
 tests/test_settings_registration.py::test_registration_delete_invite_code_not_found PASSED [ 95%]
 tests/test_settings_registration.py::test_registration_invalid_form_submission PASSED [ 95%]
-tests/test_settings_registration.py::test_registration_invalid_delete_submission_preserves_redirect_and_flash PASSED [ 95%]
-tests/test_settings_registration.py::test_registration_missing_csrf_redirects_with_invalid_submission_flash PASSED [ 95%]
+tests/test_settings_registration.py::test_registration_invalid_delete_submission_preserves_redirect_and_flash PASSED [ 96%]
+tests/test_settings_registration.py::test_registration_missing_csrf_redirects_with_invalid_submission_flash PASSED [ 96%]
 tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_enable_when_not_configured PASSED [ 96%]
 tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_disable_when_already_configured PASSED [ 96%]
 tests/test_settings_twofa.py::test_toggle_2fa_redirects_to_login_without_user_id PASSED [ 96%]
@@ -6643,8 +7162,8 @@ tests/test_splash_screen.py::test_first_load_splash_duration_uses_runtime_config
 tests/test_splash_screen.py::test_first_load_splash_uses_brand_logo_fallback PASSED [ 96%]
 tests/test_splash_screen.py::test_first_load_splash_uses_custom_splash_logo PASSED [ 96%]
 tests/test_splash_screen.py::test_first_load_splash_uses_versioned_custom_splash_logo PASSED [ 96%]
-tests/test_splash_screen.py::test_first_load_splash_defaults_to_disabled PASSED [ 96%]
-tests/test_splash_screen.py::test_first_load_splash_can_be_disabled PASSED [ 96%]
+tests/test_splash_screen.py::test_first_load_splash_defaults_to_disabled PASSED [ 97%]
+tests/test_splash_screen.py::test_first_load_splash_can_be_disabled PASSED [ 97%]
 tests/test_static_typing_config.py::test_mypy_targets_python_313_semantics PASSED [ 97%]
 tests/test_storage.py::TestFsDriver::test_put_and_serve PASSED           [ 97%]
 tests/test_storage.py::TestFsDriver::test_put_and_delete PASSED          [ 97%]
@@ -6662,7 +7181,7 @@ tests/test_storage.py::test_blob_storage_abort_when_driver_not_configured PASSED
 tests/test_user_profile_location.py::test_user_new_session_id_returns_distinct_tokens PASSED [ 97%]
 tests/test_user_profile_location.py::test_profile_location_returns_country_when_us_geography_only_has_country PASSED [ 97%]
 tests/test_user_profile_location.py::test_profile_location_spells_out_state_when_city_missing PASSED [ 97%]
-tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_state_missing PASSED [ 97%]
+tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_state_missing PASSED [ 98%]
 tests/test_user_profile_location.py::test_profile_location_spells_out_country_when_it_is_the_only_field PASSED [ 98%]
 tests/test_user_profile_location.py::test_profile_location_returns_none_for_inconsistent_empty_us_geography PASSED [ 98%]
 tests/test_utils.py::test_redirect_to_self_uses_current_endpoint_and_view_args PASSED [ 98%]
@@ -6681,7 +7200,7 @@ tests/test_vision.py::test_vision_redirects_to_login_when_session_user_missing P
 tests/test_vision.py::test_vision_redirects_with_flash_when_user_missing_after_auth PASSED [ 98%]
 tests/test_vision.py::test_vision_renders_for_free_user PASSED           [ 98%]
 tests/test_vision.py::test_vision_renders_for_paid_user PASSED           [ 98%]
-tests/test_weekly_agent_report_runner.py::test_report_addresses_and_title_are_fixed PASSED [ 98%]
+tests/test_weekly_agent_report_runner.py::test_report_addresses_and_title_are_fixed PASSED [ 99%]
 tests/test_weekly_agent_report_runner.py::test_default_sources_match_monitored_logs PASSED [ 99%]
 tests/test_weekly_agent_report_runner.py::test_collect_events_from_hushline_runner_log PASSED [ 99%]
 tests/test_weekly_agent_report_runner.py::test_parse_log_timestamp_uses_timezone_abbreviation_during_fallback PASSED [ 99%]
@@ -6705,15 +7224,16 @@ tests/test_workflow_pr_head_qualification.py::test_dependency_audit_workflow_onl
 ---------- coverage: platform linux, python 3.13.13-final-0 ----------
 Name                                             Stmts   Miss  Cover
 --------------------------------------------------------------------
-hushline/__init__.py                               160      0   100%
+hushline/__init__.py                               162      0   100%
 hushline/admin.py                                  187      0   100%
 hushline/auth.py                                    73      0   100%
+hushline/cli_encrypted_field.py                    400     65    84%
 hushline/cli_password_hash.py                       56      0   100%
 hushline/cli_reg.py                                 47      0   100%
 hushline/cli_stripe.py                              32      0   100%
 hushline/config.py                                 144      0   100%
 hushline/content_safety.py                          40      0   100%
-hushline/crypto.py                                 235     17    93%
+hushline/crypto.py                                 271     23    92%
 hushline/db.py                                       6      0   100%
 hushline/email.py                                  109      0   100%
 hushline/email_headers.py                          353      0   100%
@@ -6791,27 +7311,8 @@ hushline/user_deletion.py                           18      0   100%
 hushline/utils.py                                   21      0   100%
 hushline/version.py                                  1      0   100%
 --------------------------------------------------------------------
-TOTAL                                             9042     17    99%
+TOTAL                                             9480     88    99%
 Coverage HTML written to dir /tmp/hushline-htmlcov
 
 
-========== 1861 passed, 1 deselected, 1 xfailed in 411.82s (0:06:51) ===========
-Pruning old runner logs, keeping newest 10.
-[codex/daily-issue-2018 cef80f4a] chore: agent daily for #2018 (epic #2013)
- 6 files changed, 7127 insertions(+), 474 deletions(-)
- create mode 100644 docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
- delete mode 100644 docs/agent-logs/run-20260523T014653Z-issue-1998.txt
- create mode 100644 docs/agent-logs/run-20260526T055615Z-issue-2018.txt
- create mode 100644 tests/test_encrypted_field_migration_runbook.py
-Remote branch 'codex/daily-issue-2018' does not exist; creating it with a standard push.
-remote: 
-remote: Create a pull request for 'codex/daily-issue-2018' on GitHub by visiting:        
-remote:      https://github.com/scidsg/hushline/pull/new/codex/daily-issue-2018        
-remote: 
-To github.com:scidsg/hushline.git
- * [new branch]        codex/daily-issue-2018 -> codex/daily-issue-2018
-branch 'codex/daily-issue-2018' set up to track 'origin/codex/daily-issue-2018'.
-Opened PR: https://github.com/scidsg/hushline/pull/2031
-==> Mark issue #2018 as Ready for Review
-Opened coverage gap issue: https://github.com/scidsg/hushline/issues/2032
-==> Add coverage gap issue #2032 to Agent Eligible
+========== 1903 passed, 1 deselected, 1 xfailed in 418.06s (0:06:58) ===========

--- a/tests/migrations/revision_b2039e7c0a1d.py
+++ b/tests/migrations/revision_b2039e7c0a1d.py
@@ -40,6 +40,14 @@ LEGACY_CIPHERTEXT_BY_COLUMN = {
     "smtp_password": _legacy_fernet_token("legacy-smtp-password"),
     "notification_recipient_email": _legacy_fernet_token("recipient@example.com"),
 }
+SAFE_ENVELOPE_CIPHERTEXT_BY_COLUMN = {
+    column: serialize_encrypted_field_envelope(_legacy_fernet_token(f"safe-{column}"))
+    for column in USER_COLUMNS
+}
+SAFE_ENVELOPE_CIPHERTEXT_BY_COLUMN["notification_recipient_email"] = (
+    serialize_encrypted_field_envelope(_legacy_fernet_token("safe-notification-recipient-email"))
+)
+assert all(len(value) <= 255 for value in SAFE_ENVELOPE_CIPHERTEXT_BY_COLUMN.values())
 OVERSIZED_ENVELOPE_CIPHERTEXT = serialize_encrypted_field_envelope(_legacy_fernet_token("x" * 180))
 assert len(OVERSIZED_ENVELOPE_CIPHERTEXT) > 255
 
@@ -70,7 +78,7 @@ def _assert_legacy_varchar_columns() -> None:
         assert _column_metadata(table_name, column_name) == ("character varying", 255)
 
 
-def _insert_user_with_legacy_ciphertext() -> None:
+def _insert_user(id_: int, ciphertext_by_column: dict[str, str | None]) -> None:
     db.session.execute(
         text(
             """
@@ -87,11 +95,11 @@ def _insert_user_with_legacy_ciphertext() -> None:
                 smtp_password
             )
             VALUES (
-                1,
+                :id,
                 false,
                 false,
-                '$scrypt$',
-                'session-1',
+                :password_hash,
+                :session_id,
                 :totp_secret,
                 :email,
                 :smtp_server,
@@ -100,103 +108,191 @@ def _insert_user_with_legacy_ciphertext() -> None:
             )
             """
         ),
-        {column: LEGACY_CIPHERTEXT_BY_COLUMN[column] for column in USER_COLUMNS},
+        {
+            "id": id_,
+            "password_hash": f"$scrypt${id_}",
+            "session_id": f"session-{id_}",
+            **ciphertext_by_column,
+        },
     )
 
 
-def _insert_notification_recipient_with_legacy_ciphertext() -> None:
+def _insert_notification_recipient(id_: int, user_id: int, email: str | None) -> None:
     db.session.execute(
         text(
             """
             INSERT INTO notification_recipients (
+                id,
                 user_id,
                 enabled,
                 position,
                 email
             )
             VALUES (
-                1,
+                :id,
+                :user_id,
                 true,
                 0,
                 :email
             )
             """
         ),
-        {"email": LEGACY_CIPHERTEXT_BY_COLUMN["notification_recipient_email"]},
+        {"id": id_, "user_id": user_id, "email": email},
     )
 
 
-def _assert_legacy_ciphertext_preserved() -> None:
+def _insert_user_with_legacy_ciphertext() -> None:
+    _insert_user(1, {column: LEGACY_CIPHERTEXT_BY_COLUMN[column] for column in USER_COLUMNS})
+
+
+def _insert_notification_recipient_with_legacy_ciphertext() -> None:
+    _insert_notification_recipient(
+        1,
+        1,
+        LEGACY_CIPHERTEXT_BY_COLUMN["notification_recipient_email"],
+    )
+
+
+def _insert_null_empty_and_safe_envelope_ciphertext() -> None:
+    _insert_user(2, {column: None for column in USER_COLUMNS})
+    _insert_user(3, {column: "" for column in USER_COLUMNS})
+    _insert_user(
+        4,
+        {column: SAFE_ENVELOPE_CIPHERTEXT_BY_COLUMN[column] for column in USER_COLUMNS},
+    )
+    _insert_notification_recipient(2, 2, None)
+    _insert_notification_recipient(3, 3, "")
+    _insert_notification_recipient(
+        4,
+        4,
+        SAFE_ENVELOPE_CIPHERTEXT_BY_COLUMN["notification_recipient_email"],
+    )
+
+
+def _user_ciphertext_values(id_: int) -> tuple[str | None, ...]:
     user_row = db.session.execute(
         text(
             """
             SELECT totp_secret, email, smtp_server, smtp_username, smtp_password
             FROM users
-            WHERE id = 1
+            WHERE id = :id
             """
-        )
+        ),
+        {"id": id_},
     ).one()
-    assert user_row == tuple(LEGACY_CIPHERTEXT_BY_COLUMN[column] for column in USER_COLUMNS)
+    return tuple(user_row)
 
-    recipient_email = db.session.scalar(
+
+def _notification_recipient_email(id_: int) -> str | None:
+    return db.session.scalar(
         text(
             """
             SELECT email
             FROM notification_recipients
-            WHERE user_id = 1
+            WHERE id = :id
             """
-        )
+        ),
+        {"id": id_},
     )
+
+
+def _assert_legacy_ciphertext_preserved() -> None:
+    assert _user_ciphertext_values(1) == tuple(
+        LEGACY_CIPHERTEXT_BY_COLUMN[column] for column in USER_COLUMNS
+    )
+    recipient_email = _notification_recipient_email(1)
     assert recipient_email == LEGACY_CIPHERTEXT_BY_COLUMN["notification_recipient_email"]
+
+
+def _assert_null_empty_and_safe_envelope_ciphertext_preserved() -> None:
+    assert _user_ciphertext_values(2) == tuple(None for _ in USER_COLUMNS)
+    assert _user_ciphertext_values(3) == tuple("" for _ in USER_COLUMNS)
+    assert _user_ciphertext_values(4) == tuple(
+        SAFE_ENVELOPE_CIPHERTEXT_BY_COLUMN[column] for column in USER_COLUMNS
+    )
+    assert _notification_recipient_email(2) is None
+    assert _notification_recipient_email(3) == ""
+    assert (
+        _notification_recipient_email(4)
+        == SAFE_ENVELOPE_CIPHERTEXT_BY_COLUMN["notification_recipient_email"]
+    )
 
 
 class UpgradeTester:
     def load_data(self) -> None:
         _insert_user_with_legacy_ciphertext()
         _insert_notification_recipient_with_legacy_ciphertext()
+        _insert_null_empty_and_safe_envelope_ciphertext()
         db.session.commit()
 
     def check_upgrade(self) -> None:
         _assert_text_columns()
         _assert_legacy_ciphertext_preserved()
+        _assert_null_empty_and_safe_envelope_ciphertext_preserved()
 
 
 class DowngradeTester:
     def load_data(self) -> None:
         _insert_user_with_legacy_ciphertext()
         _insert_notification_recipient_with_legacy_ciphertext()
+        _insert_null_empty_and_safe_envelope_ciphertext()
         db.session.commit()
 
     def check_downgrade(self) -> None:
         _assert_legacy_varchar_columns()
         _assert_legacy_ciphertext_preserved()
+        _assert_null_empty_and_safe_envelope_ciphertext_preserved()
 
 
 class DowngradeGuardTester:
+    def __init__(self, table_name: str, column_name: str) -> None:
+        if (table_name, column_name) not in ENCRYPTED_COLUMNS:
+            raise ValueError(f"Unexpected encrypted column: {table_name}.{column_name}")
+        self.table_name = table_name
+        self.column_name = column_name
+        self.expected_user_values: tuple[str | None, ...] | None = None
+        self.expected_recipient_email: str | None = None
+
     def load_data(self) -> None:
         _insert_user_with_legacy_ciphertext()
+        _insert_notification_recipient_with_legacy_ciphertext()
         db.session.execute(
-            text(
-                """
-                UPDATE users
-                SET email = :email
-                WHERE id = 1
-                """
-            ),
-            {"email": OVERSIZED_ENVELOPE_CIPHERTEXT},
+            text(f"UPDATE {self.table_name} SET {self.column_name} = :value WHERE id = 1"),
+            {"value": OVERSIZED_ENVELOPE_CIPHERTEXT},
         )
         db.session.commit()
+        self.expected_user_values = _user_ciphertext_values(1)
+        self.expected_recipient_email = _notification_recipient_email(1)
 
     def check_value_preserved(self) -> None:
         assert (
             db.session.scalar(
                 text(
-                    """
-                    SELECT email
-                    FROM users
+                    f"""
+                    SELECT {self.column_name}
+                    FROM {self.table_name}
                     WHERE id = 1
                     """
                 )
             )
             == OVERSIZED_ENVELOPE_CIPHERTEXT
+        )
+        assert self.expected_user_values is not None
+        assert _user_ciphertext_values(1) == self.expected_user_values
+        assert _notification_recipient_email(1) == self.expected_recipient_email
+
+
+class RollbackReadabilityTester:
+    def load_data(self) -> None:
+        _insert_user_with_legacy_ciphertext()
+        _insert_notification_recipient_with_legacy_ciphertext()
+        _insert_null_empty_and_safe_envelope_ciphertext()
+        db.session.commit()
+
+    def encrypted_values(self) -> tuple[str, ...]:
+        return (
+            *(value for value in _user_ciphertext_values(1) if isinstance(value, str) and value),
+            *(value for value in _user_ciphertext_values(4) if isinstance(value, str) and value),
+            LEGACY_CIPHERTEXT_BY_COLUMN["notification_recipient_email"],
+            SAFE_ENVELOPE_CIPHERTEXT_BY_COLUMN["notification_recipient_email"],
         )

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -18,6 +18,10 @@ from sqlalchemy import text
 from hushline import crypto
 from hushline.config import ENCRYPTED_FIELD_WRITE_FORMAT, EncryptedFieldWriteFormat
 from hushline.db import db, migrate
+from tests.migrations.revision_b2039e7c0a1d import (
+    ENCRYPTED_COLUMNS,
+    LEGACY_FERNET_KEY,
+)
 
 REVISIONS_ROOT = Path(__file__).parent.parent / "migrations"
 assert REVISIONS_ROOT.exists()
@@ -119,7 +123,15 @@ def test_double_upgrade(revision: str, app: Flask) -> None:
     command.upgrade(cfg, revision)
 
 
-def test_encrypted_column_downgrade_refuses_oversized_ciphertext(app: Flask) -> None:
+@pytest.mark.parametrize(
+    ("table_name", "column_name"),
+    crypto.ENCRYPTED_FIELD_ENVELOPE_READY_COLUMNS,
+)
+def test_encrypted_column_downgrade_refuses_oversized_ciphertext(
+    table_name: str,
+    column_name: str,
+    app: Flask,
+) -> None:
     cfg = typing.cast(alembic.config.Config, migrate.get_config())
     command.upgrade(cfg, "b2039e7c0a1d")
 
@@ -127,11 +139,12 @@ def test_encrypted_column_downgrade_refuses_oversized_ciphertext(app: Flask) -> 
         "tests.migrations.revision_b2039e7c0a1d",
         fromlist=["DowngradeGuardTester"],
     )
-    downgrade_guard_tester = mod.DowngradeGuardTester()
+    downgrade_guard_tester = mod.DowngradeGuardTester(table_name, column_name)
     downgrade_guard_tester.load_data()
     db.session.close()
 
-    with pytest.raises(RuntimeError, match=r"users\.email.*exceed 255 characters"):
+    expected_column = rf"{table_name}\.{column_name}"
+    with pytest.raises(RuntimeError, match=expected_column + r".*exceed 255 characters"):
         command.downgrade(cfg, "-1")
 
     db.session.rollback()
@@ -144,7 +157,40 @@ def test_envelope_schema_readiness_columns_match_widening_migration() -> None:
         fromlist=["ENCRYPTED_SHORT_STRING_COLUMNS"],
     )
 
+    assert ENCRYPTED_COLUMNS == mod.ENCRYPTED_SHORT_STRING_COLUMNS
     assert crypto.ENCRYPTED_FIELD_ENVELOPE_READY_COLUMNS == mod.ENCRYPTED_SHORT_STRING_COLUMNS
+
+
+def test_encrypted_field_preflight_tracks_widening_migration_readiness(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = typing.cast(alembic.config.Config, migrate.get_config())
+    command.upgrade(cfg, "a4c8f2d9e713")
+    monkeypatch.setenv("ENCRYPTION_KEY", LEGACY_FERNET_KEY)
+    runner = app.test_cli_runner()
+
+    pre_migration_result = runner.invoke(args=["encrypted-field", "preflight"])
+
+    assert pre_migration_result.exit_code == 1
+    assert "Current Alembic revision: a4c8f2d9e713" in pre_migration_result.output
+    for table_name, column_name in crypto.ENCRYPTED_FIELD_ENVELOPE_READY_COLUMNS:
+        assert f"({table_name}.{column_name}): blocked (length 255)" in (
+            pre_migration_result.output
+        )
+    assert "Encrypted-field preflight readiness: blocked" in pre_migration_result.output
+    assert "schema is not envelope-ready" in pre_migration_result.output
+
+    db.session.close()
+    command.upgrade(cfg, "b2039e7c0a1d")
+
+    post_migration_result = runner.invoke(args=["encrypted-field", "preflight"])
+
+    assert post_migration_result.exit_code == 0
+    assert "Current Alembic revision: b2039e7c0a1d" in post_migration_result.output
+    for table_name, column_name in crypto.ENCRYPTED_FIELD_ENVELOPE_READY_COLUMNS:
+        assert f"({table_name}.{column_name}): ready (unbounded)" in (post_migration_result.output)
+    assert "Encrypted-field preflight readiness: ready" in post_migration_result.output
 
 
 def test_legacy_encrypted_field_writes_do_not_require_envelope_schema(
@@ -191,3 +237,34 @@ def test_envelope_encrypted_field_writes_accept_widened_schema(
     assert encrypted is not None
     assert encrypted.startswith(crypto.ENCRYPTED_FIELD_ENVELOPE_PREFIX)
     assert crypto.decrypt_field(encrypted) == "secret"
+
+
+def test_downgrade_preserves_mixed_ciphertexts_readable_by_dual_reader(
+    app: Flask,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cfg = typing.cast(alembic.config.Config, migrate.get_config())
+    command.upgrade(cfg, "b2039e7c0a1d")
+    monkeypatch.setenv("ENCRYPTION_KEY", LEGACY_FERNET_KEY)
+    app.config[ENCRYPTED_FIELD_WRITE_FORMAT] = EncryptedFieldWriteFormat.ENVELOPE_FERNET
+
+    mod = __import__(
+        "tests.migrations.revision_b2039e7c0a1d",
+        fromlist=["RollbackReadabilityTester"],
+    )
+    rollback_tester = mod.RollbackReadabilityTester()
+    rollback_tester.load_data()
+    db.session.close()
+
+    command.downgrade(cfg, "-1")
+    app.config[ENCRYPTED_FIELD_WRITE_FORMAT] = EncryptedFieldWriteFormat.LEGACY_FERNET
+
+    for encrypted_value in rollback_tester.encrypted_values():
+        decrypted_value = crypto.decrypt_field(encrypted_value)
+        assert decrypted_value is not None
+        assert decrypted_value.startswith(("legacy", "recipient", "safe", "smtp.legacy"))
+
+    post_rollback_ciphertext = crypto.encrypt_field("post-rollback secret")
+    assert post_rollback_ciphertext is not None
+    assert not post_rollback_ciphertext.startswith(crypto.ENCRYPTED_FIELD_ENVELOPE_PREFIX)
+    assert crypto.decrypt_field(post_rollback_ciphertext) == "post-rollback secret"


### PR DESCRIPTION
This PR implements child issue #2057 (`Phase 13: deepen encrypted-field migration downgrade and rollback tests`) under epic #2013 (`Epic: modernize symmetric encrypted-field cryptography safely`).
It is intended to merge into the epic branch first, not directly into `main`.

This PR addresses the issue "Phase 13: deepen encrypted-field migration downgrade and rollback tests" by updating automated tests in `tests/migrations/revision_b2039e7c0a1d.py` and automated tests in `tests/test_migrations.py`.
The change focuses on automated tests, confirming the expected behavior without a broader product change.
It touches 2 non-log file(s) (4 total including runner artifacts), primarily in tests/migrations and tests/test_migrations.py.

## Summary
- Automated daily runner update for child issue #2057.
- Part of epic #2013: Epic: modernize symmetric encrypted-field cryptography safely
- This PR targets the epic integration branch `codex/epic-2013`.
- The child issue is closed explicitly by workflow after this PR merges into the epic branch.

Linked issue: #2057

## Context
- Epic: https://github.com/scidsg/hushline/issues/2013
- Child issue: https://github.com/scidsg/hushline/issues/2057
- Branch: codex/daily-issue-2057
- Base branch: codex/epic-2013
- Runner log: docs/agent-logs/run-20260527T094627Z-issue-2057.txt

## Changed Files
- `docs/agent-logs/run-20260526T055615Z-issue-2018.txt`
- `docs/agent-logs/run-20260527T094627Z-issue-2057.txt`
- `tests/migrations/revision_b2039e7c0a1d.py`
- `tests/test_migrations.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
