### PR TITLE
Lazy-load directory tab listings

### DIFF
--- a/assets/js/directory_verified.js
+++ b/assets/js/directory_verified.js
@@ -31,6 +31,8 @@ document.addEventListener("DOMContentLoaded", function () {
   const searchStatus = document.getElementById("directory-search-status");
   const publicRecordCountBadge = document.getElementById("public-record-count");
   const newsroomCountBadge = document.getElementById("newsroom-count");
+  const securedropCountBadge = document.getElementById("securedrop-count");
+  const globaleaksCountBadge = document.getElementById("globaleaks-count");
   const allFiltersToggleShell = document.getElementById("all-filters-toggle-shell");
   const allFiltersPanelShell = document.getElementById("all-filters-panel-shell");
   const allFiltersToggle = document.getElementById("all-filters-toggle");
@@ -51,8 +53,8 @@ document.addEventListener("DOMContentLoaded", function () {
   const newsroomCountryFilter = document.getElementById("newsroom-country-filter");
   const newsroomRegionFilter = document.getElementById("newsroom-region-filter");
   const initialMarkup = new Map();
-  let userData = [];
-  let allTabUserData = [];
+  const tabDataCache = new Map();
+  const tabDataRequests = new Map();
   let hasRenderedSearch = false;
   let directoryDataRequestController = null;
   let directoryDataLoadingController = null;
@@ -85,8 +87,40 @@ document.addEventListener("DOMContentLoaded", function () {
     return document.querySelector(".tab-content.active") || document.getElementById("all");
   }
 
+  function sharedDirectorySearch(search) {
+    return removeSearchParams(search, ["all_country", "all_region", "all_listing_type"]);
+  }
+
+  function allTabDirectorySearch(search) {
+    return removeSearchParams(search, [
+      "country",
+      "region",
+      "newsroom_country",
+      "newsroom_region",
+    ]);
+  }
+
+  function tabScopedSearch(tab, search) {
+    return tab === "all" ? allTabDirectorySearch(search) : sharedDirectorySearch(search);
+  }
+
+  function tabDataSearch(tab, search) {
+    const params = new URLSearchParams(tabScopedSearch(tab, search));
+    params.set("tab", tab);
+    const nextSearch = params.toString();
+    return nextSearch ? `?${nextSearch}` : "";
+  }
+
+  function tabDataCacheKey(tab, search = window.location.search) {
+    return `${tab}\n${tabScopedSearch(tab, search)}`;
+  }
+
+  function hasTabData(tab, search = window.location.search) {
+    return tabDataCache.has(tabDataCacheKey(tab, search));
+  }
+
   function usersForTab(tab = activeTabName()) {
-    return tab === "all" ? allTabUserData : userData;
+    return tabDataCache.get(tabDataCacheKey(tab, loadedDirectorySearch)) || [];
   }
 
   function updateTabScrollControls() {
@@ -158,25 +192,24 @@ document.addEventListener("DOMContentLoaded", function () {
     searchInput.placeholder = "Search directory...";
   }
 
-  function scopeLabel() {
-    const activeTab = activeTabName();
-    if (activeTab === "verified") {
+  function scopeLabel(tab = activeTabName()) {
+    if (tab === "verified") {
       return "verified users";
     }
 
-    if (activeTab === "public-records") {
+    if (tab === "public-records") {
       return "attorneys";
     }
 
-    if (activeTab === "newsrooms") {
+    if (tab === "newsrooms") {
       return "journalists and newsrooms";
     }
 
-    if (activeTab === "globaleaks") {
+    if (tab === "globaleaks") {
       return "GlobaLeaks instances";
     }
 
-    if (activeTab === "securedrop") {
+    if (tab === "securedrop") {
       return "SecureDrop instances";
     }
 
@@ -571,17 +604,16 @@ document.addEventListener("DOMContentLoaded", function () {
     return panel.innerHTML;
   }
 
-  function refreshInitialMarkup() {
-    ["public-records", "newsrooms", "all"].forEach((panelId) => {
-      if (document.getElementById(panelId)) {
-        initialMarkup.set(panelId, buildDefaultPanelMarkup(panelId));
-      }
-    });
+  function refreshInitialMarkup(tab = activeTabName()) {
+    if (document.getElementById(tab) && hasTabData(tab, loadedDirectorySearch)) {
+      initialMarkup.set(tab, buildDefaultPanelMarkup(tab));
+    }
   }
 
   function handleSearchInput() {
     const query = searchInput.value.trim();
     const panel = activePanel();
+    const tab = activeTabName();
     const currentScopeLabel = scopeLabel();
     const hasQuery = query.length > 0;
 
@@ -589,6 +621,11 @@ document.addEventListener("DOMContentLoaded", function () {
       clearIcon.style.visibility = hasQuery ? "visible" : "hidden";
       clearIcon.hidden = !hasQuery;
       clearIcon.setAttribute("aria-hidden", hasQuery ? "false" : "true");
+    }
+
+    if (!hasTabData(tab, loadedDirectorySearch)) {
+      void ensureTabData(tab, window.location.search, { showLoading: false });
+      return;
     }
 
     if (query.length === 0) {
@@ -619,19 +656,6 @@ document.addEventListener("DOMContentLoaded", function () {
     });
     const nextSearch = params.toString();
     return nextSearch ? `?${nextSearch}` : "";
-  }
-
-  function sharedDirectorySearch(search) {
-    return removeSearchParams(search, ["all_country", "all_region", "all_listing_type"]);
-  }
-
-  function allTabDirectorySearch(search) {
-    return removeSearchParams(search, [
-      "country",
-      "region",
-      "newsroom_country",
-      "newsroom_region",
-    ]);
   }
 
   function createLocationFilterController(config) {
@@ -1266,14 +1290,26 @@ document.addEventListener("DOMContentLoaded", function () {
 
   function updateLocationFilterCountBadges() {
     locationFilterControllers.forEach((controller) => {
-      controller.updateCountBadge();
+      if (hasTabData(controller.tabName, loadedDirectorySearch)) {
+        controller.updateCountBadge();
+      }
     });
+    if (securedropCountBadge && hasTabData("securedrop", loadedDirectorySearch)) {
+      securedropCountBadge.textContent = usersForTab("securedrop").length.toString();
+    }
+    if (globaleaksCountBadge && hasTabData("globaleaks", loadedDirectorySearch)) {
+      globaleaksCountBadge.textContent = usersForTab("globaleaks").length.toString();
+    }
   }
 
   function refreshLocationFilterMetadata(search = window.location.search) {
     return Promise.all(
       locationFilterControllers.map((controller) => controller.ensureMetadata(search)),
     );
+  }
+
+  function locationFilterControllerForTab(tab) {
+    return locationFilterControllers.find((controller) => controller.tabName === tab) || null;
   }
 
   function setDirectoryUrl(search) {
@@ -1284,36 +1320,69 @@ document.addEventListener("DOMContentLoaded", function () {
     );
   }
 
-  function loadData(search = window.location.search, options = {}) {
+  function setPanelBusy(tab, isBusy) {
+    const panel = document.getElementById(tab);
+    if (panel) {
+      panel.setAttribute("aria-busy", isBusy ? "true" : "false");
+    }
+  }
+
+  function renderTabLoading(tab) {
+    const panel = document.getElementById(tab);
+    if (!panel) {
+      return;
+    }
+
+    panel.innerHTML = `${panelIntroMarkup(tab)}
+      <p class="empty-message" role="status">Loading ${scopeLabel(tab)}...</p>`;
+    setPanelBusy(tab, true);
+  }
+
+  function renderTabError(tab) {
+    const panel = document.getElementById(tab);
+    if (!panel) {
+      return;
+    }
+
+    panel.innerHTML = `${panelIntroMarkup(tab)}
+      <p class="empty-message" role="alert">Unable to load ${scopeLabel(tab)}. Please try again.</p>`;
+    setPanelBusy(tab, false);
+  }
+
+  function loadData(tab, search = window.location.search, options = {}) {
     const requestOptions = {};
     if (options.signal) {
       requestOptions.signal = options.signal;
     }
 
-    const fetchUsers = (search) =>
-      fetch(`${directoryPath}/users.json${search}`, requestOptions).then((response) => {
-        if (!response.ok) {
-          throw new Error("Network response was not ok");
-        }
-        return response.json();
-      });
+    const fetchUsers = (tab, search) =>
+      fetch(`${directoryPath}/users.json${tabDataSearch(tab, search)}`, requestOptions).then(
+        (response) => {
+          if (!response.ok) {
+            throw new Error("Network response was not ok");
+          }
+          return response.json();
+        },
+      );
 
     return Promise.all([
-      fetchUsers(sharedDirectorySearch(search)),
-      fetchUsers(allTabDirectorySearch(search)),
-      refreshLocationFilterMetadata(search),
-    ]).then(([directoryData, nextAllTabUserData]) => {
-      userData = directoryData;
-      allTabUserData = nextAllTabUserData;
+      fetchUsers(tab, search),
+      locationFilterControllerForTab(tab)?.ensureMetadata(search) || Promise.resolve(null),
+    ]).then(([directoryData]) => {
+      tabDataCache.set(tabDataCacheKey(tab, search), directoryData);
       loadedDirectorySearch = search;
       updateLocationFilterCountBadges();
-      refreshInitialMarkup();
-      handleSearchInput();
+      refreshInitialMarkup(tab);
+      if (activeTabName() === tab) {
+        handleSearchInput();
+      }
+      setPanelBusy(tab, false);
+      return directoryData;
     });
   }
 
   function requestDirectoryData(search = window.location.search, options = {}) {
-    const { loadingController = null } = options;
+    const { loadingController = null, tabName = activeTabName() } = options;
 
     if (directoryDataRequestController) {
       directoryDataRequestController.abort();
@@ -1331,7 +1400,7 @@ document.addEventListener("DOMContentLoaded", function () {
       loadingController.setLoadingState(true);
     }
 
-    return loadData(search, { signal: controller.signal }).finally(() => {
+    return loadData(tabName, search, { signal: controller.signal }).finally(() => {
       if (directoryDataRequestController === controller) {
         directoryDataRequestController = null;
         if (directoryDataLoadingController === loadingController) {
@@ -1342,6 +1411,54 @@ document.addEventListener("DOMContentLoaded", function () {
         }
       }
     });
+  }
+
+  function ensureTabData(tab, search = window.location.search, options = {}) {
+    if (hasTabData(tab, search)) {
+      loadedDirectorySearch = search;
+      refreshInitialMarkup(tab);
+      handleSearchInput();
+      return Promise.resolve(tabDataCache.get(tabDataCacheKey(tab, search)));
+    }
+
+    const requestKey = tabDataCacheKey(tab, search);
+    if (tabDataRequests.has(requestKey)) {
+      return tabDataRequests.get(requestKey);
+    }
+
+    if (options.showLoading !== false) {
+      renderTabLoading(tab);
+    } else {
+      setPanelBusy(tab, true);
+    }
+    setSearchStatus(`Loading ${scopeLabel(tab)}.`);
+    const request = requestDirectoryData(search, { tabName: tab })
+      .then((users) => {
+        tabDataRequests.delete(requestKey);
+        if (!searchInput.value.trim() && activeTabName() === tab) {
+          setSearchStatus(`Showing all ${scopeLabel(tab)}.`);
+        }
+        return users;
+      })
+      .catch((error) => {
+        tabDataRequests.delete(requestKey);
+        if (error.name === "AbortError") {
+          setPanelBusy(tab, false);
+          return [];
+        }
+
+        if (options.showLoading !== false) {
+          renderTabError(tab);
+        } else {
+          setPanelBusy(tab, false);
+        }
+        setSearchStatus(`Unable to load ${scopeLabel(tab)}.`);
+        console.error(`Failed to load ${scopeLabel(tab)}:`, error);
+        return [];
+      });
+
+    tabDataRequests.set(requestKey, request);
+    return request;
   }
 
   if (searchInput) {
@@ -1392,7 +1509,15 @@ document.addEventListener("DOMContentLoaded", function () {
 
     updateLocationFilterVisibility();
     updatePlaceholder();
-    handleSearchInput();
+    if (hasTabData(selectedTab.getAttribute("data-tab"), window.location.search)) {
+      handleSearchInput();
+    } else {
+      void ensureTabData(selectedTab.getAttribute("data-tab"), window.location.search, {
+        showLoading: Boolean(
+          targetPanel.querySelector("[data-directory-lazy-placeholder]"),
+        ),
+      });
+    }
     requestAnimationFrame(updateTabScrollControls);
   };
 
@@ -1488,14 +1613,4 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   updatePlaceholder();
-  locationFilterControllers.forEach((controller) => {
-    void controller.ensureMetadata();
-  });
-  requestDirectoryData().catch((error) => {
-    if (error.name === "AbortError") {
-      return;
-    }
-
-    console.error("Failed to load user data:", error);
-  });
 });

--- a/hushline/routes/directory.py
+++ b/hushline/routes/directory.py
@@ -731,6 +731,68 @@ def register_directory_routes(app: Flask) -> None:
     def directory() -> Response | str:
         logged_in = "user_id" in session
         usernames = list(get_directory_usernames())
+        pgp_usernames = [username for username in usernames if _user_message_capable(username.user)]
+        info_usernames = [
+            username for username in usernames if not _user_message_capable(username.user)
+        ]
+        verified_pgp_usernames = [username for username in pgp_usernames if username.is_verified]
+        verified_info_usernames = [username for username in info_usernames if username.is_verified]
+        if app.config["DIRECTORY_VERIFIED_TAB_ENABLED"] and not request.args:
+            attorney_usernames = [
+                username for username in usernames if _is_self_reported_attorney(username)
+            ]
+            journalism_usernames = [
+                username for username in usernames if _is_self_reported_journalism_account(username)
+            ]
+            public_record_listings = list(get_public_record_listings())
+            newsroom_listings = list(get_newsroom_directory_listings())
+            globaleaks_listings = list(get_globaleaks_directory_listings())
+            securedrop_listings = list(get_securedrop_directory_listings())
+            return render_template(
+                "directory.html",
+                intro_text=OrganizationSetting.fetch_one(OrganizationSetting.DIRECTORY_INTRO_TEXT),
+                pgp_usernames=pgp_usernames,
+                info_usernames=info_usernames,
+                verified_pgp_usernames=verified_pgp_usernames,
+                verified_info_usernames=verified_info_usernames,
+                attorney_usernames=[],
+                public_record_all_listings=[],
+                public_record_listings=[],
+                legacy_public_record_listings=[],
+                public_record_total_count=len(attorney_usernames) + len(public_record_listings),
+                attorney_filter_metadata={"countries": [], "regions": {}},
+                attorney_filter_state={"country": None, "region": None, "region_code": None},
+                attorney_filter_clear_url=_directory_filter_clear_url("country", "region"),
+                globaleaks_listings=[],
+                globaleaks_total_count=len(globaleaks_listings),
+                journalism_usernames=[],
+                newsroom_listings=[],
+                newsroom_automated_sources=[],
+                newsroom_total_count=len(journalism_usernames) + len(newsroom_listings),
+                newsroom_filter_metadata={"countries": [], "regions": {}},
+                newsroom_filter_state={"country": None, "region": None, "region_code": None},
+                newsroom_filter_clear_url=_directory_filter_clear_url(
+                    "newsroom_country", "newsroom_region"
+                ),
+                all_filter_metadata=_empty_all_filter_metadata(),
+                all_filter_state={
+                    "country": None,
+                    "region": None,
+                    "region_code": None,
+                    "listing_type": None,
+                },
+                all_filter_clear_url=_directory_filter_clear_url(
+                    "all_country", "all_region", "all_listing_type"
+                ),
+                securedrop_listings=[],
+                securedrop_total_count=len(securedrop_listings),
+                all_directory_entries=[],
+                truncate_directory_bio=_directory_card_bio,
+                user_message_capable=_user_message_capable,
+                lazy_directory_tabs=True,
+                logged_in=logged_in,
+            )
+
         attorney_usernames = [
             username for username in usernames if _is_self_reported_attorney(username)
         ]
@@ -796,12 +858,6 @@ def register_directory_routes(app: Flask) -> None:
             filtered_journalism_usernames = journalism_usernames
             all_newsroom_listings = []
             newsroom_listings = []
-        pgp_usernames = [username for username in usernames if _user_message_capable(username.user)]
-        info_usernames = [
-            username for username in usernames if not _user_message_capable(username.user)
-        ]
-        verified_pgp_usernames = [username for username in pgp_usernames if username.is_verified]
-        verified_info_usernames = [username for username in info_usernames if username.is_verified]
         all_directory_entries = _build_all_directory_entries(
             usernames,
             all_public_record_listings,
@@ -881,6 +937,7 @@ def register_directory_routes(app: Flask) -> None:
             all_directory_entries=filtered_all_directory_entries,
             truncate_directory_bio=_directory_card_bio,
             user_message_capable=_user_message_capable,
+            lazy_directory_tabs=False,
             logged_in=logged_in,
         )
 
@@ -1006,6 +1063,102 @@ def register_directory_routes(app: Flask) -> None:
 
     @app.route("/directory/users.json")
     def directory_users() -> list[dict[str, object | None]]:
+        requested_tab = request.args.get("tab")
+
+        def with_client_sort_fields(
+            entries: Sequence[dict[str, object | None]],
+        ) -> list[dict[str, object | None]]:
+            return [
+                {
+                    **entry,
+                    **_all_directory_entry_client_sort_fields(entry),
+                }
+                for entry in entries
+            ]
+
+        if requested_tab == "verified":
+            return with_client_sort_fields(
+                [
+                    _directory_user_row(username)
+                    for username in get_directory_usernames()
+                    if username.is_verified
+                ]
+            )
+
+        if requested_tab == "public-records":
+            if not app.config["DIRECTORY_VERIFIED_TAB_ENABLED"]:
+                return []
+
+            directory_usernames = list(get_directory_usernames())
+            public_record_listings = list(get_public_record_listings())
+            attorney_usernames = tuple(
+                username for username in directory_usernames if _is_self_reported_attorney(username)
+            )
+            attorney_filter_state = _attorney_filter_state(
+                _attorney_filter_metadata(public_record_listings, attorney_usernames)
+            )
+            return with_client_sort_fields(
+                [
+                    *[
+                        _directory_user_row(username)
+                        for username in attorney_usernames
+                        if _username_matches_attorney_filters(username, attorney_filter_state)
+                    ],
+                    *[
+                        _public_record_row(listing)
+                        for listing in _filter_public_record_listings(
+                            public_record_listings, attorney_filter_state
+                        )
+                    ],
+                ]
+            )
+
+        if requested_tab == "newsrooms":
+            if not app.config["DIRECTORY_VERIFIED_TAB_ENABLED"]:
+                return []
+
+            directory_usernames = list(get_directory_usernames())
+            newsroom_listings = list(get_newsroom_directory_listings())
+            journalism_usernames = tuple(
+                username
+                for username in directory_usernames
+                if _is_self_reported_journalism_account(username)
+            )
+            newsroom_filter_state = _newsroom_filter_state(
+                _newsroom_filter_metadata(newsroom_listings, journalism_usernames)
+            )
+            return with_client_sort_fields(
+                [
+                    *[
+                        _directory_user_row(username)
+                        for username in journalism_usernames
+                        if _username_matches_newsroom_filters(username, newsroom_filter_state)
+                    ],
+                    *[
+                        _newsroom_row(listing)
+                        for listing in _filter_newsroom_listings(
+                            newsroom_listings, newsroom_filter_state
+                        )
+                    ],
+                ]
+            )
+
+        if requested_tab == "globaleaks":
+            if not app.config["DIRECTORY_VERIFIED_TAB_ENABLED"]:
+                return []
+
+            return with_client_sort_fields(
+                [_globaleaks_row(listing) for listing in get_globaleaks_directory_listings()]
+            )
+
+        if requested_tab == "securedrop":
+            if not app.config["DIRECTORY_VERIFIED_TAB_ENABLED"]:
+                return []
+
+            return with_client_sort_fields(
+                [_securedrop_row(listing) for listing in get_securedrop_directory_listings()]
+            )
+
         directory_usernames = list(get_directory_usernames())
         public_record_listings = (
             list(get_public_record_listings())
@@ -1106,10 +1259,4 @@ def register_directory_routes(app: Flask) -> None:
                 *securedrop_rows,
             ]
         )
-        return [
-            {
-                **entry,
-                **_all_directory_entry_client_sort_fields(entry),
-            }
-            for entry in entries
-        ]
+        return with_client_sort_fields(entries)

--- a/hushline/static/js/directory_verified.js
+++ b/hushline/static/js/directory_verified.js
@@ -38,6 +38,8 @@
       "public-record-count",
     );
     const newsroomCountBadge = document.getElementById("newsroom-count");
+    const securedropCountBadge = document.getElementById("securedrop-count");
+    const globaleaksCountBadge = document.getElementById("globaleaks-count");
     const allFiltersToggleShell = document.getElementById(
       "all-filters-toggle-shell",
     );
@@ -88,8 +90,8 @@
       "newsroom-region-filter",
     );
     const initialMarkup = new Map();
-    let userData = [];
-    let allTabUserData = [];
+    const tabDataCache = new Map();
+    const tabDataRequests = new Map();
     let hasRenderedSearch = false;
     let directoryDataRequestController = null;
     let directoryDataLoadingController = null;
@@ -130,8 +132,48 @@
       );
     }
 
+    function sharedDirectorySearch(search) {
+      return removeSearchParams(search, [
+        "all_country",
+        "all_region",
+        "all_listing_type",
+      ]);
+    }
+
+    function allTabDirectorySearch(search) {
+      return removeSearchParams(search, [
+        "country",
+        "region",
+        "newsroom_country",
+        "newsroom_region",
+      ]);
+    }
+
+    function tabScopedSearch(tab, search) {
+      return tab === "all"
+        ? allTabDirectorySearch(search)
+        : sharedDirectorySearch(search);
+    }
+
+    function tabDataSearch(tab, search) {
+      const params = new URLSearchParams(tabScopedSearch(tab, search));
+      params.set("tab", tab);
+      const nextSearch = params.toString();
+      return nextSearch ? `?${nextSearch}` : "";
+    }
+
+    function tabDataCacheKey(tab, search = window.location.search) {
+      return `${tab}\n${tabScopedSearch(tab, search)}`;
+    }
+
+    function hasTabData(tab, search = window.location.search) {
+      return tabDataCache.has(tabDataCacheKey(tab, search));
+    }
+
     function usersForTab(tab = activeTabName()) {
-      return tab === "all" ? allTabUserData : userData;
+      return (
+        tabDataCache.get(tabDataCacheKey(tab, loadedDirectorySearch)) || []
+      );
     }
 
     function updateTabScrollControls() {
@@ -215,25 +257,24 @@
       searchInput.placeholder = "Search directory...";
     }
 
-    function scopeLabel() {
-      const activeTab = activeTabName();
-      if (activeTab === "verified") {
+    function scopeLabel(tab = activeTabName()) {
+      if (tab === "verified") {
         return "verified users";
       }
 
-      if (activeTab === "public-records") {
+      if (tab === "public-records") {
         return "attorneys";
       }
 
-      if (activeTab === "newsrooms") {
+      if (tab === "newsrooms") {
         return "journalists and newsrooms";
       }
 
-      if (activeTab === "globaleaks") {
+      if (tab === "globaleaks") {
         return "GlobaLeaks instances";
       }
 
-      if (activeTab === "securedrop") {
+      if (tab === "securedrop") {
         return "SecureDrop instances";
       }
 
@@ -639,17 +680,19 @@
       return panel.innerHTML;
     }
 
-    function refreshInitialMarkup() {
-      ["public-records", "newsrooms", "all"].forEach((panelId) => {
-        if (document.getElementById(panelId)) {
-          initialMarkup.set(panelId, buildDefaultPanelMarkup(panelId));
-        }
-      });
+    function refreshInitialMarkup(tab = activeTabName()) {
+      if (
+        document.getElementById(tab) &&
+        hasTabData(tab, loadedDirectorySearch)
+      ) {
+        initialMarkup.set(tab, buildDefaultPanelMarkup(tab));
+      }
     }
 
     function handleSearchInput() {
       const query = searchInput.value.trim();
       const panel = activePanel();
+      const tab = activeTabName();
       const currentScopeLabel = scopeLabel();
       const hasQuery = query.length > 0;
 
@@ -657,6 +700,11 @@
         clearIcon.style.visibility = hasQuery ? "visible" : "hidden";
         clearIcon.hidden = !hasQuery;
         clearIcon.setAttribute("aria-hidden", hasQuery ? "false" : "true");
+      }
+
+      if (!hasTabData(tab, loadedDirectorySearch)) {
+        void ensureTabData(tab, window.location.search, { showLoading: false });
+        return;
       }
 
       if (query.length === 0) {
@@ -687,23 +735,6 @@
       });
       const nextSearch = params.toString();
       return nextSearch ? `?${nextSearch}` : "";
-    }
-
-    function sharedDirectorySearch(search) {
-      return removeSearchParams(search, [
-        "all_country",
-        "all_region",
-        "all_listing_type",
-      ]);
-    }
-
-    function allTabDirectorySearch(search) {
-      return removeSearchParams(search, [
-        "country",
-        "region",
-        "newsroom_country",
-        "newsroom_region",
-      ]);
     }
 
     function createLocationFilterController(config) {
@@ -1410,8 +1441,24 @@
 
     function updateLocationFilterCountBadges() {
       locationFilterControllers.forEach((controller) => {
-        controller.updateCountBadge();
+        if (hasTabData(controller.tabName, loadedDirectorySearch)) {
+          controller.updateCountBadge();
+        }
       });
+      if (
+        securedropCountBadge &&
+        hasTabData("securedrop", loadedDirectorySearch)
+      ) {
+        securedropCountBadge.textContent =
+          usersForTab("securedrop").length.toString();
+      }
+      if (
+        globaleaksCountBadge &&
+        hasTabData("globaleaks", loadedDirectorySearch)
+      ) {
+        globaleaksCountBadge.textContent =
+          usersForTab("globaleaks").length.toString();
+      }
     }
 
     function refreshLocationFilterMetadata(search = window.location.search) {
@@ -1419,6 +1466,14 @@
         locationFilterControllers.map((controller) =>
           controller.ensureMetadata(search),
         ),
+      );
+    }
+
+    function locationFilterControllerForTab(tab) {
+      return (
+        locationFilterControllers.find(
+          (controller) => controller.tabName === tab,
+        ) || null
       );
     }
 
@@ -1430,33 +1485,66 @@
       );
     }
 
-    function loadData(search = window.location.search, options = {}) {
+    function setPanelBusy(tab, isBusy) {
+      const panel = document.getElementById(tab);
+      if (panel) {
+        panel.setAttribute("aria-busy", isBusy ? "true" : "false");
+      }
+    }
+
+    function renderTabLoading(tab) {
+      const panel = document.getElementById(tab);
+      if (!panel) {
+        return;
+      }
+
+      panel.innerHTML = `${panelIntroMarkup(tab)}
+      <p class="empty-message" role="status">Loading ${scopeLabel(tab)}...</p>`;
+      setPanelBusy(tab, true);
+    }
+
+    function renderTabError(tab) {
+      const panel = document.getElementById(tab);
+      if (!panel) {
+        return;
+      }
+
+      panel.innerHTML = `${panelIntroMarkup(tab)}
+      <p class="empty-message" role="alert">Unable to load ${scopeLabel(tab)}. Please try again.</p>`;
+      setPanelBusy(tab, false);
+    }
+
+    function loadData(tab, search = window.location.search, options = {}) {
       const requestOptions = {};
       if (options.signal) {
         requestOptions.signal = options.signal;
       }
 
-      const fetchUsers = (search) =>
-        fetch(`${directoryPath}/users.json${search}`, requestOptions).then(
-          (response) => {
-            if (!response.ok) {
-              throw new Error("Network response was not ok");
-            }
-            return response.json();
-          },
-        );
+      const fetchUsers = (tab, search) =>
+        fetch(
+          `${directoryPath}/users.json${tabDataSearch(tab, search)}`,
+          requestOptions,
+        ).then((response) => {
+          if (!response.ok) {
+            throw new Error("Network response was not ok");
+          }
+          return response.json();
+        });
 
       return Promise.all([
-        fetchUsers(sharedDirectorySearch(search)),
-        fetchUsers(allTabDirectorySearch(search)),
-        refreshLocationFilterMetadata(search),
-      ]).then(([directoryData, nextAllTabUserData]) => {
-        userData = directoryData;
-        allTabUserData = nextAllTabUserData;
+        fetchUsers(tab, search),
+        locationFilterControllerForTab(tab)?.ensureMetadata(search) ||
+          Promise.resolve(null),
+      ]).then(([directoryData]) => {
+        tabDataCache.set(tabDataCacheKey(tab, search), directoryData);
         loadedDirectorySearch = search;
         updateLocationFilterCountBadges();
-        refreshInitialMarkup();
-        handleSearchInput();
+        refreshInitialMarkup(tab);
+        if (activeTabName() === tab) {
+          handleSearchInput();
+        }
+        setPanelBusy(tab, false);
+        return directoryData;
       });
     }
 
@@ -1464,7 +1552,7 @@
       search = window.location.search,
       options = {},
     ) {
-      const { loadingController = null } = options;
+      const { loadingController = null, tabName = activeTabName() } = options;
 
       if (directoryDataRequestController) {
         directoryDataRequestController.abort();
@@ -1485,17 +1573,67 @@
         loadingController.setLoadingState(true);
       }
 
-      return loadData(search, { signal: controller.signal }).finally(() => {
-        if (directoryDataRequestController === controller) {
-          directoryDataRequestController = null;
-          if (directoryDataLoadingController === loadingController) {
-            if (loadingController) {
-              loadingController.setLoadingState(false);
+      return loadData(tabName, search, { signal: controller.signal }).finally(
+        () => {
+          if (directoryDataRequestController === controller) {
+            directoryDataRequestController = null;
+            if (directoryDataLoadingController === loadingController) {
+              if (loadingController) {
+                loadingController.setLoadingState(false);
+              }
+              directoryDataLoadingController = null;
             }
-            directoryDataLoadingController = null;
           }
-        }
-      });
+        },
+      );
+    }
+
+    function ensureTabData(tab, search = window.location.search, options = {}) {
+      if (hasTabData(tab, search)) {
+        loadedDirectorySearch = search;
+        refreshInitialMarkup(tab);
+        handleSearchInput();
+        return Promise.resolve(tabDataCache.get(tabDataCacheKey(tab, search)));
+      }
+
+      const requestKey = tabDataCacheKey(tab, search);
+      if (tabDataRequests.has(requestKey)) {
+        return tabDataRequests.get(requestKey);
+      }
+
+      if (options.showLoading !== false) {
+        renderTabLoading(tab);
+      } else {
+        setPanelBusy(tab, true);
+      }
+      setSearchStatus(`Loading ${scopeLabel(tab)}.`);
+      const request = requestDirectoryData(search, { tabName: tab })
+        .then((users) => {
+          tabDataRequests.delete(requestKey);
+          if (!searchInput.value.trim() && activeTabName() === tab) {
+            setSearchStatus(`Showing all ${scopeLabel(tab)}.`);
+          }
+          return users;
+        })
+        .catch((error) => {
+          tabDataRequests.delete(requestKey);
+          if (error.name === "AbortError") {
+            setPanelBusy(tab, false);
+            return [];
+          }
+
+          if (options.showLoading !== false) {
+            renderTabError(tab);
+          } else {
+            setPanelBusy(tab, false);
+          }
+          setSearchStatus(`Unable to load ${scopeLabel(tab)}.`);
+          console.error(`Failed to load ${scopeLabel(tab)}:`, error);
+          return [];
+        });
+
+      tabDataRequests.set(requestKey, request);
+      return request;
     }
 
     if (searchInput) {
@@ -1548,7 +1686,21 @@
 
       updateLocationFilterVisibility();
       updatePlaceholder();
-      handleSearchInput();
+      if (
+        hasTabData(selectedTab.getAttribute("data-tab"), window.location.search)
+      ) {
+        handleSearchInput();
+      } else {
+        void ensureTabData(
+          selectedTab.getAttribute("data-tab"),
+          window.location.search,
+          {
+            showLoading: Boolean(
+              targetPanel.querySelector("[data-directory-lazy-placeholder]"),
+            ),
+          },
+        );
+      }
       requestAnimationFrame(updateTabScrollControls);
     };
 
@@ -1658,16 +1810,6 @@
     }
 
     updatePlaceholder();
-    locationFilterControllers.forEach((controller) => {
-      void controller.ensureMetadata();
-    });
-    requestDirectoryData().catch((error) => {
-      if (error.name === "AbortError") {
-        return;
-      }
-
-      console.error("Failed to load user data:", error);
-    });
   });
 
   /******/

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -48,7 +48,7 @@
             >
               Attorneys
               <span id="public-record-count" class="badge" role="img" aria-label="Attorney count"
-                >{{ public_record_total_count }}</span
+                >{{ "..." if public_record_total_count is none else public_record_total_count }}</span
               >
             </button>
           </li>
@@ -68,7 +68,7 @@
                 class="badge"
                 role="img"
                 aria-label="Journalist and newsroom listing count"
-                >{{ newsroom_total_count }}</span
+                >{{ "..." if newsroom_total_count is none else newsroom_total_count }}</span
               >
             </button>
           </li>
@@ -83,8 +83,12 @@
               id="securedrop-tab"
             >
               SecureDrop
-              <span class="badge" role="img" aria-label="SecureDrop instance count"
-                >{{ securedrop_total_count }}</span
+              <span
+                id="securedrop-count"
+                class="badge"
+                role="img"
+                aria-label="SecureDrop instance count"
+                >{{ "..." if securedrop_total_count is none else securedrop_total_count }}</span
               >
             </button>
           </li>
@@ -99,8 +103,12 @@
               id="globaleaks-tab"
             >
               GlobaLeaks
-              <span class="badge" role="img" aria-label="GlobaLeaks instance count"
-                >{{ globaleaks_total_count }}</span
+              <span
+                id="globaleaks-count"
+                class="badge"
+                role="img"
+                aria-label="GlobaLeaks instance count"
+                >{{ "..." if globaleaks_total_count is none else globaleaks_total_count }}</span
               >
             </button>
           </li>
@@ -659,6 +667,10 @@
             </article>
           {% endfor %}
         </div>
+      {% elif lazy_directory_tabs %}
+        <p class="empty-message" data-directory-lazy-placeholder="true">
+          Select this tab to load attorney listings.
+        </p>
       {% endif %}
     </div>
   {% endif %}
@@ -720,6 +732,10 @@
             </article>
           {% endfor %}
         </div>
+      {% elif lazy_directory_tabs %}
+        <p class="empty-message" data-directory-lazy-placeholder="true">
+          Select this tab to load journalist and newsroom listings.
+        </p>
       {% endif %}
     </div>
   {% endif %}
@@ -750,6 +766,10 @@
             </article>
           {% endfor %}
         </div>
+      {% elif lazy_directory_tabs %}
+        <p class="empty-message" data-directory-lazy-placeholder="true">
+          Select this tab to load GlobaLeaks listings.
+        </p>
       {% endif %}
     </div>
   {% endif %}
@@ -781,6 +801,10 @@
             </article>
           {% endfor %}
         </div>
+      {% elif lazy_directory_tabs %}
+        <p class="empty-message" data-directory-lazy-placeholder="true">
+          Select this tab to load SecureDrop listings.
+        </p>
       {% endif %}
     </div>
   {% endif %}
@@ -798,6 +822,11 @@
       </p>
     {% endif %}
     <div class="user-list">
+      {% if lazy_directory_tabs %}
+        <p class="empty-message" data-directory-lazy-placeholder="true">
+          Select this tab to load directory listings.
+        </p>
+      {% endif %}
       {% for entry in all_directory_entries %}
         <article class="user">
           <h3>{{ entry.display_name }}</h3>

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -237,6 +237,10 @@ def _legacy_public_record_listings() -> list[PublicRecordListing]:
     ]
 
 
+def _eager_directory_url() -> str:
+    return f"{url_for('directory')}?eager=1"
+
+
 def _find_directory_card(panel: BeautifulSoup | Tag | None, display_name: str) -> Tag:
     assert panel is not None
     for card in panel.select("article.user"):
@@ -254,12 +258,28 @@ def test_directory_accessible(client: FlaskClient) -> None:
     assert "Journalists" in response.text
     assert "GlobaLeaks" in response.text
     assert "SecureDrop" in response.text
-    assert "🤖 Automated" in response.text
-    assert "⚖️ Attorney" in response.text
+    assert "Select this tab to load attorney listings." in response.text
+    assert "🤖 Automated" not in response.text
+    assert "⚖️ Attorney" not in response.text
+
+
+def test_directory_initial_render_lazy_loads_inactive_tab_bodies(client: FlaskClient) -> None:
+    response = client.get(url_for("directory"))
+    assert response.status_code == 200
+    assert "Select this tab to load attorney listings." in response.text
+    assert "Select this tab to load directory listings." in response.text
+    assert "🤖 Automated" not in response.text
+    assert "⚖️ Attorney" not in response.text
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    assert soup.select_one("#public-record-count").get_text(strip=True).isdigit()
+    assert soup.select_one("#newsroom-count").get_text(strip=True).isdigit()
+    assert soup.select_one("#globaleaks-count").get_text(strip=True).isdigit()
+    assert soup.select_one("#securedrop-count").get_text(strip=True).isdigit()
 
 
 def test_directory_public_record_banner_links_to_admin(client: FlaskClient) -> None:
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -283,7 +303,7 @@ def test_directory_public_record_banner_links_to_admin(client: FlaskClient) -> N
 def test_directory_securedrop_banner_links_to_admin_without_tor_copy(
     client: FlaskClient,
 ) -> None:
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -311,7 +331,7 @@ def test_directory_securedrop_banner_links_to_admin_without_tor_copy(
 def test_directory_globaleaks_banner_links_to_admin_without_tor_copy(
     client: FlaskClient,
 ) -> None:
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -345,7 +365,7 @@ def test_directory_newsrooms_banner_links_to_admin(
         lambda: (_sample_newsroom_listing(), _sample_european_network_listing()),
     )
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -384,7 +404,7 @@ def test_directory_newsrooms_banner_links_to_admin(
 
 
 def test_directory_all_tab_banner_links_to_admin(client: FlaskClient) -> None:
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -406,7 +426,7 @@ def test_directory_all_tab_banner_links_to_admin(client: FlaskClient) -> None:
 def test_directory_hides_tab_bar_when_verified_tabs_disabled(client: FlaskClient) -> None:
     client.application.config["DIRECTORY_VERIFIED_TAB_ENABLED"] = False
     try:
-        response = client.get(url_for("directory"))
+        response = client.get(_eager_directory_url())
     finally:
         client.application.config["DIRECTORY_VERIFIED_TAB_ENABLED"] = True
 
@@ -448,12 +468,12 @@ def test_directory_users_json_excludes_public_records_when_verified_tabs_disable
 def test_directory_lists_only_opted_in_users(client: FlaskClient, user: User) -> None:
     user.primary_username.show_in_directory = True
     db.session.commit()
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert user.primary_username.username in response.text, response.text
 
     user.primary_username.show_in_directory = False
     db.session.commit()
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert user.primary_username.username not in response.text
 
 
@@ -708,7 +728,7 @@ def test_directory_self_reported_attorneys_render_in_attorneys_tab(
     user2.primary_username._display_name = "Non-Attorney"
     db.session.commit()
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -743,7 +763,7 @@ def test_directory_self_reported_journalists_and_newsrooms_render_in_newsrooms_t
     user2.primary_username.bio = "Newsroom profile."
     db.session.commit()
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -919,7 +939,7 @@ def test_directory_public_records_render_only_in_public_records_and_all(
 ) -> None:
     listing = _first_public_record_listing_or_skip()
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -1053,6 +1073,35 @@ def test_directory_users_json_excludes_verified_tab_sources_when_disabled(
     assert rows[0]["entry_type"] == "user"
 
 
+def test_directory_users_json_loads_only_requested_lazy_tab(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    listing = _sample_globaleaks_listing()
+
+    monkeypatch.setattr(
+        "hushline.routes.directory.get_globaleaks_directory_listings",
+        lambda: (listing,),
+    )
+
+    def fail_unselected_tab_load() -> None:
+        raise AssertionError("unselected tab data should not be loaded")
+
+    monkeypatch.setattr(
+        "hushline.routes.directory.get_public_record_listings", fail_unselected_tab_load
+    )
+    monkeypatch.setattr(
+        "hushline.routes.directory.get_newsroom_directory_listings", fail_unselected_tab_load
+    )
+    monkeypatch.setattr(
+        "hushline.routes.directory.get_securedrop_directory_listings", fail_unselected_tab_load
+    )
+
+    response = client.get(f"{url_for('directory_users')}?tab=globaleaks")
+    assert response.status_code == 200
+    rows = response.json or []
+    assert [row["display_name"] for row in rows] == [listing.name]
+
+
 def test_directory_card_bio_uses_bio_length_limit_with_ascii_ellipsis() -> None:
     short_bio = "Short automated listing bio."
     long_bio = "A" * (directory_routes.Username.BIO_MAX_LENGTH + 10)
@@ -1125,7 +1174,7 @@ def test_directory_public_record_cards_truncate_long_automated_listing_bios(
     monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
     monkeypatch.setattr("hushline.routes.directory.get_securedrop_directory_listings", lambda: ())
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -1145,7 +1194,7 @@ def test_directory_public_record_cards_truncate_long_automated_listing_bios(
 def test_directory_public_record_cards_do_not_show_location(client: FlaskClient) -> None:
     listing = _first_public_record_listing_or_skip()
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -1282,7 +1331,7 @@ def test_directory_attorney_filter_panel_hidden_by_default(
     monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
     monkeypatch.setattr("hushline.routes.directory.get_securedrop_directory_listings", lambda: ())
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -1363,7 +1412,7 @@ def test_directory_newsroom_filter_panel_hidden_by_default(
     monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
     monkeypatch.setattr("hushline.routes.directory.get_securedrop_directory_listings", lambda: ())
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -1479,7 +1528,7 @@ def test_directory_all_filter_panel_hidden_by_default(
         lambda: (globaleaks_listing,),
     )
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -2988,7 +3037,7 @@ def test_directory_securedrop_render_only_in_securedrop_and_all(
 ) -> None:
     listing = _first_securedrop_listing_or_skip()
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -3022,7 +3071,7 @@ def test_directory_globaleaks_render_only_in_globaleaks_and_all(
         lambda: (listing,),
     )
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -3092,7 +3141,7 @@ def test_directory_globaleaks_cards_do_not_show_location(
         lambda: (listing,),
     )
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -3179,7 +3228,7 @@ def test_directory_newsroom_cards_do_not_show_location(
         lambda: (listing,),
     )
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -3222,7 +3271,7 @@ def test_directory_users_json_includes_securedrop_rows(client: FlaskClient) -> N
 def test_directory_securedrop_cards_do_not_show_location(client: FlaskClient) -> None:
     listing = _first_securedrop_listing_or_skip()
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -3572,7 +3621,7 @@ def test_directory_all_tab_is_homogeneous_with_admin_first_and_info_only_badge(
         lambda: mocked_newsroom_listings,
     )
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -3652,7 +3701,7 @@ def test_directory_attorney_and_journalist_tabs_show_info_only_badge(
     monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
     monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -3714,7 +3763,7 @@ def test_directory_all_tab_does_not_promote_non_admin_named_admin(
     monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
     monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -3789,7 +3838,7 @@ def test_directory_all_tab_moves_caution_accounts_to_bottom(
     monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
     monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -3869,7 +3918,7 @@ def test_directory_all_tab_orders_users_by_display_name_after_admin_pin(
     monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
     monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")
@@ -3929,7 +3978,7 @@ def test_directory_all_tab_preserves_transliterated_display_name_order(
     monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
     monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
 
-    response = client.get(url_for("directory"))
+    response = client.get(_eager_directory_url())
     assert response.status_code == 200
 
     soup = BeautifulSoup(response.text, "html.parser")

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -200,6 +200,8 @@ def test_directory_search_accessibility_hooks_exist() -> None:
     assert 'id="directory-search-status"' in directory_template
     assert 'id="public-record-count"' in directory_template
     assert 'id="newsroom-count"' in directory_template
+    assert 'id="securedrop-count"' in directory_template
+    assert 'id="globaleaks-count"' in directory_template
     assert 'id="all-filters-toggle"' in directory_template
     assert 'id="all-filters-panel"' in directory_template
     assert 'id="attorney-filters-toggle"' in directory_template
@@ -270,10 +272,23 @@ def test_directory_search_accessibility_hooks_exist() -> None:
     assert "controller.activeFilterCount = function () {" in directory_verified_js
     assert "controller.updateCountBadge = function () {" in directory_verified_js
     assert "updateLocationFilterCountBadges();" in directory_verified_js
+    assert "hasTabData(controller.tabName, loadedDirectorySearch)" in directory_verified_js
+    assert "hasTabData(controller.tabName, loadedDirectorySearch)" in directory_verified_static_js
     assert 'const directoryPath = window.location.pathname.replace(/\\/$/, "");' in (
         directory_verified_js
     )
-    assert "fetch(`${directoryPath}/users.json${search}`, requestOptions)" in directory_verified_js
+    assert "tabDataCache" in directory_verified_js
+    assert 'params.set("tab", tab);' in directory_verified_js
+    assert "void ensureTabData(tab, window.location.search, { showLoading: false });" in (
+        directory_verified_js
+    )
+    assert "void ensureTabData(tab, window.location.search, { showLoading: false });" in (
+        directory_verified_static_js
+    )
+    assert 'role="status">Loading ${scopeLabel(tab)}...' in directory_verified_js
+    assert "fetch(`${directoryPath}/users.json${tabDataSearch(tab, search)}`" in (
+        directory_verified_js
+    )
     assert 'metadataPath: "all-filters.json"' in directory_verified_js
     assert 'metadataPath: "attorney-filters.json"' in directory_verified_js
     assert 'metadataPath: "newsroom-filters.json"' in directory_verified_js
@@ -373,6 +388,8 @@ def test_directory_search_accessibility_hooks_exist() -> None:
     assert "user.subdivision," in directory_verified_js
     assert "Array.isArray(user.countries)" in directory_verified_js
     assert "users.json" in directory_verified_static_js
+    assert "tabDataCache" in directory_verified_static_js
+    assert 'params.set("tab", tab);' in directory_verified_static_js
     assert "all-filters.json" in directory_verified_static_js
     assert "attorney-filters.json" in directory_verified_static_js
     assert "fetch(`${directoryPath}/${controller.metadataPath}${search}`)" in (


### PR DESCRIPTION
## Summary
- Restore the closed PR #1997 directory lazy-loading work on current `main`.
- Load inactive directory tab listing payloads only when the visitor selects a tab, with accessible loading/error states and same-session cache reuse.
- Keep first-load tab badge counts numeric so the Directory remains informative, addressing the feedback left before #1997 was closed.
- Preserve search behavior when verified tabs are disabled by lazily fetching the all-tab data on first search input.

## Why
PR #1997 was closed before the remaining review feedback was handled. The main regression called out there was that badge counts became placeholders on first load. This replacement patch keeps the performance-oriented lazy listing payload behavior while preserving visible counts.

## Validation
- `docker compose run --rm app poetry run pytest tests/test_directory.py tests/test_frontend_compat.py -q -m "not external_network"` - passed: 149 passed, 1 deselected.
- `make lint` - passed.
- `make test` - passed: 1,959 passed, 1 deselected, 1 xfailed; total coverage 99%.
- `make audit-node-runtime` - passed: found 0 vulnerabilities.
- `make audit-python` - passed: no known vulnerabilities found.

## Manual Testing
- In a local or staging environment, open `/directory` and confirm the Verified tab renders immediately while inactive tabs show lazy placeholders.
- Confirm Attorneys, Journalists, SecureDrop, and GlobaLeaks badge counts are numeric on first load.
- Select each inactive tab and confirm its listings load with the expected empty/loading/error behavior.
- With verified tabs disabled, type in the Directory search box and confirm All-directory search still filters after the lazy JSON fetch completes.

## Risks / Follow-ups
- Initial render still computes badge counts so the Directory remains informative; the heavier inactive tab cards are deferred.
- No encryption, disclosure submission, inbox, authentication, or CSP policy paths are changed.