### PR TITLE
Gate production encrypted-field migration

### DIFF
--- a/docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
+++ b/docs/ENCRYPTED-FIELD-MIGRATION-RUNBOOK.md
@@ -130,8 +130,9 @@ size ceiling, and rollback plan proven in staging or restored-backup rehearsal.
 
 ## Production Release Gate
 
-Before changing `ENCRYPTED_FIELD_WRITE_FORMAT` in production, operators must run
-the checkable production release gate:
+Before changing `ENCRYPTED_FIELD_WRITE_FORMAT` in production or running live
+production encrypted-field migration, operators must run the checkable
+production release gate:
 
 ```shell
 flask encrypted-field release-gate \
@@ -140,8 +141,9 @@ flask encrypted-field release-gate \
 ```
 
 The gate must report `Encrypted-field production release gate: ready` before
-operators enable `envelope-fernet` writes. The command is read-only. The
-preflight artifact must cover every encrypted-field contract, report ready,
+operators enable `envelope-fernet` writes or run
+`flask encrypted-field migrate --live --production`. The command is read-only.
+The preflight artifact must cover every encrypted-field contract, report ready,
 scan every encrypted-field row, and have zero malformed values or decrypt
 failures.
 
@@ -219,10 +221,11 @@ The evidence manifest must be a redacted JSON file with these minimum controls:
 The manifest must not include plaintext, private keys, tokens, raw encrypted
 values, or full ciphertext. It is a release artifact that points to reviewed
 evidence, including the restored-backup or staging rehearsal report; it is not
-a replacement for maintainer review. If the gate blocks, do not change
-production write-format configuration until the missing evidence or
-rollback/zero-downtime control is fixed and reviewed. The gate requires zero
-planned downtime, bounded batches, and no full-table rewrite transaction.
+a replacement for maintainer review. If the gate blocks,
+do not change production write-format configuration or run live production
+migration until the missing evidence or rollback/zero-downtime control is fixed
+and reviewed. The gate requires zero planned downtime, bounded batches, and no
+full-table rewrite transaction.
 
 ## Preflight Checks
 
@@ -303,14 +306,36 @@ small enough to avoid long locks, large transactions, and operational surprise;
 production batch-size increases require operator review of staging timing and
 production health.
 
-Run live mode with the maintainer-approved target format:
+Run local or staging live mode with the maintainer-approved target format:
 
 `flask encrypted-field migrate --live --target-format TARGET-FORMAT --batch-size 10`
+
+Production live mode must include `--production`, a non-sensitive
+`--environment-name`, and the exact release-gate artifacts reviewed by
+maintainers:
+
+```shell
+flask encrypted-field migrate --live --production \
+  --environment-name production \
+  --preflight-artifact PATH/production-preflight.json \
+  --evidence-manifest PATH/production-release-gate.json \
+  --target-format TARGET-FORMAT \
+  --batch-size 10
+```
+
+The helper refuses `--production --live` unless both release-gate artifacts are
+present and pass the same checks as `flask encrypted-field release-gate`.
+Production gate artifacts are not accepted without `--production`, so rehearsal
+runs cannot accidentally imply production approval.
 
 Resume an interrupted live run with the exact token reported by the prior run:
 
 ```shell
-flask encrypted-field migrate --live --target-format TARGET-FORMAT \
+flask encrypted-field migrate --live --production \
+  --environment-name production \
+  --preflight-artifact PATH/production-preflight.json \
+  --evidence-manifest PATH/production-release-gate.json \
+  --target-format TARGET-FORMAT \
   --batch-size 10 --resume-token TOKEN
 ```
 

--- a/hushline/cli_encrypted_field.py
+++ b/hushline/cli_encrypted_field.py
@@ -670,12 +670,14 @@ def _print_migration_reports(  # noqa: PLR0913
     dry_run: bool,
     batch_size: int,
     target_format: EncryptedFieldWriteFormat,
+    environment_name: str,
     next_resume_state: EncryptedFieldMigrationResumeState | None,
     elapsed_seconds: float,
 ) -> None:
     click.echo(f"Helper version: {ENCRYPTED_FIELD_MIGRATION_HELPER_VERSION}")
     click.echo(f"Mode: {'dry-run' if dry_run else 'live'}")
     click.echo(f"Target format: {target_format.value}")
