### PR TITLE
Allow embedded form fonts to load cross-origin

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2518,7 +2518,13 @@ img.alert {
 .featured-directory.is-enhanced .featured-directory-slide {
   flex: 0 0 calc(100% - (2 * var(--featured-carousel-peek)));
   grid-area: auto;
+  position: relative;
   visibility: visible;
+  z-index: 1;
+}
+
+.featured-directory.is-enhanced .featured-directory-slide.active {
+  z-index: 2;
 }
 
 .featured-directory.is-enhanced .featured-directory-slide:not(.active) {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3624,6 +3624,7 @@ p.bio+.extra-fields {
 }
 
 .embed-meta {
+  font-family: var(--font-mono);
   margin: 0.25rem 0 0;
 }
 

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -99,6 +99,11 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
         if not (app.config.get("SERVER_NAME") or "").endswith(".onion"):
             response.headers["Strict-Transport-Security"] = "max-age=63072000; includeSubdomains"
 
+        if request.endpoint == "static":
+            filename = str((request.view_args or {}).get("filename", ""))
+            if filename.startswith("fonts/") and filename.endswith((".woff", ".woff2")):
+                response.headers["Access-Control-Allow-Origin"] = "*"
+
         return response
 
     # Add Onion-Location header to all responses

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1393,6 +1393,7 @@ def test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source
     embed_shell_block = stylesheet_source.split(".embed-shell {", 1)[1].split("}", 1)[0]
     assert "box-sizing: border-box;" in embed_shell_block
     assert "padding: 2.5rem 2rem;" in stylesheet_source
+    assert ".embed-meta {\n  font-family: var(--font-mono);" in stylesheet_source
     assert ".embed-profile-summary" not in stylesheet_source
     assert ".embed-actions" not in stylesheet_source
     assert ".embed-page a,\n.embed-page a.meta" not in stylesheet_source

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -418,6 +418,17 @@ def test_directory_search_accessibility_hooks_exist() -> None:
         r"padding-bottom: var\(--featured-carousel-shadow-overflow\);",
         scss,
     )
+    assert re.search(
+        r"\.featured-directory\.is-enhanced \.featured-directory-slide \{[^}]*"
+        r"position: relative;[^}]*"
+        r"z-index: 1;",
+        scss,
+    )
+    assert re.search(
+        r"\.featured-directory\.is-enhanced \.featured-directory-slide\.active \{[^}]*"
+        r"z-index: 2;",
+        scss,
+    )
     assert "controller.countryLabelForValue = function (value) {" in directory_verified_static_js
     assert "replaceState" in directory_verified_static_js
     assert ".directory-sticky-shell" in scss

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -92,6 +92,21 @@ def test_embed_profile_uses_allowed_origin_frame_ancestors(client: FlaskClient, 
     assert "X-Frame-Options" not in response.headers
 
 
+def test_static_fonts_allow_cross_origin_embed_loading(client: FlaskClient) -> None:
+    response = client.get(url_for("static", filename="fonts/AtkinsonHyperlegible-Regular.woff2"))
+    assert response.status_code == 200
+
+    assert response.headers["Access-Control-Allow-Origin"] == "*"
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_static_non_font_assets_do_not_enable_cors(client: FlaskClient) -> None:
+    response = client.get(url_for("static", filename="css/style.css"))
+    assert response.status_code == 200
+
+    assert "Access-Control-Allow-Origin" not in response.headers
+
+
 def test_password_reset_pages_keep_csp_enforced(client: FlaskClient) -> None:
     paths = (
         url_for("request_password_reset"),

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from flask import Flask, url_for
 from flask.testing import FlaskClient
@@ -92,7 +94,14 @@ def test_embed_profile_uses_allowed_origin_frame_ancestors(client: FlaskClient, 
     assert "X-Frame-Options" not in response.headers
 
 
-def test_static_fonts_allow_cross_origin_embed_loading(client: FlaskClient) -> None:
+def test_static_fonts_allow_cross_origin_embed_loading(
+    client: FlaskClient, app: Flask, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    font_path = tmp_path / "fonts" / "AtkinsonHyperlegible-Regular.woff2"
+    font_path.parent.mkdir()
+    font_path.write_bytes(b"test font")
+    monkeypatch.setattr(app, "static_folder", str(tmp_path))
+
     response = client.get(url_for("static", filename="fonts/AtkinsonHyperlegible-Regular.woff2"))
     assert response.status_code == 200
 
@@ -100,7 +109,14 @@ def test_static_fonts_allow_cross_origin_embed_loading(client: FlaskClient) -> N
     assert response.headers["X-Content-Type-Options"] == "nosniff"
 
 
-def test_static_non_font_assets_do_not_enable_cors(client: FlaskClient) -> None:
+def test_static_non_font_assets_do_not_enable_cors(
+    client: FlaskClient, app: Flask, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    stylesheet_path = tmp_path / "css" / "style.css"
+    stylesheet_path.parent.mkdir()
+    stylesheet_path.write_text("body { color: black; }")
+    monkeypatch.setattr(app, "static_folder", str(tmp_path))
+
     response = client.get(url_for("static", filename="css/style.css"))
     assert response.status_code == 200
 


### PR DESCRIPTION
## What changed
- Added `Access-Control-Allow-Origin: *` only for public static font files under `/static/fonts/*.woff` and `/static/fonts/*.woff2`.
- Kept CORS off non-font static assets and sensitive app routes.
- Updated `.embed-meta` to use the mono font in the embed stylesheet source.
- Added regression tests for cross-origin font loading and non-font static assets.

## Why
Embedded forms can render cross-origin, but Firefox/Safari block downloadable fonts unless the font responses include an explicit CORS header. The failed requests were 200 responses without `Access-Control-Allow-Origin`.

## Validation
- `docker compose run --rm --no-deps app poetry run pytest tests/test_security_headers.py tests/test_embeddable_forms_settings.py::test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source -q` (`19 passed`)
- `git diff --check`
- `make lint` passed before the final reapply; final focused format check initially caught and fixed `tests/test_security_headers.py`.

## Manual testing
Not run locally against `tips.hushline.app`; expected manual check is loading an embedded form from a different origin and confirming `/static/fonts/*.woff2` responses include `Access-Control-Allow-Origin: *`.

## Known risks
The CORS header is limited to committed public font files. It does not enable CORS for embed submissions, APIs, CSS, JavaScript, or uploaded content.