### PR TITLE
Fix iOS directory carousel overflow

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1353,7 +1353,6 @@ body {
 }
 
 body.directory-page {
-  overflow-x: clip;
   scroll-behavior: smooth;
 }
 
@@ -2500,8 +2499,10 @@ img.alert {
 
 .featured-directory.is-enhanced .featured-directory-window {
   clip-path: inset(0 0 calc(-1 * var(--featured-carousel-shadow-overflow)) 0);
+  margin-bottom: calc(-1 * var(--featured-carousel-shadow-overflow));
   margin-inline: calc(-1 * var(--featured-carousel-peek));
-  overflow: visible;
+  overflow: hidden;
+  padding-bottom: var(--featured-carousel-shadow-overflow);
 }
 
 .featured-directory.is-enhanced .featured-directory-track {

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -388,11 +388,17 @@ def test_directory_search_accessibility_hooks_exist() -> None:
         r"\.featured-directory \.user \{[^}]*box-shadow: var\(--shadow-dynamic\);",
         scss,
     )
-    assert re.search(r"body\.directory-page \{[^}]*overflow-x: clip;", scss)
     assert re.search(r"\.featured-directory \{[^}]*overflow: visible;", scss)
     assert "--featured-carousel-peek: var(--container-padding, 1.25rem);" in scss
     assert "--featured-carousel-shadow-overflow: 0.75rem;" in scss
     assert "clip-path: inset(0 0 calc(-1 * var(--featured-carousel-shadow-overflow)) 0);" in scss
+    assert re.search(
+        r"\.featured-directory\.is-enhanced \.featured-directory-window \{[^}]*"
+        r"margin-bottom: calc\(-1 \* var\(--featured-carousel-shadow-overflow\)\);[^}]*"
+        r"overflow: hidden;[^}]*"
+        r"padding-bottom: var\(--featured-carousel-shadow-overflow\);",
+        scss,
+    )
     assert "controller.countryLabelForValue = function (value) {" in directory_verified_static_js
     assert "replaceState" in directory_verified_static_js
     assert ".directory-sticky-shell" in scss


### PR DESCRIPTION
## What changed

- Removed page-level horizontal overflow clipping from the Directory page so the sticky tabs and search remain pinned while scrolling.
- Clips the enhanced featured-directory carousel window instead, which should stop iOS/iPadOS Safari horizontal page scrolling while preserving the peeking cards.
- Adds bottom padding plus a matching negative margin to the carousel window so card shadows can render without increasing layout height.
- Locks the expected CSS behavior in the frontend compatibility test.

## Why

The previous body-level `overflow-x: clip` approach was not reliable enough on iOS/iPadOS Safari. Expanding that containment to the root fixed overflow locally but broke sticky positioning for the Directory tabs/search. This patch keeps overflow management local to the carousel viewport.

## Validation

- `git diff --check`
- `docker compose run --rm --no-deps app poetry run pytest -q -m "not external_network" tests/test_frontend_compat.py::test_directory_search_accessibility_hooks_exist`
- `make lint`
- `make test`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

- Not run in browser locally. The patch is CSS-only and the existing directory/frontend tests cover the sticky hooks, featured carousel hooks, shadow overflow handling, and docs screenshot manifest coverage.

## Risk

- Low. The change is scoped to the featured carousel window and removes page/root overflow containment so sticky positioning is no longer affected.