+    click.echo(f"Environment: {environment_name}")
     click.echo(f"Batch size: {batch_size}")
     click.echo(f"Elapsed seconds: {elapsed_seconds:.3f}")
     for report in reports:
@@ -1141,6 +1143,21 @@ def _release_gate_manifest_errors(manifest: dict[str, Any]) -> list[str]:
     return errors
 
 
+def _validate_production_migration_gate(
+    *,
+    preflight_artifact: Path,
+    evidence_manifest: Path,
+) -> None:
+    preflight_report = _load_json_artifact(preflight_artifact, "preflight")
+    manifest = _load_json_artifact(evidence_manifest, "release-gate manifest")
+    errors = _release_gate_preflight_errors(preflight_report)
+    errors.extend(_release_gate_manifest_errors(manifest))
+    if errors:
+        raise click.ClickException(
+            "Encrypted-field production migration gate: blocked (" + "; ".join(errors) + ")"
+        )
+
+
 def register_encrypted_field_commands(app: Flask) -> None:
     encrypted_field_cli = AppGroup(
         "encrypted-field",
@@ -1241,14 +1258,19 @@ def register_encrypted_field_commands(app: Flask) -> None:
     )
     def release_gate(preflight_artifact: Path, evidence_manifest: Path) -> None:
         """Validate production envelope-write evidence before configuration changes."""
