### PR TITLE
Fix docs screenshot capture sources

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -16,6 +16,13 @@ on:
         required: false
         default: ""
         type: string
+    secrets:
+      HUSHLINE_DOCS_SCREENSHOTS_PAT:
+        required: false
+      HUSHLINE_WEBSITE_SCREENSHOTS_PAT:
+        required: false
+      SCREENSHOTS_PUSH_TOKEN:
+        required: false
   workflow_dispatch:
     inputs:
       release_key:
@@ -153,19 +160,36 @@ jobs:
         id: capture_manifest
         if: steps.manifest.outputs.enabled == 'true'
         env:
+          DOCS_REPOSITORY: scidsg/hushline-docs
+          DOCS_DEFAULT_BRANCH: main
           WEBSITE_REPOSITORY: scidsg/hushline-website
           WEBSITE_DEFAULT_BRANCH: main
+          DOCS_READ_TOKEN: ${{ secrets.HUSHLINE_DOCS_SCREENSHOTS_PAT || secrets.SCREENSHOTS_PUSH_TOKEN }}
           WEBSITE_READ_TOKEN: ${{ secrets.HUSHLINE_WEBSITE_SCREENSHOTS_PAT || secrets.SCREENSHOTS_PUSH_TOKEN }}
         run: |
           set -euo pipefail
+          DOCS_DIR="${RUNNER_TEMP}/hushline-docs"
           WEBSITE_DIR="${RUNNER_TEMP}/hushline-website"
           CAPTURE_MANIFEST="${RUNNER_TEMP}/docs-screenshot-capture-manifest.json"
           CAPTURE_FILES="${RUNNER_TEMP}/docs-screenshot-capture-files.json"
+
+          DOCS_CLONE_URL="https://github.com/${DOCS_REPOSITORY}.git"
+          if [ -n "${DOCS_READ_TOKEN:-}" ]; then
+            DOCS_CLONE_URL="https://x-access-token:${DOCS_READ_TOKEN}@github.com/${DOCS_REPOSITORY}.git"
+          fi
 
           CLONE_URL="https://github.com/${WEBSITE_REPOSITORY}.git"
           if [ -n "${WEBSITE_READ_TOKEN:-}" ]; then
             CLONE_URL="https://x-access-token:${WEBSITE_READ_TOKEN}@github.com/${WEBSITE_REPOSITORY}.git"
           fi
+
+          git clone \
+            --depth 1 \
+            --filter=blob:none \
+            --single-branch \
+            --branch "${DOCS_DEFAULT_BRANCH}" \
+            "$DOCS_CLONE_URL" \
+            "$DOCS_DIR"
 
           git clone \
             --depth 1 \
@@ -177,6 +201,7 @@ jobs:
 
           python3 .trusted-workflow/scripts/resolve-doc-screenshot-allowlist.py \
             --hushline-dir "$GITHUB_WORKSPACE" \
+            --docs-dir "$DOCS_DIR" \
             --website-dir "$WEBSITE_DIR" \
             --screenshot-root src/assets/img/screenshots \
             --manifest-in docs/screenshots/scenes.json \

--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -170,8 +170,7 @@ jobs:
 
           FILTERED_CURRENT_ROOT="$(mktemp -d)"
           python3 "${GITHUB_WORKSPACE}/scripts/resolve-doc-screenshot-allowlist.py" \
-            --hushline-dir "$GITHUB_WORKSPACE" \
-            --website-dir "$PWD" \
+            --refs-input "${ARTIFACT_DIR}/capture_files.json" \
             --screenshot-root "$WEBSITE_SCREENSHOT_ROOT" \
             --current-root "$CURRENT_ROOT" \
             --filtered-root "$FILTERED_CURRENT_ROOT"

