### PR TITLE
Blur docs screenshot masks

### DIFF
--- a/scripts/capture-doc-screenshots.mjs
+++ b/scripts/capture-doc-screenshots.mjs
@@ -267,6 +267,7 @@ function buildScrollOffsets(scrollHeight, viewportHeight) {
 }
 
 function buildScreenshotOptions(page, scene) {
+  void page;
   if (
     !Array.isArray(scene.screenshotMasks) ||
     scene.screenshotMasks.length === 0
@@ -274,9 +275,20 @@ function buildScreenshotOptions(page, scene) {
     return {};
   }
 
+  const maskSelectors = scene.screenshotMasks
+    .map((selector) => String(selector).trim())
+    .filter(Boolean);
+  if (maskSelectors.length === 0) {
+    return {};
+  }
+
   return {
-    mask: scene.screenshotMasks.map((selector) => page.locator(selector)),
-    maskColor: "#111827",
+    style: `
+${maskSelectors.join(", ")} {
+  filter: blur(14px) !important;
+  -webkit-filter: blur(14px) !important;
+}
+`,
   };
 }
 

--- a/tests/test_docs_screenshots_manifest.py
+++ b/tests/test_docs_screenshots_manifest.py
@@ -168,8 +168,9 @@ def test_docs_screenshot_capture_supports_scene_masks() -> None:
     script = CAPTURE_SCRIPT_PATH.read_text(encoding="utf-8")
 
     assert "function buildScreenshotOptions(page, scene)" in script
-    assert "scene.screenshotMasks.map((selector) => page.locator(selector))" in script
-    assert 'maskColor: "#111827"' in script
+    assert "maskSelectors.join" in script
+    assert "filter: blur(14px) !important;" in script
+    assert "maskColor" not in script
     assert "...buildScreenshotOptions(page, scene)" in script
     assert "buildScreenshotOptions(page, scene)," in script
 


### PR DESCRIPTION
## Summary
- Replace Playwright screenshot mask overlays with temporary CSS blur for configured 2FA selectors.
- Keep the existing scene manifest screenshotMasks contract while avoiding solid black QR/text-code blocks.

## Validation
- docker compose run --rm app poetry run pytest tests/test_docs_screenshots_manifest.py
- Manual recapture against local app verified the 2FA QR and text code are blurred, not blacked out.

## Related
- Docs source PR: https://github.com/scidsg/hushline-docs/pull/67
- Website launch PR: https://github.com/scidsg/hushline-website/pull/87