### PR TITLE
Add dynamic height resizing for embedded forms

### DIFF
--- a/assets/js/embed-resize.js
+++ b/assets/js/embed-resize.js
@@ -1,0 +1,95 @@
+(function () {
+  const script = document.currentScript;
+  const MESSAGE_TYPE = "hushline:embed:height";
+  const MIN_HEIGHT = 320;
+  const MAX_HEIGHT = 4096;
+  const HEIGHT_STEP = 32;
+
+  function allowedOrigins() {
+    try {
+      const parsed = JSON.parse(script?.dataset.allowedOrigins || "[]");
+      return Array.isArray(parsed)
+        ? parsed.filter((origin) => typeof origin === "string" && origin.length > 0)
+        : [];
+    } catch {
+      return [];
+    }
+  }
+
+  const targetOrigins = allowedOrigins();
+  if (window.parent === window || targetOrigins.length === 0) {
+    return;
+  }
+
+  function boundedHeight(height) {
+    const rounded = Math.ceil(height / HEIGHT_STEP) * HEIGHT_STEP;
+    return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, rounded));
+  }
+
+  function documentHeight() {
+    const body = document.body;
+    const html = document.documentElement;
+    return Math.max(
+      body?.scrollHeight || 0,
+      body?.offsetHeight || 0,
+      html?.scrollHeight || 0,
+      html?.offsetHeight || 0,
+    );
+  }
+
+  let lastHeight = 0;
+  let pendingAnimationFrame = 0;
+
+  function publishHeight() {
+    pendingAnimationFrame = 0;
+    const height = boundedHeight(documentHeight());
+    if (height === lastHeight) {
+      return;
+    }
+    lastHeight = height;
+    const message = {
+      type: MESSAGE_TYPE,
+      version: 1,
+      height,
+    };
+    for (const origin of targetOrigins) {
+      window.parent.postMessage(message, origin);
+    }
+  }
+
+  function queueHeightPublish() {
+    if (pendingAnimationFrame) {
+      return;
+    }
+    pendingAnimationFrame = window.requestAnimationFrame(publishHeight);
+  }
+
+  function start() {
+    queueHeightPublish();
+    window.addEventListener("load", queueHeightPublish);
+    window.addEventListener("pageshow", queueHeightPublish);
+
+    if ("ResizeObserver" in window) {
+      const resizeObserver = new ResizeObserver(queueHeightPublish);
+      resizeObserver.observe(document.documentElement);
+      if (document.body) {
+        resizeObserver.observe(document.body);
+      }
+    }
+
+    if ("MutationObserver" in window && document.body) {
+      const mutationObserver = new MutationObserver(queueHeightPublish);
+      mutationObserver.observe(document.body, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+      });
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", start, { once: true });
+  } else {
+    start();
+  }
+})();

--- a/assets/js/embed-resize.js
+++ b/assets/js/embed-resize.js
@@ -26,14 +26,17 @@
     return Math.min(MAX_HEIGHT, Math.max(MIN_HEIGHT, rounded));
   }
 
