### PR TITLE
Fix featured carousel horizontal overflow

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2475,7 +2475,8 @@ img.alert {
   --featured-carousel-peek: 2rem;
   --featured-carousel-shadow-overflow: 0.75rem;
   margin: 0 0 0.5rem 0;
-  overflow: visible;
+  overflow-x: clip;
+  overflow-y: visible;
 }
 
 .featured-directory-window {

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -388,6 +388,8 @@ def test_directory_search_accessibility_hooks_exist() -> None:
         r"\.featured-directory \.user \{[^}]*box-shadow: var\(--shadow-dynamic\);",
         scss,
     )
+    assert "overflow-x: clip;" in scss
+    assert "overflow-y: visible;" in scss
     assert "--featured-carousel-peek: var(--container-padding, 1.25rem);" in scss
     assert "--featured-carousel-shadow-overflow: 0.75rem;" in scss
     assert "clip-path: inset(0 0 calc(-1 * var(--featured-carousel-shadow-overflow)) 0);" in scss


### PR DESCRIPTION
## What changed

- Clips inline overflow on the featured-directory wrapper while leaving vertical overflow visible for the card shadow.
- Adds a frontend compatibility assertion so the carousel wrapper keeps horizontal overflow clipped.

## Why

The merged featured carousel allows the enhanced carousel window and track to overflow visibly so card shadows are not clipped. Combined with the negative inline carousel margins, that can widen the Directory page and create massive horizontal scrolling. Clipping only the inline axis at the featured wrapper prevents page-level horizontal overflow while preserving the bottom shadow.

## Security and privacy

This is a CSS-only Directory presentation fix plus a test assertion. It does not change message submission, inbox, E2EE, authentication, notification, or private disclosure data paths. CSP was not broadened.

## Validation

- `docker compose run --rm --no-deps app poetry run pytest -q -m "not external_network" tests/test_frontend_compat.py::test_directory_search_accessibility_hooks_exist`
- `make lint`
- `git diff --check`

## Manual testing

Not run locally; browser screenshot tooling is not installed in this checkout.
