### PR TITLE
Fix coverage gap temp file cleanup

### DIFF
--- a/scripts/agent_daily_issue_runner.sh
+++ b/scripts/agent_daily_issue_runner.sh
@@ -3046,7 +3046,6 @@ open_coverage_gap_issue_after_pr() {
     return 0
   fi
 
-  issue_body_file="$(mktemp)"
   if [[ -n "$pr_number" ]]; then
     issue_title="Close test coverage gaps from PR #${pr_number}"
   else
@@ -3087,6 +3086,7 @@ open_coverage_gap_issue_after_pr() {
     return 0
   fi
 
+  issue_body_file="$(mktemp)"
   write_coverage_gap_issue_body \
     "$pr_number" \
     "$pr_url" \

--- a/tests/test_agent_daily_issue_runner.py
+++ b/tests/test_agent_daily_issue_runner.py
@@ -1710,6 +1710,8 @@ def test_open_coverage_gap_issue_after_pr_creates_agent_eligible_issue(
     check_log = tmp_path / "check.log"
     call_log = tmp_path / "calls.txt"
     body_copy = tmp_path / "body.md"
+    temp_dir = tmp_path / "tmp"
+    temp_dir.mkdir()
     check_log.write_text(
         """
 Name                                             Stmts   Miss  Cover
@@ -1723,6 +1725,7 @@ TOTAL                                            8881     36    99%
 
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
+export TMPDIR={shlex.quote(str(temp_dir))}
 CHECK_LOG_FILE={shlex.quote(str(check_log))}
 add_issue_to_project_status() {{
   printf 'project:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(call_log))}
@@ -1783,6 +1786,7 @@ open_coverage_gap_issue_after_pr \\
     assert "`make test`" in body
     assert "hushline/email.py" in body
     assert "hushline/routes/profile.py" in body
+    assert list(temp_dir.iterdir()) == []
 
 
 def test_open_coverage_gap_issue_after_pr_comments_on_existing_gap_issue(
@@ -1791,6 +1795,8 @@ def test_open_coverage_gap_issue_after_pr_comments_on_existing_gap_issue(
     check_log = tmp_path / "check.log"
     call_log = tmp_path / "calls.txt"
     comment_copy = tmp_path / "comment.md"
+    temp_dir = tmp_path / "tmp"
+    temp_dir.mkdir()
     check_log.write_text(
         """
 Name                                             Stmts   Miss  Cover   Missing
@@ -1804,6 +1810,7 @@ TOTAL                                            8881     36    99%
 
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
+export TMPDIR={shlex.quote(str(temp_dir))}
 CHECK_LOG_FILE={shlex.quote(str(check_log))}
 add_issue_to_project_status() {{
   printf 'project:%s:%s\\n' "$1" "$2" >> {shlex.quote(str(call_log))}
@@ -1872,12 +1879,15 @@ open_coverage_gap_issue_after_pr \\
     assert "hushline/routes/profile.py" in comment
     assert "105-106, 573" in comment
     assert "instead of opening another follow-up ticket" in comment
+    assert list(temp_dir.iterdir()) == []
 
 
 def test_open_coverage_gap_issue_after_pr_skips_duplicate_when_lookup_fails(
     tmp_path: Path,
 ) -> None:
     check_log = tmp_path / "check.log"
+    temp_dir = tmp_path / "tmp"
+    temp_dir.mkdir()
     check_log.write_text(
         """
 Name                                             Stmts   Miss  Cover
@@ -1890,6 +1900,7 @@ TOTAL                                            8881      1    99%
 
     shell_script = f"""
 source {shlex.quote(str(RUNNER_SCRIPT))}
+export TMPDIR={shlex.quote(str(temp_dir))}
 CHECK_LOG_FILE={shlex.quote(str(check_log))}
 gh() {{
   if [[ "${{1-}} ${{2-}}" == "issue list" ]]; then
@@ -1920,6 +1931,7 @@ open_coverage_gap_issue_after_pr \\
     assert "refusing to create a possible duplicate" in result.stderr
     assert "Opened coverage gap issue" not in result.stdout
     assert "Updated coverage gap issue" not in result.stdout
+    assert list(temp_dir.iterdir()) == []
 
 
 def test_collect_issue_candidates_from_project_filters_open_issues_in_target_status() -> None:


### PR DESCRIPTION
### Motivation
- Prevent temporary issue-body files from being leaked to `TMPDIR` when `open_coverage_gap_issue_after_pr` either fails the existing-issue lookup or reallocates the temp-file variable for the existing-issue comment path.
- This is an operational hygiene fix to avoid stale files/inodes accumulating on runner hosts while preserving existing behavior for create/comment flows.

### Description
- Delay creation of the coverage-gap issue body temp file until after `find_open_coverage_gap_issue` succeeds, so a lookup failure returns without leaving an allocated file behind.
- Ensure a single `mktemp` allocation is used per control path (create vs comment) so the file that is written is the same one that gets cleaned up with `rm -f`.
- Add regression assertions in `tests/test_agent_daily_issue_runner.py` that set `TMPDIR` to a test temp directory and assert it is empty after the create, existing-issue comment, and lookup-failure paths.
- Keep all user-visible behavior unchanged (issue creation, commenting, and project-status updates remain the same).

### Testing
- Ran the focused tests for the changed functionality with `python -m pytest tests/test_agent_daily_issue_runner.py -k 'open_coverage_gap_issue_after_pr' -q` and observed `3 passed, 120 deselected`.
- Ran the full runner test file with `python -m pytest tests/test_agent_daily_issue_runner.py -q` and observed `123 passed`.
- Ran formatting and lint checks on the modified test with `python -m ruff format --check tests/test_agent_daily_issue_runner.py && python -m ruff check tests/test_agent_daily_issue_runner.py` and they passed.
- Performed a shell syntax check with `bash -n scripts/agent_daily_issue_runner.sh` and it passed.
- Environment limits prevented running `make lint`, `make test`, and the dependency audits because `docker` is unavailable in this environment; those checks should run in CI before merge.
- Commit was created locally (`git commit`); an attempt to create a GPG-signed commit failed due to no key being configured in this environment, so the commit is unsigned.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f4913b914832faef69dbecfda0af8)