### PR TITLE
Fix featured carousel mobile edge gap and shadow clipping

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2473,6 +2473,7 @@ img.alert {
 .featured-directory {
   --featured-carousel-gap: 0.75rem;
   --featured-carousel-peek: 2rem;
+  --featured-carousel-shadow-overflow: 0.75rem;
   margin: 0 0 0.5rem 0;
   overflow: visible;
 }
@@ -2497,8 +2498,9 @@ img.alert {
 }
 
 .featured-directory.is-enhanced .featured-directory-window {
+  clip-path: inset(0 0 calc(-1 * var(--featured-carousel-shadow-overflow)) 0);
   margin-inline: calc(-1 * var(--featured-carousel-peek));
-  overflow: hidden;
+  overflow: visible;
 }
 
 .featured-directory.is-enhanced .featured-directory-track {
@@ -2618,7 +2620,7 @@ img.alert {
 
 @media only screen and (max-width: 800px) {
   .featured-directory {
-    --featured-carousel-peek: 1rem;
+    --featured-carousel-peek: var(--container-padding, 1.25rem);
   }
 }
 

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -388,6 +388,9 @@ def test_directory_search_accessibility_hooks_exist() -> None:
         r"\.featured-directory \.user \{[^}]*box-shadow: var\(--shadow-dynamic\);",
         scss,
     )
+    assert "--featured-carousel-peek: var(--container-padding, 1.25rem);" in scss
+    assert "--featured-carousel-shadow-overflow: 0.75rem;" in scss
+    assert "clip-path: inset(0 0 calc(-1 * var(--featured-carousel-shadow-overflow)) 0);" in scss
     assert "controller.countryLabelForValue = function (value) {" in directory_verified_static_js
     assert "replaceState" in directory_verified_static_js
     assert ".directory-sticky-shell" in scss


### PR DESCRIPTION
## What changed

- Changes the mobile featured-carousel peek size to use the shared `--container-padding` value instead of a fixed `1rem`.
- Lets the featured carousel shadow extend below the visible window while clipping overflow at the outer carousel window edges.
- Adds frontend compatibility assertions so the mobile carousel peek and shadow clipping behavior stay in place.

## Why

At narrow mobile widths, the container padding is `1.25rem` while the carousel peek was `1rem`, leaving a visible white gap between the peeking card and the viewport/container edge. Reusing the container padding makes the peeking card connect cleanly to the edge.

The carousel window previously relied on `overflow: hidden`, which also clipped the bottom of the dynamic card shadow. Switching the enhanced window to a side-clipping `clip-path` with a small bottom allowance keeps peeking cards clipped at the outside of the parent container while preserving the visible shadow below the active card.

## Security and privacy

This is a CSS-only directory presentation fix plus test assertions. It does not change message submission, inbox, E2EE, authentication, notification, or private disclosure data paths. CSP was not broadened.

## Validation

- `docker compose run --rm --no-deps app poetry run pytest -q -m "not external_network" tests/test_frontend_compat.py::test_directory_search_accessibility_hooks_exist`
- `make lint`
- `make audit-python`
- `make audit-node-runtime`
- `git diff --check`

`make test` was attempted twice locally. The first run hit the repository-documented Postgres recovery-mode failure; I reset the Docker stack with `docker compose down -v --remove-orphans`. The second run progressed cleanly through the premium worker tests but the app test container was killed with exit 137 before completion. CI should provide the full-suite result for this small CSS/test change.

## Manual testing

Not run locally; this is a narrow CSS alignment/shadow clipping fix and browser screenshot tooling is not installed in this checkout.
