### PR TITLE
Recognize AES-GCM encrypted-field envelopes in rollout tooling

### DIFF
--- a/docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
+++ b/docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
@@ -225,8 +225,8 @@ Run the executable preflight before enabling envelope writes:
 The command reports the current Alembic revision, envelope-safe storage
 capacity for each encrypted-field contract, schema revision, contract-set
 version, selected contract IDs, batch size, row counts, legacy Fernet, envelope
-Fernet, null/empty, malformed, and decrypt-failure counts, and whether every
-non-empty value decrypts through the deployed reader. It must not print
+Fernet, envelope AES-GCM, null/empty, malformed, and decrypt-failure counts,
+and whether every non-empty value decrypts through the deployed reader. It must not print
 plaintext or raw full ciphertext.
 
 Use `--contract CONTRACT_ID` one or more times for targeted checks before a

--- a/hushline/cli_encrypted_field.py
+++ b/hushline/cli_encrypted_field.py
@@ -29,6 +29,7 @@ from hushline.crypto import (
     build_encrypted_field_aad,
     decrypt_field,
     encrypt_field,
+    parse_encrypted_field_aead_envelope,
     parse_encrypted_field_envelope,
 )
 from hushline.db import db
@@ -59,6 +60,7 @@ class EncryptedFieldCiphertextReport:
     scanned_rows: int
     legacy_fernet: int
     envelope_fernet: int
+    envelope_aes_gcm: int
     null_empty: int
     malformed: int
     decrypt_failures: int
@@ -74,6 +76,7 @@ class EncryptedFieldCiphertextCounts:
     scanned_rows: int = 0
     legacy_fernet: int = 0
     envelope_fernet: int = 0
+    envelope_aes_gcm: int = 0
     null_empty: int = 0
     malformed: int = 0
     decrypt_failures: int = 0
@@ -311,9 +314,20 @@ def _classify_migration_value(value: Any) -> str:
     if not isinstance(value, str):
         return "malformed"
     if value.startswith(ENCRYPTED_FIELD_ENVELOPE_PREFIX):
-        parse_encrypted_field_envelope(value)
-        return "envelope_fernet"
+        return _classify_envelope_value(value)
     return "legacy_fernet"
+
+
+def _classify_envelope_value(value: str) -> str:
+    try:
+        parse_encrypted_field_envelope(value)
+    except InvalidToken as fernet_error:
+        try:
+            parse_encrypted_field_aead_envelope(value)
+        except InvalidToken as aead_error:
+            raise fernet_error from aead_error
+        return "envelope_aes_gcm"
+    return "envelope_fernet"
 
 
 @contextmanager
@@ -380,6 +394,23 @@ def _verify_ciphertext_plaintext(
         )
 
 