--- a/scripts/resolve-doc-screenshot-allowlist.py
+++ b/scripts/resolve-doc-screenshot-allowlist.py
@@ -65,9 +65,19 @@ def parse_args() -> argparse.Namespace:
         help="Website repository checkout to scan. Can be provided more than once.",
     )
     parser.add_argument(
+        "--docs-dir",
+        action="append",
+        default=[],
+        help="Docs repository checkout to scan. Can be provided more than once.",
+    )
+    parser.add_argument(
         "--hushline-dir",
         default=".",
         help="Hush Line repository checkout to scan for docs references.",
+    )
+    parser.add_argument(
+        "--refs-input",
+        help="Precomputed captureFiles JSON array to use instead of scanning source trees.",
     )
     parser.add_argument(
         "--screenshot-root",
@@ -193,6 +203,13 @@ def write_capture_manifest(manifest_in: Path, manifest_out: Path, refs: list[str
     manifest_out.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
 
 
+def read_refs_input(refs_input: Path) -> list[str]:
+    refs = json.loads(refs_input.read_text(encoding="utf-8"))
+    if not isinstance(refs, list) or not all(isinstance(ref, str) for ref in refs):
+        raise SystemExit(f"Expected captureFiles JSON array at {refs_input}")
+    return sorted(set(refs))
+
+
 def copy_filtered_current(current_root: Path, filtered_root: Path, refs: list[str]) -> None:
     available = available_images(current_root)
     missing = sorted(set(refs) - available)
@@ -217,27 +234,38 @@ def main() -> int:
     screenshot_root = args.screenshot_root.strip("/")
     patterns = compile_reference_patterns(screenshot_root)
 
-    refs = set()
-    hushline_dir = Path(args.hushline_dir)
-    refs.update(
-        collect_references(
-            hushline_dir,
-            docs_only=True,
-            patterns=patterns,
-            screenshot_root=screenshot_root,
-        )
-    )
-    for website_dir in args.website_dir:
+    if args.refs_input:
+        ordered_refs = read_refs_input(Path(args.refs_input))
+    else:
+        refs = set()
+        hushline_dir = Path(args.hushline_dir)
         refs.update(
             collect_references(
-                Path(website_dir),
-                docs_only=False,
+                hushline_dir,
+                docs_only=True,
                 patterns=patterns,
                 screenshot_root=screenshot_root,
             )
         )
-
-    ordered_refs = sorted(refs)
+        for docs_dir in args.docs_dir:
+            refs.update(
+                collect_references(
+                    Path(docs_dir),
+                    docs_only=True,
+                    patterns=patterns,
+                    screenshot_root=screenshot_root,
+                )
+            )
+        for website_dir in args.website_dir:
+            refs.update(
+                collect_references(
+                    Path(website_dir),
+                    docs_only=False,
+                    patterns=patterns,
+                    screenshot_root=screenshot_root,
+                )
+            )
+        ordered_refs = sorted(refs)
 
     if args.output:
         output = Path(args.output)

--- a/tests/test_docs_screenshots_manifest.py
+++ b/tests/test_docs_screenshots_manifest.py
@@ -177,8 +177,10 @@ def test_docs_screenshot_capture_supports_scene_masks() -> None:
 def test_docs_screenshot_allowlist_resolves_only_referenced_images(tmp_path: Path) -> None:
     script = _load_allowlist_script()
     website_dir = tmp_path / "website"
+    docs_dir = tmp_path / "docs_repo"
     hushline_dir = tmp_path / "hushline"
     (website_dir / "src" / "pages").mkdir(parents=True)
+    (docs_dir / "docs" / "docs" / "getting-started").mkdir(parents=True)
     (hushline_dir / "docs" / "screenshots").mkdir(parents=True)
 
     (website_dir / "src" / "pages" / "index.astro").write_text(
@@ -188,6 +190,12 @@ def test_docs_screenshot_allowlist_resolves_only_referenced_images(tmp_path: Pat
                 'import img from "../assets/img/screenshots/current/admin/imported.png";',
             ]
         ),
+        encoding="utf-8",
+    )
+    (docs_dir / "docs" / "docs" / "getting-started" / "secure-your-account.md").write_text(
+        "![Scan QR](https://github.com/scidsg/hushline-screenshots/blob/main/"
+        "releases/latest/artvandelay/auth-artvandelay-enable-2fa-desktop-light-fold.png"
+        "?raw=true)",
         encoding="utf-8",
     )
     (hushline_dir / "README.md").write_text(
@@ -201,20 +209,30 @@ def test_docs_screenshot_allowlist_resolves_only_referenced_images(tmp_path: Pat
     )
 
     patterns = script.compile_reference_patterns("src/assets/img/screenshots")
-    refs = script.collect_references(
-        website_dir,
-        docs_only=False,
-        patterns=patterns,
-        screenshot_root="src/assets/img/screenshots",
-    ) | script.collect_references(
-        hushline_dir,
-        docs_only=True,
-        patterns=patterns,
-        screenshot_root="src/assets/img/screenshots",
+    refs = (
+        script.collect_references(
+            website_dir,
+            docs_only=False,
+            patterns=patterns,
+            screenshot_root="src/assets/img/screenshots",
+        )
+        | script.collect_references(
+            docs_dir,
+            docs_only=True,
+            patterns=patterns,
+            screenshot_root="src/assets/img/screenshots",
+        )
+        | script.collect_references(
+            hushline_dir,
+            docs_only=True,
+            patterns=patterns,
+            screenshot_root="src/assets/img/screenshots",
+        )
     )
 
     assert refs == {
         "admin/imported.png",
+        "artvandelay/auth-artvandelay-enable-2fa-desktop-light-fold.png",
         "guest/used-from-website.png",
         "newman/used-from-docs.png",
     }
@@ -232,6 +250,27 @@ def test_docs_screenshot_allowlist_filters_current_tree(tmp_path: Path) -> None:
 
     assert (filtered_root / "guest" / "used.png").read_bytes() == b"used"
     assert not (filtered_root / "guest" / "unused.png").exists()
+
+
+def test_docs_screenshot_allowlist_can_reuse_capture_files_artifact(tmp_path: Path) -> None:
+    script = _load_allowlist_script()
+    refs_input = tmp_path / "capture_files.json"
+
+    refs_input.write_text(
+        json.dumps(
+            [
+                "guest/used.png",
+                "guest/used.png",
+                "artvandelay/auth-artvandelay-enable-2fa-desktop-light-fold.png",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    assert script.read_refs_input(refs_input) == [
+        "artvandelay/auth-artvandelay-enable-2fa-desktop-light-fold.png",
+        "guest/used.png",
+    ]
 
 
 def test_docs_screenshots_manifest_artvandelay_notifications_waits_for_third_recipient() -> None:

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -121,6 +121,10 @@ def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> 
     assert "ref: ${{ job.workflow_sha }}" in trusted_checkout_section
     assert "ref: ${{ github.workflow_sha }}" not in trusted_checkout_section
     assert "Resolve screenshot capture manifest" in capture_workflow_text
+    assert "DOCS_REPOSITORY: scidsg/hushline-docs" in capture_workflow_text
+    assert 'DOCS_DIR="${RUNNER_TEMP}/hushline-docs"' in capture_workflow_text
+    assert '--branch "${DOCS_DEFAULT_BRANCH}"' in capture_workflow_text
+    assert '--docs-dir "$DOCS_DIR"' in capture_workflow_text
     assert '--manifest-out "$CAPTURE_MANIFEST"' in capture_workflow_text
     assert '--output "$CAPTURE_FILES"' in capture_workflow_text
     assert 'cp -R "$RELEASE_ROOT" "${ARTIFACT_ROOT}/screenshots/release"' in artifact_section
@@ -137,6 +141,7 @@ def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> 
     assert 'LEGACY_CURRENT_ROOT="${ARTIFACT_DIR}/screenshots/current"' in website_section
     assert '--branch "${WEBSITE_DEFAULT_BRANCH}"' in website_section
     assert 'git sparse-checkout set "${WEBSITE_SCREENSHOT_ROOT}/current"' not in website_section
+    assert '--refs-input "${ARTIFACT_DIR}/capture_files.json"' in website_section
     assert '--current-root "$CURRENT_ROOT"' in website_section
     assert '--filtered-root "$FILTERED_CURRENT_ROOT"' in website_section
     assert 'mkdir -p "${WEBSITE_SCREENSHOT_ROOT}/current"' in website_section


### PR DESCRIPTION
## What changed
- Scan `scidsg/hushline-docs` source alongside the app repo and website repo when resolving docs screenshot references.
- Carry the capture job's resolved `capture_files.json` into the publish job so `hushline-website` is filtered from the exact capture allowlist instead of recomputing against potentially stale website content.
- Keep reusable workflow secrets explicit for docs and website screenshot read tokens.
- Add tests covering docs-source references, QR/2FA screenshot allowlisting, capture artifact reuse, and workflow wiring.

## Why
The public site build consumes docs artifacts, but the authoritative screenshot references can live in `hushline-docs` source. The capture workflow now sees those references directly, including the masked 2FA QR scene, and the publish workflow no longer risks dropping screenshots because it recalculated references from stale downstream content.

## Security and privacy
- No user data paths or application runtime behavior changed.
- The existing QR/2FA scene remains covered by screenshot masks for `.qr` and `.totp-secret`; this PR keeps that screenshot in the capture allowlist when docs source references it.
- Cross-repo clone tokens are used only for read access in the workflow environment.

## Validation
- `make lint`
- `make test` (`1932 passed, 1 deselected, 1 xfailed`)
- `docker compose run --rm app poetry run pytest -q tests/test_docs_screenshots_manifest.py tests/test_workflow_pr_head_qualification.py` (`23 passed`)
- `make audit-python` (`No known vulnerabilities found`)
- `make audit-node-runtime` (`found 0 vulnerabilities`)

## Manual testing
Not applicable for runtime UI. This is workflow/script behavior covered by focused workflow and manifest tests.

## Known risks or follow-ups
Companion docs PR: https://github.com/scidsg/hushline-docs/pull/62. That PR updates the weekly article runner so built docs copied into `hushline-website` use the curated website screenshot tree.