### PR TITLE
Avoid persisting PATs in docs-screenshots workflow clones

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -173,31 +173,51 @@ jobs:
           CAPTURE_MANIFEST="${RUNNER_TEMP}/docs-screenshot-capture-manifest.json"
           CAPTURE_FILES="${RUNNER_TEMP}/docs-screenshot-capture-files.json"
 
-          DOCS_CLONE_URL="https://github.com/${DOCS_REPOSITORY}.git"
-          if [ -n "${DOCS_READ_TOKEN:-}" ]; then
-            DOCS_CLONE_URL="https://x-access-token:${DOCS_READ_TOKEN}@github.com/${DOCS_REPOSITORY}.git"
-          fi
+          GIT_ASKPASS_HELPER="${RUNNER_TEMP}/git-askpass-doc-screenshots.sh"
+          cat > "$GIT_ASKPASS_HELPER" <<'EOF'
+          #!/usr/bin/env sh
+          case "$1" in
+            *Username*) printf '%s\n' "x-access-token" ;;
+            *Password*) printf '%s\n' "${GIT_ASKPASS_TOKEN:?}" ;;
+            *) printf '\n' ;;
+          esac
+          EOF
+          chmod 700 "$GIT_ASKPASS_HELPER"
+          trap 'rm -f "$GIT_ASKPASS_HELPER"' EXIT
 
-          CLONE_URL="https://github.com/${WEBSITE_REPOSITORY}.git"
-          if [ -n "${WEBSITE_READ_TOKEN:-}" ]; then
-            CLONE_URL="https://x-access-token:${WEBSITE_READ_TOKEN}@github.com/${WEBSITE_REPOSITORY}.git"
-          fi
+          clone_with_optional_token() {
+            local repository="$1"
+            local branch="$2"
+            local destination="$3"
+            local token="${4:-}"
+            local clone_url="https://github.com/${repository}.git"
 
-          git clone \
-            --depth 1 \
-            --filter=blob:none \
-            --single-branch \
-            --branch "${DOCS_DEFAULT_BRANCH}" \
-            "$DOCS_CLONE_URL" \
-            "$DOCS_DIR"
+            if [ -n "$token" ]; then
+              GIT_TERMINAL_PROMPT=0 \
+                GIT_ASKPASS="$GIT_ASKPASS_HELPER" \
+                GIT_ASKPASS_TOKEN="$token" \
+                git clone \
+                  --depth 1 \
+                  --filter=blob:none \
+                  --single-branch \
+                  --branch "$branch" \
+                  "$clone_url" \
+                  "$destination"
+            else
+              git clone \
+                --depth 1 \
+                --filter=blob:none \
+                --single-branch \
+                --branch "$branch" \
+                "$clone_url" \
+                "$destination"
+            fi
 
-          git clone \
-            --depth 1 \
-            --filter=blob:none \
-            --single-branch \
-            --branch "${WEBSITE_DEFAULT_BRANCH}" \
-            "$CLONE_URL" \
-            "$WEBSITE_DIR"
+            git -C "$destination" remote set-url origin "$clone_url"
+          }
+
+          clone_with_optional_token "$DOCS_REPOSITORY" "$DOCS_DEFAULT_BRANCH" "$DOCS_DIR" "${DOCS_READ_TOKEN:-}"
+          clone_with_optional_token "$WEBSITE_REPOSITORY" "$WEBSITE_DEFAULT_BRANCH" "$WEBSITE_DIR" "${WEBSITE_READ_TOKEN:-}"
 
           python3 .trusted-workflow/scripts/resolve-doc-screenshot-allowlist.py \
             --hushline-dir "$GITHUB_WORKSPACE" \

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -123,7 +123,11 @@ def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> 
     assert "Resolve screenshot capture manifest" in capture_workflow_text
     assert "DOCS_REPOSITORY: scidsg/hushline-docs" in capture_workflow_text
     assert 'DOCS_DIR="${RUNNER_TEMP}/hushline-docs"' in capture_workflow_text
