### PR TITLE
Harden docs screenshot publishing

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -256,8 +256,8 @@ jobs:
           name: docs-screenshots-${{ steps.vars.outputs.release_key }}
           path: ${{ steps.artifact.outputs.artifact_root }}
 
-  publish-manual:
-    if: ${{ github.event_name != 'workflow_call' }}
+  publish-release:
+    if: ${{ github.event_name == 'release' }}
     needs: capture
     uses: ./.github/workflows/publish-docs-screenshots.yml
     with:

--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -32,6 +32,50 @@ jobs:
           fetch-depth: 1
           persist-credentials: false
 
+      - name: Verify trusted source run
+        id: source
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_ID: ${{ inputs.source_run_id }}
+          CURRENT_RUN_ID: ${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          RUN_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}")"
+          RUN_JSON="$RUN_JSON" CURRENT_RUN_ID="$CURRENT_RUN_ID" python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          run = json.loads(os.environ["RUN_JSON"])
+          current_run_id = os.environ["CURRENT_RUN_ID"]
+          errors = []
+
+          if str(run.get("id")) != os.environ["RUN_ID"]:
+              errors.append("source run ID mismatch")
+          if run.get("event") != "release":
+              errors.append(f"source run event must be release, got {run.get('event')!r}")
+          if run.get("path") != ".github/workflows/docs-screenshots.yml":
+              errors.append(f"source run workflow path is unexpected: {run.get('path')!r}")
+          head_repository = run.get("head_repository") or {}
+          if head_repository.get("full_name") != os.environ["GITHUB_REPOSITORY"]:
+              errors.append(
+                  "source run repository must match "
+                  f"{os.environ['GITHUB_REPOSITORY']}, got {head_repository.get('full_name')!r}"
+              )
+          if str(run.get("id")) != current_run_id and run.get("conclusion") != "success":
+              errors.append("completed source runs must have a successful conclusion")
+
+          if errors:
+              for error in errors:
+                  print(f"::error::{error}")
+              sys.exit(1)
+
+          print(
+              "Trusted docs screenshot source run verified: "
+              f"id={run.get('id')} event={run.get('event')} path={run.get('path')}"
+          )
+          PY
+
       - name: Download screenshot artifact
         id: artifact
         env:
@@ -57,6 +101,64 @@ jobs:
             -o /tmp/docs-screenshots-artifact/artifact.zip
           unzip -q /tmp/docs-screenshots-artifact/artifact.zip -d /tmp/docs-screenshots-artifact/unpacked
           rm -f /tmp/docs-screenshots-artifact/artifact.zip
+
+          python3 - <<'PY'
+          from pathlib import Path
+          import json
+          import re
+          import sys
+
+          artifact_root = Path("/tmp/docs-screenshots-artifact/unpacked")
+          image_extensions = {".avif", ".gif", ".jpeg", ".jpg", ".png", ".webp"}
+          allowed_exact = {
+              Path("release_key.txt"),
+              Path("capture_files.json"),
+              Path("screenshots/README.md"),
+          }
+
+          def fail(message: str) -> None:
+              print(f"::error::{message}")
+              sys.exit(1)
+
+          release_key_path = artifact_root / "release_key.txt"
+          refs_path = artifact_root / "capture_files.json"
+          release_root = artifact_root / "screenshots" / "release"
+          if not release_key_path.is_file():
+              fail("docs screenshot artifact is missing release_key.txt")
+          if not refs_path.is_file():
+              fail("docs screenshot artifact is missing capture_files.json")
+          if not release_root.is_dir():
+              fail("docs screenshot artifact is missing screenshots/release")
+
+          release_key = release_key_path.read_text(encoding="utf-8").strip()
+          if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", release_key):
+              fail(f"Unexpected docs screenshot release key: {release_key!r}")
+          refs = json.loads(refs_path.read_text(encoding="utf-8"))
+          if not isinstance(refs, list) or not all(isinstance(ref, str) for ref in refs):
+              fail("capture_files.json must contain a JSON array of screenshot paths")
+
+          for path in artifact_root.rglob("*"):
+              relative = path.relative_to(artifact_root)
+              if path.is_symlink():
+                  fail(f"docs screenshot artifact must not contain symlinks: {relative}")
+              if path.is_dir():
+                  continue
+              if relative in allowed_exact:
+                  continue
+              is_current_image = relative.parts[:2] == ("screenshots", "current")
+              is_release_image = relative.parts[:2] == ("screenshots", "release")
+              is_legacy_release_image = relative.parts[:3] == (
+                  "screenshots",
+                  "releases",
+                  release_key,
+              )
+              if (is_current_image or is_release_image or is_legacy_release_image) and (
+                  path.suffix.lower() in image_extensions
+              ):
+                  continue
+              fail(f"Unexpected docs screenshot artifact file: {relative}")
+          PY
+
           echo "found=true" >> "$GITHUB_OUTPUT"
           echo "artifact_dir=/tmp/docs-screenshots-artifact/unpacked" >> "$GITHUB_OUTPUT"
 

