### PR TITLE
Align embedded form submit button styles

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3698,9 +3698,9 @@ h2.submit#embed-recipient-heading {
 
 .embed-page button[type="submit"],
 .embed-page input[type="submit"] {
-  background-color: var(--color-brand-bg);
+  background-color: var(--color-brand);
   border: var(--border-button);
-  color: var(--theme-color);
+  color: white;
   box-shadow: 0px 2px 0px 0px oklch(from var(--color-brand) l c h / 0.25);
 }
 

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1389,7 +1389,7 @@ def test_embed_profile_template_has_compact_trust_chrome_and_form(
     assert "script-widget" not in response.text
 
 
-def test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source() -> None:
+def test_embed_profile_layout_theme_and_focus_styles_are_in_compiled_stylesheet_source() -> None:
     stylesheet_source = Path("assets/scss/style.scss").read_text()
 
     assert "body.embed-page" in stylesheet_source
@@ -1418,6 +1418,25 @@ def test_embed_profile_layout_and_focus_styles_are_in_compiled_stylesheet_source
     assert ".embed-error-summary" in stylesheet_source
     assert ".embed-noscript" in stylesheet_source
     assert ".embed-page .captcha_container {\n  align-items: center;" in stylesheet_source
+    assert ".embed-page a,\n.embed-page a.meta {\n  color: var(--theme-color);" in stylesheet_source
+    assert (
+        '.embed-page button[type="submit"],\n.embed-page input[type="submit"] {'
+        in stylesheet_source
+    )
+    assert "background-color: var(--color-brand);" in stylesheet_source
+    assert "border: var(--border-button);" in stylesheet_source
+    assert (
+        "box-shadow: 0px 2px 0px 0px oklch(from var(--color-brand) l c h / 0.25);"
+        in stylesheet_source
+    )
+    assert "@media (prefers-color-scheme: dark)" in stylesheet_source
+    assert (
+        '.embed-page .icon.verifiedURL {\n    background-image: url("../img/icon-verified-lm.png");'
+        in stylesheet_source
+    )
+    assert ".embed-page h2.submit + .badgeContainer .badge {" in stylesheet_source
+    assert "border-color: var(--color-brand);" in stylesheet_source
+    assert ".embed-page #messageForm {\n    border-top: var(--border);" in stylesheet_source
     assert (
         "#messageForm {\n  position: relative;\n  padding-top: 1.5rem;\n  margin-top: 0;"
         in stylesheet_source


### PR DESCRIPTION
## What changed

- Aligns embedded form submit buttons with the app brand button treatment.
- Keeps current `main` embed layout, iframe defaults, links, and dark-mode embed styles intact.
- Expands the embed stylesheet contract test to lock the theme, submit button, and dark-mode rules that are hard to QA visually.

## Why

Embedded forms are difficult to QA visually because they render outside the main app shell. Pinning the CSS contract in tests gives reviewers a concrete regression check for the light/dark styling and submit button behavior while keeping the form aligned with existing app tokens.

## Validation

- `npm run build:prod` (passes; existing Dart Sass legacy JS API deprecation warning)
- `make test TESTS=tests/test_embeddable_forms_settings.py` (`52 passed`)
- `IS_DOCKER=1 make lint`
- `make audit-node-runtime` (`found 0 vulnerabilities`)
- `make audit-python` (`No known vulnerabilities found`)
- `make test` (`2059 passed, 1 deselected, 1 xfailed`)

## Manual testing

- Not separately performed for this metadata/test pass; coverage is via stylesheet contract test and production asset build.

## Risks / follow-ups

- Rebased onto current `main` and resolved the embedded SCSS conflict before rerunning validation.
- Existing Sass legacy JS API warning remains a tooling follow-up outside this PR.
