### PR TITLE
Stop runner retries on Codex auth failures

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -149,6 +149,11 @@ const child = spawn("codex", ["app-server", "--listen", "stdio://"], {
 });
 let completed = false;
 let stdoutBuffer = "";
+let stderrBuffer = "";
+
+function isAuthFailure(text) {
+  return /token[_ -]?(invalidated|reused)|refresh token|access token|unauthorized|sign in again|log out and sign in again/i.test(text || "");
+}
 
 function finish(code) {
   if (completed) return;
@@ -178,23 +183,29 @@ child.stdout.on("data", (chunk) => {
     }
     if (message.id === 2) {
       if (message.error) {
-        console.error(`Codex /status rate limit check failed: ${message.error.message || "unknown error"}`);
-        finish(2);
+        const errorMessage = message.error.message || "unknown error";
+        console.error(`Codex /status rate limit check failed: ${errorMessage}`);
+        finish(isAuthFailure(errorMessage) ? 3 : 2);
       }
       process.stdout.write(`${JSON.stringify(message.result || {})}\n`);
       finish(0);
     }
   }
 });
-child.stderr.on("data", () => {});
+child.stderr.on("data", (chunk) => {
+  stderrBuffer += chunk.toString();
+  if (stderrBuffer.length > 12000) {
+    stderrBuffer = stderrBuffer.slice(-12000);
+  }
+});
 child.on("error", (error) => {
   console.error(`Codex /status rate limit check failed: ${error.message}`);
-  finish(2);
+  finish(isAuthFailure(error.message) ? 3 : 2);
 });
 child.on("exit", (code) => {
   if (!completed) {
     console.error(`Codex /status rate limit check exited before returning status: ${code}`);
-    finish(2);
+    finish(isAuthFailure(stderrBuffer) ? 3 : 2);
   }
 });
 
