### PR TITLE
Keep info-only accounts out of featured carousel

### DIFF
--- a/assets/js/directory_verified.js
+++ b/assets/js/directory_verified.js
@@ -528,6 +528,7 @@ document.addEventListener("DOMContentLoaded", function () {
       tab === "verified" &&
       user.is_featured &&
       user.is_verified &&
+      user.has_pgp_key &&
       !user.is_public_record &&
       !user.is_globaleaks &&
       !user.is_newsroom &&

--- a/hushline/routes/directory.py
+++ b/hushline/routes/directory.py
@@ -464,16 +464,24 @@ def _featured_directory_usernames(usernames: Sequence[Username]) -> list[Usernam
         [
             username
             for username in usernames
-            if username.is_verified and bool(getattr(username, "is_featured", False))
+            if (
+                username.is_verified
+                and bool(getattr(username, "is_featured", False))
+                and _user_message_capable(username.user)
+            )
         ]
     )
+
+
+def _is_featured_directory_row(row: dict[str, object | None]) -> bool:
+    return row.get("is_featured") is True and row.get("message_capable") is True
 
 
 def _featured_directory_rows_first(
     rows: Sequence[dict[str, object | None]],
 ) -> list[dict[str, object | None]]:
-    featured_rows = [row for row in rows if row.get("is_featured") is True]
-    standard_rows = [row for row in rows if row.get("is_featured") is not True]
+    featured_rows = [row for row in rows if _is_featured_directory_row(row)]
+    standard_rows = [row for row in rows if not _is_featured_directory_row(row)]
     return [*_shuffle_featured_directory_items(featured_rows), *standard_rows]
 
 

--- a/hushline/static/js/directory_verified.js
+++ b/hushline/static/js/directory_verified.js
@@ -591,6 +591,7 @@
         tab === "verified" &&
         user.is_featured &&
         user.is_verified &&
+        user.has_pgp_key &&
         !user.is_public_record &&
         !user.is_globaleaks &&
         !user.is_newsroom &&

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -651,7 +651,7 @@
       {% if verified_info_usernames %}
         <p class="label">📇 Info-Only Accounts</p>
         <div class="user-list">
-          {% for username in verified_info_usernames if not (username.is_featured | default(false)) %}
+          {% for username in verified_info_usernames %}
             {{ verified_user_card(username) }}
           {% endfor %}
         </div>

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -375,6 +375,77 @@ def test_directory_verified_tab_promotes_featured_users_first(
     assert normal_card_heading.get_text(strip=True) == "Admin User"
 
 
+def test_directory_verified_tab_keeps_featured_info_only_accounts_in_info_only_section(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    featured_info_only_user = _directory_username(
+        username="featured-info-only-user",
+        display_name="Featured Info Only User",
+        is_verified=True,
+        is_featured=True,
+        pgp_key="",
+    )
+    featured_message_capable_user = _directory_username(
+        username="featured-message-capable-user",
+        display_name="Featured Message Capable User",
+        is_verified=True,
+        is_featured=True,
+    )
+    standard_user = _directory_username(
+        username="standard-user",
+        display_name="Standard User",
+        is_verified=True,
+    )
+    monkeypatch.setattr(
+        "hushline.routes.directory.get_directory_usernames",
+        lambda: (
+            featured_info_only_user,
+            featured_message_capable_user,
+            standard_user,
+        ),
+    )
+    monkeypatch.setattr("hushline.routes.directory.get_public_record_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_securedrop_directory_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
+    monkeypatch.setattr(
+        directory_routes,
+        "_shuffle_featured_directory_items",
+        lambda items: list(items),
+    )
+
+    response = client.get(url_for("directory"))
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+    verified_panel = soup.find(id="verified")
+    assert verified_panel is not None
+
+    featured_section = verified_panel.select_one("[data-featured-carousel]")
+    assert featured_section is not None
+    featured_headings = [
+        heading.get_text(strip=True)
+        for heading in featured_section.select("[data-featured-slide] h3")
+    ]
+    assert featured_headings == ["Featured Message Capable User"]
+
+    info_label = verified_panel.find("p", class_="label", string="📇 Info-Only Accounts")
+    assert info_label is not None
+    info_list = info_label.find_next_sibling("div", class_="user-list")
+    assert info_list is not None
+    info_headings = [heading.get_text(strip=True) for heading in info_list.select("h3")]
+    assert info_headings == ["Featured Info Only User"]
+
+    users_response = client.get(url_for("directory_users", tab="verified"))
+    assert users_response.status_code == 200
+    rows = users_response.json or []
+    assert [row["primary_username"] for row in rows] == [
+        "featured-message-capable-user",
+        "featured-info-only-user",
+        "standard-user",
+    ]
+    assert rows[1]["has_pgp_key"] is False
+
+
 def test_directory_randomizes_featured_user_order(
     client: FlaskClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation
- Prevent verified but non-message-capable (Info-Only) accounts from being promoted into the Verified tab featured carousel, which removed their Info-Only context in the listing. 

### Description
- Require message-capable accounts when selecting featured usernames for the server-rendered carousel by filtering with `_user_message_capable(...)` in `_featured_directory_usernames` and by only treating rows with `message_capable` as featured in `_featured_directory_rows_first` (and a new helper `_is_featured_directory_row`).
- Mirror the server rule on the client by requiring `user.has_pgp_key` in the `isPromotableFeaturedUser` check in both `assets/js/directory_verified.js` and the built `hushline/static/js/directory_verified.js` so client-side re-rendering keeps Info-Only entries in the Info-Only section.
- Add a regression test `test_directory_verified_tab_keeps_featured_info_only_accounts_in_info_only_section` to `tests/test_directory.py` verifying a featured-but-info-only account is left in the `📇 Info-Only Accounts` section and not included in the featured carousel or promoted ahead of message-capable entries.

### Testing
- Code style and static checks passed with `ruff format`/`ruff check` and `prettier` for affected JS files. 
- The frontend-compat smoke test `pytest -q tests/test_frontend_compat.py::test_directory_search_accessibility_hooks_exist` passed. 
- New regression test added to `tests/test_directory.py` exercises the server-rendered HTML and `users.json` ordering for the `verified` tab, but running the directory integration tests in this environment failed due to the PostgreSQL host `postgres` being unavailable, producing SQL connection `OperationalError` (so full `pytest` of directory tests could not complete here). 
- Docker-dependent project-level checks (`make lint`, `make test`, `make audit-python`, `make audit-node-runtime`) could not be executed locally because Docker is not available in this environment and must pass in CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29034c008883309cd84f13ee50b0a8)