### PR TITLE
Tighten embed CSP and privacy notice

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -3637,6 +3637,14 @@ p.bio+.extra-fields {
   margin: 0.25rem 0 0;
 }
 
+.embed-privacy-note {
+  color: var(--color-text-light);
+  font-family: var(--font-mono);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  margin: 0;
+}
+
 .embed-page .badgeContainer {
   flex-wrap: wrap;
 }

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -80,6 +80,14 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
             "https://js.stripe.com",
             "https://cdn.jsdelivr.net",
         ]
+        form_action_sources = ["'self'"]
+        if app.config.get("STRIPE_SECRET_KEY"):
+            form_action_sources.extend(
+                [
+                    "https://checkout.stripe.com",
+                    "https://billing.stripe.com",
+                ]
+            )
         if embed_asset_origin:
             style_sources.append(embed_asset_origin)
             font_sources.append(embed_asset_origin)
@@ -97,7 +105,7 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
                 "media-src": "'self' data:",
                 "worker-src": "'self' blob:",
                 "frame-ancestors": frame_ancestors,
-                "form-action": "'self'",
+                "form-action": " ".join(form_action_sources),
                 "connect-src": "'self' https://api.stripe.com https://cdn.jsdelivr.net data:",
                 "child-src": "https://js.stripe.com",
                 "frame-src": "https://js.stripe.com",

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -97,6 +97,7 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
                 "media-src": "'self' data:",
                 "worker-src": "'self' blob:",
                 "frame-ancestors": frame_ancestors,
+                "form-action": "'self'",
                 "connect-src": "'self' https://api.stripe.com https://cdn.jsdelivr.net data:",
                 "child-src": "https://js.stripe.com",
                 "frame-src": "https://js.stripe.com",

--- a/hushline/templates/embed_profile.html
+++ b/hushline/templates/embed_profile.html
@@ -250,6 +250,25 @@
           </div>
         {% endif %}
       </form>
