### PR TITLE
Improve featured directory carousel

### DIFF
--- a/assets/js/directory_verified.js
+++ b/assets/js/directory_verified.js
@@ -597,6 +597,40 @@ document.addEventListener("DOMContentLoaded", function () {
     featuredCarouselCleanups = [];
   }
 
+  function featuredFocusableElements(slide) {
+    return slide.querySelectorAll(
+      "a, button, input, select, textarea, [tabindex], [data-featured-had-tabindex], [data-featured-original-tabindex]",
+    );
+  }
+
+  function setFeaturedSlideInteractive(slide, isInteractive) {
+    if (isInteractive) {
+      slide.removeAttribute("inert");
+      featuredFocusableElements(slide).forEach((element) => {
+        if (element.dataset.featuredOriginalTabindex !== undefined) {
+          element.setAttribute("tabindex", element.dataset.featuredOriginalTabindex);
+          delete element.dataset.featuredOriginalTabindex;
+        } else if (element.dataset.featuredHadTabindex === "false") {
+          element.removeAttribute("tabindex");
+          delete element.dataset.featuredHadTabindex;
+        }
+      });
+      return;
+    }
+
+    slide.setAttribute("inert", "");
+    featuredFocusableElements(slide).forEach((element) => {
+      if (element.dataset.featuredHadTabindex === undefined) {
+        if (element.hasAttribute("tabindex")) {
+          element.dataset.featuredOriginalTabindex = element.getAttribute("tabindex");
+        } else {
+          element.dataset.featuredHadTabindex = "false";
+        }
+      }
+      element.setAttribute("tabindex", "-1");
+    });
+  }
+
   function initializeFeaturedCarousels() {
     clearFeaturedCarouselTimers();
 
@@ -675,8 +709,10 @@ document.addEventListener("DOMContentLoaded", function () {
           const isActive = index === activeIndex;
           slide.classList.toggle("active", isActive);
           slide.setAttribute("aria-hidden", isActive ? "false" : "true");
+          setFeaturedSlideInteractive(slide, isActive);
         });
       };
+      setActiveSlideState();
 
       const stopProgress = () => {
         if (autoAdvanceTimer) {

--- a/assets/js/directory_verified.js
+++ b/assets/js/directory_verified.js
@@ -582,8 +582,10 @@ document.addEventListener("DOMContentLoaded", function () {
 
     return `
       <section class="featured-directory" aria-label="Featured verified accounts" data-featured-carousel>
-        <div class="featured-directory-track">
-          ${slideMarkup}
+        <div class="featured-directory-window" data-featured-window>
+          <div class="featured-directory-track" data-featured-track>
+            ${slideMarkup}
+          </div>
         </div>
         ${controlsMarkup}
       </section>
@@ -599,11 +601,32 @@ document.addEventListener("DOMContentLoaded", function () {
     clearFeaturedCarouselTimers();
 
     document.querySelectorAll("[data-featured-carousel]").forEach((carousel) => {
+      const track = carousel.querySelector("[data-featured-track]");
+      const windowEl = carousel.querySelector("[data-featured-window]");
       const slides = Array.from(carousel.querySelectorAll("[data-featured-slide]"));
       const dots = Array.from(carousel.querySelectorAll("[data-featured-dot]"));
-      if (slides.length < 2 || dots.length < 2) {
+      if (!track || !windowEl || slides.length < 2 || dots.length < 2) {
         return;
       }
+
+      track.querySelectorAll("[data-featured-clone]").forEach((clone) => clone.remove());
+
+      const firstClone = slides[0].cloneNode(true);
+      const lastClone = slides[slides.length - 1].cloneNode(true);
+      [firstClone, lastClone].forEach((clone) => {
+        clone.classList.remove("active");
+        clone.removeAttribute("data-featured-slide");
+        clone.setAttribute("data-featured-clone", "");
+        clone.setAttribute("aria-hidden", "true");
+        clone.setAttribute("inert", "");
+        clone.querySelectorAll("a, button, input, select, textarea").forEach((element) => {
+          element.setAttribute("tabindex", "-1");
+        });
+      });
+      track.insertBefore(lastClone, slides[0]);
+      track.appendChild(firstClone);
+      carousel.classList.add("is-enhanced");
+      const visualSlides = Array.from(track.querySelectorAll(".featured-directory-slide"));
 
       const prefersReducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)")
         .matches;
@@ -615,6 +638,7 @@ document.addEventListener("DOMContentLoaded", function () {
       let progressFrame = null;
       let progressStartedAt = 0;
       let touchStartX = null;
+      let pendingSnapIndex = null;
 
       const setProgress = (progress) => {
         dots.forEach((dot, index) => {
@@ -622,6 +646,35 @@ document.addEventListener("DOMContentLoaded", function () {
             "--featured-dot-progress",
             index === activeIndex ? `${progress * 100}%` : "0%",
           );
+        });
+      };
+
+      const setTrackPosition = (visualIndex, options = {}) => {
+        const animate = options.animate !== false && !prefersReducedMotion;
+        const previousTransition = track.style.transition;
+        if (!animate) {
+          track.style.transition = "none";
+        }
+
+        const trackStyles = window.getComputedStyle(track);
+        const gap =
+          Number.parseFloat(trackStyles.columnGap || trackStyles.gap || "0") || 0;
+        const slideWidth = visualSlides[0]?.getBoundingClientRect().width || 0;
+        const windowWidth = windowEl.getBoundingClientRect().width;
+        const offset = (windowWidth - slideWidth) / 2 - visualIndex * (slideWidth + gap);
+        track.style.transform = `translateX(${offset}px)`;
+
+        if (!animate) {
+          track.getBoundingClientRect();
+          track.style.transition = previousTransition;
+        }
+      };
+
+      const setActiveSlideState = () => {
+        slides.forEach((slide, index) => {
+          const isActive = index === activeIndex;
+          slide.classList.toggle("active", isActive);
+          slide.setAttribute("aria-hidden", isActive ? "false" : "true");
         });
       };
 
@@ -657,19 +710,36 @@ document.addEventListener("DOMContentLoaded", function () {
       };
 
       const showSlide = (nextIndex) => {
+        const previousIndex = activeIndex;
         activeIndex = (nextIndex + slides.length) % slides.length;
-        slides.forEach((slide, index) => {
-          const isActive = index === activeIndex;
-          slide.classList.toggle("active", isActive);
-          slide.setAttribute("aria-hidden", isActive ? "false" : "true");
-        });
+        let visualIndex = activeIndex + 1;
+        pendingSnapIndex = null;
+        if (previousIndex === slides.length - 1 && nextIndex >= slides.length) {
+          visualIndex = slides.length + 1;
+          pendingSnapIndex = activeIndex + 1;
+        } else if (previousIndex === 0 && nextIndex < 0) {
+          visualIndex = 0;
+          pendingSnapIndex = activeIndex + 1;
+        }
+
+        setActiveSlideState();
         dots.forEach((dot, index) => {
           const isActive = index === activeIndex;
           dot.classList.toggle("active", isActive);
           dot.setAttribute("aria-selected", isActive ? "true" : "false");
         });
+        setTrackPosition(visualIndex, { animate: true });
         scheduleAutoAdvance();
       };
+
+      const handleTrackTransitionEnd = (event) => {
+        if (event.target !== track || pendingSnapIndex === null) {
+          return;
+        }
+        setTrackPosition(pendingSnapIndex, { animate: false });
+        pendingSnapIndex = null;
+      };
+      track.addEventListener("transitionend", handleTrackTransitionEnd);
 
       dots.forEach((dot) => {
         dot.addEventListener("click", () => {
@@ -703,7 +773,18 @@ document.addEventListener("DOMContentLoaded", function () {
       );
 
       scheduleAutoAdvance();
-      featuredCarouselCleanups.push(stopProgress);
+      setActiveSlideState();
+      setTrackPosition(activeIndex + 1, { animate: false });
+
+      const handleResize = () => {
+        setTrackPosition(activeIndex + 1, { animate: false });
+      };
+      window.addEventListener("resize", handleResize);
+      featuredCarouselCleanups.push(() => {
+        stopProgress();
+        track.removeEventListener("transitionend", handleTrackTransitionEnd);
+        window.removeEventListener("resize", handleResize);
+      });
     });
   }
 

--- a/assets/js/directory_verified.js
+++ b/assets/js/directory_verified.js
@@ -560,7 +560,7 @@ document.addEventListener("DOMContentLoaded", function () {
         ? `
           <div class="featured-directory-controls">
             <div></div>
-            <div class="featured-directory-dots" role="tablist" aria-label="Featured accounts">
+            <div class="featured-directory-dots" role="group" aria-label="Featured accounts">
               ${featuredUsers
                 .map(
                   (_user, index) => `
@@ -568,7 +568,7 @@ document.addEventListener("DOMContentLoaded", function () {
                       type="button"
                       class="featured-directory-dot${index === 0 ? " active" : ""}"
                       aria-label="Show featured account ${index + 1} of ${featuredUsers.length}"
-                      aria-selected="${index === 0 ? "true" : "false"}"
+                      ${index === 0 ? 'aria-current="true"' : ""}
                       data-featured-dot
                       data-featured-index="${index}"
                     ></button>
@@ -726,7 +726,11 @@ document.addEventListener("DOMContentLoaded", function () {
         dots.forEach((dot, index) => {
           const isActive = index === activeIndex;
           dot.classList.toggle("active", isActive);
-          dot.setAttribute("aria-selected", isActive ? "true" : "false");
+          if (isActive) {
+            dot.setAttribute("aria-current", "true");
+          } else {
+            dot.removeAttribute("aria-current");
+          }
         });
         setTrackPosition(visualIndex, { animate: true });
         scheduleAutoAdvance();

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2567,6 +2567,7 @@ img.alert {
 
 .featured-directory-dot.active {
   color: var(--color-brand);
+  width: 44px;
 }
 
 .featured-directory-dot.active::before {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2473,7 +2473,6 @@ img.alert {
 .featured-directory {
   --featured-carousel-gap: 0.75rem;
   --featured-carousel-peek: 2rem;
-  --featured-carousel-fade-bg: white;
   margin: 0 0 0.5rem 0;
   overflow: visible;
 }
@@ -2502,27 +2501,6 @@ img.alert {
   overflow: hidden;
 }
 
-.featured-directory.is-enhanced .featured-directory-window::before,
-.featured-directory.is-enhanced .featured-directory-window::after {
-  bottom: 0;
-  content: "";
-  pointer-events: none;
-  position: absolute;
-  top: 0;
-  width: calc(var(--featured-carousel-peek) + 0.5rem);
-  z-index: 2;
-}
-
-.featured-directory.is-enhanced .featured-directory-window::before {
-  background: linear-gradient(90deg, var(--featured-carousel-fade-bg) 0%, transparent 100%);
-  left: 0;
-}
-
-.featured-directory.is-enhanced .featured-directory-window::after {
-  background: linear-gradient(270deg, var(--featured-carousel-fade-bg) 0%, transparent 100%);
-  right: 0;
-}
-
 .featured-directory.is-enhanced .featured-directory-track {
   align-items: stretch;
   display: flex;
@@ -2542,6 +2520,7 @@ img.alert {
 }
 
 .featured-directory .user {
+  box-shadow: var(--shadow-dynamic);
   margin-bottom: 0;
   width: 100%;
 }
@@ -2608,10 +2587,6 @@ img.alert {
 }
 
 @media (prefers-color-scheme: dark) {
-  .featured-directory {
-    --featured-carousel-fade-bg: var(--color-dark-bg-alt);
-  }
-
   .featured-directory-dot {
     color: var(--color-border-dark);
   }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2471,7 +2471,14 @@ img.alert {
 }
 
 .featured-directory {
+  --featured-carousel-gap: 0.75rem;
+  --featured-carousel-peek: 2rem;
   margin: 0 0 0.5rem 0;
+  overflow: visible;
+}
+
+.featured-directory-window {
+  overflow: visible;
 }
 
 .featured-directory-track {
@@ -2483,9 +2490,32 @@ img.alert {
   grid-area: 1 / 1;
 }
 
-.featured-directory-slide:not(.active) {
+.featured-directory:not(.is-enhanced) .featured-directory-slide:not(.active) {
   pointer-events: none;
   visibility: hidden;
+}
+
+.featured-directory.is-enhanced .featured-directory-window {
+  margin-inline: calc(-1 * var(--featured-carousel-peek));
+  overflow: hidden;
+}
+
+.featured-directory.is-enhanced .featured-directory-track {
+  align-items: stretch;
+  display: flex;
+  gap: var(--featured-carousel-gap);
+  transition: transform 0.35s ease;
+  will-change: transform;
+}
+
+.featured-directory.is-enhanced .featured-directory-slide {
+  flex: 0 0 calc(100% - (2 * var(--featured-carousel-peek)));
+  grid-area: auto;
+  visibility: visible;
+}
+
+.featured-directory.is-enhanced .featured-directory-slide:not(.active) {
+  pointer-events: none;
 }
 
 .featured-directory .user {
@@ -2574,6 +2604,18 @@ img.alert {
         var(--featured-dot-progress) 100%
     );
     box-shadow: inset 0 0 0 1px var(--color-brand-dark-min-saturation);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .featured-directory.is-enhanced .featured-directory-track {
+    transition: none;
+  }
+}
+
+@media only screen and (max-width: 800px) {
+  .featured-directory {
+    --featured-carousel-peek: 1rem;
   }
 }
 

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2473,12 +2473,14 @@ img.alert {
 .featured-directory {
   --featured-carousel-gap: 0.75rem;
   --featured-carousel-peek: 2rem;
+  --featured-carousel-fade-bg: white;
   margin: 0 0 0.5rem 0;
   overflow: visible;
 }
 
 .featured-directory-window {
   overflow: visible;
+  position: relative;
 }
 
 .featured-directory-track {
@@ -2498,6 +2500,27 @@ img.alert {
 .featured-directory.is-enhanced .featured-directory-window {
   margin-inline: calc(-1 * var(--featured-carousel-peek));
   overflow: hidden;
+}
+
+.featured-directory.is-enhanced .featured-directory-window::before,
+.featured-directory.is-enhanced .featured-directory-window::after {
+  bottom: 0;
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  top: 0;
+  width: calc(var(--featured-carousel-peek) + 0.5rem);
+  z-index: 2;
+}
+
+.featured-directory.is-enhanced .featured-directory-window::before {
+  background: linear-gradient(90deg, var(--featured-carousel-fade-bg) 0%, transparent 100%);
+  left: 0;
+}
+
+.featured-directory.is-enhanced .featured-directory-window::after {
+  background: linear-gradient(270deg, var(--featured-carousel-fade-bg) 0%, transparent 100%);
+  right: 0;
 }
 
 .featured-directory.is-enhanced .featured-directory-track {
@@ -2585,6 +2608,10 @@ img.alert {
 }
 
 @media (prefers-color-scheme: dark) {
+  .featured-directory {
+    --featured-carousel-fade-bg: var(--color-dark-bg-alt);
+  }
+
   .featured-directory-dot {
     color: var(--color-border-dark);
   }

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -16,6 +16,10 @@ Each release stores images by session under `releases/<version>/<session>/`.
 - Path: [releases/one-off-directory/README.md](./releases/one-off-directory/README.md)
 - Latest alias: [releases/latest/README.md](./releases/latest/README.md)
 
+## Featured Directory
+
+![Directory featured carousel](./releases/latest/guest/guest-directory-featured-carousel-desktop-light-fold.png)
+
 ## Required accounts
 
 - admin (admin and org settings scenes)

--- a/docs/screenshots/scenes.json
+++ b/docs/screenshots/scenes.json
@@ -671,6 +671,16 @@
       "waitForSelector": "#verified.tab-content.active"
     },
     {
+      "slug": "guest-directory-featured-carousel",
+      "title": "Directory - Featured Carousel",
+      "path": "/directory",
+      "session": "guest",
+      "captureModes": ["fold"],
+      "viewports": ["desktop"],
+      "themes": ["light"],
+      "waitForSelector": "[data-featured-carousel].is-enhanced .featured-directory-slide.active"
+    },
+    {
       "slug": "guest-directory-attorneys-closed-filters",
       "title": "Directory - Attorneys (filters closed)",
       "path": "/directory",

--- a/hushline/routes/directory.py
+++ b/hushline/routes/directory.py
@@ -1,5 +1,6 @@
+import random
 import unicodedata
-from typing import Sequence, cast
+from typing import Sequence, TypeVar, cast
 from urllib.parse import urlencode
 
 from flask import (
@@ -61,6 +62,7 @@ _ALL_LISTING_TYPE_LABELS = (
     ("securedrop", "SecureDrop"),
     ("globaleaks", "GlobaLeaks"),
 )
+_FeaturedItem = TypeVar("_FeaturedItem")
 _DIRECTORY_CARD_BIO_ELLIPSIS = "..."
 _SELF_REPORTED_JOURNALISM_ACCOUNT_CATEGORIES = frozenset(
     {
@@ -451,6 +453,30 @@ def _directory_user_row(username: Username) -> dict[str, object | None]:
     }
 
 
+def _shuffle_featured_directory_items(items: Sequence[_FeaturedItem]) -> list[_FeaturedItem]:
+    shuffled_items = list(items)
+    random.shuffle(shuffled_items)
+    return shuffled_items
+
+
+def _featured_directory_usernames(usernames: Sequence[Username]) -> list[Username]:
+    return _shuffle_featured_directory_items(
+        [
+            username
+            for username in usernames
+            if username.is_verified and bool(getattr(username, "is_featured", False))
+        ]
+    )
+
+
+def _featured_directory_rows_first(
+    rows: Sequence[dict[str, object | None]],
+) -> list[dict[str, object | None]]:
+    featured_rows = [row for row in rows if row.get("is_featured") is True]
+    standard_rows = [row for row in rows if row.get("is_featured") is not True]
+    return [*_shuffle_featured_directory_items(featured_rows), *standard_rows]
+
+
 def _public_record_row(listing: PublicRecordListing) -> dict[str, object | None]:
     geography = listing.geography
     return {
@@ -807,11 +833,7 @@ def register_directory_routes(app: Flask) -> None:
         ]
         verified_pgp_usernames = [username for username in pgp_usernames if username.is_verified]
         verified_info_usernames = [username for username in info_usernames if username.is_verified]
-        featured_usernames = [
-            username
-            for username in usernames
-            if username.is_verified and bool(getattr(username, "is_featured", False))
-        ]
+        featured_usernames = _featured_directory_usernames(usernames)
         if app.config["DIRECTORY_VERIFIED_TAB_ENABLED"]:
             all_filter_metadata = _empty_all_filter_metadata()
             all_filter_state = {
@@ -1004,7 +1026,7 @@ def register_directory_routes(app: Flask) -> None:
             if username.is_verified
         ]
         if tab == "verified":
-            return verified_rows
+            return _featured_directory_rows_first(verified_rows)
 
         if tab == "globaleaks":
             return (

--- a/hushline/static/js/directory_verified.js
+++ b/hushline/static/js/directory_verified.js
@@ -625,7 +625,7 @@
           ? `
           <div class="featured-directory-controls">
             <div></div>
-            <div class="featured-directory-dots" role="tablist" aria-label="Featured accounts">
+            <div class="featured-directory-dots" role="group" aria-label="Featured accounts">
               ${featuredUsers
                 .map(
                   (_user, index) => `
@@ -633,7 +633,7 @@
                       type="button"
                       class="featured-directory-dot${index === 0 ? " active" : ""}"
                       aria-label="Show featured account ${index + 1} of ${featuredUsers.length}"
-                      aria-selected="${index === 0 ? "true" : "false"}"
+                      ${index === 0 ? 'aria-current="true"' : ""}
                       data-featured-dot
                       data-featured-index="${index}"
                     ></button>
@@ -811,7 +811,11 @@
             dots.forEach((dot, index) => {
               const isActive = index === activeIndex;
               dot.classList.toggle("active", isActive);
-              dot.setAttribute("aria-selected", isActive ? "true" : "false");
+              if (isActive) {
+                dot.setAttribute("aria-current", "true");
+              } else {
+                dot.removeAttribute("aria-current");
+              }
             });
             setTrackPosition(visualIndex, { animate: true });
             scheduleAutoAdvance();

--- a/hushline/static/js/directory_verified.js
+++ b/hushline/static/js/directory_verified.js
@@ -662,6 +662,44 @@
       featuredCarouselCleanups = [];
     }
 
+    function featuredFocusableElements(slide) {
+      return slide.querySelectorAll(
+        "a, button, input, select, textarea, [tabindex], [data-featured-had-tabindex], [data-featured-original-tabindex]",
+      );
+    }
+
+    function setFeaturedSlideInteractive(slide, isInteractive) {
+      if (isInteractive) {
+        slide.removeAttribute("inert");
+        featuredFocusableElements(slide).forEach((element) => {
+          if (element.dataset.featuredOriginalTabindex !== undefined) {
+            element.setAttribute(
+              "tabindex",
+              element.dataset.featuredOriginalTabindex,
+            );
+            delete element.dataset.featuredOriginalTabindex;
+          } else if (element.dataset.featuredHadTabindex === "false") {
+            element.removeAttribute("tabindex");
+            delete element.dataset.featuredHadTabindex;
+          }
+        });
+        return;
+      }
+
+      slide.setAttribute("inert", "");
+      featuredFocusableElements(slide).forEach((element) => {
+        if (element.dataset.featuredHadTabindex === undefined) {
+          if (element.hasAttribute("tabindex")) {
+            element.dataset.featuredOriginalTabindex =
+              element.getAttribute("tabindex");
+          } else {
+            element.dataset.featuredHadTabindex = "false";
+          }
+        }
+        element.setAttribute("tabindex", "-1");
+      });
+    }
+
     function initializeFeaturedCarousels() {
       clearFeaturedCarouselTimers();
 
@@ -757,8 +795,10 @@
               const isActive = index === activeIndex;
               slide.classList.toggle("active", isActive);
               slide.setAttribute("aria-hidden", isActive ? "false" : "true");
+              setFeaturedSlideInteractive(slide, isActive);
             });
           };
+          setActiveSlideState();
 
           const stopProgress = () => {
             if (autoAdvanceTimer) {

--- a/hushline/static/js/directory_verified.js
+++ b/hushline/static/js/directory_verified.js
@@ -647,8 +647,10 @@
 
       return `
       <section class="featured-directory" aria-label="Featured verified accounts" data-featured-carousel>
-        <div class="featured-directory-track">
-          ${slideMarkup}
+        <div class="featured-directory-window" data-featured-window>
+          <div class="featured-directory-track" data-featured-track>
+            ${slideMarkup}
+          </div>
         </div>
         ${controlsMarkup}
       </section>
@@ -666,15 +668,42 @@
       document
         .querySelectorAll("[data-featured-carousel]")
         .forEach((carousel) => {
+          const track = carousel.querySelector("[data-featured-track]");
+          const windowEl = carousel.querySelector("[data-featured-window]");
           const slides = Array.from(
             carousel.querySelectorAll("[data-featured-slide]"),
           );
           const dots = Array.from(
             carousel.querySelectorAll("[data-featured-dot]"),
           );
-          if (slides.length < 2 || dots.length < 2) {
+          if (!track || !windowEl || slides.length < 2 || dots.length < 2) {
             return;
           }
+
+          track
+            .querySelectorAll("[data-featured-clone]")
+            .forEach((clone) => clone.remove());
+
+          const firstClone = slides[0].cloneNode(true);
+          const lastClone = slides[slides.length - 1].cloneNode(true);
+          [firstClone, lastClone].forEach((clone) => {
+            clone.classList.remove("active");
+            clone.removeAttribute("data-featured-slide");
+            clone.setAttribute("data-featured-clone", "");
+            clone.setAttribute("aria-hidden", "true");
+            clone.setAttribute("inert", "");
+            clone
+              .querySelectorAll("a, button, input, select, textarea")
+              .forEach((element) => {
+                element.setAttribute("tabindex", "-1");
+              });
+          });
+          track.insertBefore(lastClone, slides[0]);
+          track.appendChild(firstClone);
+          carousel.classList.add("is-enhanced");
+          const visualSlides = Array.from(
+            track.querySelectorAll(".featured-directory-slide"),
+          );
 
           const prefersReducedMotion = window.matchMedia(
             "(prefers-reduced-motion: reduce)",
@@ -687,6 +716,7 @@
           let progressFrame = null;
           let progressStartedAt = 0;
           let touchStartX = null;
+          let pendingSnapIndex = null;
 
           const setProgress = (progress) => {
             dots.forEach((dot, index) => {
@@ -694,6 +724,39 @@
                 "--featured-dot-progress",
                 index === activeIndex ? `${progress * 100}%` : "0%",
               );
+            });
+          };
+
+          const setTrackPosition = (visualIndex, options = {}) => {
+            const animate = options.animate !== false && !prefersReducedMotion;
+            const previousTransition = track.style.transition;
+            if (!animate) {
+              track.style.transition = "none";
+            }
+
+            const trackStyles = window.getComputedStyle(track);
+            const gap =
+              Number.parseFloat(
+                trackStyles.columnGap || trackStyles.gap || "0",
+              ) || 0;
+            const slideWidth =
+              visualSlides[0]?.getBoundingClientRect().width || 0;
+            const windowWidth = windowEl.getBoundingClientRect().width;
+            const offset =
+              (windowWidth - slideWidth) / 2 - visualIndex * (slideWidth + gap);
+            track.style.transform = `translateX(${offset}px)`;
+
+            if (!animate) {
+              track.getBoundingClientRect();
+              track.style.transition = previousTransition;
+            }
+          };
+
+          const setActiveSlideState = () => {
+            slides.forEach((slide, index) => {
+              const isActive = index === activeIndex;
+              slide.classList.toggle("active", isActive);
+              slide.setAttribute("aria-hidden", isActive ? "false" : "true");
             });
           };
 
@@ -729,19 +792,39 @@
           };
 
           const showSlide = (nextIndex) => {
+            const previousIndex = activeIndex;
             activeIndex = (nextIndex + slides.length) % slides.length;
-            slides.forEach((slide, index) => {
-              const isActive = index === activeIndex;
-              slide.classList.toggle("active", isActive);
-              slide.setAttribute("aria-hidden", isActive ? "false" : "true");
-            });
+            let visualIndex = activeIndex + 1;
+            pendingSnapIndex = null;
+            if (
+              previousIndex === slides.length - 1 &&
+              nextIndex >= slides.length
+            ) {
+              visualIndex = slides.length + 1;
+              pendingSnapIndex = activeIndex + 1;
+            } else if (previousIndex === 0 && nextIndex < 0) {
+              visualIndex = 0;
+              pendingSnapIndex = activeIndex + 1;
+            }
+
+            setActiveSlideState();
             dots.forEach((dot, index) => {
               const isActive = index === activeIndex;
               dot.classList.toggle("active", isActive);
               dot.setAttribute("aria-selected", isActive ? "true" : "false");
             });
+            setTrackPosition(visualIndex, { animate: true });
             scheduleAutoAdvance();
           };
+
+          const handleTrackTransitionEnd = (event) => {
+            if (event.target !== track || pendingSnapIndex === null) {
+              return;
+            }
+            setTrackPosition(pendingSnapIndex, { animate: false });
+            pendingSnapIndex = null;
+          };
+          track.addEventListener("transitionend", handleTrackTransitionEnd);
 
           dots.forEach((dot) => {
             dot.addEventListener("click", () => {
@@ -775,7 +858,21 @@
           );
 
           scheduleAutoAdvance();
-          featuredCarouselCleanups.push(stopProgress);
+          setActiveSlideState();
+          setTrackPosition(activeIndex + 1, { animate: false });
+
+          const handleResize = () => {
+            setTrackPosition(activeIndex + 1, { animate: false });
+          };
+          window.addEventListener("resize", handleResize);
+          featuredCarouselCleanups.push(() => {
+            stopProgress();
+            track.removeEventListener(
+              "transitionend",
+              handleTrackTransitionEnd,
+            );
+            window.removeEventListener("resize", handleResize);
+          });
         });
     }
 

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -626,13 +626,13 @@
           {% if featured_usernames|length > 1 %}
             <div class="featured-directory-controls">
               <div></div>
-              <div class="featured-directory-dots" role="tablist" aria-label="Featured accounts">
+              <div class="featured-directory-dots" role="group" aria-label="Featured accounts">
                 {% for username in featured_usernames %}
                   <button
                     type="button"
                     class="featured-directory-dot{% if loop.first %} active{% endif %}"
                     aria-label="Show featured account {{ loop.index }} of {{ featured_usernames|length }}"
-                    aria-selected="{{ 'true' if loop.first else 'false' }}"
+                    {% if loop.first %}aria-current="true"{% endif %}
                     data-featured-dot
                     data-featured-index="{{ loop.index0 }}"
                   ></button>

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -610,16 +610,18 @@
           aria-label="Featured verified accounts"
           data-featured-carousel
         >
-          <div class="featured-directory-track">
-            {% for username in featured_usernames %}
-              <div
-                class="featured-directory-slide{% if loop.first %} active{% endif %}"
-                data-featured-slide
-                aria-hidden="{{ 'false' if loop.first else 'true' }}"
-              >
-                {{ featured_user_card(username) }}
-              </div>
-            {% endfor %}
+          <div class="featured-directory-window" data-featured-window>
+            <div class="featured-directory-track" data-featured-track>
+              {% for username in featured_usernames %}
+                <div
+                  class="featured-directory-slide{% if loop.first %} active{% endif %}"
+                  data-featured-slide
+                  aria-hidden="{{ 'false' if loop.first else 'true' }}"
+                >
+                  {{ featured_user_card(username) }}
+                </div>
+              {% endfor %}
+            </div>
           </div>
           {% if featured_usernames|length > 1 %}
             <div class="featured-directory-controls">

--- a/scripts/dev_data.py
+++ b/scripts/dev_data.py
@@ -87,6 +87,7 @@ def default_users() -> list[dict[str, object]]:
             "password": "Test-testtesttesttest-1",
             "is_admin": False,
             "is_verified": True,
+            "is_featured": True,
             "display_name": "Jerry Seinfeld",
             "bio": (
                 "I'm a neurotic stand-up comic who loves cereal and Superman. "
@@ -119,6 +120,7 @@ def default_users() -> list[dict[str, object]]:
             "password": "Test-testtesttesttest-1",
             "is_admin": False,
             "is_verified": True,
+            "is_featured": True,
             "display_name": "Elaine Benes",
             "bio": (
                 "I dance like nobody’s watching—because they shouldn’t. "
@@ -133,7 +135,7 @@ def default_users() -> list[dict[str, object]]:
             "username": "cosmokramer",
             "password": "Test-testtesttesttest-1",
             "is_admin": False,
-            "is_verified": False,
+            "is_verified": True,
             "display_name": "Cosmo Kramer",
             "bio": (
                 "I'm the wacky neighbor with grand schemes (pizza bagels, anyone?). "
@@ -180,23 +182,25 @@ def default_users() -> list[dict[str, object]]:
             "username": "gobbluth",
             "password": "Test-testtesttesttest-1",
             "is_admin": False,
-            "is_verified": False,
+            "is_verified": True,
             "display_name": "Gob Bluth",
             "bio": (
                 "I'm an illusionist, not a magician—tricks are what a hooker does for money. "
                 "Tip me off to any half-decent gigs or adorable rabbits."
             ),
+            "pgp_key": PGP_KEY,
         },
         {
             "username": "busterbluth",
             "password": "Test-testtesttesttest-1",
             "is_admin": False,
-            "is_verified": False,
+            "is_verified": True,
             "display_name": "Buster Bluth",
             "bio": (
                 "Motherboy champion and proud hook-hand owner. "
                 "Use my tip line for anything related to juice boxes or loose seals."
             ),
+            "pgp_key": PGP_KEY,
         },
         {
             "username": "lucillebluth",
@@ -217,12 +221,13 @@ def default_users() -> list[dict[str, object]]:
             "username": "tobiasfunke",
             "password": "Test-testtesttesttest-1",
             "is_admin": False,
-            "is_verified": False,
+            "is_verified": True,
             "display_name": "Tobias Fünke",
             "bio": (
                 "Never-nude, aspiring actor, and first analrapist. "
                 "Tip me on potential casting calls or discreet cutoffs sales."
             ),
+            "pgp_key": PGP_KEY,
         },
         {
             "username": "larrydavid",
@@ -282,6 +287,126 @@ def default_users() -> list[dict[str, object]]:
                 "Time-traveling teen with a hoverboard. "
                 "Use my tip line if someone calls me chicken or there's a DeLorean sighting."
             ),
+            "pgp_key": PGP_KEY,
+        },
+        {
+            "username": "civicdesk",
+            "password": "Test-testtesttesttest-1",
+            "is_admin": False,
+            "is_verified": True,
+            "display_name": "Civic Desk",
+            "bio": (
+                "A public-interest reporting desk focused on local accountability, records, "
+                "and tips from people who know how institutions really work."
+            ),
+            "extra_fields": [
+                ("Website", "https://civicdesk.example", True),
+            ],
+            "pgp_key": PGP_KEY,
+        },
+        {
+            "username": "publicintegritylab",
+            "password": "Test-testtesttesttest-1",
+            "is_admin": False,
+            "is_verified": True,
+            "display_name": "Public Integrity Lab",
+            "bio": (
+                "Researchers and editors reviewing public-sector misconduct, contracting, "
+                "procurement, and oversight tips."
+            ),
+            "extra_fields": [
+                ("Website", "https://integritylab.example", True),
+            ],
+            "pgp_key": PGP_KEY,
+        },
+        {
+            "username": "studentpresswatch",
+            "password": "Test-testtesttesttest-1",
+            "is_admin": False,
+            "is_verified": True,
+            "display_name": "Student Press Watch",
+            "bio": (
+                "A student newsroom collective receiving tips about schools, universities, "
+                "and campus governance."
+            ),
+            "extra_fields": [
+                ("Website", "https://studentpress.example", True),
+            ],
+            "pgp_key": PGP_KEY,
+        },
+        {
+            "username": "laborrightsclinic",
+            "password": "Test-testtesttesttest-1",
+            "is_admin": False,
+            "is_verified": True,
+            "display_name": "Labor Rights Clinic",
+            "bio": (
+                "Legal advocates reviewing workplace safety, wage, retaliation, and organizing "
+                "concerns from workers."
+            ),
+            "extra_fields": [
+                ("Website", "https://laborrights.example", True),
+            ],
+            "pgp_key": PGP_KEY,
+        },
+        {
+            "username": "opensourcewatch",
+            "password": "Test-testtesttesttest-1",
+            "is_admin": False,
+            "is_verified": True,
+            "display_name": "Open Source Watch",
+            "bio": (
+                "Software maintainers and security researchers coordinating responsible tips "
+                "about digital infrastructure risks."
+            ),
+            "extra_fields": [
+                ("Website", "https://opensourcewatch.example", True),
+            ],
+            "pgp_key": PGP_KEY,
+        },
+        {
+            "username": "communitylegalaid",
+            "password": "Test-testtesttesttest-1",
+            "is_admin": False,
+            "is_verified": True,
+            "display_name": "Community Legal Aid",
+            "bio": (
+                "Attorneys and advocates available for civil rights, housing, benefits, and "
+                "community accountability tips."
+            ),
+            "extra_fields": [
+                ("Website", "https://legalaid.example", True),
+            ],
+            "pgp_key": PGP_KEY,
+        },
+        {
+            "username": "climateaccountability",
+            "password": "Test-testtesttesttest-1",
+            "is_admin": False,
+            "is_verified": True,
+            "display_name": "Climate Accountability Desk",
+            "bio": (
+                "Reporters investigating environmental compliance, climate risk disclosures, "
+                "and public-interest science."
+            ),
+            "extra_fields": [
+                ("Website", "https://climatedesk.example", True),
+            ],
+            "pgp_key": PGP_KEY,
+        },
+        {
+            "username": "privacyresearchdesk",
+            "password": "Test-testtesttesttest-1",
+            "is_admin": False,
+            "is_verified": True,
+            "display_name": "Privacy Research Desk",
+            "bio": (
+                "Researchers collecting tips about data misuse, surveillance, privacy harms, "
+                "and accountability failures."
+            ),
+            "extra_fields": [
+                ("Website", "https://privacyresearch.example", True),
+            ],
             "pgp_key": PGP_KEY,
         },
         {

--- a/scripts/dev_data.py
+++ b/scripts/dev_data.py
@@ -42,6 +42,7 @@ def default_users() -> list[dict[str, object]]:
             "password": "Test-testtesttesttest-1",
             "is_admin": True,
             "is_verified": True,
+            "is_featured": True,
             "display_name": "Hush Line Admin",
             "bio": (
                 "Message for account verification, technical problems, and general feedback!"
@@ -61,6 +62,7 @@ def default_users() -> list[dict[str, object]]:
             "password": "Test-testtesttesttest-1",
             "is_admin": False,
             "is_verified": True,
+            "is_featured": True,
             "tier": "Super User",
             "display_name": "Art Vandelay",
             "bio": (
@@ -311,6 +313,7 @@ def create_users() -> None:
         display_name = cast(str, data.get("display_name", username))
         bio = cast(str, data.get("bio", ""))[:250]  # Ensure truncation to 250 characters
         is_verified = cast(bool, data.get("is_verified", False))
+        is_featured = cast(bool, data.get("is_featured", False))
         extra_fields = cast(List[Tuple[str, str, bool]], data.get("extra_fields", []))
         pgp_key = cast(Optional[str], data.get("pgp_key"))  # Optional PGP key
         onboarding_complete = cast(bool, data.get("onboarding_complete", True))
@@ -340,6 +343,7 @@ def create_users() -> None:
                 is_primary=True,
                 show_in_directory=True,
                 is_verified=is_verified,
+                is_featured=is_featured,
             )
             db.session.add(primary)
 
@@ -395,6 +399,7 @@ def create_users() -> None:
         primary.bio = bio
         primary.show_in_directory = True
         primary.is_verified = is_verified
+        primary.is_featured = is_featured
 
         for i in range(1, MAX_EXTRA_FIELDS + 1):
             setattr(primary, f"extra_field_label{i}", None)

--- a/tests/test_dev_data.py
+++ b/tests/test_dev_data.py
@@ -42,3 +42,13 @@ def test_default_users_seed_paid_artvandelay_with_three_notification_recipients(
         {"email": "standards@vandelay.news", "pgp_key": dev_data.PGP_KEY, "enabled": True},
         {"email": "board@vandelay.news", "pgp_key": dev_data.PGP_KEY, "enabled": True},
     ]
+
+
+def test_default_users_seed_featured_verified_directory_accounts() -> None:
+    dev_data = _load_dev_data_module()
+
+    featured_usernames = {
+        user["username"] for user in dev_data.default_users() if user.get("is_featured") is True
+    }
+
+    assert featured_usernames == {"admin", "artvandelay"}

--- a/tests/test_dev_data.py
+++ b/tests/test_dev_data.py
@@ -51,4 +51,14 @@ def test_default_users_seed_featured_verified_directory_accounts() -> None:
         user["username"] for user in dev_data.default_users() if user.get("is_featured") is True
     }
 
-    assert featured_usernames == {"admin", "artvandelay"}
+    assert featured_usernames == {"admin", "artvandelay", "jerryseinfeld", "elainebenes"}
+
+
+def test_default_users_seed_more_than_twenty_verified_directory_accounts() -> None:
+    dev_data = _load_dev_data_module()
+
+    verified_usernames = [
+        user["username"] for user in dev_data.default_users() if user.get("is_verified") is True
+    ]
+
+    assert len(verified_usernames) > 20

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -324,6 +324,11 @@ def test_directory_verified_tab_promotes_featured_users_first(
     monkeypatch.setattr("hushline.routes.directory.get_securedrop_directory_listings", lambda: ())
     monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
     monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
+    monkeypatch.setattr(
+        directory_routes,
+        "_shuffle_featured_directory_items",
+        lambda items: list(items),
+    )
 
     response = client.get(url_for("directory"))
     assert response.status_code == 200
@@ -368,6 +373,56 @@ def test_directory_verified_tab_promotes_featured_users_first(
     normal_card_heading = normal_cards[0].select_one("h3")
     assert normal_card_heading is not None
     assert normal_card_heading.get_text(strip=True) == "Admin User"
+
+
+def test_directory_randomizes_featured_user_order(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    featured_user = _directory_username(
+        username="featured-user",
+        display_name="Featured User",
+        is_verified=True,
+        is_featured=True,
+    )
+    second_featured_user = _directory_username(
+        username="second-featured-user",
+        display_name="Second Featured User",
+        is_verified=True,
+        is_featured=True,
+    )
+    admin_user = _directory_username(
+        username="admin-user",
+        display_name="Admin User",
+        is_verified=True,
+        is_admin=True,
+    )
+    monkeypatch.setattr(
+        "hushline.routes.directory.get_directory_usernames",
+        lambda: (featured_user, second_featured_user, admin_user),
+    )
+    monkeypatch.setattr("hushline.routes.directory.get_public_record_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_securedrop_directory_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
+    monkeypatch.setattr(
+        directory_routes,
+        "_shuffle_featured_directory_items",
+        lambda items: list(reversed(items)),
+    )
+
+    response = client.get(url_for("directory"))
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+    featured_headings = [
+        heading.get_text(strip=True)
+        for heading in soup.select("#verified [data-featured-slide] h3")
+    ]
+    assert featured_headings == ["Second Featured User", "Featured User"]
+
+    users_response = client.get(url_for("directory_users", tab="verified"))
+    assert users_response.status_code == 200
+    usernames = [row["primary_username"] for row in users_response.json or []]
+    assert usernames[:3] == ["second-featured-user", "featured-user", "admin-user"]
 
 
 def test_directory_public_record_banner_links_to_admin(client: FlaskClient) -> None:

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -333,6 +333,8 @@ def test_directory_verified_tab_promotes_featured_users_first(
 
     featured_section = verified_panel.select_one("[data-featured-carousel]")
     assert featured_section is not None
+    assert featured_section.select_one("[data-featured-window]") is not None
+    assert featured_section.select_one("[data-featured-track]") is not None
     first_card = verified_panel.select_one("article.user")
     assert first_card is not None
     first_card_heading = first_card.select_one("h3")
@@ -341,6 +343,7 @@ def test_directory_verified_tab_promotes_featured_users_first(
     assert first_card.find_previous("article.user") is None
     assert len(featured_section.select("[data-featured-dot]")) == 2
     assert not featured_section.select("[data-featured-slide][hidden]")
+    assert featured_section.select_one("[data-featured-slide].active") is not None
     more_link = first_card.select_one(".featured-directory-bio a")
     assert more_link is not None
     assert more_link.get_text(strip=True) == "more..."

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -341,7 +341,14 @@ def test_directory_verified_tab_promotes_featured_users_first(
     assert first_card_heading is not None
     assert first_card_heading.get_text(strip=True) == "Featured User"
     assert first_card.find_previous("article.user") is None
-    assert len(featured_section.select("[data-featured-dot]")) == 2
+    featured_dot_container = featured_section.select_one(".featured-directory-dots")
+    assert featured_dot_container is not None
+    assert featured_dot_container.get("role") == "group"
+    featured_dots = featured_section.select("[data-featured-dot]")
+    assert len(featured_dots) == 2
+    assert featured_dots[0].get("aria-current") == "true"
+    assert featured_dots[1].get("aria-current") is None
+    assert not featured_section.select("[data-featured-dot][aria-selected]")
     assert not featured_section.select("[data-featured-slide][hidden]")
     assert featured_section.select_one("[data-featured-slide].active") is not None
     more_link = first_card.select_one(".featured-directory-bio a")

--- a/tests/test_docs_screenshots_manifest.py
+++ b/tests/test_docs_screenshots_manifest.py
@@ -116,6 +116,30 @@ def test_docs_screenshots_manifest_disables_full_page_for_heavy_directory_scenes
     assert scenes["guest-directory-all"]["captureModes"] == ["fold", "scroll"]
 
 
+def test_docs_screenshots_manifest_includes_featured_directory_carousel() -> None:
+    scenes = _scene_map()
+    screenshots_readme = (REPO_ROOT / "docs" / "screenshots" / "README.md").read_text(
+        encoding="utf-8"
+    )
+
+    featured_scene = scenes["guest-directory-featured-carousel"]
+
+    assert featured_scene["title"] == "Directory - Featured Carousel"
+    assert featured_scene["path"] == "/directory"
+    assert featured_scene["session"] == "guest"
+    assert featured_scene["captureModes"] == ["fold"]
+    assert featured_scene["viewports"] == ["desktop"]
+    assert featured_scene["themes"] == ["light"]
+    assert (
+        featured_scene["waitForSelector"]
+        == "[data-featured-carousel].is-enhanced .featured-directory-slide.active"
+    )
+    assert (
+        "./releases/latest/guest/guest-directory-featured-carousel-desktop-light-fold.png"
+        in screenshots_readme
+    )
+
+
 def test_docs_screenshot_capture_suppresses_first_load_splash() -> None:
     script = CAPTURE_SCRIPT_PATH.read_text(encoding="utf-8")
 

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -384,9 +384,10 @@ def test_directory_search_accessibility_hooks_exist() -> None:
     assert 'slide.setAttribute("inert", "");' in directory_verified_js
     assert 'slide.removeAttribute("inert");' in directory_verified_js
     assert "[data-featured-original-tabindex]" in directory_verified_js
-    assert ".featured-directory-window::before" in scss
-    assert ".featured-directory-window::after" in scss
-    assert "--featured-carousel-fade-bg" in scss
+    assert re.search(
+        r"\.featured-directory \.user \{[^}]*box-shadow: var\(--shadow-dynamic\);",
+        scss,
+    )
     assert "controller.countryLabelForValue = function (value) {" in directory_verified_static_js
     assert "replaceState" in directory_verified_static_js
     assert ".directory-sticky-shell" in scss

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -380,6 +380,13 @@ def test_directory_search_accessibility_hooks_exist() -> None:
     assert "fetch(`${directoryPath}/${controller.metadataPath}${search}`)" in (
         directory_verified_static_js
     )
+    assert "function setFeaturedSlideInteractive(slide, isInteractive)" in directory_verified_js
+    assert 'slide.setAttribute("inert", "");' in directory_verified_js
+    assert 'slide.removeAttribute("inert");' in directory_verified_js
+    assert "[data-featured-original-tabindex]" in directory_verified_js
+    assert ".featured-directory-window::before" in scss
+    assert ".featured-directory-window::after" in scss
+    assert "--featured-carousel-fade-bg" in scss
     assert "controller.countryLabelForValue = function (value) {" in directory_verified_static_js
     assert "replaceState" in directory_verified_static_js
     assert ".directory-sticky-shell" in scss


### PR DESCRIPTION
## What changed

- Enhances the featured verified-account carousel so adjacent featured cards peek from both sides of the active card, with wraparound slide animation through cloned edge slides.
- Randomizes the featured-card order per render/API response while keeping the regular Verified list stable.
- Adds the shared dynamic card shadow to featured cards so the peeking row has the same polished depth as the rest of the UI.
- Keeps featured cards at a common carousel height and preserves existing dot progress pagination, click, and touch-swipe behavior.
- Uses valid carousel button semantics for the pagination controls: grouped buttons with `aria-current` on the active card instead of invalid tab-style `aria-selected`.
- Makes inactive original carousel slides inert and removes/restores descendant tab stops so keyboard focus stays on the active card.
- Seeds four featured verified accounts and 25 verified primary directory accounts in dev data so the default directory shows the full featured row and a populated Verified tab.
- Adds a docs screenshot scene and README reference for the featured directory carousel.

## Why

The featured row should read as a horizontal carousel, not a single card swap. Showing the neighboring cards gives users a clearer affordance that more featured accounts are available and that the active card will slide horizontally.

The latest updates also fix the W3C/a11y failure caused by featured carousel dot buttons using `aria-selected` without tab roles, address review feedback about inactive slide focus, and make the default seeded directory useful for manual review.

## Security and privacy

This touches public directory presentation, dev seed data, and docs screenshot configuration. It does not change message submission, inbox, E2EE, notification, authentication, or private disclosure data paths. CSP was not broadened.

## Validation

- Dependabot pre-check: no open Dependabot PRs.
- `docker compose run --rm dev_data`
- Verified seeded counts in the app container: 25 verified primary directory accounts and 4 featured verified accounts.
- `docker compose run --rm --no-deps app poetry run pytest -q -m "not external_network" tests/test_directory.py::test_directory_verified_tab_promotes_featured_users_first tests/test_directory.py::test_directory_randomizes_featured_user_order tests/test_frontend_compat.py::test_static_js_bundles_avoid_eval_wrappers tests/test_frontend_compat.py::test_directory_search_accessibility_hooks_exist`
- `docker compose run --rm --no-deps app poetry run pytest -q -m "not external_network" tests/test_directory.py::test_directory_verified_tab_promotes_featured_users_first tests/test_dev_data.py tests/test_docs_screenshots_manifest.py::test_docs_screenshots_manifest_includes_featured_directory_carousel tests/test_frontend_compat.py::test_static_js_bundles_avoid_eval_wrappers`
- `docker compose run --rm --no-deps app poetry run pytest -q -m "not external_network" tests/test_docs_screenshots_manifest.py`
- `docker compose run --rm --no-deps app poetry run pytest -q -m "not external_network" tests/test_frontend_compat.py::test_directory_search_accessibility_hooks_exist tests/test_frontend_compat.py::test_static_js_bundles_avoid_eval_wrappers`
- `docker compose run --rm --no-deps app poetry run ruff format --check scripts/dev_data.py tests/test_dev_data.py tests/test_docs_screenshots_manifest.py tests/test_directory.py`
- `docker compose run --rm --no-deps app poetry run ruff check --output-format full scripts/dev_data.py tests/test_dev_data.py tests/test_docs_screenshots_manifest.py tests/test_directory.py`
- `docker compose run --rm --no-deps app poetry run ruff format --check tests/test_frontend_compat.py`
- `docker compose run --rm --no-deps app poetry run ruff check --output-format full tests/test_frontend_compat.py`
- `./node_modules/.bin/prettier --ignore-path /dev/null --check docs/screenshots/README.md docs/screenshots/scenes.json ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js`
- W3C Nu validator against rendered `/` and `/directory` HTML: pass.
- Lighthouse accessibility against local app container: 100.
- `git diff --check`
- `make lint`
- `make test`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

Browser-level screenshot/geometry verification was not run locally because Playwright and browser binaries are not installed in this checkout without pulling additional tooling. The screenshot workflow scene is covered by manifest tests and will capture the seeded four-card featured row in CI/workflow execution.

Dev login for manual review: `admin` / `Test-testtesttesttest-1`.