-  function documentHeight() {
-    const body = document.body;
-    const html = document.documentElement;
+  function contentRoot() {
+    return document.querySelector(".embed-shell") || document.body || document.documentElement;
+  }
+
+  function contentHeight() {
+    const root = contentRoot();
+    const rect = root.getBoundingClientRect();
+    const top = rect.top + window.scrollY;
     return Math.max(
-      body?.scrollHeight || 0,
-      body?.offsetHeight || 0,
-      html?.scrollHeight || 0,
-      html?.offsetHeight || 0,
+      rect.bottom + window.scrollY,
+      top + (root.scrollHeight || 0),
     );
   }
 
@@ -42,7 +45,7 @@
 
   function publishHeight() {
     pendingAnimationFrame = 0;
-    const height = boundedHeight(documentHeight());
+    const height = boundedHeight(contentHeight());
     if (height === lastHeight) {
       return;
     }
@@ -71,7 +74,7 @@
 
     if ("ResizeObserver" in window) {
       const resizeObserver = new ResizeObserver(queueHeightPublish);
-      resizeObserver.observe(document.documentElement);
+      resizeObserver.observe(contentRoot());
       if (document.body) {
         resizeObserver.observe(document.body);
       }

--- a/docs/EMBEDDABLE-E2EE-PROFILE-FORMS-FEASIBILITY.md
+++ b/docs/EMBEDDABLE-E2EE-PROFILE-FORMS-FEASIBILITY.md
@@ -8,7 +8,7 @@ This study evaluates whether Hush Line should support embeddable profile forms o
 
 Recommendation: `Proceed with a restricted hosted iframe embed`, gated behind explicit administrator controls and recipient opt-in for eligible profiles.
 
-The preferred path is a Hush Line-hosted embed endpoint that renders a minimal intake form in a sandboxed iframe. The form, JavaScript, CSRF token, CAPTCHA, custom fields, client-side E2EE bundle, submission POST, success state, and no-JS fallback should all remain served by Hush Line. The embedding site should receive only the iframe URL and fixed-size container guidance.
+The preferred path is a Hush Line-hosted embed endpoint that renders a minimal intake form in a sandboxed iframe. The form, JavaScript, CSRF token, CAPTCHA, custom fields, client-side E2EE bundle, submission POST, success state, and no-JS fallback should all remain served by Hush Line. The embedding site should receive only the iframe URL, a fallback fixed-size container, and an optional bounded height-only resize listener.
 
 Reject script widgets, static generated forms, and any model where the parent website owns the form DOM or submission JavaScript. Those approaches let the embedding site observe or alter plaintext disclosure content before Hush Line encryption can run.
 
@@ -35,6 +35,7 @@ Shape:
 - The parent site receives an `<iframe>` snippet, not a script snippet.
 - The iframe uses `sandbox` attributes that allow forms and scripts but do not grant same-origin access to the parent.
 - The iframe owns the form DOM, CSRF token, CAPTCHA, recipient public keys JSON, client-side encryption bundle, and POST target.
+- The iframe may publish bounded, quantized height updates to configured parent origins so the parent can fit the frame without learning submission data.
 - The iframe success state should show the reply link inside Hush Line-controlled UI and include a clear option to open the reply page in a new top-level Hush Line tab.
 - Hush Line should continue to support server-side encryption fallback when JavaScript is unavailable, but the embed should clearly indicate when the sender should open the full Hush Line profile for the strongest experience.
 
@@ -176,7 +177,8 @@ The iframe model can preserve client-side E2EE because the encryption code, reci
 
 - Recipient public keys are loaded from Hush Line, not from parent-page attributes.
 - Parent pages cannot pass replacement keys into the iframe.
-- `postMessage` is not used for plaintext, ciphertext, keys, field definitions, reply slugs, or validation errors.
+- `postMessage` is not used for plaintext, ciphertext, keys, field definitions, reply slugs, validation errors, parent-page metadata, or arbitrary submission state.
+- Any `postMessage` resize payload is limited to a message type, protocol version, and bounded rounded height.
 - The server-side fallback remains available for no-JS or failed-client-crypto submissions, matching current behavior.
 - Existing padding behavior for encrypted fields remains in place to reduce field-length inference.
 
@@ -220,7 +222,8 @@ An embed cannot make sender activity invisible to the parent site. The parent ca
 - Treat parent cooperation as helpful but not sufficient; a hostile or modified parent page can remove the iframe attribute.
 - Avoid putting usernames, field names, disclosure subjects, campaign names, or sender-specific values in query strings.
 - Do not send parent URL, title, analytics IDs, or arbitrary metadata to Hush Line.
-- Use fixed or bounded iframe sizing where possible so height changes do not reveal which field validation path occurred.
+- Use a fixed fallback height and bounded, quantized iframe resize messages so height changes do not reveal exact form state.
+- Send resize messages only to configured embed origins and have the parent listener accept them only from the matching iframe window.
 - Do not expose reply slugs to the parent page.
 
 ### Logging and Analytics

--- a/hushline/embeds.py
+++ b/hushline/embeds.py
@@ -22,7 +22,10 @@ EMBED_IFRAME_SANDBOX = (
     "allow-scripts allow-top-navigation-by-user-activation"
 )
 EMBED_IFRAME_HEIGHT = 1300
+EMBED_IFRAME_MIN_HEIGHT = 320
+EMBED_IFRAME_MAX_HEIGHT = 4096
 EMBED_IFRAME_MAX_WIDTH = 720
+EMBED_RESIZE_MESSAGE_TYPE = "hushline:embed:height"
 
 
 @dataclass(frozen=True)
@@ -42,7 +45,7 @@ def embed_iframe_snippet(username: Username) -> str:
     title = html.escape(
         f"Send a secure Hush Line message to {username.display_name or username.username}"
     )
-    return (
+    iframe = (
         f'<iframe src="{src}" '
         f'title="{title}" '
         f'sandbox="{EMBED_IFRAME_SANDBOX}" '
@@ -54,6 +57,27 @@ def embed_iframe_snippet(username: Username) -> str:
         "border-radius:0.25rem;"
         'box-shadow:0px 4px 8px -4px rgba(0,0,0,0.15);"></iframe>'
     )
+    resize_script = (
+        "<script>(function(){"
+        "var iframe=document.currentScript&&document.currentScript.previousElementSibling;"
+        'if(!iframe||iframe.tagName!=="IFRAME")return;'
+        "var origin;"
+        "try{origin=new URL(iframe.src).origin;}catch(error){return;}"
+        'window.addEventListener("message",function(event){'
+        "if(event.source!==iframe.contentWindow)return;"
+        'if(event.origin!==origin&&event.origin!=="null")return;'
+        "var data=event.data||{};"
+        f'if(data.type!=="{EMBED_RESIZE_MESSAGE_TYPE}"||data.version!==1)return;'
+        "var height=Number(data.height);"
+        "if(!Number.isInteger(height)"
+        f"||height<{EMBED_IFRAME_MIN_HEIGHT}"
+        f"||height>{EMBED_IFRAME_MAX_HEIGHT})return;"
+        "iframe.height=String(height);"
+        'iframe.style.height=height+"px";'
+        "});"
+        "})();</script>"
+    )
+    return iframe + resize_script
 
 
 def _embed_hmac(value: str) -> str:

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -289,6 +289,11 @@ def register_profile_routes(app: Flask) -> None:
                 owner_guard_signature=owner_guard_signature,
                 is_embedded=is_embedded,
                 embed_captcha_token=embed_captcha_token,
+                embed_allowed_origins=(
+                    Username.normalize_embed_allowed_origins(uname.embed_allowed_origins or [])
+                    if is_embedded
+                    else []
+                ),
             )
             if status_code is None:
                 return rendered

--- a/hushline/templates/embed_profile.html
+++ b/hushline/templates/embed_profile.html
@@ -10,6 +10,11 @@
       href="{{ url_for('static', filename='css/style.css') }}"
     />
     <script src="{{ url_for('static', filename='no-js.js') }}"></script>
+    <script
+      defer
+      src="{{ url_for('static', filename='js/embed-resize.js') }}"
+      data-allowed-origins='{{ embed_allowed_origins | tojson }}'
+    ></script>
     <style>
       :root {
         --color-brand: oklch(from {{ brand_primary_color }} l c h);

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1,3 +1,4 @@
+import json
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -96,7 +97,6 @@ def _iframe_from_snippet(response_text: str) -> BeautifulSoup:
     snippet = page.find("textarea", id="embed_iframe_snippet")
     assert snippet is not None
     snippet_text = snippet.get_text()
-    assert "<script" not in snippet_text.lower()
     return BeautifulSoup(snippet_text, "html.parser")
 
 
@@ -1015,6 +1015,26 @@ def test_embed_profile_has_no_postmessage_submission_path(client: FlaskClient, u
     assert "postMessage" not in Path("assets/js/message_success.js").read_text()
 
 
+def test_embed_resize_script_posts_only_bounded_height_metadata() -> None:
+    source = Path("assets/js/embed-resize.js").read_text()
+
+    assert 'const MESSAGE_TYPE = "hushline:embed:height";' in source
+    assert "const MIN_HEIGHT = 320;" in source
+    assert "const MAX_HEIGHT = 4096;" in source
+    assert "const HEIGHT_STEP = 32;" in source
+    assert 'JSON.parse(script?.dataset.allowedOrigins || "[]")' in source
+    assert "Math.ceil(height / HEIGHT_STEP) * HEIGHT_STEP" in source
+    assert "window.parent.postMessage(message, origin)" in source
+    assert "ResizeObserver" in source
+    assert "MutationObserver" in source
+    assert "requestAnimationFrame" in source
+    assert "field_" not in source
+    assert "csrf" not in source.lower()
+    assert "cipher" not in source.lower()
+    assert "reply" not in source.lower()
+    assert "message_slug" not in source
+
+
 def test_profile_settings_do_not_render_embed_settings(client: FlaskClient, user: User) -> None:
     _make_message_capable(user)
     _configure_embed(user.primary_username)
@@ -1324,6 +1344,20 @@ def test_primary_embed_settings_update_origins_and_render_iframe_snippet(
     assert "outline:1px solid rgba(0,0,0,0.18)" in iframe["style"]
     assert "border-radius:0.25rem" in iframe["style"]
     assert "box-shadow:0px 4px 8px -4px rgba(0,0,0,0.15)" in iframe["style"]
+    scripts = snippet.find_all("script")
+    assert len(scripts) == 1
+    resize_listener = scripts[0].get_text()
+    assert "hushline:embed:height" in resize_listener
+    assert "event.source!==iframe.contentWindow" in resize_listener
+    assert 'event.origin!==origin&&event.origin!=="null"' in resize_listener
+    assert "Number.isInteger(height)" in resize_listener
+    assert "height<320" in resize_listener
+    assert "height>4096" in resize_listener
+    assert 'iframe.style.height=height+"px"' in resize_listener
+    assert "field_" not in resize_listener
+    assert "csrf" not in resize_listener.lower()
+    assert "cipher" not in resize_listener.lower()
+    assert "reply" not in resize_listener.lower()
 
 
 def test_embed_profile_template_has_compact_trust_chrome_and_form(
@@ -1384,6 +1418,10 @@ def test_embed_profile_template_has_compact_trust_chrome_and_form(
     script_sources = [script.get("src", "") for script in page.find_all("script")]
     assert url_for("static", filename="js/diceware-words.js") in script_sources
     assert url_for("static", filename="js/client-side-encryption.js") in script_sources
+    assert url_for("static", filename="js/embed-resize.js") in script_sources
+    resize_script = page.find("script", src=url_for("static", filename="js/embed-resize.js"))
+    assert resize_script is not None
+    assert json.loads(resize_script["data-allowed-origins"]) == ["https://tips.example"]
     assert not any("submit-message.js" in source for source in script_sources)
     assert page.find("iframe") is None
     assert "script-widget" not in response.text

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1023,6 +1023,8 @@ def test_embed_resize_script_posts_only_bounded_height_metadata() -> None:
     assert "const MAX_HEIGHT = 4096;" in source
     assert "const HEIGHT_STEP = 32;" in source
     assert 'JSON.parse(script?.dataset.allowedOrigins || "[]")' in source
+    assert 'document.querySelector(".embed-shell")' in source
+    assert "root.getBoundingClientRect()" in source
     assert "Math.ceil(height / HEIGHT_STEP) * HEIGHT_STEP" in source
     assert "window.parent.postMessage(message, origin)" in source
     assert "ResizeObserver" in source

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -68,6 +68,8 @@ def test_embed_resize_bundle_is_declared_and_height_only() -> None:
     assert "const MIN_HEIGHT = 320;" in js
     assert "const MAX_HEIGHT = 4096;" in js
     assert "const HEIGHT_STEP = 32;" in js
+    assert 'document.querySelector(".embed-shell")' in js
+    assert "root.getBoundingClientRect()" in js
     assert "window.parent.postMessage(message, origin)" in js
     assert "ResizeObserver" in js
     assert "MutationObserver" in js

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -59,6 +59,24 @@ def test_static_js_bundles_avoid_eval_wrappers() -> None:
         assert "webpack://" not in bundle, static_js.name
 
 
+def test_embed_resize_bundle_is_declared_and_height_only() -> None:
+    webpack_config = (ROOT / "webpack.config.js").read_text(encoding="utf-8")
+    js = (ROOT / "assets/js/embed-resize.js").read_text(encoding="utf-8")
+
+    assert '"embed-resize",' in webpack_config
+    assert 'const MESSAGE_TYPE = "hushline:embed:height";' in js
+    assert "const MIN_HEIGHT = 320;" in js
+    assert "const MAX_HEIGHT = 4096;" in js
+    assert "const HEIGHT_STEP = 32;" in js
+    assert "window.parent.postMessage(message, origin)" in js
+    assert "ResizeObserver" in js
+    assert "MutationObserver" in js
+    assert "field_" not in js
+    assert "csrf" not in js.lower()
+    assert "cipher" not in js.lower()
+    assert "reply" not in js.lower()
+
+
 def test_client_side_encryption_has_platform_guards() -> None:
     js = (ROOT / "assets/js/client-side-encryption.js").read_text(encoding="utf-8")
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -10,6 +10,7 @@ modules = [
   "diceware-words",
   "directory",
   "directory_verified",
+  "embed-resize",
   "global",
   "inbox",
   "mailvelope",


### PR DESCRIPTION
## What changed

- Added a Hush Line-hosted `embed-resize.js` bundle for embedded profile forms.
- Updated generated iframe snippets to include a small parent-page listener that resizes only the matching iframe.
- Kept the existing `1300px` iframe height as the no-JS or parent-CSP fallback.
- Bounded and quantized resize heights to reduce exact form-state leakage.
- Updated embed documentation and regression tests for the resize path.

## Why

Embedded forms currently require customers to hard-code iframe height. This lets the iframe grow or shrink with its Hush Line-rendered contents while preserving the hosted iframe model.

## Security and privacy impact

- The iframe sandbox is unchanged.
- The resize message is height-only: message type, protocol version, and bounded rounded height.
- The resize path does not send plaintext, ciphertext, keys, field definitions, reply slugs, CSRF tokens, parent-page metadata, or validation details.
- The iframe posts only to the profile's configured embed origins.
- The parent listener accepts messages only from the matching iframe window and rejects out-of-range heights.
- E2EE, submission POSTs, CSP frame allowlists, and server-side fallback behavior are unchanged.

## Validation

- `npm run build:prod` (passed; existing Sass legacy JS API warning)
- `make lint` (passed)
- `make test` (passed: 2061 passed, 1 deselected, 1 xfailed, 100% coverage)
- `make audit-node-runtime` (passed: 0 vulnerabilities)
- `make audit-python` (passed: no known vulnerabilities)

## Manual testing

1. Enable embeddable forms globally and for a message-capable paid profile.
2. Configure an allowed embedding origin and paste the generated snippet onto that origin.
3. Load the parent page and verify the iframe height adjusts to the form, validation-error state, and success state without clipping or nested scrolling.
4. Verify that a parent page blocking the inline listener with CSP still gets the fixed `1300px` fallback height.

## Known risks

- A strict parent-page CSP can block the generated inline listener; the fallback height remains in place.
- Height is rounded to 32px steps and capped, so the iframe may leave a small amount of whitespace by design.
