### PR TITLE
Allow sandboxed Safari embeds to load Hush Line assets

### DIFF
--- a/docs/EMBEDDABLE-E2EE-PROFILE-FORMS-FEASIBILITY.md
+++ b/docs/EMBEDDABLE-E2EE-PROFILE-FORMS-FEASIBILITY.md
@@ -210,6 +210,7 @@ Embed responses should:
 - Avoid wildcard origins.
 - Avoid path-based trust; browsers enforce `frame-ancestors` at the origin level.
 - Omit `X-Frame-Options` on embed responses only if required for modern `frame-ancestors` compatibility, and test that normal pages still send `DENY`.
+- Include the exact canonical Hush Line origin in embed-only script and style directives because sandboxed Safari frames may not treat `'self'` as the document URL origin.
 - Use a restrictive `sandbox` snippet recommendation such as `allow-forms allow-scripts allow-popups allow-popups-to-escape-sandbox`, adding `allow-same-origin` only if the implementation proves it is required for current client-side encryption and CSRF behavior.
 - Keep script sources limited to Hush Line-owned assets and existing approved dependencies.
 

--- a/docs/EMBEDDABLE-E2EE-PROFILE-FORMS-FEASIBILITY.md
+++ b/docs/EMBEDDABLE-E2EE-PROFILE-FORMS-FEASIBILITY.md
@@ -210,7 +210,7 @@ Embed responses should:
 - Avoid wildcard origins.
 - Avoid path-based trust; browsers enforce `frame-ancestors` at the origin level.
 - Omit `X-Frame-Options` on embed responses only if required for modern `frame-ancestors` compatibility, and test that normal pages still send `DENY`.
-- Include the exact canonical Hush Line origin in embed-only script and style directives because sandboxed Safari frames may not treat `'self'` as the document URL origin.
+- Include the exact canonical Hush Line origin in embed-only script, style, and font directives because sandboxed Safari frames may not treat `'self'` as the document URL origin.
 - Use a restrictive `sandbox` snippet recommendation such as `allow-forms allow-scripts allow-popups allow-popups-to-escape-sandbox`, adding `allow-same-origin` only if the implementation proves it is required for current client-side encryption and CSRF behavior.
 - Keep script sources limited to Hush Line-owned assets and existing approved dependencies.
 

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -1,5 +1,6 @@
 import logging
 import math
+import urllib.parse
 from http import HTTPStatus
 from typing import Any, Mapping, Optional, Tuple, Union
 
@@ -15,6 +16,7 @@ from hushline.cli_reg import register_reg_commands
 from hushline.cli_stripe import register_stripe_commands
 from hushline.config import SPLASH_SCREEN_DURATION_MS, AliasMode, load_config
 from hushline.db import db, migrate
+from hushline.external_urls import canonical_external_url
 from hushline.md import md_to_html
 from hushline.model import OrganizationSetting, User
 from hushline.secure_session import EncryptedSessionInterface
@@ -56,25 +58,38 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
     @app.after_request
     def add_security_header(response: Response) -> Response:
         frame_ancestors = getattr(g, "embed_frame_ancestors", "'none'")
-        if (
-            request.endpoint in {"embed_profile", "embed_profile_legacy"}
-            and response.status_code == HTTPStatus.NOT_FOUND
-        ):
+        is_embed_route = request.endpoint in {"embed_profile", "embed_profile_legacy"}
+        if is_embed_route and response.status_code == HTTPStatus.NOT_FOUND:
             frame_ancestors = "'none'"
