### PR TITLE
Mask 2FA secrets in docs screenshots

### DIFF
--- a/docs/screenshots/scenes.json
+++ b/docs/screenshots/scenes.json
@@ -514,6 +514,7 @@
       "path": "/settings/auth",
       "session": "artvandelay",
       "waitForSelector": ".settings-tabs",
+      "screenshotMasks": [".qr", ".totp-secret"],
       "actions": [
         {
           "type": "click",

--- a/scripts/capture-doc-screenshots.mjs
+++ b/scripts/capture-doc-screenshots.mjs
@@ -266,10 +266,33 @@ function buildScrollOffsets(scrollHeight, viewportHeight) {
   return offsets;
 }
 
-async function screenshotAtOffset(page, offsetY, filePath) {
+function buildScreenshotOptions(page, scene) {
+  if (
+    !Array.isArray(scene.screenshotMasks) ||
+    scene.screenshotMasks.length === 0
+  ) {
+    return {};
+  }
+
+  return {
+    mask: scene.screenshotMasks.map((selector) => page.locator(selector)),
+    maskColor: "#111827",
+  };
+}
+
+async function screenshotAtOffset(
+  page,
+  offsetY,
+  filePath,
+  screenshotOptions = {},
+) {
   await page.evaluate((y) => window.scrollTo(0, y), offsetY);
   await sleep(120);
-  await page.screenshot({ path: filePath, fullPage: false });
+  await page.screenshot({
+    path: filePath,
+    fullPage: false,
+    ...screenshotOptions,
+  });
 }
 
 async function hideFooters(page) {
@@ -598,6 +621,7 @@ async function main() {
             await page.screenshot({
               path: path.join(debugDir, debugFile),
               fullPage: false,
+              ...buildScreenshotOptions(page, scene),
             });
             throw new Error(
               `Scene ${scene.slug} (${viewport.id}, ${theme}) failed waiting for selector ${scene.waitForSelector}. Debug: ${sessionDir}/${debugFile}. ${err}`,
@@ -633,7 +657,12 @@ async function main() {
             if (!shouldCaptureFile(captureFiles, relativeFile)) {
               continue;
             }
-            await screenshotAtOffset(page, 0, path.join(targetDir, fileName));
+            await screenshotAtOffset(
+              page,
+              0,
+              path.join(targetDir, fileName),
+              buildScreenshotOptions(page, scene),
+            );
             files.push({
               mode: "fold",
               file: relativeFile,
@@ -670,6 +699,7 @@ async function main() {
                 page,
                 offsets[i],
                 path.join(targetDir, fileName),
+                buildScreenshotOptions(page, scene),
               );
               files.push({
                 mode: modeName,
@@ -692,6 +722,7 @@ async function main() {
               await page.screenshot({
                 path: path.join(targetDir, fileName),
                 fullPage: true,
+                ...buildScreenshotOptions(page, scene),
               });
               files.push({
                 mode: "full",
@@ -741,7 +772,9 @@ async function main() {
     const capturedFiles = new Set(
       captured.flatMap((item) => item.files.map((entry) => entry.file)),
     );
-    const missing = [...captureFiles].filter((file) => !capturedFiles.has(file));
+    const missing = [...captureFiles].filter(
+      (file) => !capturedFiles.has(file),
+    );
     if (missing.length > 0) {
       throw new Error(
         `Required screenshot captures were not produced: ${missing.join(", ")}`,

--- a/tests/test_docs_screenshots_manifest.py
+++ b/tests/test_docs_screenshots_manifest.py
@@ -164,6 +164,16 @@ def test_docs_screenshot_capture_filters_to_manifest_capture_files() -> None:
     assert "Required screenshot captures were not produced" in script
 
 
+def test_docs_screenshot_capture_supports_scene_masks() -> None:
+    script = CAPTURE_SCRIPT_PATH.read_text(encoding="utf-8")
+
+    assert "function buildScreenshotOptions(page, scene)" in script
+    assert "scene.screenshotMasks.map((selector) => page.locator(selector))" in script
+    assert 'maskColor: "#111827"' in script
+    assert "...buildScreenshotOptions(page, scene)" in script
+    assert "buildScreenshotOptions(page, scene)," in script
+
+
 def test_docs_screenshot_allowlist_resolves_only_referenced_images(tmp_path: Path) -> None:
     script = _load_allowlist_script()
     website_dir = tmp_path / "website"
@@ -232,6 +242,15 @@ def test_docs_screenshots_manifest_artvandelay_notifications_waits_for_third_rec
     assert artvandelay_notifications["session"] == "artvandelay"
     assert artvandelay_notifications["path"] == "/settings/notifications"
     assert artvandelay_notifications["waitForSelector"] == "a:has-text('board@vandelay.news')"
+
+
+def test_docs_screenshots_manifest_masks_artvandelay_2fa_secret() -> None:
+    scenes = _scene_map()
+
+    enable_2fa = scenes["auth-artvandelay-enable-2fa"]
+
+    assert enable_2fa["path"] == "/settings/auth"
+    assert enable_2fa["screenshotMasks"] == [".qr", ".totp-secret"]
 
 
 def test_docs_screenshots_manifest_guest_message_submission_skips_choice_list_fill() -> None:


### PR DESCRIPTION
## What changed

- Added manifest-driven `screenshotMasks` support to the docs screenshot capture script.
- Applied screenshot masks to debug, fold, scroll-window, and full-page Playwright screenshots.
- Marked the `auth-artvandelay-enable-2fa` scene to mask the QR image and manual TOTP text code before screenshots are written.
- Added focused tests that lock the screenshot mask support and the 2FA scene configuration.

## Why

Public docs were serving a generated 2FA setup screenshot containing a live TOTP enrollment QR. That QR and the adjacent text code expose the shared seed for the example account. The capture workflow should redact these sensitive elements before generated screenshots become docs or website assets.

## Impact

Future docs screenshot captures for the 2FA enrollment screen will preserve the page layout while replacing the QR and manual setup secret with an opaque mask. Existing generated screenshot artifacts and website assets still need to be regenerated and republished from this change.

## Validation

- `node --check scripts/capture-doc-screenshots.mjs`
- `git diff --check`
- `./node_modules/.bin/prettier --check scripts/capture-doc-screenshots.mjs docs/screenshots/scenes.json`
- `docker compose run --rm app poetry run pytest tests/test_docs_screenshots_manifest.py -q` (`15 passed`)
- `docker compose run --rm app poetry run ruff format --check tests/test_docs_screenshots_manifest.py`
- `docker compose run --rm app poetry run ruff check tests/test_docs_screenshots_manifest.py`

## Manual testing

Not run: a live screenshot regeneration would rewrite `docs/screenshots/releases/latest`. The normal docs screenshot workflow should be run after merge to regenerate sanitized artifacts, then `hushline-screenshots` and `hushline-website` should be rebuilt/published.

## Follow-up

- Rotate the exposed `artvandelay` TOTP seed if that account exists in any real or staging environment.
- Purge any CDN/static-host cache entries for the old QR-bearing PNG after the website is republished.