--- a/scripts/resolve-doc-screenshot-allowlist.py
+++ b/scripts/resolve-doc-screenshot-allowlist.py
@@ -207,7 +207,13 @@ def read_refs_input(refs_input: Path) -> list[str]:
     refs = json.loads(refs_input.read_text(encoding="utf-8"))
     if not isinstance(refs, list) or not all(isinstance(ref, str) for ref in refs):
         raise SystemExit(f"Expected captureFiles JSON array at {refs_input}")
-    return sorted(set(refs))
+    normalized_refs = []
+    for ref in refs:
+        normalized = normalize_ref(ref)
+        if normalized != ref:
+            raise SystemExit(f"Unexpected captureFiles screenshot path: {ref!r}")
+        normalized_refs.append(normalized)
+    return sorted(set(normalized_refs))
 
 
 def copy_filtered_current(current_root: Path, filtered_root: Path, refs: list[str]) -> None:

--- a/tests/test_docs_screenshots_manifest.py
+++ b/tests/test_docs_screenshots_manifest.py
@@ -3,6 +3,8 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
+
 REPO_ROOT = Path(__file__).resolve().parents[1]
 MANIFEST_PATH = REPO_ROOT / "docs" / "screenshots" / "scenes.json"
 CAPTURE_SCRIPT_PATH = REPO_ROOT / "scripts" / "capture-doc-screenshots.mjs"
@@ -272,6 +274,19 @@ def test_docs_screenshot_allowlist_can_reuse_capture_files_artifact(tmp_path: Pa
         "artvandelay/auth-artvandelay-enable-2fa-desktop-light-fold.png",
         "guest/used.png",
     ]
+
+
+def test_docs_screenshot_allowlist_rejects_unsafe_capture_files_artifact(tmp_path: Path) -> None:
+    script = _load_allowlist_script()
+    refs_input = tmp_path / "capture_files.json"
+
+    refs_input.write_text(
+        json.dumps(["guest/used.png", "../escape.png", "guest/script.js"]),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(SystemExit, match="Unexpected captureFiles screenshot path"):
+        script.read_refs_input(refs_input)
 
 
 def test_docs_screenshots_manifest_artvandelay_notifications_waits_for_third_recipient() -> None:

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -63,6 +63,9 @@ def test_public_directory_weekly_report_refreshes_stats_branch_lease_before_push
 
 def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> None:
     workflow_text = _workflow_text(".github/workflows/publish-docs-screenshots.yml")
+    source_section = workflow_text.split("      - name: Verify trusted source run", 1)[1].split(
+        "      - name: Download screenshot artifact", 1
+    )[0]
     artifact_section = workflow_text.split("      - name: Download screenshot artifact", 1)[
         1
     ].split("      - name: Publish screenshots to hushline-screenshots", 1)[0]
@@ -70,7 +73,16 @@ def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> No
         "      - name: Publish screenshots to hushline-screenshots", 1
     )[1].split("      - name: Publish current screenshots to hushline-website", 1)[0]
 
+    assert 'run.get("event") != "release"' in source_section
+    assert 'run.get("path") != ".github/workflows/docs-screenshots.yml"' in source_section
+    assert 'head_repository.get("full_name") != os.environ["GITHUB_REPOSITORY"]' in source_section
+    assert 'run.get("conclusion") != "success"' in source_section
     assert "rm -f /tmp/docs-screenshots-artifact/artifact.zip" in artifact_section
