### PR TITLE
Keep embedded forms on a light surface

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3685,7 +3685,7 @@ p.bio+.extra-fields {
   color: var(--theme-color);
 }
 
-.embed-page button,
+.embed-page button[type="submit"],
 .embed-page input[type="submit"] {
   background-color: var(--color-brand-bg);
   border: var(--border-button);

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -1362,6 +1362,9 @@ body.directory-page {
 
 body.embed-page {
   align-items: stretch;
+  background-color: white;
+  color: var(--color-text);
+  color-scheme: light;
   display: block;
   padding: 0;
 }
@@ -3660,13 +3663,34 @@ p.bio+.extra-fields {
 }
 
 .embed-page select {
+  appearance: none;
+  background-color: white;
   background-image: url("../img/dropdown.png");
+  color: var(--color-text);
+  -webkit-text-fill-color: currentColor;
 }
 
 .embed-page textarea,
 .embed-page input:not([type="hidden"]),
 .embed-page select {
+  background-color: white;
+  border: var(--border);
+  color: var(--color-text);
+  color-scheme: light;
   width: 100%;
+}
+
+.embed-page a,
+.embed-page a.meta {
+  color: var(--theme-color);
+}
+
+.embed-page button,
+.embed-page input[type="submit"] {
+  background-color: var(--color-brand-bg);
+  border: var(--border-button);
+  color: var(--theme-color);
+  box-shadow: 0px 2px 0px 0px oklch(from var(--color-brand) l c h / 0.25);
 }
 
 .embed-page .captcha_container {

--- a/hushline/embeds.py
+++ b/hushline/embeds.py
@@ -21,7 +21,7 @@ EMBED_IFRAME_SANDBOX = (
     "allow-forms allow-popups allow-popups-to-escape-sandbox "
     "allow-scripts allow-top-navigation-by-user-activation"
 )
-EMBED_IFRAME_HEIGHT = 700
+EMBED_IFRAME_HEIGHT = 1300
 EMBED_IFRAME_MAX_WIDTH = 720
 
 

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1401,7 +1401,11 @@ def test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source
     assert ".embed-actions" not in stylesheet_source
     assert ".embed-page a,\n.embed-page a.meta" in stylesheet_source
     assert ".embed-page .badge {\n  border:" not in stylesheet_source
-    assert '.embed-page button,\n.embed-page input[type="submit"] {' in stylesheet_source
+    assert ".embed-page button,\n.embed-page input" not in stylesheet_source
+    assert (
+        '.embed-page button[type="submit"],\n.embed-page input[type="submit"] {'
+        in stylesheet_source
+    )
     assert "h2.submit+p {\n  margin-top: 1rem;" not in stylesheet_source
     assert "h2.submit:not(:has(+ p.bio))" not in stylesheet_source
     assert ".embed-error-summary" in stylesheet_source
@@ -1539,6 +1543,9 @@ def test_embed_profile_template_shows_caution_state(client: FlaskClient, user: U
     assert response.status_code == 200
     page = BeautifulSoup(response.text, "html.parser")
     assert "⚠️ Caution" in _badge_texts(page)
+    help_trigger = page.select_one("button.meta.badgeHelpTrigger")
+    assert help_trigger is not None
+    assert help_trigger["type"] == "button"
     assert "Visitors should be cautious of interacting with this account." in response.text
 
 

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1311,7 +1311,8 @@ def test_primary_embed_settings_update_origins_and_render_iframe_snippet(
     expected_title_recipient = user.primary_username.display_name or user.primary_username.username
     assert expected_title_recipient in iframe["title"]
     assert iframe["width"] == "100%"
-    assert iframe["height"] == "700"
+    assert iframe["height"] == "1300"
+    assert "height:1300px" in iframe["style"]
     assert "max-width:720px" in iframe["style"]
     assert "outline:1px solid rgba(0,0,0,0.18)" in iframe["style"]
     assert "border-radius:0.25rem" in iframe["style"]
@@ -1387,8 +1388,10 @@ def test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source
     assert "body.embed-page" in stylesheet_source
     assert "body.embed-page *:not(button)" not in stylesheet_source
     assert (
-        "body.embed-page {\n  align-items: stretch;\n  background-color:" not in stylesheet_source
+        "body.embed-page {\n  align-items: stretch;\n  background-color: white;"
+        in stylesheet_source
     )
+    assert "  color-scheme: light;" in stylesheet_source
     assert ".embed-shell" in stylesheet_source
     embed_shell_block = stylesheet_source.split(".embed-shell {", 1)[1].split("}", 1)[0]
     assert "box-sizing: border-box;" in embed_shell_block
@@ -1396,9 +1399,9 @@ def test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source
     assert ".embed-meta {\n  font-family: var(--font-mono);" in stylesheet_source
     assert ".embed-profile-summary" not in stylesheet_source
     assert ".embed-actions" not in stylesheet_source
-    assert ".embed-page a,\n.embed-page a.meta" not in stylesheet_source
+    assert ".embed-page a,\n.embed-page a.meta" in stylesheet_source
     assert ".embed-page .badge {\n  border:" not in stylesheet_source
-    assert ".embed-page button {\n  background-color:" not in stylesheet_source
+    assert '.embed-page button,\n.embed-page input[type="submit"] {' in stylesheet_source
     assert "h2.submit+p {\n  margin-top: 1rem;" not in stylesheet_source
     assert "h2.submit:not(:has(+ p.bio))" not in stylesheet_source
     assert ".embed-error-summary" in stylesheet_source


### PR DESCRIPTION
## What changed
- Forces `body.embed-page` onto a white, light-only surface with embed-scoped text/control/link/button colors.
- Keeps embedded form controls from inheriting host or system dark-mode styling.
- Raises the generated iframe height from 700px to 1300px.
- Updates embed settings/style tests to lock in the new iframe height and light-surface CSS expectations.

## Why
Embedded forms can appear on unknown host pages, so they should render predictably instead of following the viewer's dark-mode preference or host page assumptions. The taller default iframe height also reduces clipping for longer embedded forms.

## Validation
- `docker compose run --rm --no-deps app poetry run pytest tests/test_embeddable_forms_settings.py::test_primary_embed_settings_update_origins_and_render_iframe_snippet tests/test_embeddable_forms_settings.py::test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source tests/test_embeddable_forms_settings.py::test_embed_profile_template_has_compact_trust_chrome_and_form -q`
- `make lint`
- `make test` after `docker compose down -v` fresh-stack reset: `2059 passed, 1 deselected, 1 xfailed`

## Manual testing
Not run in browser locally. The generated snippet and embed stylesheet behavior are covered by focused tests.

## Known risks
The fixed 1300px iframe may leave extra whitespace for short forms, but avoids clipping longer embedded forms and keeps host-page integration simple.