+
+      <p class="embed-privacy-note">
+        Privacy and retention: Hush Line limits operational data, encrypts
+        fields marked encrypted for the recipient, and lets recipients delete messages.
+        Read the
+        <a
+          href="https://github.com/scidsg/hushline/blob/main/docs/PRIVACY.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Privacy Policy</a
+        >
+        and
+        <a
+          href="https://github.com/scidsg/hushline/blob/main/docs/TERMS.md"
+          target="_blank"
+          rel="noopener noreferrer"
+          >Terms</a
+        >.
+      </p>
     </main>
   </body>
 </html>

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1392,6 +1392,25 @@ def test_embed_profile_template_has_compact_trust_chrome_and_form(
     assert "Sending to" not in response.text
     assert "Example Recipient" in response.text
     assert page.find("p", class_="embed-meta") is None
+    privacy_note = page.find("p", class_="embed-privacy-note")
+    assert privacy_note is not None
+    privacy_text = privacy_note.get_text(" ", strip=True)
+    assert "Privacy and retention" in privacy_text
+    assert "limits operational data" in privacy_text
+    assert "fields marked encrypted" in privacy_text
+    assert "delete messages" in privacy_text
+    privacy_link = privacy_note.find(
+        "a", href="https://github.com/scidsg/hushline/blob/main/docs/PRIVACY.md"
+    )
+    assert privacy_link is not None
+    assert privacy_link.get_text(strip=True) == "Privacy Policy"
+    assert privacy_link.get("target") == "_blank"
+    assert privacy_link.get("rel") == ["noopener", "noreferrer"]
+    terms_link = privacy_note.find(
+        "a", href="https://github.com/scidsg/hushline/blob/main/docs/TERMS.md"
+    )
+    assert terms_link is not None
+    assert terms_link.get_text(strip=True) == "Terms"
     badge_texts = _badge_texts(page)
     assert "⭐️ Verified" in badge_texts
     assert "🔒 End-to-End Encrypted" in badge_texts
@@ -1400,6 +1419,7 @@ def test_embed_profile_template_has_compact_trust_chrome_and_form(
     assert "Client-side encryption enabled" not in visible_text
     csp = response.headers["Content-Security-Policy"]
     assert "default-src 'self'" in csp
+    assert "form-action 'self'" in csp
     assert "frame-ancestors https://tips.example" in csp
     assert "frame-ancestors *" not in csp
     assert page.select_one(".skip-link") is None
@@ -1447,6 +1467,8 @@ def test_embed_profile_layout_theme_and_focus_styles_are_in_compiled_stylesheet_
     assert "box-sizing: border-box;" in embed_shell_block
     assert "padding: 2.5rem 2rem;" in stylesheet_source
     assert ".embed-meta {\n  font-family: var(--font-mono);" in stylesheet_source
+    assert ".embed-privacy-note" in stylesheet_source
+    assert "  font-size: 0.875rem;" in stylesheet_source
     assert ".embed-profile-summary" not in stylesheet_source
     assert ".embed-actions" not in stylesheet_source
     assert ".embed-page a,\n.embed-page a.meta" in stylesheet_source

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -30,6 +30,32 @@ def test_csp(client: FlaskClient) -> None:
     assert "form-action 'self'" in csp
 
 
+def test_csp_form_action_allows_stripe_redirect_hosts_when_premium_enabled(
+    client: FlaskClient, app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setitem(app.config, "STRIPE_SECRET_KEY", "sk_test_enabled")
+
+    response = client.get(url_for("directory"), follow_redirects=True)
+    assert response.status_code == 200
+
+    directives = _csp_directives(response.headers)
+    assert directives["form-action"] == (
+        "'self' https://checkout.stripe.com https://billing.stripe.com"
+    )
+
+
+def test_csp_form_action_omits_stripe_redirect_hosts_when_premium_disabled(
+    client: FlaskClient, app: Flask, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setitem(app.config, "STRIPE_SECRET_KEY", "")
+
+    response = client.get(url_for("directory"), follow_redirects=True)
+    assert response.status_code == 200
+
+    directives = _csp_directives(response.headers)
+    assert directives["form-action"] == "'self'"
+
+
 def test_csp_script_src_elem_disallows_inline_scripts(client: FlaskClient) -> None:
     response = client.get(url_for("directory"), follow_redirects=True)
     assert response.status_code == 200
@@ -105,7 +131,9 @@ def test_embed_profile_uses_allowed_origins_for_frames_and_sandboxed_assets(
 
     directives = _csp_directives(response.headers)
     assert directives["frame-ancestors"] == "https://tips.example https://newsroom.example:8443"
-    assert directives["form-action"] == "'self'"
+    assert directives["form-action"] == (
+        "'self' https://checkout.stripe.com https://billing.stripe.com"
+    )
     assert directives["style-src"] == "'self' 'unsafe-inline' https://tips.hushline.app"
     assert directives["font-src"] == "'self' https://tips.hushline.app"
     assert directives["script-src"] == (

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -27,6 +27,7 @@ def test_csp(client: FlaskClient) -> None:
     assert csp
     assert "'unsafe-eval'" not in csp
     assert "img-src 'self' data: https:" in csp
+    assert "form-action 'self'" in csp
 
 
 def test_csp_script_src_elem_disallows_inline_scripts(client: FlaskClient) -> None:
@@ -104,6 +105,7 @@ def test_embed_profile_uses_allowed_origins_for_frames_and_sandboxed_assets(
 
     directives = _csp_directives(response.headers)
     assert directives["frame-ancestors"] == "https://tips.example https://newsroom.example:8443"
+    assert directives["form-action"] == "'self'"
     assert directives["style-src"] == "'self' 'unsafe-inline' https://tips.hushline.app"
     assert directives["font-src"] == "'self' https://tips.hushline.app"
     assert directives["script-src"] == (


### PR DESCRIPTION
## What changed
- Added an explicit form-action directive to the global CSP, including embeddable form responses.
- Kept non-premium deployments constrained to form-action self.
- Allowed Stripe Checkout and Billing Portal form-action targets only when Stripe is configured, preserving payment and billing redirects.
- Added a concise privacy and retention note inside the embedded form with links to the Privacy Policy and Terms.
- Added tests covering the CSP directive, Stripe/no-Stripe behavior, embed copy, linked destinations, and compact embed layout behavior.

## Why it changed
The contact form study identified two observable follow-ups before Hush Line can defensibly claim it passes the full observable rubric: an explicit form submission destination policy and visible privacy/retention context in the embed.

## Security / privacy notes
- Threat/risk: missing form-action leaves form submission destination policy implicit; missing in-embed retention/privacy context weakens sender transparency.
- Affected data paths: public profile and embeddable message submission forms; Stripe-enabled payment and billing flows.
- Mitigation: message form submissions remain constrained to same-origin destinations, while Stripe-enabled deployments explicitly allow only the required Stripe Checkout and Billing Portal form-action targets. Embed users see concise retention/privacy guidance without interrupting keyboard-first message submission.

## Validation
- make lint
- make test
- make test TESTS="tests/test_security_headers.py tests/test_embeddable_forms_settings.py"
- make test TESTS="tests/test_security_headers.py"
- make audit-node-runtime
- make audit-python

## Manual testing
- Not separately run; covered by focused embed/security template tests and full test suite.

## Known risks / follow-ups
- The contact form study should describe this as implemented in this PR until the PR is merged and deployed.