+    assert "path.is_symlink()" in artifact_section
+    assert 'is_current_image = relative.parts[:2] == ("screenshots", "current")' in artifact_section
+    assert 'is_release_image = relative.parts[:2] == ("screenshots", "release")' in artifact_section
+    assert "is_legacy_release_image = relative.parts[:3]" in artifact_section
+    assert "path.suffix.lower() in image_extensions" in artifact_section
     assert "SCREENSHOTS_DEFAULT_BRANCH: main" in archive_section
     assert 'SCREENSHOT_ROOT="${ARTIFACT_DIR}/screenshots/release"' in archive_section
     assert (
@@ -102,6 +114,7 @@ def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> No
 def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> None:
     capture_workflow_text = _workflow_text(".github/workflows/docs-screenshots.yml")
     publish_workflow_text = _workflow_text(".github/workflows/publish-docs-screenshots.yml")
+    publish_job_section = capture_workflow_text.split("  publish-release:", 1)[1]
     artifact_section = capture_workflow_text.split("      - name: Prepare publish artifact", 1)[
         1
     ].split("      - name: Upload screenshot artifacts", 1)[0]
@@ -115,6 +128,8 @@ def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> 
         "      - name: Publish current screenshots to hushline-website", 1
     )[1]
 
+    assert "if: ${{ github.event_name == 'release' }}" in publish_job_section
+    assert "if: ${{ github.event_name != 'workflow_call' }}" not in capture_workflow_text
     assert "fetch-depth: 1" in checkout_section
     assert "fetch-depth: 0" not in checkout_section
     assert "repository: ${{ job.workflow_repository }}" in trusted_checkout_section


### PR DESCRIPTION
### Motivation
- A security scan identified a supply-chain integrity issue where a caller-controlled screenshot run could cause unreviewed files from an artifact to be pushed to the public website repository using stored automation credentials. 
- The goal is to ensure only trusted release-origin runs may trigger the secret-consuming publish path and to prevent arbitrary artifact contents from being committed to `scidsg/hushline-website`.
- Preserve the existing release publishing flow while adding provenance checks and artifact validation as defense-in-depth.

### Description
- Restrict the automatic publish handoff so the publish job is invoked only for release-triggered captures by changing the capture workflow to call the publish workflow on `release` events instead of all non-`workflow_call` runs (`docs-screenshots.yml`).
- Add a `Verify trusted source run` step that fetches the source run metadata and validates the requested run ID, event type (`release`), workflow path (`.github/workflows/docs-screenshots.yml`), originating repository, and successful conclusion for completed runs before downloading artifacts (`publish-docs-screenshots.yml`).
- Validate artifact contents immediately after unzip by requiring `release_key.txt` and `capture_files.json`, checking `release_key` format, rejecting symlinks, and allowing only expected image files under `screenshots/current` / `screenshots/release` / legacy `screenshots/releases/<release_key>`, plus a small set of allowed exact files (`publish-docs-screenshots.yml`).
- Tighten `capture_files.json` parsing in `scripts/resolve-doc-screenshot-allowlist.py` so input paths are normalized, rejected if they contain traversal or non-image extensions, and only safe normalized refs are accepted before filtering the current screenshot tree.
- Add regression assertions in `tests/test_workflow_pr_head_qualification.py` and a unit test `test_docs_screenshot_allowlist_rejects_unsafe_capture_files_artifact` in `tests/test_docs_screenshots_manifest.py` to lock intended workflow/text changes and validate unsafe capture-file rejection.

### Testing
- Ran targeted pytest selection: `tests/test_workflow_pr_head_qualification.py::test_screenshots_archive_workflow_publishes_directly_without_pr_flow`, `tests/test_workflow_pr_head_qualification.py::test_screenshots_workflow_publishes_current_folder_to_website_directly`, `tests/test_docs_screenshots_manifest.py::test_docs_screenshot_allowlist_can_reuse_capture_files_artifact`, and `tests/test_docs_screenshots_manifest.py::test_docs_screenshot_allowlist_rejects_unsafe_capture_files_artifact`; all passed.
- Ran formatter/lint checks on touched files with `ruff format` and `ruff check` and they passed for the modified files.
- Ran `git diff --check` and found no whitespace/patch errors.
- Full `make lint`, full `make test`, and dependency audits (`make audit-python`, `make audit-node-runtime`) could not be executed in this environment because Docker is not available; these checks must be run in CI or another environment with Docker before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29ee17cbd883309356b2576f681c9f)