+        embed_asset_origin = ""
+        if is_embed_route and frame_ancestors != "'none'":
+            canonical_url = urllib.parse.urlsplit(canonical_external_url("directory"))
+            embed_asset_origin = urllib.parse.urlunsplit(
+                (canonical_url.scheme, canonical_url.netloc, "", "", "")
+            )
+        style_sources = ["'self'", "'unsafe-inline'"]
+        script_sources = [
+            "'self'",
+            "https://js.stripe.com",
+            "https://cdn.jsdelivr.net",
+            "'wasm-unsafe-eval'",
+        ]
+        script_element_sources = [
+            "'self'",
+            "https://js.stripe.com",
+            "https://cdn.jsdelivr.net",
+        ]
+        if embed_asset_origin:
+            style_sources.append(embed_asset_origin)
+            script_sources.append(embed_asset_origin)
+            script_element_sources.append(embed_asset_origin)
         response.headers["Content-Security-Policy"] = ";".join(
             f"{k} {v}"
             for (k, v) in {
                 "default-src": "'self'",
-                "style-src": "'self' 'unsafe-inline'",
-                "script-src": " ".join(
-                    [
-                        "'self'",
-                        "https://js.stripe.com",
-                        "https://cdn.jsdelivr.net",
-                        "'wasm-unsafe-eval'",
-                    ]
-                ),
-                "script-src-elem": "'self' https://js.stripe.com https://cdn.jsdelivr.net",
+                "style-src": " ".join(style_sources),
+                "script-src": " ".join(script_sources),
+                "script-src-elem": " ".join(script_element_sources),
                 "img-src": "'self' data: https:",
                 "media-src": "'self' data:",
                 "worker-src": "'self' blob:",

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -68,6 +68,7 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
                 (canonical_url.scheme, canonical_url.netloc, "", "", "")
             )
         style_sources = ["'self'", "'unsafe-inline'"]
+        font_sources = ["'self'"]
         script_sources = [
             "'self'",
             "https://js.stripe.com",
@@ -81,6 +82,7 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
         ]
         if embed_asset_origin:
             style_sources.append(embed_asset_origin)
+            font_sources.append(embed_asset_origin)
             script_sources.append(embed_asset_origin)
             script_element_sources.append(embed_asset_origin)
         response.headers["Content-Security-Policy"] = ";".join(
@@ -88,6 +90,7 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
             for (k, v) in {
                 "default-src": "'self'",
                 "style-src": " ".join(style_sources),
+                "font-src": " ".join(font_sources),
                 "script-src": " ".join(script_sources),
                 "script-src-elem": " ".join(script_element_sources),
                 "img-src": "'self' data: https:",

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -105,6 +105,7 @@ def test_embed_profile_uses_allowed_origins_for_frames_and_sandboxed_assets(
     directives = _csp_directives(response.headers)
     assert directives["frame-ancestors"] == "https://tips.example https://newsroom.example:8443"
     assert directives["style-src"] == "'self' 'unsafe-inline' https://tips.hushline.app"
+    assert directives["font-src"] == "'self' https://tips.hushline.app"
     assert directives["script-src"] == (
         "'self' https://js.stripe.com https://cdn.jsdelivr.net "
         "'wasm-unsafe-eval' https://tips.hushline.app"
@@ -123,6 +124,7 @@ def test_non_embed_csp_does_not_add_canonical_asset_origin(client: FlaskClient, 
     assert response.status_code == 200
     directives = _csp_directives(response.headers)
     assert directives["style-src"] == "'self' 'unsafe-inline'"
+    assert directives["font-src"] == "'self'"
     assert directives["script-src-elem"] == (
         "'self' https://js.stripe.com https://cdn.jsdelivr.net"
     )
@@ -139,6 +141,7 @@ def test_denied_embed_csp_does_not_add_canonical_asset_origin(
     directives = _csp_directives(response.headers)
     assert directives["frame-ancestors"] == "'none'"
     assert directives["style-src"] == "'self' 'unsafe-inline'"
+    assert directives["font-src"] == "'self'"
     assert directives["script-src-elem"] == (
         "'self' https://js.stripe.com https://cdn.jsdelivr.net"
     )

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -3,9 +3,20 @@ from pathlib import Path
 import pytest
 from flask import Flask, url_for
 from flask.testing import FlaskClient
+from werkzeug.datastructures import Headers
 
 from hushline.db import db
 from hushline.model import OrganizationSetting, StripeSubscriptionStatusEnum, User
+
+
+def _csp_directives(response_headers: Headers) -> dict[str, str]:
+    csp = response_headers["Content-Security-Policy"]
+    return {
+        directive: sources
+        for directive, sources in (
+            part.strip().split(" ", 1) for part in csp.split(";") if part.strip()
+        )
+    }
 
 
 def test_csp(client: FlaskClient) -> None:
@@ -73,7 +84,10 @@ def test_settings_profile_keeps_frame_restrictions(client: FlaskClient) -> None:
     assert response.headers["X-Frame-Options"] == "DENY"
 
 
-def test_embed_profile_uses_allowed_origin_frame_ancestors(client: FlaskClient, user: User) -> None:
+def test_embed_profile_uses_allowed_origins_for_frames_and_sandboxed_assets(
+    client: FlaskClient, app: Flask, user: User
+) -> None:
+    app.config["PUBLIC_BASE_URL"] = "https://tips.hushline.app"
     with open("tests/test_pgp_key.txt") as file:
         user.pgp_key = file.read().strip()
     user.set_business_tier()
@@ -88,10 +102,47 @@ def test_embed_profile_uses_allowed_origin_frame_ancestors(client: FlaskClient, 
     response = client.get(url_for("embed_profile", username=user.primary_username.username))
     assert response.status_code == 200
 
-    csp = (response.headers.get("Content-Security-Policy") or "").strip()
-    frame_ancestors = next(part for part in csp.split(";") if part.startswith("frame-ancestors "))
-    assert frame_ancestors == "frame-ancestors https://tips.example https://newsroom.example:8443"
+    directives = _csp_directives(response.headers)
+    assert directives["frame-ancestors"] == "https://tips.example https://newsroom.example:8443"
+    assert directives["style-src"] == "'self' 'unsafe-inline' https://tips.hushline.app"
+    assert directives["script-src"] == (
+        "'self' https://js.stripe.com https://cdn.jsdelivr.net "
+        "'wasm-unsafe-eval' https://tips.hushline.app"
+    )
+    assert directives["script-src-elem"] == (
+        "'self' https://js.stripe.com https://cdn.jsdelivr.net https://tips.hushline.app"
+    )
     assert "X-Frame-Options" not in response.headers
+
+
+def test_non_embed_csp_does_not_add_canonical_asset_origin(client: FlaskClient, app: Flask) -> None:
+    app.config["PUBLIC_BASE_URL"] = "https://tips.hushline.app"
+
+    response = client.get(url_for("directory"))
+
+    assert response.status_code == 200
+    directives = _csp_directives(response.headers)
+    assert directives["style-src"] == "'self' 'unsafe-inline'"
+    assert directives["script-src-elem"] == (
+        "'self' https://js.stripe.com https://cdn.jsdelivr.net"
+    )
+
+
+def test_denied_embed_csp_does_not_add_canonical_asset_origin(
+    client: FlaskClient, app: Flask
+) -> None:
+    app.config["PUBLIC_BASE_URL"] = "https://tips.hushline.app"
+
+    response = client.get(url_for("embed_profile", username="does-not-exist"))
+
+    assert response.status_code == 404
+    directives = _csp_directives(response.headers)
+    assert directives["frame-ancestors"] == "'none'"
+    assert directives["style-src"] == "'self' 'unsafe-inline'"
+    assert directives["script-src-elem"] == (
+        "'self' https://js.stripe.com https://cdn.jsdelivr.net"
+    )
+    assert response.headers["X-Frame-Options"] == "DENY"
 
 
 def test_static_fonts_allow_cross_origin_embed_loading(


### PR DESCRIPTION
## What changed

- Add the exact canonical Hush Line origin to `style-src`, `font-src`, `script-src`, and `script-src-elem` for allowed embed responses.
- Keep the existing restrictive iframe sandbox and frame-origin allowlist unchanged.
- Keep CSP behavior unchanged for normal pages and denied embed responses.
- Add regression tests for allowed embeds, normal pages, and denied embeds.
- Document why sandboxed Safari embeds require the explicit origin.

## Why

Safari and iOS Safari treat a sandboxed iframe without `allow-same-origin` as an opaque origin. In that context, `'self'` does not reliably authorize CSS, fonts, and JavaScript served from the iframe document's own URL, so embedded forms loaded without their complete presentation or client-side scripts.

The embedding website already allows `https://tips.hushline.app`; the blocked requests are governed by the iframe response's own CSP.

## Security and privacy

**Risk:** Broadening script or style sources could permit untrusted assets to execute in the whistleblower submission flow.

**Affected path:** Paid-user embedded profile forms and their client-side encryption assets.

**Mitigation:** This change adds only the configured canonical Hush Line origin, only for an allowed embed response. It does not add wildcards, does not add `allow-same-origin`, does not change `frame-ancestors`, and does not broaden normal or denied-page CSP.

## Validation

- `make lint`
- `make test` - 2,063 passed, 1 xfailed, 1 deselected; 100% coverage
- Focused CSP security-header tests - 4 passed
- `make audit-python` - no known vulnerabilities
- `make audit-node-runtime` - 0 vulnerabilities
- Commit signature verified locally

No open Dependabot pull requests were present. The Dependabot alerts API was unavailable to the current token, so the required `Dependency Security Audit` check must pass before merge.

## Manual testing

1. Deploy with `PUBLIC_BASE_URL=https://tips.hushline.app`.
2. Open the embedded form from `https://hushline.app/embed.html` in desktop Safari and iOS/iPadOS Safari.
3. Confirm the form stylesheet, fonts, and Hush Line scripts load without CSP errors.
4. Confirm the form remains styled, dynamically resizes, and submits a client-side encrypted message.
5. Confirm the embed response includes the exact canonical origin in its script/style directives, while a regular page and a denied embed do not.