-        preflight_report = _load_json_artifact(preflight_artifact, "preflight")
-        manifest = _load_json_artifact(evidence_manifest, "release-gate manifest")
-        errors = _release_gate_preflight_errors(preflight_report)
-        errors.extend(_release_gate_manifest_errors(manifest))
-        if errors:
-            raise click.ClickException(
-                "Encrypted-field production release gate: blocked (" + "; ".join(errors) + ")"
+        try:
+            _validate_production_migration_gate(
+                preflight_artifact=preflight_artifact,
+                evidence_manifest=evidence_manifest,
             )
+        except click.ClickException as exc:
+            message = str(exc)
+            message = message.replace(
+                "Encrypted-field production migration gate",
+                "Encrypted-field production release gate",
+                1,
+            )
+            raise click.ClickException(message) from exc
 
         click.echo("Encrypted-field production release gate: ready")
         click.echo(f"Target format: {ENCRYPTED_FIELD_MIGRATION_TARGET_FORMAT.value}")
@@ -1282,6 +1304,12 @@ def register_encrypted_field_commands(app: Flask) -> None:
         help="Maximum rows to examine in this run.",
     )
     @click.option(
+        "--environment-name",
+        default="unspecified",
+        show_default=True,
+        help="Non-sensitive environment label for migration progress output.",
+    )
+    @click.option(
         "--contract",
         "contract_ids",
         multiple=True,
@@ -1290,6 +1318,30 @@ def register_encrypted_field_commands(app: Flask) -> None:
     @click.option(
         "--resume-token",
         help="Resume from a prior run's next resume token.",
+    )
+    @click.option(
+        "--production",
+        is_flag=True,
+        help=(
+            "Require production release-gate evidence before live writes. "
+            "Use only for approved production execution."
+        ),
+    )
+    @click.option(
+        "--preflight-artifact",
+        type=click.Path(exists=True, dir_okay=False, path_type=Path),
+        help=(
+            "Redacted JSON artifact produced by encrypted-field preflight --output json. "
+            "Required with --production --live."
+        ),
+    )
+    @click.option(
+        "--evidence-manifest",
+        type=click.Path(exists=True, dir_okay=False, path_type=Path),
+        help=(
+            "Redacted production release-gate evidence manifest. "
+            "Required with --production --live."
+        ),
     )
     @click.option(
         "--full-scan",
@@ -1305,8 +1357,12 @@ def register_encrypted_field_commands(app: Flask) -> None:
     def migrate(  # noqa: PLR0913
         mode: str,
         batch_size: int,
+        environment_name: str,
         contract_ids: tuple[str, ...],
         resume_token: str | None,
+        production: bool,
+        preflight_artifact: Path | None,
+        evidence_manifest: Path | None,
         full_scan: bool,
         target_format: str,
     ) -> None:
@@ -1319,6 +1375,24 @@ def register_encrypted_field_commands(app: Flask) -> None:
             raise click.ClickException(
                 "Encrypted-field migration only supports target format "
                 f"{ENCRYPTED_FIELD_MIGRATION_TARGET_FORMAT.value}"
+            )
+        if (preflight_artifact is not None or evidence_manifest is not None) and not production:
+            raise click.ClickException(
+                "Production gate artifacts are only accepted with --production"
+            )
+        if production and mode == "dry-run":
+            raise click.ClickException(
+                "Production mode is only valid for --live after rehearsal and release-gate approval"
+            )
+        if production:
+            if preflight_artifact is None or evidence_manifest is None:
+                raise click.ClickException(
+                    "Production live migration requires --preflight-artifact and "
+                    "--evidence-manifest"
+                )
+            _validate_production_migration_gate(
+                preflight_artifact=preflight_artifact,
+                evidence_manifest=evidence_manifest,
             )
 
         contracts = _selected_contracts(contract_ids)
@@ -1353,6 +1427,7 @@ def register_encrypted_field_commands(app: Flask) -> None:
             dry_run=mode == "dry-run",
             batch_size=batch_size,
             target_format=parsed_target_format,
+            environment_name=environment_name,
             next_resume_state=next_resume_state,
             elapsed_seconds=time.monotonic() - started,
         )

--- a/tests/test_cli_commands.py
+++ b/tests/test_cli_commands.py
@@ -639,6 +639,24 @@ def test_encrypted_field_release_gate_requires_rehearsal_report_reference(
     assert "rehearsal_report must be a non-empty string" in result.output
 
 
+def _write_valid_encrypted_field_release_gate_artifacts(
+    app: Flask,
+    tmp_path: Path,
+) -> tuple[Path, Path]:
+    runner = app.test_cli_runner()
+    preflight_result = runner.invoke(args=["encrypted-field", "preflight", "--output", "json"])
+    assert preflight_result.exit_code == 0
+
+    preflight_artifact = tmp_path / "preflight.json"
+    evidence_manifest = tmp_path / "release-gate.json"
+    preflight_artifact.write_text(preflight_result.output, encoding="utf-8")
+    evidence_manifest.write_text(
+        json.dumps(_valid_encrypted_field_release_gate_manifest()),
+        encoding="utf-8",
+    )
+    return preflight_artifact, evidence_manifest
+
+
 def _next_resume_token(output: str) -> str:
     for line in output.splitlines():
         if line.startswith("Next resume token: "):
@@ -753,6 +771,84 @@ def test_encrypted_field_migrate_live_rewrites_and_verifies_post_write(
     assert "would migrate: 0; migrated: 1" in result.output
     assert "verification failures: 0; update failures: 0; remaining rows: 0" in result.output
     assert "Next resume token: complete" in result.output
+    assert plaintext not in result.output
+    assert original_ciphertext not in result.output
+    db.session.refresh(user)
+    assert user._totp_secret is not None
+    assert user._totp_secret.startswith(crypto.ENCRYPTED_FIELD_ENVELOPE_PREFIX)
+    assert user.totp_secret == plaintext
+
+
+def test_encrypted_field_migrate_production_live_requires_release_gate_artifacts(
+    app: Flask, user: User, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("ENCRYPTION_KEY", TEST_ENCRYPTION_KEY)
+    runner = app.test_cli_runner()
+    plaintext = "ungated production migration secret"
+    user._totp_secret = crypto.encrypt_field(plaintext)
+    original_ciphertext = user._totp_secret
+    assert original_ciphertext is not None
+    db.session.commit()
+
+    result = runner.invoke(
+        args=[
+            "encrypted-field",
+            "migrate",
+            "--live",
+            "--production",
+            "--contract",
+            "User.totp_secret",
+        ]
+    )
+
+    assert result.exit_code == 1
+    assert "Production live migration requires --preflight-artifact" in result.output
+    db.session.refresh(user)
+    assert user._totp_secret == original_ciphertext
+    assert user.totp_secret == plaintext
+
+
+def test_encrypted_field_migrate_production_live_accepts_valid_release_gate(
+    app: Flask,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setenv("ENCRYPTION_KEY", TEST_ENCRYPTION_KEY)
+    runner = app.test_cli_runner()
+    plaintext = "gated production migration secret"
+    user._totp_secret = crypto.encrypt_field(plaintext)
+    original_ciphertext = user._totp_secret
+    assert original_ciphertext is not None
+    db.session.commit()
+    preflight_artifact, evidence_manifest = _write_valid_encrypted_field_release_gate_artifacts(
+        app,
+        tmp_path,
+    )
+
+    result = runner.invoke(
+        args=[
+            "encrypted-field",
+            "migrate",
+            "--live",
+            "--production",
+            "--environment-name",
+            "production",
+            "--preflight-artifact",
+            str(preflight_artifact),
+            "--evidence-manifest",
+            str(evidence_manifest),
+            "--contract",
+            "User.totp_secret",
+            "--batch-size",
+            "10",
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert "Mode: live" in result.output
+    assert "Environment: production" in result.output
+    assert "migrated: 1" in result.output
     assert plaintext not in result.output
     assert original_ciphertext not in result.output
     db.session.refresh(user)

--- a/tests/test_encrypted_field_migration_runbook.py
+++ b/tests/test_encrypted_field_migration_runbook.py
@@ -56,6 +56,9 @@ def test_encrypted_field_migration_runbook_covers_required_execution_paths() -> 
         "rehearsal_report",
         "--contract CONTRACT_ID",
         "--batch-size N",
+        "flask encrypted-field migrate --live --production",
+        "--preflight-artifact PATH/production-preflight.json",
+        "--evidence-manifest PATH/production-release-gate.json",
     ):
         assert phrase in content
 
@@ -77,9 +80,11 @@ def test_encrypted_field_migration_runbook_locks_security_guardrails() -> None:
         "not cryptographic aad binding",
         "completed rehearsal evidence report is reviewed",
         "before changing `encrypted_field_write_format` in production",
+        "or running live production encrypted-field migration",
         "preflight artifact must cover every encrypted-field contract",
         "zero planned downtime",
         "new_writes_can_revert_to_legacy",
+        "the helper refuses `--production --live` unless both release-gate artifacts are present",
         "stop before live mode if any non-empty row cannot be classified or decrypted",
         "dry-run mode must execute the same selection, classification, decryption",
         "skip rows already in the target envelope format after verifying",


### PR DESCRIPTION
Refs #2088
Parent epic: #2092
Base branch: `codex/epic-2092`

## What changed
- Added a production-only gate to `flask encrypted-field migrate --live` requiring `--production`, a preflight artifact, and a release-gate evidence manifest before any live production migration can run.
- Reused the encrypted-field release gate validation for production migration readiness checks.
- Added an environment label to migration output for production auditability without logging plaintext or ciphertext.
- Updated the encrypted-field migration runbook with production preflight, execution, retry/resume, and gate-refusal guidance.
- Added tests for blocked ungated production migration and successful gated production migration.

## Why
Production migration of existing encrypted-field values should not run without documented rehearsal evidence and maintainer-reviewed readiness artifacts. Local and staging live rehearsals remain available without the production gate.

## Security and privacy
Threat/risk summary: an accidental or premature live production migration could rewrite encrypted-field values before rehearsal, backup, and rollback readiness are confirmed.

Affected data paths: encrypted-field migration CLI handling encrypted columns for users, notification recipients, and custom field values.

Mitigation: production live mode refuses to run unless both release-gate artifacts pass validation; blocked runs leave source ciphertext unchanged; no plaintext, ciphertext, keys, or sensitive tokens are added to logs.

## Validation
- `./scripts/agent_issue_bootstrap.sh`
- `make test TESTS="tests/test_cli_commands.py tests/test_encrypted_field_migration_runbook.py tests/test_encrypted_field_consolidated_coverage.py tests/test_encrypted_field_inventory.py tests/test_crypto.py"`
- `make lint`
- `make test` (`2009 passed, 1 deselected, 1 xfailed`)
- `make audit-python`
- `make audit-node-runtime`

## Manual testing
Not applicable beyond CLI coverage in this branch. A real production execution requires environment-specific preflight and release-gate artifacts plus maintainer approval.

## Known risks and follow-up
- `flask encrypted-field migrate --live` without `--production` remains available for local and staging rehearsals; the runbook mandates `--production` for production.
- Because this child PR targets the epic branch, issue #2088 should be closed explicitly after this PR merges into `codex/epic-2092`.