### PR TITLE
Add Safari fallback for embedded form branding

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -125,7 +125,12 @@ document.addEventListener("DOMContentLoaded", function () {
   if (colorPicker) {
     for (const eventName of ["input", "change"]) {
       colorPicker.addEventListener(eventName, function (event) {
-        const brandColor = `oklch(from ${event.target.value} l c h)`;
+        const brandColor = CSS.supports(
+          "color",
+          `oklch(from ${event.target.value} l c h)`,
+        )
+          ? `oklch(from ${event.target.value} l c h)`
+          : event.target.value;
         document.documentElement.style.setProperty("--color-brand", brandColor);
       });
     }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3701,7 +3701,14 @@ h2.submit#embed-recipient-heading {
   background-color: var(--color-brand);
   border: var(--border-button);
   color: white;
+  box-shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.18);
   box-shadow: 0px 2px 0px 0px oklch(from var(--color-brand) l c h / 0.25);
+}
+
+.embed-page h2.submit + .badgeContainer .badge {
+  background-color: white;
+  border-color: var(--color-brand);
+  color: var(--color-brand);
 }
 
 @media (prefers-color-scheme: dark) {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3705,7 +3705,7 @@ h2.submit#embed-recipient-heading {
   box-shadow: 0px 2px 0px 0px oklch(from var(--color-brand) l c h / 0.25);
 }
 
-.embed-page h2.submit + .badgeContainer .badge {
+.embed-page h2.submit + .badgeContainer .badge:not(.badgeCaution) {
   background-color: white;
   border-color: var(--color-brand);
   color: var(--color-brand);
@@ -3720,7 +3720,7 @@ h2.submit#embed-recipient-heading {
     background-image: url("../img/icon-verified-lm.png");
   }
 
-  .embed-page h2.submit + .badgeContainer .badge {
+  .embed-page h2.submit + .badgeContainer .badge:not(.badgeCaution) {
     background-color: white;
     border-color: var(--color-brand);
     color: var(--color-brand);

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -157,8 +157,14 @@
     <script defer src="{{ url_for('static', filename='js/global.js') }}"></script>
     <style>
       :root {
-        --color-brand: oklch(from {{ brand_primary_color }} l c h);
+        --color-brand: {{ brand_primary_color }};
         --theme-color-dark: {{ brand_primary_color_dark }};
+      }
+
+      @supports (color: oklch(from #000000 l c h)) {
+        :root {
+          --color-brand: oklch(from {{ brand_primary_color }} l c h);
+        }
       }
     </style>
   </head>

--- a/hushline/templates/embed_profile.html
+++ b/hushline/templates/embed_profile.html
@@ -12,7 +12,13 @@
     <script src="{{ url_for('static', filename='no-js.js') }}"></script>
     <style>
       :root {
-        --color-brand: oklch(from {{ brand_primary_color }} l c h);
+        --color-brand: {{ brand_primary_color }};
+      }
+
+      @supports (color: oklch(from #000000 l c h)) {
+        :root {
+          --color-brand: oklch(from {{ brand_primary_color }} l c h);
+        }
       }
     </style>
     {% if not message_submission_block_reason %}

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1433,14 +1433,18 @@ def test_embed_profile_layout_theme_and_focus_styles_are_in_compiled_stylesheet_
         "box-shadow: 0px 2px 0px 0px oklch(from var(--color-brand) l c h / 0.25);"
         in stylesheet_source
     )
-    assert ".embed-page h2.submit + .badgeContainer .badge {" in stylesheet_source
+    assert (
+        ".embed-page h2.submit + .badgeContainer .badge:not(.badgeCaution) {" in stylesheet_source
+    )
     assert "border-color: var(--color-brand);" in stylesheet_source
     assert "@media (prefers-color-scheme: dark)" in stylesheet_source
     assert (
         '.embed-page .icon.verifiedURL {\n    background-image: url("../img/icon-verified-lm.png");'
         in stylesheet_source
     )
-    assert ".embed-page h2.submit + .badgeContainer .badge {" in stylesheet_source
+    assert (
+        ".embed-page h2.submit + .badgeContainer .badge:not(.badgeCaution) {" in stylesheet_source
+    )
     assert "border-color: var(--color-brand);" in stylesheet_source
     assert ".embed-page #messageForm {\n    border-top: var(--border);" in stylesheet_source
     assert (
@@ -1452,7 +1456,7 @@ def test_embed_profile_layout_theme_and_focus_styles_are_in_compiled_stylesheet_
     assert "outline: 3px solid var(--theme-color-dark)" not in stylesheet_source
     assert ".embed-page .meta {\n    color: var(--color-text-light);" in stylesheet_source
     assert ".embed-page .icon.verifiedURL" in stylesheet_source
-    assert ".embed-page h2.submit + .badgeContainer .badge" in stylesheet_source
+    assert ".embed-page h2.submit + .badgeContainer .badge:not(.badgeCaution)" in stylesheet_source
     assert ".embed-page #messageForm" in stylesheet_source
 
 

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1345,7 +1345,10 @@ def test_embed_profile_template_has_compact_trust_chrome_and_form(
     assert stylesheet.get("href") == url_for("static", filename="css/style.css")
     runtime_style = page.find("style")
     assert runtime_style is not None
-    assert "--color-brand: oklch(from" in runtime_style.get_text()
+    runtime_style_text = runtime_style.get_text()
+    assert "--color-brand: #7d25c1;" in runtime_style_text
+    assert "@supports (color: oklch(from #000000 l c h))" in runtime_style_text
+    assert "--color-brand: oklch(from" in runtime_style_text
     assert "--theme-color-dark:" not in runtime_style.get_text()
     assert page.find(string="Secure Hush Line form") is None
     assert "Hosted by" not in response.text
@@ -1425,10 +1428,13 @@ def test_embed_profile_layout_theme_and_focus_styles_are_in_compiled_stylesheet_
     )
     assert "background-color: var(--color-brand);" in stylesheet_source
     assert "border: var(--border-button);" in stylesheet_source
+    assert "box-shadow: 0px 2px 0px 0px rgba(0, 0, 0, 0.18);" in stylesheet_source
     assert (
         "box-shadow: 0px 2px 0px 0px oklch(from var(--color-brand) l c h / 0.25);"
         in stylesheet_source
     )
+    assert ".embed-page h2.submit + .badgeContainer .badge {" in stylesheet_source
+    assert "border-color: var(--color-brand);" in stylesheet_source
     assert "@media (prefers-color-scheme: dark)" in stylesheet_source
     assert (
         '.embed-page .icon.verifiedURL {\n    background-image: url("../img/icon-verified-lm.png");'
@@ -1549,7 +1555,9 @@ def test_embed_profile_required_chrome_survives_recipient_branding_settings(
     assert page.find(string="Secure Hush Line form") is None
     runtime_style = page.find("style")
     assert runtime_style is not None
-    assert "--color-brand: oklch(from #005f73 l c h);" in runtime_style.get_text()
+    runtime_style_text = runtime_style.get_text()
+    assert "--color-brand: #005f73;" in runtime_style_text
+    assert "--color-brand: oklch(from #005f73 l c h);" in runtime_style_text
     assert not page.find(string=lambda value: value and "Hosted by Recipient Brand" in value)
     assert "Powered by Hush Line" not in response.text
     assert "Recipient Newsroom" in response.text

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -2390,7 +2390,11 @@ def test_update_brand_primary_color(client: FlaskClient, admin: User) -> None:
     styles = soup.find_all("style")
     assert styles  # sensibility check
     for style in styles:
-        if f"--color-brand: oklch(from {color} l c h);" in style.string:
+        style_text = style.get_text()
+        if (
+            f"--color-brand: {color};" in style_text
+            and f"--color-brand: oklch(from {color} l c h);" in style_text
+        ):
             break
     else:
         pytest.fail("Brand color CSS not updated in response <style>")


### PR DESCRIPTION
## What changed

- Added plain hex `--color-brand` fallbacks in the base and embedded profile templates.
- Kept the existing relative `oklch(from ...)` brand color path behind an explicit `@supports` guard.
- Added embed-specific fallback styling for submit button shadow and trust badges so older WebKit keeps visible brand styling when relative color syntax is unsupported.
- Updated embed and branding tests to require both the fallback and modern color paths.

## Why

Safari and iOS Safari before full relative OKLCH support can reject `oklch(from ...)` values. The embedded form currently writes the recipient brand color only through that newer syntax, which can leave affected WebKit versions with missing or degraded embed styling. This preserves the modern color behavior where supported while giving older Safari/iOS a normal hex color path.

## Impact

This is a CSS compatibility fix for embedded forms and branded pages. It does not change embed sandboxing, CSP, frame ancestors, message submission, CSRF, encryption, or notification behavior.

## Validation

- `npm run build:prod` passed; emitted the existing Sass legacy JS API deprecation warning only.
- `make lint` passed.
- Focused tests passed:
  - `make test TESTS="tests/test_embeddable_forms_settings.py::test_embed_profile_template_has_compact_trust_chrome_and_form tests/test_embeddable_forms_settings.py::test_embed_profile_layout_theme_and_focus_styles_are_in_compiled_stylesheet_source tests/test_embeddable_forms_settings.py::test_embed_profile_required_chrome_survives_recipient_branding_settings tests/test_settings.py::test_update_brand_primary_color"`
- Full test suite passed: `make test` (`2059 passed, 1 deselected, 1 xfailed`, 100% coverage).
- `make audit-node-runtime` passed with 0 vulnerabilities.
- `make audit-python` passed with no known vulnerabilities found.

## Manual testing

Not run on older physical iOS/iPadOS hardware. Recommended manual check before merge or immediately after staging deploy: open a customer iframe embed on the affected Safari/iOS version and verify the embedded form shows padding, fonts, button/badge colors, borders, and field styling.

## Risks and follow-ups

- Current WebKit 26 rendered the live iframe correctly in Playwright before this change; this PR targets older Safari/iOS relative color syntax gaps.
- The fallback uses the configured hex brand color directly, so older browsers may not get the same contrast-adjusted derived colors as modern browsers, but they keep visible styling instead of dropping brand-dependent declarations.