### PR TITLE
Use brand color for embedded form links

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3693,7 +3693,7 @@ h2.submit#embed-recipient-heading {
 
 .embed-page a,
 .embed-page a.meta {
-  color: var(--theme-color);
+  color: var(--color-brand);
 }
 
 .embed-page button[type="submit"],

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1418,7 +1418,7 @@ def test_embed_profile_layout_theme_and_focus_styles_are_in_compiled_stylesheet_
     assert ".embed-error-summary" in stylesheet_source
     assert ".embed-noscript" in stylesheet_source
     assert ".embed-page .captcha_container {\n  align-items: center;" in stylesheet_source
-    assert ".embed-page a,\n.embed-page a.meta {\n  color: var(--theme-color);" in stylesheet_source
+    assert ".embed-page a,\n.embed-page a.meta {\n  color: var(--color-brand);" in stylesheet_source
     assert (
         '.embed-page button[type="submit"],\n.embed-page input[type="submit"] {'
         in stylesheet_source


### PR DESCRIPTION
## What changed
- Updated embedded form links to use the configured brand color token directly.
- Updated the embed stylesheet source test to lock the link color to `var(--color-brand)`.

## Why
Embedded form links should match the organization brand color consistently instead of relying on the broader theme color alias.

## Validation
- `docker compose run --rm app poetry run pytest tests/test_embeddable_forms_settings.py::test_embed_profile_layout_theme_and_focus_styles_are_in_compiled_stylesheet_source -q`
- `make lint`
- `make test`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing
- Not applicable; this is a stylesheet token update covered by the embedded form stylesheet source test.

## Risk
Low. The change is scoped to links inside `body.embed-page` and does not alter form submission, CSP, frame ancestors, or encryption behavior.