### PR TITLE
Retry CI compose image pulls

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,18 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
+      - name: Pull compose dependency images
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose pull postgres blob-storage; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
+
       - name: Test
         run: make test PYTEST_ADDOPTS="--skip-local-only"
 
@@ -45,6 +57,18 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Pull compose dependency images
+        run: |
+          for attempt in 1 2 3; do
+            if docker compose pull postgres blob-storage; then
+              exit 0
+            fi
+            if [ "$attempt" -eq 3 ]; then
+              exit 1
+            fi
+            sleep $((attempt * 10))
+          done
 
       - name: Test with alembic
         run: make test


### PR DESCRIPTION
## Summary

- Adds a retrying `docker compose pull postgres blob-storage` step before the `test` job.
- Adds the same retrying pre-pull before the `test-with-alembic` job.

## Root Cause

The failing `Run Linter and Tests` workflow on `main` failed in the `test` job before pytest started. Docker Hub timed out while pulling the compose dependency images:

```text
blob-storage Error Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection
postgres Error Get "https://registry-1.docker.io/v2/": net/http: request canceled while waiting for connection
```

This is a CI dependency image pull reliability issue, not a lint or test assertion failure.

## Validation

- `git diff --check`
- `python3 scripts/check_workflow_pr_head_qualification.py`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/tests.yml")'`

Not run locally:

- Full `make test`; this PR changes only the GitHub Actions workflow retry behavior.
- PyYAML validation because host Python does not have `yaml` installed.

## Manual Testing

- Inspected failed run `26789534669` and confirmed the failing job was `test`, not `lint`.
