### PR TITLE
Protect multi-recipient encrypted notification bodies

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -480,9 +480,8 @@ def register_profile_routes(app: Flask) -> None:
                         if uname.user.email_encrypt_entire_body:
                             encrypted_email_body = (form.encrypted_email_body.data or "").strip()
                             client_body_is_armored = _is_armored_pgp_message(encrypted_email_body)
-                            can_trust_client_encrypted_body = (
-                                client_body_is_armored
-                                and notification_encryption_target is not None
+                            can_trust_client_encrypted_body = client_body_is_armored and isinstance(
+                                notification_encryption_target, str
                             )
                             if can_trust_client_encrypted_body:
                                 email_body = encrypted_email_body

--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -205,7 +205,7 @@ def test_contract_notifications_full_body_mode_falls_back_to_server_encrypt(
 
 
 @pytest.mark.usefixtures("_authenticated_user", "_pgp_user")
-def test_contract_notifications_full_body_mode_uses_client_body_for_all_enabled_recipients(
+def test_contract_notifications_full_body_mode_server_encrypts_for_multiple_recipients(
     client: FlaskClient, user: User
 ) -> None:
     user.enable_email_notifications = True
@@ -220,13 +220,23 @@ def test_contract_notifications_full_body_mode_uses_client_body_for_all_enabled_
     client_body = (
         "-----BEGIN PGP MESSAGE-----\n\nclient encrypted body\n\n-----END PGP MESSAGE-----"
     )
+    server_body = (
+        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
+    )
     with (
         patch("hushline.routes.profile.do_send_email", new=MagicMock()) as send_email_mock,
-        patch("hushline.routes.profile.encrypt_message", new=MagicMock()) as encrypt_mock,
+        patch(
+            "hushline.routes.profile.encrypt_message", new=MagicMock(return_value=server_body)
+        ) as encrypt_mock,
     ):
         _submit_message(client, user, encrypted_email_body=client_body)
-        encrypt_mock.assert_not_called()
-        send_email_mock.assert_called_once_with(user, client_body)
+        expected_plaintext_body = format_full_message_email_body(
+            [("Contact Method", "Signal"), ("Message", "Contract test message")]
+        )
+        encrypt_mock.assert_called_once_with(
+            expected_plaintext_body, [user.pgp_key, secondary_pgp_key]
+        )
+        send_email_mock.assert_called_once_with(user, server_body)
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -589,7 +589,7 @@ def test_notifications_full_body_encryption_embedded_markers_use_server_fallback
 @pytest.mark.usefixtures("_pgp_user")
 @patch("hushline.routes.profile.encrypt_message")
 @patch("hushline.routes.profile.do_send_email")
-def test_notifications_full_body_encryption_uses_client_body_for_all_enabled_recipients(
+def test_notifications_full_body_encryption_server_encrypts_for_multiple_recipients(
     mock_do_send_email: MagicMock,
     mock_encrypt_message: MagicMock,
     app: Flask,
@@ -609,6 +609,11 @@ def test_notifications_full_body_encryption_uses_client_body_for_all_enabled_rec
         "-----BEGIN PGP MESSAGE-----\n\nclient encrypted body\n\n-----END PGP MESSAGE-----"
     )
 
+    server_encrypted_email_body = (
+        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
+    )
+    mock_encrypt_message.return_value = server_encrypted_email_body
+
     response = client.post(
         url_for("profile", username=user.primary_username.username),
         data={
@@ -621,15 +626,20 @@ def test_notifications_full_body_encryption_uses_client_body_for_all_enabled_rec
     )
 
     assert response.status_code == 200, response.text
-    mock_encrypt_message.assert_not_called()
-    mock_do_send_email.assert_called_once_with(user, client_encrypted_email_body)
+    expected_fallback_body = format_full_message_email_body(
+        [("Contact Method", msg_contact_method), ("Message", msg_content)]
+    )
+    mock_encrypt_message.assert_called_once_with(
+        expected_fallback_body, [user.pgp_key, secondary_pgp_key]
+    )
+    mock_do_send_email.assert_called_once_with(user, server_encrypted_email_body)
 
 
 @pytest.mark.usefixtures("_authenticated_user")
 @pytest.mark.usefixtures("_pgp_user")
 @patch("hushline.routes.profile.encrypt_message")
 @patch("hushline.routes.profile.do_send_email")
-def test_notifications_full_body_multi_recipient_does_not_wrap_encrypted_fields(
+def test_notifications_full_body_multi_recipient_server_encrypts_stored_fields(
     mock_do_send_email: MagicMock,
     mock_encrypt_message: MagicMock,
     client: FlaskClient,
@@ -653,6 +663,11 @@ def test_notifications_full_body_multi_recipient_does_not_wrap_encrypted_fields(
         "-----BEGIN PGP MESSAGE-----\n\nstored encrypted message\n\n-----END PGP MESSAGE-----"
     )
 
+    server_encrypted_email_body = (
+        "-----BEGIN PGP MESSAGE-----\n\nserver encrypted body\n\n-----END PGP MESSAGE-----"
+    )
+    mock_encrypt_message.return_value = server_encrypted_email_body
+
     response = client.post(
         url_for("profile", username=user.primary_username.username),
         data={
@@ -665,8 +680,13 @@ def test_notifications_full_body_multi_recipient_does_not_wrap_encrypted_fields(
     )
 
     assert response.status_code == 200, response.text
-    mock_encrypt_message.assert_not_called()
-    mock_do_send_email.assert_called_once_with(user, client_encrypted_email_body)
+    expected_fallback_body = format_full_message_email_body(
+        [("Contact Method", stored_contact_field), ("Message", stored_message_field)]
+    )
+    mock_encrypt_message.assert_called_once_with(
+        expected_fallback_body, [user.pgp_key, f"{user.pgp_key}\n"]
+    )
+    mock_do_send_email.assert_called_once_with(user, server_encrypted_email_body)
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -43,6 +43,10 @@ def _configure_embed(username: Username, origin: str = "https://tips.example") -
     username.set_embed_allowed_origins([origin])
 
 
+def _embed_post_headers(**extra_headers: str) -> dict[str, str]:
+    return {"Origin": "http://localhost:8080", **extra_headers}
+
+
 def _embed_submission_data(response_text: str) -> dict[str, str]:
     page = BeautifulSoup(response_text, "html.parser")
     label = page.find("label", attrs={"for": "captcha_answer"})
@@ -311,6 +315,7 @@ def test_embed_profile_rejects_non_numeric_captcha(client: FlaskClient, user: Us
             "field_1": msg_content,
             **submission_data,
         },
+        headers=_embed_post_headers(),
     )
 
     assert response.status_code == 400
@@ -339,6 +344,7 @@ def test_embed_profile_rejects_expired_captcha_token(client: FlaskClient, user: 
                 "field_1": msg_content,
                 **submission_data,
             },
+            headers=_embed_post_headers(),
         )
 
     assert response.status_code == 400
@@ -367,6 +373,7 @@ def test_embed_profile_rejects_bad_captcha_token(client: FlaskClient, user: User
                 "field_1": msg_content,
                 **submission_data,
             },
+            headers=_embed_post_headers(),
         )
 
     assert response.status_code == 400
@@ -406,6 +413,7 @@ def test_embed_profile_rejects_captcha_token_for_different_profile(
             "field_1": msg_content,
             **submission_data,
         },
+        headers=_embed_post_headers(),
     )
 
     assert response.status_code == 400
@@ -440,6 +448,7 @@ def test_embed_profile_post_404s_if_account_is_suspended_after_render(
                 "field_1": msg_content,
                 **submission_data,
             },
+            headers=_embed_post_headers(),
         )
 
     assert response.status_code == 404
@@ -483,6 +492,7 @@ def test_embed_profile_rejects_if_account_is_suspended_during_submission(
                 "field_1": msg_content,
                 **submission_data,
             },
+            headers=_embed_post_headers(),
         )
 
     assert response.status_code == 400
@@ -534,6 +544,7 @@ def test_embed_profile_rejects_if_recipient_keys_are_removed_during_submission(
                 "field_1": msg_content,
                 **submission_data,
             },
+            headers=_embed_post_headers(),
         )
 
     assert response.status_code == 400


### PR DESCRIPTION
### Motivation
- Public profile submissions could supply an ASCII-armored `encrypted_email_body` that the server trusted for multi-recipient notification targets, allowing an unauthenticated sender to bypass server-side full-body encryption for accounts with multiple recipients. 
- The intent is to preserve E2EE guarantees and ensure multi-recipient notifications are encrypted server-side to the configured recipient keys instead of blindly forwarding client-supplied armor.

### Description
- Restore the trust guard when accepting a client-supplied full-body PGP field by requiring the `notification_encryption_target` to be a single `str` before sending the client armor unchanged, otherwise fall back to server-side encryption; change implemented in `hushline/routes/profile.py` by checking `isinstance(notification_encryption_target, str)`.
- Update notification and behavior-contract tests in `tests/test_notifications.py` and `tests/test_behavior_contracts.py` to assert that multi-recipient full-body notification flows use the server-side encryption fallback (encrypting to the list of recipient keys) while single-recipient client-encrypted bodies remain accepted.
- Apply automatic formatting/lint fixes to the touched files to satisfy style checks.

### Testing
- Ran formatter and linter checks with `poetry run ruff format` and `poetry run ruff check` on the modified files, which completed successfully. 
- Verified that Python files compile with `python -m compileall`, which completed without errors for the modified files. 
- Attempted targeted pytest runs for notification behavior, but execution was blocked by the environment because the test harness could not resolve the expected PostgreSQL host (`postgres`), producing connection errors; as a result full pytest validation could not complete locally. 
- `make lint`, full `make test`, and dependency audit commands were attempted but blocked in this environment because Docker is not available, so CI-style checks must run in the repository CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a73d027008330bb5f1bcf77644047)