-    assert '--branch "${DOCS_DEFAULT_BRANCH}"' in capture_workflow_text
+    assert '--branch "$branch"' in capture_workflow_text
+    assert (
+        'clone_with_optional_token "$DOCS_REPOSITORY" "$DOCS_DEFAULT_BRANCH"'
+        in capture_workflow_text
+    )
     assert '--docs-dir "$DOCS_DIR"' in capture_workflow_text
     assert '--manifest-out "$CAPTURE_MANIFEST"' in capture_workflow_text
     assert '--output "$CAPTURE_FILES"' in capture_workflow_text
@@ -154,6 +158,22 @@ def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> 
     assert "gh pr create \\" not in website_section
     assert 'gh pr merge "$pr_url" \\' not in website_section
     assert "${WEBSITE_SCREENSHOT_ROOT}/releases" not in website_section
+
+
+def test_docs_screenshot_capture_manifest_does_not_persist_read_tokens() -> None:
+    workflow_text = _workflow_text(".github/workflows/docs-screenshots.yml")
+    manifest_section = workflow_text.split("      - name: Resolve screenshot capture manifest", 1)[
+        1
+    ].split("      - name: Capture screenshots", 1)[0]
+
+    assert "DOCS_READ_TOKEN:" in manifest_section
+    assert "WEBSITE_READ_TOKEN:" in manifest_section
+    assert "GIT_ASKPASS_HELPER=" in manifest_section
+    assert 'GIT_ASKPASS_TOKEN="$token"' in manifest_section
+    assert 'git -C "$destination" remote set-url origin "$clone_url"' in manifest_section
+    assert "https://x-access-token:${DOCS_READ_TOKEN}" not in manifest_section
+    assert "https://x-access-token:${WEBSITE_READ_TOKEN}" not in manifest_section
+    assert "DOCS_CLONE_URL=" not in manifest_section
 
 
 def test_dev_deploy_workflow_generates_session_fernet_key_for_terraform_runs() -> None:


### PR DESCRIPTION
### Motivation
- The docs screenshot workflow previously cloned external repos using URLs that embedded a PAT, and Git persisted those URLs (including secrets) in the cloned repo `.git/config` under `RUNNER_TEMP`, which a malicious `release_ref`-controlled script could read and exfiltrate. 
- The change's intent is to prevent CI secrets from being written into persisted git remotes while preserving the existing screenshot-capture behavior.

### Description
- Replace credential-bearing clone URLs with an ephemeral `GIT_ASKPASS` helper and use `GIT_ASKPASS_TOKEN` so `git clone` authenticates without embedding userinfo in the remote URL in `/.github/workflows/docs-screenshots.yml`.
- Add a `clone_with_optional_token()` helper that conditionally sets `GIT_ASKPASS`/`GIT_ASKPASS_TOKEN` for authenticated clones and falls back to unauthenticated clones when no token is present.
- After each clone, run `git -C "$destination" remote set-url origin "$clone_url"` to ensure the checked-out repository's remote URL is tokenless before any untrusted code runs. 
- Update `tests/test_workflow_pr_head_qualification.py` to reflect the new helper-based clone flow and add `test_docs_screenshot_capture_manifest_does_not_persist_read_tokens` which asserts the manifest step no longer constructs `https://x-access-token:...` clone URLs and includes the askpass-related lines.

### Testing
- Ran `python -m pytest tests/test_workflow_pr_head_qualification.py -q` and all tests in that file passed (`8 passed`).
- Ran `python -m ruff format` and `python -m ruff check` on the modified test file and formatting/lint checks passed, and ran Prettier check on the workflow which passed. 
- Ran `git diff --check` with no findings. 
- Could not run `make lint`, `make test`, or the dependency-audit targets locally because Docker is not available in the execution environment, so CI must run the full `make`/audit checks before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29ee90607c83308b95b99e6621b76f)