@@ -258,6 +269,7 @@ codex_status_reached_type_blocks_issue_work() {
 
 wait_for_codex_status_credit_window() {
   local status_json=""
+  local status_rc=0
   local parsed_status=""
   local used_percent=""
   local window_duration_mins=""
@@ -275,7 +287,14 @@ wait_for_codex_status_credit_window() {
 
   while :; do
     echo "==> Check Codex /status usage limits"
-    if ! status_json="$(fetch_codex_status_json)"; then
+    if status_json="$(fetch_codex_status_json)"; then
+      status_rc=0
+    else
+      status_rc=$?
+      if (( status_rc == 3 )); then
+        echo "Blocked: Codex /status reported an authentication failure; sign in again for CODEX_HOME before running assigned work." >&2
+        return 1
+      fi
       echo "Warning: Codex /status preflight failed; continuing so the runner can still attempt assigned work." >&2
       return 0
     fi
@@ -3390,6 +3409,14 @@ codex_transcript_has_rate_quota_or_credit_failure() {
   grep -Eiq "$access_failure_pattern" "$transcript_file"
 }
 
+codex_transcript_has_auth_failure() {
+  local transcript_file="$1"
+  local auth_failure_pattern
+
+  auth_failure_pattern='(^|[^[:alnum:]_])((token[ _-]*(invalidated|reused))|refresh[ _-]*token|access[ _-]*token|unauthorized|sign[ _-]*in[ _-]*again|log[ _-]*out[ _-]*and[ _-]*sign[ _-]*in[ _-]*again)([^[:alnum:]_]|$)'
+  grep -Eiq "$auth_failure_pattern" "$transcript_file"
+}
+
 run_codex_from_prompt() {
   local rc=0
   CODEX_EXEC_UNAVAILABLE=0
@@ -3407,7 +3434,6 @@ run_codex_from_prompt() {
   codex exec \
     --model "$CODEX_MODEL" \
     -c "model_reasoning_effort=\"$CODEX_REASONING_EFFORT\"" \
-    --full-auto \
     --sandbox workspace-write \
     -C "$REPO_DIR" \
     -o "$CODEX_OUTPUT_FILE" \
@@ -3426,6 +3452,9 @@ run_codex_from_prompt() {
     if grep -Eq '"has_credits"[[:space:]]*:[[:space:]]*false' "$CODEX_TRANSCRIPT_FILE"; then
       CODEX_EXEC_UNAVAILABLE=1
       echo "Codex unavailable: account has no credits; self-heal cannot proceed until credits are restored."
+    elif codex_transcript_has_auth_failure "$CODEX_TRANSCRIPT_FILE"; then
+      CODEX_EXEC_UNAVAILABLE=1
+      echo "Codex unavailable: authentication failed; sign in again for CODEX_HOME before retrying assigned work."
     elif codex_transcript_has_rate_quota_or_credit_failure "$CODEX_TRANSCRIPT_FILE"; then
       CODEX_EXEC_UNAVAILABLE=1
       echo "Codex unavailable: transcript indicates a rate limit, quota, or credit failure; self-heal cannot proceed until access is restored."

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -181,6 +181,34 @@ printf 'rc=%s\\n' "$rc"
     assert "5h window still has capacity; proceeding" not in result.stdout
 
 
+def test_wait_for_codex_status_credit_window_blocks_auth_failure() -> None:
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+CODEX_STATUS_CHECK_ENABLED=1
+fetch_codex_status_json() {{
+  printf 'Codex /status rate limit check exited before returning status: 1\\n' >&2
+  return 3
+}}
+sleep() {{
+  printf 'unexpected-sleep:%s\\n' "$1"
+  return 1
+}}
+set +e
+wait_for_codex_status_credit_window
+rc=$?
+set -e
+printf 'rc=%s\\n' "$rc"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert "rc=1" in result.stdout
+    assert "unexpected-sleep" not in result.stdout
+    assert "authentication failure" in result.stderr
+    assert "continuing so the runner can still attempt assigned work" not in result.stderr
+
+
 def test_wait_for_codex_status_credit_window_allows_shared_usage_without_credit_balance() -> None:
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
@@ -2635,6 +2663,51 @@ printf 'rc=%s unavailable=%s\\n' "$rc" "$CODEX_EXEC_UNAVAILABLE"
     transcript_text = transcript_file.read_text(encoding="utf-8")
     assert "Codex unavailable:" in run_log_text
     assert "usage limit" in transcript_text
+
+
+def test_run_codex_from_prompt_reports_auth_failure_without_retries(
+    tmp_path: Path,
+) -> None:
+    prompt_file = tmp_path / "prompt.txt"
+    output_file = tmp_path / "codex-output.txt"
+    transcript_file = tmp_path / "codex-transcript.txt"
+    run_log_file = tmp_path / "run-log.txt"
+    console_file = tmp_path / "console.txt"
+
+    prompt_file.write_text("issue prompt\n", encoding="utf-8")
+
+    shell_script = f"""
+source {shlex.quote(str(RUNNER_SCRIPT))}
+REPO_DIR={shlex.quote(str(tmp_path))}
+PROMPT_FILE={shlex.quote(str(prompt_file))}
+CODEX_OUTPUT_FILE={shlex.quote(str(output_file))}
+CODEX_TRANSCRIPT_FILE={shlex.quote(str(transcript_file))}
+CODEX_MODEL=test-model
+CODEX_REASONING_EFFORT=high
+VERBOSE_CODEX_OUTPUT=0
+exec 3>{shlex.quote(str(console_file))}
+codex() {{
+  printf '%s' "ERROR: Your access token could not be refreshed because "
+  printf '%s\\n' "your refresh token was already used. Please log out and sign in again."
+  return 1
+}}
+if run_codex_from_prompt > {shlex.quote(str(run_log_file))} 2>&1; then
+  rc=0
+else
+  rc=$?
+fi
+printf 'rc=%s unavailable=%s\\n' "$rc" "$CODEX_EXEC_UNAVAILABLE"
+"""
+
+    result = _run_bash(shell_script)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "rc=1 unavailable=1"
+    run_log_text = run_log_file.read_text(encoding="utf-8")
+    transcript_text = transcript_file.read_text(encoding="utf-8")
+    assert "Codex unavailable: authentication failed" in run_log_text
+    assert "access token could not be refreshed" in transcript_text
+    assert "log out and sign in again" in transcript_text
 
 
 def test_write_pr_narrative_lead_adds_plain_language_summary() -> None:


### PR DESCRIPTION
## Summary
- Stop the daily issue runner immediately when Codex `/status` reports an authentication failure.
- Classify `codex exec` token invalidation, token reuse, unauthorized, and sign-in-required transcript failures as Codex unavailable so issue/fix loops do not burn every retry.
- Remove the deprecated `--full-auto` flag because `--sandbox workspace-write` now carries the intended noninteractive sandbox mode.

## Why
The runner was retrying issue work ten times after the Codex child process failed with an invalidated/reused token. Because the transcript is intentionally excluded from persisted logs, the runner surfaced only `Codex execution failed (exit 1)` and a clean worktree. This makes the actionable repair path invisible and wastes every issue attempt.

## Validation
- `make test TESTS=tests/test_agent_daily_issue_runner.py PYTEST_ADDOPTS=-q` passed
- `make lint` passed
- `make test` was attempted twice; both runs reached the tail of the suite and then failed from Docker VM disk exhaustion in Postgres test database creation. Latest run: `1946 passed, 1 deselected, 1 xfailed, 10 errors`; errors were `psycopg.errors.DiskFull` / `No space left on device`. Docker VM root was `100%` full.

## Manual Testing
Not applicable. This changes local automation behavior and is covered by runner shell tests.

## Risks
- Low product risk: changes are limited to local runner automation and tests.
- The host still needs Docker Desktop disk image size increased before the full local suite can complete reliably.
