### PR TITLE
Feature verified directory accounts

### DIFF
--- a/assets/js/directory_verified.js
+++ b/assets/js/directory_verified.js
@@ -54,10 +54,13 @@ document.addEventListener("DOMContentLoaded", function () {
   const directoryDataByTab = new Map();
   const directoryDataSearchByTab = new Map();
   const directoryDataRequestsByTab = new Map();
+  const directoryCardBioMaxLength = 250;
+  const featuredCarouselDurationMs = 7000;
   let hasRenderedSearch = false;
   let directoryDataRequestController = null;
   let directoryDataLoadingController = null;
   let loadedDirectorySearch = window.location.search;
+  let featuredCarouselCleanups = [];
 
   tabPanels.forEach((panel) => {
     initialMarkup.set(panel.id, panel.innerHTML);
@@ -393,6 +396,11 @@ document.addEventListener("DOMContentLoaded", function () {
       return badgeContainer;
     }
 
+    if (tab === "verified" && user.is_featured) {
+      badgeContainer +=
+        '<span class="badge" role="img" aria-label="Featured account">💎 Featured</span>';
+    }
+
     if (user.is_admin) {
       badgeContainer +=
         '<span class="badge" role="img" aria-label="Administrator account">⚙️ Admin</span>';
@@ -447,7 +455,34 @@ document.addEventListener("DOMContentLoaded", function () {
     `;
   }
 
-  function buildUserCard(user, query, tab) {
+  function directoryCardBio(text) {
+    if (!text || text.length <= directoryCardBioMaxLength) {
+      return {
+        isTruncated: false,
+        text: text || "",
+      };
+    }
+
+    return {
+      isTruncated: true,
+      text: `${text.slice(0, directoryCardBioMaxLength - 3)}`,
+    };
+  }
+
+  function buildFeaturedBio(user, query, safeProfileUrl) {
+    if (!user.bio) {
+      return "";
+    }
+
+    const featuredBio = directoryCardBio(user.bio);
+    const bioHighlighted = highlightMatch(featuredBio.text, query);
+    const moreLink = featuredBio.isTruncated
+      ? ` <a href="${safeProfileUrl}">more...</a>`
+      : "";
+    return `<p class="bio featured-directory-bio">${bioHighlighted}${moreLink}</p>`;
+  }
+
+  function buildUserCard(user, query, tab, options = {}) {
     const safeDisplayName = userSearch.escapeHtml(
       user.display_name || user.primary_username || "",
     );
@@ -459,7 +494,11 @@ document.addEventListener("DOMContentLoaded", function () {
       query,
     );
     const usernameHighlighted = highlightMatch(user.primary_username, query);
-    const bioHighlighted = user.bio ? highlightMatch(user.bio, query) : "";
+    const bioMarkup = options.featuredCarousel
+      ? buildFeaturedBio(user, query, safeProfileUrl)
+      : user.bio
+        ? `<p class="bio">${highlightMatch(user.bio, query)}</p>`
+        : "";
 
     if (user.is_public_record || user.is_globaleaks || user.is_newsroom || user.is_securedrop) {
       return buildAutomatedListingCard(user, query, tab);
@@ -476,12 +515,196 @@ document.addEventListener("DOMContentLoaded", function () {
         <h3>${displayNameHighlighted}</h3>
         <p class="meta">@${usernameHighlighted}</p>
         ${badges ? `<div class="badgeContainer">${badges}</div>` : ""}
-        ${bioHighlighted ? `<p class="bio">${bioHighlighted}</p>` : ""}
+        ${bioMarkup}
         <div class="user-actions">
           <a href="${safeProfileUrl}" aria-label="${safeDisplayName}'s profile">View Profile</a>
         </div>
       </article>
     `;
+  }
+
+  function isPromotableFeaturedUser(user, tab) {
+    return (
+      tab === "verified" &&
+      user.is_featured &&
+      user.is_verified &&
+      !user.is_public_record &&
+      !user.is_globaleaks &&
+      !user.is_newsroom &&
+      !user.is_securedrop
+    );
+  }
+
+  function buildFeaturedCarousel(users, query, tab) {
+    const featuredUsers = users.filter((user) => isPromotableFeaturedUser(user, tab));
+    if (!featuredUsers.length) {
+      return "";
+    }
+
+    const slideMarkup = featuredUsers
+      .map(
+        (user, index) => `
+          <div
+            class="featured-directory-slide${index === 0 ? " active" : ""}"
+            data-featured-slide
+            aria-hidden="${index === 0 ? "false" : "true"}"
+          >
+            ${buildUserCard(user, query, tab, { featuredCarousel: true })}
+          </div>
+        `,
+      )
+      .join("");
+
+    const controlsMarkup =
+      featuredUsers.length > 1
+        ? `
+          <div class="featured-directory-controls">
+            <div></div>
+            <div class="featured-directory-dots" role="tablist" aria-label="Featured accounts">
+              ${featuredUsers
+                .map(
+                  (_user, index) => `
+                    <button
+                      type="button"
+                      class="featured-directory-dot${index === 0 ? " active" : ""}"
+                      aria-label="Show featured account ${index + 1} of ${featuredUsers.length}"
+                      aria-selected="${index === 0 ? "true" : "false"}"
+                      data-featured-dot
+                      data-featured-index="${index}"
+                    ></button>
+                  `,
+                )
+                .join("")}
+            </div>
+          </div>
+        `
+        : "";
+
+    return `
+      <section class="featured-directory" aria-label="Featured verified accounts" data-featured-carousel>
+        <div class="featured-directory-track">
+          ${slideMarkup}
+        </div>
+        ${controlsMarkup}
+      </section>
+    `;
+  }
+
+  function clearFeaturedCarouselTimers() {
+    featuredCarouselCleanups.forEach((cleanup) => cleanup());
+    featuredCarouselCleanups = [];
+  }
+
+  function initializeFeaturedCarousels() {
+    clearFeaturedCarouselTimers();
+
+    document.querySelectorAll("[data-featured-carousel]").forEach((carousel) => {
+      const slides = Array.from(carousel.querySelectorAll("[data-featured-slide]"));
+      const dots = Array.from(carousel.querySelectorAll("[data-featured-dot]"));
+      if (slides.length < 2 || dots.length < 2) {
+        return;
+      }
+
+      const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)")
+        .matches;
+      let activeIndex = Math.max(
+        0,
+        slides.findIndex((slide) => slide.classList.contains("active")),
+      );
+      let autoAdvanceTimer = null;
+      let progressFrame = null;
+      let progressStartedAt = 0;
+      let touchStartX = null;
+
+      const setProgress = (progress) => {
+        dots.forEach((dot, index) => {
+          dot.style.setProperty(
+            "--featured-dot-progress",
+            index === activeIndex ? `${progress * 100}%` : "0%",
+          );
+        });
+      };
+
+      const stopProgress = () => {
+        if (autoAdvanceTimer) {
+          window.clearTimeout(autoAdvanceTimer);
+          autoAdvanceTimer = null;
+        }
+        if (progressFrame) {
+          window.cancelAnimationFrame(progressFrame);
+          progressFrame = null;
+        }
+      };
+
+      const scheduleAutoAdvance = () => {
+        stopProgress();
+        setProgress(0);
+        if (prefersReducedMotion) {
+          return;
+        }
+
+        progressStartedAt = performance.now();
+        const updateProgress = (timestamp) => {
+          const elapsed = timestamp - progressStartedAt;
+          setProgress(Math.min(elapsed / featuredCarouselDurationMs, 1));
+          progressFrame = window.requestAnimationFrame(updateProgress);
+        };
+
+        progressFrame = window.requestAnimationFrame(updateProgress);
+        autoAdvanceTimer = window.setTimeout(() => {
+          showSlide(activeIndex + 1);
+        }, featuredCarouselDurationMs);
+      };
+
+      const showSlide = (nextIndex) => {
+        activeIndex = (nextIndex + slides.length) % slides.length;
+        slides.forEach((slide, index) => {
+          const isActive = index === activeIndex;
+          slide.classList.toggle("active", isActive);
+          slide.setAttribute("aria-hidden", isActive ? "false" : "true");
+        });
+        dots.forEach((dot, index) => {
+          const isActive = index === activeIndex;
+          dot.classList.toggle("active", isActive);
+          dot.setAttribute("aria-selected", isActive ? "true" : "false");
+        });
+        scheduleAutoAdvance();
+      };
+
+      dots.forEach((dot) => {
+        dot.addEventListener("click", () => {
+          showSlide(Number(dot.dataset.featuredIndex || 0));
+        });
+      });
+
+      carousel.addEventListener(
+        "touchstart",
+        (event) => {
+          touchStartX = event.changedTouches[0]?.clientX ?? null;
+        },
+        { passive: true },
+      );
+
+      carousel.addEventListener(
+        "touchend",
+        (event) => {
+          if (touchStartX === null) {
+            return;
+          }
+          const touchEndX = event.changedTouches[0]?.clientX ?? touchStartX;
+          const deltaX = touchEndX - touchStartX;
+          touchStartX = null;
+          if (Math.abs(deltaX) < 40) {
+            return;
+          }
+          showSlide(activeIndex + (deltaX < 0 ? 1 : -1));
+        },
+        { passive: true },
+      );
+
+      scheduleAutoAdvance();
+      featuredCarouselCleanups.push(stopProgress);
+    });
   }
 
   function appendSection(panel, label, users, query, tab) {
@@ -537,8 +760,21 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     if (tab === "verified") {
-      appendSection(panel, "", withPgp, query, tab);
-      appendSection(panel, "📇 Info-Only Accounts", infoOnly, query, tab);
+      panel.insertAdjacentHTML("beforeend", buildFeaturedCarousel(users, query, tab));
+      appendSection(
+        panel,
+        "",
+        withPgp.filter((user) => !isPromotableFeaturedUser(user, tab)),
+        query,
+        tab,
+      );
+      appendSection(
+        panel,
+        "📇 Info-Only Accounts",
+        infoOnly.filter((user) => !isPromotableFeaturedUser(user, tab)),
+        query,
+        tab,
+      );
       return;
     }
 
@@ -553,6 +789,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     renderPanelContent(panel, users, query, tab);
+    initializeFeaturedCarousels();
   }
 
   function panelIntroMarkup(panelId) {
@@ -606,6 +843,7 @@ document.addEventListener("DOMContentLoaded", function () {
     if (query.length === 0) {
       if (panel && initialMarkup.has(panel.id)) {
         panel.innerHTML = initialMarkup.get(panel.id);
+        initializeFeaturedCarousels();
       }
       if (hasRenderedSearch) {
         setSearchStatus(`Showing all ${currentScopeLabel}.`);

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2470,6 +2470,113 @@ img.alert {
   margin-bottom: 0.75rem;
 }
 
+.featured-directory {
+  margin: 0 0 0.5rem 0;
+}
+
+.featured-directory-track {
+  display: grid;
+}
+
+.featured-directory-slide {
+  display: flex;
+  grid-area: 1 / 1;
+}
+
+.featured-directory-slide:not(.active) {
+  pointer-events: none;
+  visibility: hidden;
+}
+
+.featured-directory .user {
+  margin-bottom: 0;
+  width: 100%;
+}
+
+.featured-directory-controls {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.featured-directory-dots {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25rem;
+  margin: 0;
+}
+
+.featured-directory-dot {
+  --featured-dot-progress: 0%;
+  align-items: center;
+  background: transparent;
+  border: 0;
+  box-shadow: none !important;
+  color: #8f8f8f;
+  display: inline-flex;
+  height: 44px;
+  justify-content: center;
+  margin: 0;
+  min-height: 44px;
+  min-width: 28px;
+  padding: 0;
+  position: relative;
+  width: 28px;
+}
+
+.featured-directory-dot::before {
+  background-color: #cfcfcf;
+  border-radius: 50vw;
+  content: "";
+  height: 0.625rem;
+  position: absolute;
+  width: 0.625rem;
+}
+
+.featured-directory-dot.active {
+  color: var(--color-brand);
+}
+
+.featured-directory-dot.active::before {
+  background: linear-gradient(
+    90deg,
+    var(--color-brand) 0 var(--featured-dot-progress),
+    oklch(from var(--color-brand) l c h / 0.18) var(--featured-dot-progress) 100%
+  );
+  box-shadow: inset 0 0 0 1px var(--color-brand);
+  width: 1.75rem;
+}
+
+.featured-directory-bio a {
+  white-space: nowrap;
+}
+
+@media (prefers-color-scheme: dark) {
+  .featured-directory-dot {
+    color: var(--color-border-dark);
+  }
+
+  .featured-directory-dot::before {
+    background-color: var(--color-border-dark-1);
+  }
+
+  .featured-directory-dot.active {
+    color: var(--color-brand-dark-min-saturation);
+  }
+
+  .featured-directory-dot.active::before {
+    background: linear-gradient(
+      90deg,
+      var(--color-brand-dark-min-saturation) 0 var(--featured-dot-progress),
+      oklch(from var(--color-brand-dark-min-saturation) l c h / 0.22)
+        var(--featured-dot-progress) 100%
+    );
+    box-shadow: inset 0 0 0 1px var(--color-brand-dark-min-saturation);
+  }
+}
+
 #results>div {
   border-radius: 0.25rem;
 }

--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -39,6 +39,7 @@ The app and public directory support more than individual profiles. Current disc
 - Individual tip lines for reporters, lawyers, educators, organizers, and security contacts
 - Shared or role-based intake points such as board, ethics, compliance, or security-reporting inboxes
 - Verified first-party Hush Line profiles
+- Featured verified profiles promoted by instance administrators
 - Imported public-interest directories for attorneys and newsrooms
 - Imported SecureDrop and GlobaLeaks listings
 
@@ -60,6 +61,7 @@ The app and public directory support more than individual profiles. Current disc
 | Whistleblower | Find a credible recipient without creating an account                          | I can report quickly without procedural friction                                                         | Directory, profile pages                              |
 | Whistleblower | Search the directory by name                                                   | I can find a known person or organization directly                                                       | Directory search                                      |
 | Whistleblower | Filter recipients by trust or type                                             | I can narrow the list to verified accounts, attorneys, newsrooms, SecureDrop, GlobaLeaks, or all sources | Directory tabs and filters                            |
+| Whistleblower | See administrator-featured verified recipients first                           | I can quickly find the accounts this deployment most wants visitors to notice                            | Directory verified tab                                |
 | Whistleblower | Filter by geography                                                            | I can find a recipient relevant to my jurisdiction or risk environment                                   | Directory country/region filters                      |
 | Whistleblower | Inspect a public profile before I send anything                                | I can judge whether this tip line belongs to the right person or organization                            | `/to/<username>` profile page                         |
 | Whistleblower | See trust signals on a profile                                                 | I can reduce impersonation risk before contacting someone                                                | Verified badge, caution badge, linked profile details |
@@ -152,6 +154,7 @@ The app and public directory support more than individual profiles. Current disc
 | Admin | Search all usernames                                                           | I can find accounts and aliases quickly in a larger deployment                     | Settings -> Admin         |
 | Admin | See aggregate usage metrics such as user count, 2FA adoption, and PGP adoption | I can evaluate account-hardening posture and platform uptake                       | Settings -> Admin         |
 | Admin | Mark a primary account or alias as verified                                    | Visitors can see that a staff member verified the identity behind a tip line       | Settings -> Admin         |
+| Admin | Mark one or more verified accounts as featured                                 | Visitors see priority verified recipients at the top of the Verified directory tab | Settings -> Admin         |
 | Admin | Mark an account as cautious                                                    | Visitors can receive a visible warning before trusting a listing                   | Settings -> Admin         |
 | Admin | Suspend an account                                                             | The platform can stop new message intake for unsafe or abusive accounts            | Settings -> Admin         |
 | Admin | Grant or remove admin privileges                                               | Governance tasks can be shared deliberately                                        | Settings -> Admin         |

--- a/hushline/admin.py
+++ b/hushline/admin.py
@@ -70,6 +70,21 @@ def create_blueprint() -> Blueprint:
         flash(f"✅ Username verification set to {status_label}.", "success")
         return redirect(url_for("settings.admin"))
 
+    @bp.route("/toggle_featured_username/<int:username_id>", methods=["POST"])
+    @admin_authentication_required
+    def toggle_featured_username(username_id: int) -> Response:
+        _validate_csrf()
+
+        username = db.session.get(Username, username_id)
+        if username is None:
+            abort(404)
+        desired_featured = _parse_form_bool("is_featured")
+        username.is_featured = desired_featured
+        db.session.commit()
+        status_label = "featured" if desired_featured else "not featured"
+        flash(f"✅ Username featured status set to {status_label}.", "success")
+        return redirect(url_for("settings.admin"))
+
     @bp.route("/toggle_admin/<int:user_id>", methods=["POST"])
     @admin_authentication_required
     def toggle_admin(user_id: int) -> Response:

--- a/hushline/model/username.py
+++ b/hushline/model/username.py
@@ -109,6 +109,12 @@ class Username(Model):
     )
     is_primary: Mapped[bool] = mapped_column()
     is_verified: Mapped[bool] = mapped_column(default=False)
+    is_featured: Mapped[bool] = mapped_column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        server_default=text("false"),
+    )
     show_in_directory: Mapped[bool] = mapped_column(default=False)
     bio: Mapped[Optional[str]] = mapped_column(db.Text)
     embed_enabled: Mapped[bool] = mapped_column(

--- a/hushline/routes/directory.py
+++ b/hushline/routes/directory.py
@@ -427,6 +427,7 @@ def _directory_user_row(username: Username) -> dict[str, object | None]:
         "account_category_label": getattr(user, "account_category_label", None),
         "is_admin": user.is_admin,
         "is_verified": username.is_verified,
+        "is_featured": bool(getattr(username, "is_featured", False)),
         "show_caution_badge": _show_directory_caution_badge(username),
         "has_pgp_key": message_capable,
         "is_public_record": False,
@@ -461,6 +462,7 @@ def _public_record_row(listing: PublicRecordListing) -> dict[str, object | None]
         "account_category_label": None,
         "is_admin": False,
         "is_verified": False,
+        "is_featured": False,
         "show_caution_badge": False,
         "has_pgp_key": False,
         "is_public_record": True,
@@ -495,6 +497,7 @@ def _globaleaks_row(listing: GlobaLeaksDirectoryListing) -> dict[str, object | N
         "account_category_label": None,
         "is_admin": False,
         "is_verified": False,
+        "is_featured": False,
         "show_caution_badge": False,
         "has_pgp_key": False,
         "is_public_record": False,
@@ -529,6 +532,7 @@ def _newsroom_row(listing: NewsroomDirectoryListing) -> dict[str, object | None]
         "account_category_label": None,
         "is_admin": False,
         "is_verified": False,
+        "is_featured": False,
         "show_caution_badge": False,
         "has_pgp_key": False,
         "is_public_record": False,
@@ -563,6 +567,7 @@ def _securedrop_row(listing: SecureDropDirectoryListing) -> dict[str, object | N
         "account_category_label": None,
         "is_admin": False,
         "is_verified": False,
+        "is_featured": False,
         "show_caution_badge": False,
         "has_pgp_key": False,
         "is_public_record": False,
@@ -802,6 +807,11 @@ def register_directory_routes(app: Flask) -> None:
         ]
         verified_pgp_usernames = [username for username in pgp_usernames if username.is_verified]
         verified_info_usernames = [username for username in info_usernames if username.is_verified]
+        featured_usernames = [
+            username
+            for username in usernames
+            if username.is_verified and bool(getattr(username, "is_featured", False))
+        ]
         if app.config["DIRECTORY_VERIFIED_TAB_ENABLED"]:
             all_filter_metadata = _empty_all_filter_metadata()
             all_filter_state = {
@@ -830,6 +840,7 @@ def register_directory_routes(app: Flask) -> None:
             info_usernames=info_usernames,
             verified_pgp_usernames=verified_pgp_usernames,
             verified_info_usernames=verified_info_usernames,
+            featured_usernames=featured_usernames,
             attorney_usernames=filtered_attorney_usernames,
             public_record_all_listings=filtered_public_record_listings,
             public_record_listings=public_record_listings,

--- a/hushline/static/js/directory_verified.js
+++ b/hushline/static/js/directory_verified.js
@@ -91,10 +91,13 @@
     const directoryDataByTab = new Map();
     const directoryDataSearchByTab = new Map();
     const directoryDataRequestsByTab = new Map();
+    const directoryCardBioMaxLength = 250;
+    const featuredCarouselDurationMs = 7000;
     let hasRenderedSearch = false;
     let directoryDataRequestController = null;
     let directoryDataLoadingController = null;
     let loadedDirectorySearch = window.location.search;
+    let featuredCarouselCleanups = [];
 
     tabPanels.forEach((panel) => {
       initialMarkup.set(panel.id, panel.innerHTML);
@@ -451,6 +454,11 @@
         return badgeContainer;
       }
 
+      if (tab === "verified" && user.is_featured) {
+        badgeContainer +=
+          '<span class="badge" role="img" aria-label="Featured account">💎 Featured</span>';
+      }
+
       if (user.is_admin) {
         badgeContainer +=
           '<span class="badge" role="img" aria-label="Administrator account">⚙️ Admin</span>';
@@ -505,7 +513,34 @@
     `;
     }
 
-    function buildUserCard(user, query, tab) {
+    function directoryCardBio(text) {
+      if (!text || text.length <= directoryCardBioMaxLength) {
+        return {
+          isTruncated: false,
+          text: text || "",
+        };
+      }
+
+      return {
+        isTruncated: true,
+        text: `${text.slice(0, directoryCardBioMaxLength - 3)}`,
+      };
+    }
+
+    function buildFeaturedBio(user, query, safeProfileUrl) {
+      if (!user.bio) {
+        return "";
+      }
+
+      const featuredBio = directoryCardBio(user.bio);
+      const bioHighlighted = highlightMatch(featuredBio.text, query);
+      const moreLink = featuredBio.isTruncated
+        ? ` <a href="${safeProfileUrl}">more...</a>`
+        : "";
+      return `<p class="bio featured-directory-bio">${bioHighlighted}${moreLink}</p>`;
+    }
+
+    function buildUserCard(user, query, tab, options = {}) {
       const safeDisplayName = userSearch.escapeHtml(
         user.display_name || user.primary_username || "",
       );
@@ -517,7 +552,11 @@
         query,
       );
       const usernameHighlighted = highlightMatch(user.primary_username, query);
-      const bioHighlighted = user.bio ? highlightMatch(user.bio, query) : "";
+      const bioMarkup = options.featuredCarousel
+        ? buildFeaturedBio(user, query, safeProfileUrl)
+        : user.bio
+          ? `<p class="bio">${highlightMatch(user.bio, query)}</p>`
+          : "";
 
       if (
         user.is_public_record ||
@@ -539,12 +578,205 @@
         <h3>${displayNameHighlighted}</h3>
         <p class="meta">@${usernameHighlighted}</p>
         ${badges ? `<div class="badgeContainer">${badges}</div>` : ""}
-        ${bioHighlighted ? `<p class="bio">${bioHighlighted}</p>` : ""}
+        ${bioMarkup}
         <div class="user-actions">
           <a href="${safeProfileUrl}" aria-label="${safeDisplayName}'s profile">View Profile</a>
         </div>
       </article>
     `;
+    }
+
+    function isPromotableFeaturedUser(user, tab) {
+      return (
+        tab === "verified" &&
+        user.is_featured &&
+        user.is_verified &&
+        !user.is_public_record &&
+        !user.is_globaleaks &&
+        !user.is_newsroom &&
+        !user.is_securedrop
+      );
+    }
+
+    function buildFeaturedCarousel(users, query, tab) {
+      const featuredUsers = users.filter((user) =>
+        isPromotableFeaturedUser(user, tab),
+      );
+      if (!featuredUsers.length) {
+        return "";
+      }
+
+      const slideMarkup = featuredUsers
+        .map(
+          (user, index) => `
+          <div
+            class="featured-directory-slide${index === 0 ? " active" : ""}"
+            data-featured-slide
+            aria-hidden="${index === 0 ? "false" : "true"}"
+          >
+            ${buildUserCard(user, query, tab, { featuredCarousel: true })}
+          </div>
+        `,
+        )
+        .join("");
+
+      const controlsMarkup =
+        featuredUsers.length > 1
+          ? `
+          <div class="featured-directory-controls">
+            <div></div>
+            <div class="featured-directory-dots" role="tablist" aria-label="Featured accounts">
+              ${featuredUsers
+                .map(
+                  (_user, index) => `
+                    <button
+                      type="button"
+                      class="featured-directory-dot${index === 0 ? " active" : ""}"
+                      aria-label="Show featured account ${index + 1} of ${featuredUsers.length}"
+                      aria-selected="${index === 0 ? "true" : "false"}"
+                      data-featured-dot
+                      data-featured-index="${index}"
+                    ></button>
+                  `,
+                )
+                .join("")}
+            </div>
+          </div>
+        `
+          : "";
+
+      return `
+      <section class="featured-directory" aria-label="Featured verified accounts" data-featured-carousel>
+        <div class="featured-directory-track">
+          ${slideMarkup}
+        </div>
+        ${controlsMarkup}
+      </section>
+    `;
+    }
+
+    function clearFeaturedCarouselTimers() {
+      featuredCarouselCleanups.forEach((cleanup) => cleanup());
+      featuredCarouselCleanups = [];
+    }
+
+    function initializeFeaturedCarousels() {
+      clearFeaturedCarouselTimers();
+
+      document
+        .querySelectorAll("[data-featured-carousel]")
+        .forEach((carousel) => {
+          const slides = Array.from(
+            carousel.querySelectorAll("[data-featured-slide]"),
+          );
+          const dots = Array.from(
+            carousel.querySelectorAll("[data-featured-dot]"),
+          );
+          if (slides.length < 2 || dots.length < 2) {
+            return;
+          }
+
+          const prefersReducedMotion = window.matchMedia(
+            "(prefers-reduced-motion: reduce)",
+          ).matches;
+          let activeIndex = Math.max(
+            0,
+            slides.findIndex((slide) => slide.classList.contains("active")),
+          );
+          let autoAdvanceTimer = null;
+          let progressFrame = null;
+          let progressStartedAt = 0;
+          let touchStartX = null;
+
+          const setProgress = (progress) => {
+            dots.forEach((dot, index) => {
+              dot.style.setProperty(
+                "--featured-dot-progress",
+                index === activeIndex ? `${progress * 100}%` : "0%",
+              );
+            });
+          };
+
+          const stopProgress = () => {
+            if (autoAdvanceTimer) {
+              window.clearTimeout(autoAdvanceTimer);
+              autoAdvanceTimer = null;
+            }
+            if (progressFrame) {
+              window.cancelAnimationFrame(progressFrame);
+              progressFrame = null;
+            }
+          };
+
+          const scheduleAutoAdvance = () => {
+            stopProgress();
+            setProgress(0);
+            if (prefersReducedMotion) {
+              return;
+            }
+
+            progressStartedAt = performance.now();
+            const updateProgress = (timestamp) => {
+              const elapsed = timestamp - progressStartedAt;
+              setProgress(Math.min(elapsed / featuredCarouselDurationMs, 1));
+              progressFrame = window.requestAnimationFrame(updateProgress);
+            };
+
+            progressFrame = window.requestAnimationFrame(updateProgress);
+            autoAdvanceTimer = window.setTimeout(() => {
+              showSlide(activeIndex + 1);
+            }, featuredCarouselDurationMs);
+          };
+
+          const showSlide = (nextIndex) => {
+            activeIndex = (nextIndex + slides.length) % slides.length;
+            slides.forEach((slide, index) => {
+              const isActive = index === activeIndex;
+              slide.classList.toggle("active", isActive);
+              slide.setAttribute("aria-hidden", isActive ? "false" : "true");
+            });
+            dots.forEach((dot, index) => {
+              const isActive = index === activeIndex;
+              dot.classList.toggle("active", isActive);
+              dot.setAttribute("aria-selected", isActive ? "true" : "false");
+            });
+            scheduleAutoAdvance();
+          };
+
+          dots.forEach((dot) => {
+            dot.addEventListener("click", () => {
+              showSlide(Number(dot.dataset.featuredIndex || 0));
+            });
+          });
+
+          carousel.addEventListener(
+            "touchstart",
+            (event) => {
+              touchStartX = event.changedTouches[0]?.clientX ?? null;
+            },
+            { passive: true },
+          );
+
+          carousel.addEventListener(
+            "touchend",
+            (event) => {
+              if (touchStartX === null) {
+                return;
+              }
+              const touchEndX = event.changedTouches[0]?.clientX ?? touchStartX;
+              const deltaX = touchEndX - touchStartX;
+              touchStartX = null;
+              if (Math.abs(deltaX) < 40) {
+                return;
+              }
+              showSlide(activeIndex + (deltaX < 0 ? 1 : -1));
+            },
+            { passive: true },
+          );
+
+          scheduleAutoAdvance();
+          featuredCarouselCleanups.push(stopProgress);
+        });
     }
 
     function appendSection(panel, label, users, query, tab) {
@@ -602,8 +834,24 @@
       }
 
       if (tab === "verified") {
-        appendSection(panel, "", withPgp, query, tab);
-        appendSection(panel, "📇 Info-Only Accounts", infoOnly, query, tab);
+        panel.insertAdjacentHTML(
+          "beforeend",
+          buildFeaturedCarousel(users, query, tab),
+        );
+        appendSection(
+          panel,
+          "",
+          withPgp.filter((user) => !isPromotableFeaturedUser(user, tab)),
+          query,
+          tab,
+        );
+        appendSection(
+          panel,
+          "📇 Info-Only Accounts",
+          infoOnly.filter((user) => !isPromotableFeaturedUser(user, tab)),
+          query,
+          tab,
+        );
         return;
       }
 
@@ -618,6 +866,7 @@
       }
 
       renderPanelContent(panel, users, query, tab);
+      initializeFeaturedCarousels();
     }
 
     function panelIntroMarkup(panelId) {
@@ -676,6 +925,7 @@
       if (query.length === 0) {
         if (panel && initialMarkup.has(panel.id)) {
           panel.innerHTML = initialMarkup.get(panel.id);
+          initializeFeaturedCarousels();
         }
         if (hasRenderedSearch) {
           setSearchStatus(`Showing all ${currentScopeLabel}.`);

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -3,6 +3,80 @@
 {% block title %}Directory{% endblock %}
 {% block body_class %}directory-page{% endblock %}
 
+{% macro verified_user_card(username) %}
+  <article class="user">
+    <h3>{{ username.display_name or username.username }}</h3>
+    {% if username.username %}
+      <p class="meta">@{{ username.username }}</p>
+    {% endif %}
+    {% set is_featured = username.is_featured | default(false) %}
+    {% if is_featured or username.is_verified or username.user.is_admin %}
+      <div class="badgeContainer">
+        {% if is_featured %}
+          <span class="badge" role="img" aria-label="Featured account">💎 Featured</span>
+        {% endif %}
+        {% if username.user.is_admin %}
+          <span class="badge" role="img" aria-label="Administrator account">⚙️ Admin</span>
+        {% endif %}
+        {% if username.is_verified %}
+          <span class="badge" role="img" aria-label="Verified account">⭐️ Verified</span>
+        {% endif %}
+      </div>
+    {% endif %}
+    {% if username.bio %}
+      <p class="bio">{{ username.bio }}</p>
+    {% endif %}
+    <div class="user-actions">
+      <a
+        href="{{ url_for('profile', username=username.username) }}"
+        aria-label="{{ (username.display_name or username.username) }}'s profile"
+        >View Profile</a
+      >
+    </div>
+  </article>
+{% endmacro %}
+
+{% macro featured_user_card(username) %}
+  <article class="user">
+    <h3>{{ username.display_name or username.username }}</h3>
+    {% if username.username %}
+      <p class="meta">@{{ username.username }}</p>
+    {% endif %}
+    {% set is_featured = username.is_featured | default(false) %}
+    {% if is_featured or username.is_verified or username.user.is_admin %}
+      <div class="badgeContainer">
+        {% if is_featured %}
+          <span class="badge" role="img" aria-label="Featured account">💎 Featured</span>
+        {% endif %}
+        {% if username.user.is_admin %}
+          <span class="badge" role="img" aria-label="Administrator account">⚙️ Admin</span>
+        {% endif %}
+        {% if username.is_verified %}
+          <span class="badge" role="img" aria-label="Verified account">⭐️ Verified</span>
+        {% endif %}
+      </div>
+    {% endif %}
+    {% if username.bio %}
+      {% set featured_bio = truncate_directory_bio(username.bio) %}
+      <p class="bio featured-directory-bio">
+        {%- if featured_bio != username.bio and featured_bio.endswith("...") -%}
+          {{ featured_bio[:featured_bio|length - 3] }}
+          <a href="{{ url_for('profile', username=username.username) }}">more...</a>
+        {%- else -%}
+          {{ featured_bio }}
+        {%- endif -%}
+      </p>
+    {% endif %}
+    <div class="user-actions">
+      <a
+        href="{{ url_for('profile', username=username.username) }}"
+        aria-label="{{ (username.display_name or username.username) }}'s profile"
+        >View Profile</a
+      >
+    </div>
+  </article>
+{% endmacro %}
+
 {% block content %}
   <h2 id="directory-title">Whistleblower Support Directory</h2>
 
@@ -530,66 +604,53 @@
         </p>
       {% endif %}
 
-      <div class="user-list">
-        {% for username in verified_pgp_usernames %}
-          <article class="user">
-            <h3>{{ username.display_name or username.username }}</h3>
-            {% if username.username %}
-              <p class="meta">@{{ username.username }}</p>
-            {% endif %}
-            {% if username.is_verified or username.user.is_admin %}
-              <div class="badgeContainer">
-                {% if username.user.is_admin %}
-                  <span class="badge" role="img" aria-label="Administrator account">⚙️ Admin</span>
-                {% endif %}
-                {% if username.is_verified %}
-                  <span class="badge" role="img" aria-label="Verified account">⭐️ Verified</span>
-                {% endif %}
-              </div>
-            {% endif %}
-            {% if username.bio %}
-              <p class="bio">{{ username.bio }}</p>
-            {% endif %}
-            <div class="user-actions">
-              <a
-                href="{{ url_for('profile', username=username.username) }}"
-                aria-label="{{ (username.display_name or username.username) }}'s profile"
-                >View Profile</a
+      {% if featured_usernames %}
+        <section
+          class="featured-directory"
+          aria-label="Featured verified accounts"
+          data-featured-carousel
+        >
+          <div class="featured-directory-track">
+            {% for username in featured_usernames %}
+              <div
+                class="featured-directory-slide{% if loop.first %} active{% endif %}"
+                data-featured-slide
+                aria-hidden="{{ 'false' if loop.first else 'true' }}"
               >
+                {{ featured_user_card(username) }}
+              </div>
+            {% endfor %}
+          </div>
+          {% if featured_usernames|length > 1 %}
+            <div class="featured-directory-controls">
+              <div></div>
+              <div class="featured-directory-dots" role="tablist" aria-label="Featured accounts">
+                {% for username in featured_usernames %}
+                  <button
+                    type="button"
+                    class="featured-directory-dot{% if loop.first %} active{% endif %}"
+                    aria-label="Show featured account {{ loop.index }} of {{ featured_usernames|length }}"
+                    aria-selected="{{ 'true' if loop.first else 'false' }}"
+                    data-featured-dot
+                    data-featured-index="{{ loop.index0 }}"
+                  ></button>
+                {% endfor %}
+              </div>
             </div>
-          </article>
+          {% endif %}
+        </section>
+      {% endif %}
+
+      <div class="user-list">
+        {% for username in verified_pgp_usernames if not (username.is_featured | default(false)) %}
+          {{ verified_user_card(username) }}
         {% endfor %}
       </div>
       {% if verified_info_usernames %}
         <p class="label">📇 Info-Only Accounts</p>
         <div class="user-list">
-          {% for username in verified_info_usernames %}
-            <article class="user">
-              <h3>{{ username.display_name or username.username }}</h3>
-              {% if username.username %}
-                <p class="meta">@{{ username.username }}</p>
-              {% endif %}
-              {% if username.is_verified or username.user.is_admin %}
-                <div class="badgeContainer">
-                  {% if username.user.is_admin %}
-                    <span class="badge" role="img" aria-label="Administrator account">⚙️ Admin</span>
-                  {% endif %}
-                  {% if username.is_verified %}
-                    <span class="badge" role="img" aria-label="Verified account">⭐️ Verified</span>
-                  {% endif %}
-                </div>
-              {% endif %}
-              {% if username.bio %}
-                <p class="bio">{{ username.bio }}</p>
-              {% endif %}
-              <div class="user-actions">
-                <a
-                  href="{{ url_for('profile', username=username.username) }}"
-                  aria-label="{{ (username.display_name or username.username) }}'s profile"
-                  >View Profile</a
-                >
-              </div>
-            </article>
+          {% for username in verified_info_usernames if not (username.is_featured | default(false)) %}
+            {{ verified_user_card(username) }}
           {% endfor %}
         </div>
       {% endif %}

--- a/hushline/templates/settings/admin.html
+++ b/hushline/templates/settings/admin.html
@@ -83,6 +83,9 @@
           Verified: {{ "✅ Yes" if username.is_verified else "👎 No" }}
         </p>
         <p class="meta">
+          Featured: {{ "✅ Yes" if username.is_featured else "👎 No" }}
+        </p>
+        <p class="meta">
           Admin: {{ "✅ Yes" if username.user.is_admin else "👎 No" }}
         </p>
         <p class="meta">
@@ -112,6 +115,21 @@
               </button>
             </form>
           {% endif %}
+          <form
+            action="{{ url_for('admin.toggle_featured_username', username_id=username.id) }}"
+            method="POST"
+            class="formBody"
+          >
+            <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
+            <input
+              type="hidden"
+              name="is_featured"
+              value="{{ 'false' if username.is_featured else 'true' }}"
+            />
+            <button type="submit">
+              {{ "Remove Featured" if username.is_featured else "Set Featured" }}
+            </button>
+          </form>
           <form
             action="{{ url_for('admin.toggle_admin', user_id=username.user.id) }}"
             method="POST"

--- a/migrations/versions/e3b7c1a9d2f4_add_featured_usernames.py
+++ b/migrations/versions/e3b7c1a9d2f4_add_featured_usernames.py
@@ -1,0 +1,33 @@
+"""add featured usernames
+
+Revision ID: e3b7c1a9d2f4
+Revises: b2039e7c0a1d
+Create Date: 2026-05-31 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = "e3b7c1a9d2f4"
+down_revision = "b2039e7c0a1d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("usernames", schema=None) as batch_op:
+        batch_op.add_column(
+            sa.Column(
+                "is_featured",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.text("false"),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("usernames", schema=None) as batch_op:
+        batch_op.drop_column("is_featured")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -39,6 +39,8 @@ def test_admin_settings_includes_user_search(app: Flask, client: FlaskClient) ->
     assert search_form.select_one('input[name="q"]') is not None
     assert "Set Cautious" in response.text
     assert "Set Suspended" in response.text
+    assert "Set Featured" in response.text
+    assert "Featured:" in response.text
     assert "Account Category:" in response.text
 
     account_category_form = soup.select_one(
@@ -236,6 +238,22 @@ def test_toggle_verified_alias_on_managed_service(
     refreshed_alias = db.session.get(Username, user_alias.id)
     assert refreshed_alias is not None
     assert refreshed_alias.is_verified is True
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_toggle_featured_username(client: FlaskClient, user_alias: Username) -> None:
+    assert user_alias.is_featured is False
+
+    response = client.post(
+        url_for("admin.toggle_featured_username", username_id=user_alias.id),
+        data={"is_featured": "true"},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    refreshed_alias = db.session.get(Username, user_alias.id)
+    assert refreshed_alias is not None
+    assert refreshed_alias.is_featured is True
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -150,6 +150,7 @@ def _directory_username(  # noqa: PLR0913
     display_name: str,
     bio: str = "",
     is_verified: bool = False,
+    is_featured: bool = False,
     is_admin: bool = False,
     pgp_key: str = "pgp-key",
     account_category: str | None = None,
@@ -162,6 +163,7 @@ def _directory_username(  # noqa: PLR0913
         display_name=display_name,
         bio=bio,
         is_verified=is_verified,
+        is_featured=is_featured,
         user=SimpleNamespace(
             is_admin=is_admin,
             is_cautious=False,
@@ -289,6 +291,73 @@ def test_directory_accessible(client: FlaskClient) -> None:
     assert "tab-content active" in " ".join(verified_panel.get("class", []))
     assert all_panel.get("data-lazy-directory-panel") == "true"
     assert not all_panel.select("article.user")
+
+
+def test_directory_verified_tab_promotes_featured_users_first(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    long_bio = "A" * (directory_routes.Username.BIO_MAX_LENGTH + 10)
+    featured_user = _directory_username(
+        username="featured-user",
+        display_name="Featured User",
+        bio=long_bio,
+        is_verified=True,
+        is_featured=True,
+    )
+    second_featured_user = _directory_username(
+        username="second-featured-user",
+        display_name="Second Featured User",
+        is_verified=True,
+        is_featured=True,
+    )
+    admin_user = _directory_username(
+        username="admin-user",
+        display_name="Admin User",
+        is_verified=True,
+        is_admin=True,
+    )
+    monkeypatch.setattr(
+        "hushline.routes.directory.get_directory_usernames",
+        lambda: (featured_user, second_featured_user, admin_user),
+    )
+    monkeypatch.setattr("hushline.routes.directory.get_public_record_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_securedrop_directory_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
+
+    response = client.get(url_for("directory"))
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+    verified_panel = soup.find(id="verified")
+    assert verified_panel is not None
+
+    featured_section = verified_panel.select_one("[data-featured-carousel]")
+    assert featured_section is not None
+    first_card = verified_panel.select_one("article.user")
+    assert first_card is not None
+    first_card_heading = first_card.select_one("h3")
+    assert first_card_heading is not None
+    assert first_card_heading.get_text(strip=True) == "Featured User"
+    assert first_card.find_previous("article.user") is None
+    assert len(featured_section.select("[data-featured-dot]")) == 2
+    assert not featured_section.select("[data-featured-slide][hidden]")
+    more_link = first_card.select_one(".featured-directory-bio a")
+    assert more_link is not None
+    assert more_link.get_text(strip=True) == "more..."
+    assert more_link["href"] == url_for("profile", username="featured-user")
+    assert long_bio not in first_card.get_text(" ", strip=True)
+
+    badges = first_card.select(".badgeContainer .badge")
+    assert [badge.get("aria-label") for badge in badges[:2]] == [
+        "Featured account",
+        "Verified account",
+    ]
+
+    normal_cards = verified_panel.select(".user-list article.user")
+    assert len(normal_cards) == 1
+    normal_card_heading = normal_cards[0].select_one("h3")
+    assert normal_card_heading is not None
+    assert normal_card_heading.get_text(strip=True) == "Admin User"
 
 
 def test_directory_public_record_banner_links_to_admin(client: FlaskClient) -> None:
@@ -521,6 +590,7 @@ def test_directory_users_json_includes_display_name_fallback_and_flags(
     admin_user.primary_username._display_name = None
     admin_user.primary_username.bio = "admin bio"
     admin_user.primary_username.is_verified = True
+    admin_user.primary_username.is_featured = True
     db.session.commit()
 
     response = client.get(url_for("directory_users"))
@@ -536,6 +606,7 @@ def test_directory_users_json_includes_display_name_fallback_and_flags(
     assert admin_row["account_category_label"] is None
     assert admin_row["is_admin"] is True
     assert admin_row["is_verified"] is True
+    assert admin_row["is_featured"] is True
     assert admin_row["show_caution_badge"] is False
     assert isinstance(admin_row["has_pgp_key"], bool)
     assert admin_row["is_globaleaks"] is False

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -36,6 +36,7 @@ SKIPPABLE_REVISIONS = [
     "f32aa741ddc4",  # simple add/drop on columns, no data migrated
     "7b9c2d1e4f60",  # simple add/drop on columns, no data migrated
     "a4c8f2d9e713",  # simple table create/drop, no data migrated
+    "e3b7c1a9d2f4",  # simple add/drop on columns, no data migrated
 ]
 DISALLOWED_DOWNGRADES = [
     "4a53667aff6e",  # downgrading is disabled to prevent accidental data loss


### PR DESCRIPTION
## What changed
- Added an admin-controlled Featured flag on usernames, including a migration and Settings -> Admin controls.
- Promoted featured verified usernames to a first-card carousel on the Directory Verified tab, with Featured shown before Verified in the badge row.
- Added carousel dots, touch swipe navigation, and auto-advance progress shown in the active pagination dot.
- Updated directory JSON/search rendering, static assets, tests, and the canonical use-case docs.

## Why
Admins need a way to prioritize trusted verified recipients without changing the broader directory ordering or exposing the feature outside the Verified tab.

## Security and risk
- Affected data paths: public directory metadata and admin account-management actions only.
- Whistleblower disclosure, inbox, encryption, and notification paths are unchanged.
- The new mutation is admin-only, POST-only, CSRF-validated, and stores a boolean public directory ranking signal.
- No CSP changes or broadened external sources.

## Validation
- Dependabot pre-check: no open Dependabot PRs returned by `gh pr list --author app/dependabot --state open --json number,title,url`.
- `./scripts/agent_issue_bootstrap.sh`
- `make lint` attempted, blocked before lint by Compose `dev_data` dependency exiting 2.
- `docker compose run --rm --no-deps app poetry run ruff format --check`
- `docker compose run --rm --no-deps app poetry run ruff check --output-format full`
- `docker compose run --rm --no-deps app poetry run mypy .`
- `./node_modules/.bin/prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js`
- `./node_modules/.bin/webpack --config webpack.config.js --env WEBPACK_WATCH=true`
- `docker compose run --rm --no-deps app poetry run pytest --cov hushline --cov-report term-missing --cov-report html:/tmp/hushline-htmlcov -vv -m "not external_network" ./tests/` passed: 2049 passed, 1 deselected, 1 xfailed.
- `docker compose run --rm --no-deps app poetry run pytest --cov hushline --cov-report term-missing --cov-report html:/tmp/hushline-htmlcov -vv -m "not external_network" tests/test_admin.py tests/test_directory.py tests/test_frontend_compat.py` passed: 193 passed, 1 deselected.
- `docker compose run --rm --no-deps app poetry run pytest -q -m "not external_network" tests/test_directory.py::test_directory_verified_tab_promotes_featured_users_first tests/test_frontend_compat.py::test_static_js_bundles_avoid_eval_wrappers` passed: 2 passed.
- `make audit-python` attempted, blocked before audit by Compose `dev_data` dependency exiting 2.
- `docker compose run --rm --no-deps app bash -lc "poetry self add poetry-plugin-export && poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt && python -m pip install --disable-pip-version-check pip-audit==2.10.0 && pip-audit -r /tmp/requirements.txt"` passed: no known vulnerabilities found.
- `make audit-node-runtime` attempted, blocked before audit by Compose `dev_data` dependency exiting 2.
- `docker compose run --rm --no-deps app npm audit --omit=dev --package-lock-only` passed: 0 vulnerabilities.
- `git diff --check`

## Manual testing
Not run in a browser. The Directory server-rendered markup, async search data/rendering hooks, admin toggle route, and static bundle compatibility are covered by the tests above.

## Known risks or follow-ups
- The Makefile wrappers that start the full Compose dependency graph are currently blocked locally by the `dev_data` service exiting 2; direct no-dependency app-container equivalents passed.

Closes #2120