+def _preflight_scan_columns(contract: EncryptedFieldContract, table: Any) -> list[Any]:
+    columns = [table.c.id, table.c[contract.column]]
+    selected = {"id", contract.column}
+    for aad_field in contract.aad_fields:
+        if (
+            aad_field == "user_id"
+            and contract.table == "users"
+            or aad_field == "notification_recipient_id"
+            or aad_field == "field_value_id"
+        ):
+            continue
+        if aad_field in table.c and aad_field not in selected:
+            columns.append(table.c[aad_field])
+            selected.add(aad_field)
+    return columns
+
+
 def _process_migration_row(
     *,
     contract: EncryptedFieldContract,
@@ -425,6 +456,23 @@ def _process_migration_row(
     if not isinstance(value, str):
         raise AssertionError("Encrypted-field value classification allowed a non-string")
 
+    aad_values = _aad_values_for_row(contract, row)
+    if classification == "envelope_aes_gcm":
+        try:
+            decrypt_field(value, contract=contract, aad_values=aad_values)
+        except (InvalidToken, UnicodeDecodeError, ValueError) as exc:
+            report.decrypt_failures += 1
+            raise EncryptedFieldMigrationError(
+                EncryptedFieldMigrationFailure(
+                    contract_id=contract.id,
+                    primary_key=primary_key,
+                    phase="decrypt",
+                    error_class=exc.__class__.__name__,
+                )
+            ) from exc
+        report.already_migrated_rows += 1
+        return False
+
     try:
         plaintext = decrypt_field(value)
     except (InvalidToken, UnicodeDecodeError, ValueError) as exc:
@@ -441,8 +489,6 @@ def _process_migration_row(
     if plaintext is None:
         report.skipped_rows += 1
         return False
-
-    _aad_values_for_row(contract, row)
 
     if classification == "envelope_fernet":
         report.already_migrated_rows += 1
@@ -656,18 +702,32 @@ def _print_migration_reports(  # noqa: PLR0913
         click.echo(f"Next resume token: {_serialize_resume_state(next_resume_state)}")
 
 
-def _classify_preflight_value(value: Any) -> str:
+def _classify_preflight_value(
+    value: Any,
+    *,
+    contract: EncryptedFieldContract | None = None,
+    aad_values: dict[str, int] | None = None,
+) -> str:
     if value is None or value == "":
         return "null_empty"
     if not isinstance(value, str):
         return "malformed"
 
     is_envelope = value.startswith(ENCRYPTED_FIELD_ENVELOPE_PREFIX)
+    classification = "legacy_fernet"
     if is_envelope:
         try:
-            parse_encrypted_field_envelope(value)
+            classification = _classify_envelope_value(value)
         except InvalidToken:
             return "malformed"
+        if classification == "envelope_aes_gcm":
+            if contract is None or aad_values is None:
+                return classification
+            try:
+                decrypt_field(value, contract=contract, aad_values=aad_values)
+            except (InvalidToken, UnicodeDecodeError, ValueError):
+                return "decrypt_failure"
+            return classification
 
     try:
         decrypt_field(value)
@@ -676,7 +736,7 @@ def _classify_preflight_value(value: Any) -> str:
     except (UnicodeDecodeError, ValueError):
         return "decrypt_failure"
 
-    return "envelope_fernet" if is_envelope else "legacy_fernet"
+    return classification
 
 
 def _record_preflight_classification(
@@ -694,6 +754,8 @@ def _record_preflight_classification(
         counts.decrypt_failures += 1
     elif classification == "envelope_fernet":
         counts.envelope_fernet += 1
+    elif classification == "envelope_aes_gcm":
+        counts.envelope_aes_gcm += 1
     else:
         counts.legacy_fernet += 1
 
@@ -716,14 +778,13 @@ def _classify_encrypted_field_values(
         table = db.metadata.tables.get(contract.table)
         if table is None or contract.column not in table.c:
             continue
-        column = table.c[contract.column]
         counts = EncryptedFieldCiphertextCounts()
         last_primary_key = 0
 
         while True:
             rows = (
                 db.session.execute(
-                    db.select(table.c.id, column)
+                    db.select(*_preflight_scan_columns(contract, table))
                     .select_from(table)
                     .where(table.c.id > last_primary_key)
                     .order_by(table.c.id.asc())
@@ -737,9 +798,16 @@ def _classify_encrypted_field_values(
 
             for row in rows:
                 last_primary_key = row["id"]
+                classification = _classify_preflight_value(row[contract.column])
+                if classification == "envelope_aes_gcm":
+                    classification = _classify_preflight_value(
+                        row[contract.column],
+                        contract=contract,
+                        aad_values=_aad_values_for_row(contract, row),
+                    )
                 _record_preflight_classification(
                     counts,
-                    _classify_preflight_value(row[contract.column]),
+                    classification,
                 )
 
         reports.append(
@@ -751,6 +819,7 @@ def _classify_encrypted_field_values(
                 scanned_rows=counts.scanned_rows,
                 legacy_fernet=counts.legacy_fernet,
                 envelope_fernet=counts.envelope_fernet,
+                envelope_aes_gcm=counts.envelope_aes_gcm,
                 null_empty=counts.null_empty,
                 malformed=counts.malformed,
                 decrypt_failures=counts.decrypt_failures,
@@ -820,6 +889,7 @@ def _encrypted_field_preflight_report(
         capacity = capacity_by_contract_id[contract.id]
         ciphertext_report = ciphertext_by_contract_id.get(contract.id)
         row_counts = {
+            "envelope_aes_gcm": 0,
             "envelope_fernet": 0,
             "legacy_fernet": 0,
             "null_empty": 0,
@@ -829,6 +899,7 @@ def _encrypted_field_preflight_report(
         failures = {"decrypt_failures": 0, "malformed": 0}
         if ciphertext_report is not None:
             row_counts = {
+                "envelope_aes_gcm": ciphertext_report.envelope_aes_gcm,
                 "envelope_fernet": ciphertext_report.envelope_fernet,
                 "legacy_fernet": ciphertext_report.legacy_fernet,
                 "null_empty": ciphertext_report.null_empty,
@@ -859,6 +930,7 @@ def _encrypted_field_preflight_report(
 
     totals = {
         "decrypt_failures": sum(report.decrypt_failures for report in ciphertext_reports),
+        "envelope_aes_gcm": sum(report.envelope_aes_gcm for report in ciphertext_reports),
         "envelope_fernet": sum(report.envelope_fernet for report in ciphertext_reports),
         "legacy_fernet": sum(report.legacy_fernet for report in ciphertext_reports),
         "malformed": sum(report.malformed for report in ciphertext_reports),
@@ -1133,6 +1205,7 @@ def register_encrypted_field_commands(app: Flask) -> None:
                 f"({ciphertext_report.table}.{ciphertext_report.column}): "
                 f"legacy Fernet: {ciphertext_report.legacy_fernet}; "
                 f"envelope Fernet: {ciphertext_report.envelope_fernet}; "
+                f"envelope AES-GCM: {ciphertext_report.envelope_aes_gcm}; "
                 f"null/empty: {ciphertext_report.null_empty}; "
                 f"malformed: {ciphertext_report.malformed}; "
                 f"decrypt failures: {ciphertext_report.decrypt_failures}; "

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -184,6 +184,36 @@ def test_encrypted_field_preflight_reports_ready_without_sensitive_values(
     assert user._email == envelope_ciphertext
 
 
+def test_encrypted_field_preflight_accepts_aes_gcm_envelopes_with_aad(
+    app: Flask, user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ENCRYPTION_KEY", TEST_ENCRYPTION_KEY)
+    runner = app.test_cli_runner()
+    plaintext = "preflight AES-GCM secret"
+    contract = crypto.ENCRYPTED_FIELD_CONTRACT_BY_ID["User.email"]
+    assert user.id is not None
+
+    app.config[ENCRYPTED_FIELD_WRITE_FORMAT] = EncryptedFieldWriteFormat.ENVELOPE_AES_GCM
+    user._email = crypto.encrypt_field(
+        plaintext,
+        contract=contract,
+        aad_values={"user_id": user.id},
+    )
+    aead_ciphertext = user._email
+    assert aead_ciphertext is not None
+    db.session.commit()
+
+    result = runner.invoke(args=["encrypted-field", "preflight", "--contract", "User.email"])
+
+    assert result.exit_code == 0
+    assert "User.email (users.email): legacy Fernet: 0; envelope Fernet: 0" in result.output
+    assert "envelope AES-GCM: 1" in result.output
+    assert "malformed: 0; decrypt failures: 0; decryptable: yes" in result.output
+    assert "Encrypted-field preflight readiness: ready" in result.output
+    assert plaintext not in result.output
+    assert aead_ciphertext not in result.output
+
+
 def test_encrypted_field_preflight_json_reports_deterministic_redacted_artifact(
     app: Flask, user: User, user2: User, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -240,6 +270,7 @@ def test_encrypted_field_preflight_json_reports_deterministic_redacted_artifact(
     assert report["blocked_reasons"] == []
     assert report["totals"] == {
         "decrypt_failures": 0,
+        "envelope_aes_gcm": 0,
         "envelope_fernet": 1,
         "legacy_fernet": 1,
         "malformed": 0,
@@ -254,6 +285,7 @@ def test_encrypted_field_preflight_json_reports_deterministic_redacted_artifact(
             "contract_id": "User.totp_secret",
             "failures": {"decrypt_failures": 0, "malformed": 0},
             "rows": {
+                "envelope_aes_gcm": 0,
                 "envelope_fernet": 1,
                 "legacy_fernet": 1,
                 "null_empty": 0,
@@ -446,6 +478,7 @@ def test_encrypted_field_preflight_json_blocks_missing_schema_without_crashing(
         "contract_id": "User.missing_column",
         "failures": {"decrypt_failures": 0, "malformed": 0},
         "rows": {
+            "envelope_aes_gcm": 0,
             "envelope_fernet": 0,
             "legacy_fernet": 0,
             "null_empty": 0,
@@ -605,6 +638,48 @@ def test_encrypted_field_migrate_dry_run_reports_without_writing(
     assert original_ciphertext not in result.output
     db.session.refresh(user)
     assert user._totp_secret == original_ciphertext
+
+
+def test_encrypted_field_migrate_skips_existing_aes_gcm_envelopes(
+    app: Flask, user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ENCRYPTION_KEY", TEST_ENCRYPTION_KEY)
+    runner = app.test_cli_runner()
+    plaintext = "already AES-GCM migration secret"
+    contract = crypto.ENCRYPTED_FIELD_CONTRACT_BY_ID["User.email"]
+    assert user.id is not None
+
+    app.config[ENCRYPTED_FIELD_WRITE_FORMAT] = EncryptedFieldWriteFormat.ENVELOPE_AES_GCM
+    user._email = crypto.encrypt_field(
+        plaintext,
+        contract=contract,
+        aad_values={"user_id": user.id},
+    )
+    original_ciphertext = user._email
+    assert original_ciphertext is not None
+    db.session.commit()
+
+    result = runner.invoke(
+        args=[
+            "encrypted-field",
+            "migrate",
+            "--dry-run",
+            "--contract",
+            "User.email",
+            "--batch-size",
+            "10",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert "examined: 1; eligible: 0" in result.output
+    assert "already migrated: 1" in result.output
+    assert "decrypt failures: 0" in result.output
+    assert "remaining rows: 0" in result.output
+    assert plaintext not in result.output
+    assert original_ciphertext not in result.output
+    db.session.refresh(user)
+    assert user._email == original_ciphertext
 
 
 def test_encrypted_field_migrate_live_rewrites_and_verifies_post_write(

--- a/tests/test_encrypted_field_consolidated_coverage.py
+++ b/tests/test_encrypted_field_consolidated_coverage.py
@@ -199,6 +199,10 @@ def test_preflight_classification_counts_safe_buckets_without_disclosing_values(
     legacy_ciphertext = crypto.encrypt_field("legacy secret")
     assert legacy_ciphertext is not None
     envelope_ciphertext = crypto.serialize_encrypted_field_envelope(legacy_ciphertext)
+    aead_envelope = crypto.serialize_encrypted_field_aead_envelope(
+        b"synthetic-ciphertext",
+        b"0" * crypto.ENCRYPTED_FIELD_AEAD_NONCE_LENGTH,
+    )
     undecryptable_envelope = crypto.serialize_encrypted_field_envelope(
         "gAAAAABnot-a-decryptable-fernet-token"
     )
@@ -220,6 +224,7 @@ def test_preflight_classification_counts_safe_buckets_without_disclosing_values(
         cli._classify_preflight_value(undecodable_legacy),
         cli._classify_preflight_value(legacy_ciphertext),
         cli._classify_preflight_value(envelope_ciphertext),
+        cli._classify_preflight_value(aead_envelope),
     ]
     counts = cli.EncryptedFieldCiphertextCounts()
     for classification in classifications:
@@ -234,14 +239,16 @@ def test_preflight_classification_counts_safe_buckets_without_disclosing_values(
         "decrypt_failure",
         "legacy_fernet",
         "envelope_fernet",
+        "envelope_aes_gcm",
     ]
-    assert counts.row_count == 8
-    assert counts.scanned_rows == 8
+    assert counts.row_count == 9
+    assert counts.scanned_rows == 9
     assert counts.null_empty == 2
     assert counts.malformed == 2
     assert counts.decrypt_failures == 4
     assert counts.legacy_fernet == 1
     assert counts.envelope_fernet == 1
+    assert counts.envelope_aes_gcm == 1
 
 
 def test_preflight_report_marks_capacity_only_missing_schema_as_blocked() -> None:
@@ -273,6 +280,7 @@ def test_preflight_report_marks_capacity_only_missing_schema_as_blocked() -> Non
         {"code": "missing_schema", "contract_ids": ["User.missing_secret"]}
     ]
     assert report["contracts"][0]["rows"] == {
+        "envelope_aes_gcm": 0,
         "envelope_fernet": 0,
         "legacy_fernet": 0,
         "null_empty": 0,


### PR DESCRIPTION
## Summary
- Add an AES-GCM encrypted-field envelope bucket to preflight reports and JSON artifacts.
- Verify AES-GCM rows with contract/AAD when rollout tooling has row context, instead of attempting Fernet-only decryption.
- Skip valid existing AES-GCM envelopes during the Fernet envelope migration batch path and document the new preflight count.

## Why
Issue #2099 identified that once `ENCRYPTED_FIELD_WRITE_FORMAT=envelope-aes-gcm` writes exist, preflight and migration tooling still treated every `hlfield:` value as a Fernet envelope. Valid AEAD rows could be misclassified as malformed or decrypt failures and block later rollout checks.

## Validation
- `docker compose run --rm app poetry run pytest tests/test_cli_commands.py tests/test_encrypted_field_consolidated_coverage.py tests/test_crypto.py -q` (112 passed)
- `make lint`
- `make test` (first run hit the documented Postgres recovery-mode failure; reset with `docker compose down -v --remove-orphans`, rerun passed: 1993 passed, 1 deselected, 1 xfailed, 99% coverage)
- `make audit-python` (No known vulnerabilities found)
- `make audit-node-runtime` (found 0 vulnerabilities)

## Manual Testing
- Not applicable beyond CLI validation; this is rollout tooling behavior covered by automated CLI tests using AES-GCM encrypted-field rows.

## Risks / Follow-ups
- Preflight JSON now includes `envelope_aes_gcm` in row totals and per-contract rows. Existing release-gate validation continues to require zero malformed values and decrypt failures.

Closes #2099