### PR TITLE
Restore embedded form safety breakout links

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3631,6 +3631,18 @@ p.bio+.extra-fields {
   flex-wrap: wrap;
 }
 
+.embed-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.embed-actions a {
+  align-items: center;
+  display: inline-flex;
+  min-height: 2rem;
+}
+
 .embed-error-summary,
 .embed-noscript {
   border: 2px solid var(--color-error);
@@ -3707,6 +3719,10 @@ p.bio+.extra-fields {
 }
 
 @media (max-width: 28rem) {
+  .embed-actions {
+    flex-direction: column;
+  }
+
   .embed-page button[type="submit"] {
     width: 100%;
   }

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -289,6 +289,7 @@ def register_profile_routes(app: Flask) -> None:
                 owner_guard_signature=owner_guard_signature,
                 is_embedded=is_embedded,
                 embed_captcha_token=embed_captcha_token,
+                open_profile_url=url_for("profile", username=uname.username),
             )
             if status_code is None:
                 return rendered

--- a/hushline/templates/embed_profile.html
+++ b/hushline/templates/embed_profile.html
@@ -138,10 +138,27 @@
         {% endif %}
       </section>
 
+      <nav class="embed-actions" aria-label="Embed safety actions">
+        <a href="{{ open_profile_url }}" target="_blank" rel="noopener noreferrer">
+          Open on Hush Line
+        </a>
+        <a
+          href="{{ guidance_exit_button_link }}"
+          target="_top"
+          rel="noopener noreferrer"
+          aria-label="Emergency exit: {{ guidance_exit_button_text }}"
+        >
+          {{ guidance_exit_button_text }}
+        </a>
+      </nav>
+
       <noscript>
         <div class="embed-noscript" role="status">
           JavaScript is disabled. Hush Line will use its server-side encrypted fallback
-          for encrypted fields.
+          for encrypted fields, or you can
+          <a href="{{ open_profile_url }}" target="_blank" rel="noopener noreferrer">
+            open the full Hush Line profile
+          </a>.
         </div>
       </noscript>
 

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1356,14 +1356,36 @@ def test_embed_profile_template_has_compact_trust_chrome_and_form(
     assert "frame-ancestors https://tips.example" in csp
     assert "frame-ancestors *" not in csp
     assert page.select_one(".skip-link") is None
-    assert page.select_one(".embed-actions") is None
-    assert page.find("a", string=lambda value: value and "Open on Hush Line" in value) is None
-    assert page.find("a", attrs={"aria-label": "Emergency exit: Leave"}) is None
+    embed_actions = page.select_one(".embed-actions")
+    assert embed_actions is not None
+    open_profile_link = embed_actions.find(
+        "a", string=lambda value: value and "Open on Hush Line" in value
+    )
+    assert open_profile_link is not None
+    assert open_profile_link.get("href") == url_for(
+        "profile", username=user.primary_username.username
+    )
+    assert open_profile_link.get("target") == "_blank"
+    assert open_profile_link.get("rel") == ["noopener", "noreferrer"]
+    exit_link = embed_actions.find("a", attrs={"aria-label": "Emergency exit: Leave"})
+    assert exit_link is not None
+    assert exit_link.get("href") == "https://en.wikipedia.org/wiki/Main_Page"
+    assert exit_link.get("target") == "_top"
+    assert exit_link.get("rel") == ["noopener", "noreferrer"]
     noscript = page.find("noscript")
     assert noscript is not None
     noscript_text = noscript.get_text(" ", strip=True)
     assert "server-side encrypted fallback" in noscript_text
-    assert "open the full Hush Line profile" not in noscript_text
+    assert "open the full Hush Line profile" in noscript_text
+    noscript_profile_link = noscript.find(
+        "a", string=lambda value: value and "open the full Hush Line profile" in value
+    )
+    assert noscript_profile_link is not None
+    assert noscript_profile_link.get("href") == url_for(
+        "profile", username=user.primary_username.username
+    )
+    assert noscript_profile_link.get("target") == "_blank"
+    assert noscript_profile_link.get("rel") == ["noopener", "noreferrer"]
     email_settings = page.find("div", attrs={"id": "userEmailSettings"})
     assert email_settings is not None
     assert email_settings.has_attr("hidden")
@@ -1394,7 +1416,7 @@ def test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source
     assert "box-sizing: border-box;" in embed_shell_block
     assert "padding: 2.5rem 2rem;" in stylesheet_source
     assert ".embed-profile-summary" not in stylesheet_source
-    assert ".embed-actions" not in stylesheet_source
+    assert ".embed-actions" in stylesheet_source
     assert ".embed-page a,\n.embed-page a.meta" not in stylesheet_source
     assert ".embed-page .badge {\n  border:" not in stylesheet_source
     assert ".embed-page button {\n  background-color:" not in stylesheet_source
@@ -1473,11 +1495,12 @@ def test_embed_profile_keyboard_flow_and_mobile_accessibility_chrome(
     assert response.status_code == 200
     page = BeautifulSoup(response.text, "html.parser")
     focusable_labels = _focusable_labels(page)
-    assert focusable_labels[0] == "field_0"
-    assert "Open on Hush Line" not in focusable_labels
-    assert "Leave" not in focusable_labels
+    assert focusable_labels[0] == "Open on Hush Line"
+    assert focusable_labels[1] == "Leave"
+    assert "field_0" in focusable_labels
     assert "captcha_answer" in focusable_labels
     assert "Send Message" in focusable_labels
+    assert focusable_labels.index("Leave") < focusable_labels.index("field_0")
     assert focusable_labels.index("captcha_answer") < focusable_labels.index("Send Message")
     stylesheet_source = Path("assets/scss/style.scss").read_text()
     assert "@media (max-width: 28rem)" in stylesheet_source
@@ -1519,9 +1542,16 @@ def test_embed_profile_required_chrome_survives_recipient_branding_settings(
     badge_texts = _badge_texts(page)
     assert "⭐️ Verified" in badge_texts
     assert "🔒 End-to-End Encrypted" in badge_texts
-    assert page.select_one(".embed-actions") is None
-    assert page.find("a", string=lambda value: value and "Open on Hush Line" in value) is None
-    assert page.find("a", attrs={"aria-label": "Emergency exit: Exit Now"}) is None
+    embed_actions = page.select_one(".embed-actions")
+    assert embed_actions is not None
+    assert (
+        embed_actions.find("a", string=lambda value: value and "Open on Hush Line" in value)
+        is not None
+    )
+    exit_link = embed_actions.find("a", attrs={"aria-label": "Emergency exit: Exit Now"})
+    assert exit_link is not None
+    assert exit_link.get("href") == "https://example.org/safety"
+    assert exit_link.get("target") == "_top"
 
 
 def test_embed_profile_template_shows_caution_state(client: FlaskClient, user: User) -> None:


### PR DESCRIPTION
### Motivation
- A recent change removed the embedded-profile safety chrome (first‑party "Open on Hush Line" link and the emergency‑exit action), which weakens whistleblower safety when the profile is framed by an allowed origin. 
- Threat/risk: a compromised or malicious allowed embed origin could display the iframe without a first‑party breakout link or a top‑level emergency exit, degrading whistleblower anti‑phishing and escape options. 
- Affected data paths: unauthenticated embedded disclosure form rendering and user-facing embed chrome for message senders/whistleblowers. 
- Goal: restore the minimal in‑frame safety controls while preserving existing CSP/frame‑ancestors allowlist and embed eligibility checks.

### Description
- Restored an `.embed-actions` nav with an "Open on Hush Line" link and an emergency‑exit link (uses `target="_top"`) in `hushline/templates/embed_profile.html`. 
- Reintroduced `open_profile_url` into the render context in `hushline/routes/profile.py` so the template can render the canonical profile breakout link. 
- Re-added minimal responsive CSS for the embed safety actions in `assets/scss/style.scss`. 
- Updated regression tests in `tests/test_embeddable_forms_settings.py` to assert the presence, hrefs, `target` and `rel` attributes of the restored links and noscript fallback, and to validate keyboard order and stylesheet expectations.

### Testing
- Ran formatting and static checks: `poetry run ruff format` then `poetry run ruff check` on the touched files and fixed formatting issues; these checks passed after the fix. 
- Ran a targeted unit test: `poetry run pytest tests/test_embeddable_forms_settings.py::test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source -q` which passed. 
- Attempted DB‑backed pytest cases exercising the embedded template and keyboard/branding flows, but those tests were blocked in this environment due to no PostgreSQL host (`psycopg OperationalError`) and Docker not being available; CI must run the full DB-backed tests. 
- Linting and full test runs via `make lint` / `make test` and dependency audits (`make audit-python`, `make audit-node-runtime`) were blocked because the Makefile delegates to Docker which is not installed here, and `npm audit` returned an HTTP 403 from the registry audit endpoint in this environment; a passing Dependency Security Audit workflow is required before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1f71860204832fa88054f2d15ca42e)