### PR TITLE
Allow sandboxed embed form submissions

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -201,7 +201,22 @@ def register_profile_routes(app: Flask) -> None:
 
         return True
 
-    def _embed_post_origin_is_valid() -> bool:
+    def _embed_form_token_belongs_to_profile(uname: Username, token: str) -> bool:
+        try:
+            payload: dict[str, Any] = _embed_captcha_serializer().loads(
+                token,
+                max_age=EMBED_CAPTCHA_MAX_AGE_SECONDS,
+            )
+        except (BadData, SignatureExpired):
+            return False
+
+        return (
+            payload.get("v") == 1
+            and payload.get("username") == uname.username
+            and payload.get("user_id") == uname.user_id
+        )
+
+    def _embed_post_origin_is_valid(uname: Username) -> bool:
         origin = request.headers.get("Origin", "").strip()
         if not origin:
             referer = request.headers.get("Referer", "").strip()
@@ -210,7 +225,10 @@ def register_profile_routes(app: Flask) -> None:
                 origin = f"{parsed_referer.scheme}://{parsed_referer.netloc}"
 
         if not origin or origin == "null":
-            return False
+            return _embed_form_token_belongs_to_profile(
+                uname,
+                request.form.get("embed_captcha_token", ""),
+            )
 
         parsed_origin = urlsplit(origin)
         parsed_host = urlsplit(request.host_url)
@@ -326,7 +344,7 @@ def register_profile_routes(app: Flask) -> None:
 
             embed_rate_limit_result = None
             if is_embedded:
-                if not _embed_post_origin_is_valid():
+                if not _embed_post_origin_is_valid(uname):
                     flash("⛔️ Invalid embed request origin. Please reload.")
                     return _render_profile(400)
 

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -704,7 +704,9 @@ def test_embed_profile_submission_rejects_invalid_csrf_token(
     assert _first_message_for(user.primary_username) is None
 
 
-def test_embed_profile_submission_rejects_missing_origin(client: FlaskClient, user: User) -> None:
+def test_embed_profile_submission_allows_sandboxed_null_origin(
+    client: FlaskClient, user: User
+) -> None:
     _enable_embeds_globally()
     _make_message_capable(user)
     _configure_embed(user.primary_username)
@@ -720,6 +722,83 @@ def test_embed_profile_submission_rejects_missing_origin(client: FlaskClient, us
             "field_1": "Embedded message",
             **submission_data,
         },
+        headers={"Origin": "null"},
+    )
+
+    assert post_response.status_code == 200, post_response.text
+    assert _first_message_for(user.primary_username) is not None
+
+
+def test_embed_profile_submission_allows_token_bound_missing_origin(
+    client: FlaskClient, user: User
+) -> None:
+    _enable_embeds_globally()
+    _make_message_capable(user)
+    _configure_embed(user.primary_username)
+
+    response = client.get(url_for("embed_profile", username=user.primary_username.username))
+    assert response.status_code == 200
+    submission_data = _embed_submission_data(response.text)
+
+    post_response = client.post(
+        url_for("embed_profile", username=user.primary_username.username),
+        data={
+            "field_0": "Embedded Signal contact",
+            "field_1": "Embedded message",
+            **submission_data,
+        },
+    )
+
+    assert post_response.status_code == 200, post_response.text
+    assert _first_message_for(user.primary_username) is not None
+
+
+def test_embed_profile_submission_rejects_missing_origin_without_embed_form_token(
+    client: FlaskClient, user: User
+) -> None:
+    _enable_embeds_globally()
+    _make_message_capable(user)
+    _configure_embed(user.primary_username)
+
+    response = client.get(url_for("embed_profile", username=user.primary_username.username))
+    assert response.status_code == 200
+    submission_data = _embed_submission_data(response.text)
+    submission_data.pop("embed_captcha_token")
+
+    post_response = client.post(
+        url_for("embed_profile", username=user.primary_username.username),
+        data={
+            "field_0": "Embedded Signal contact",
+            "field_1": "Embedded message",
+            **submission_data,
+        },
+    )
+
+    assert post_response.status_code == 400
+    assert "Invalid embed request origin" in post_response.text
+    assert _first_message_for(user.primary_username) is None
+
+
+def test_embed_profile_submission_rejects_null_origin_without_embed_form_token(
+    client: FlaskClient, user: User
+) -> None:
+    _enable_embeds_globally()
+    _make_message_capable(user)
+    _configure_embed(user.primary_username)
+
+    response = client.get(url_for("embed_profile", username=user.primary_username.username))
+    assert response.status_code == 200
+    submission_data = _embed_submission_data(response.text)
+    submission_data.pop("embed_captcha_token")
+
+    post_response = client.post(
+        url_for("embed_profile", username=user.primary_username.username),
+        data={
+            "field_0": "Embedded Signal contact",
+            "field_1": "Embedded message",
+            **submission_data,
+        },
+        headers={"Origin": "null"},
     )
 
     assert post_response.status_code == 400


### PR DESCRIPTION
### Motivation
- Recent origin validation unconditionally rejected missing or `Origin: null` headers which blocked legitimate submissions from the official sandboxed embed iframe that omits `allow-same-origin` and uses `referrerpolicy="no-referrer"`.
- The change must preserve protections against cross-site replayed embed posts while restoring availability for authentic sandboxed embed submissions.

### Description
- Add `_embed_form_token_belongs_to_profile(uname, token)` which verifies the signed embed CAPTCHA token payload matches the target username and user id and is unexpired.
- Modify `_embed_post_origin_is_valid` to accept the target `uname` and, when `Origin` is missing or `null`, allow the request only if the submitted `embed_captcha_token` belongs to that profile; otherwise keep same-origin/referer checks for normal origins.
- Update the embedded submission path to pass `uname` into the origin validator before rate limiting and standard form validation.
- Add regression tests in `tests/test_embeddable_forms_settings.py` that cover sandboxed `Origin: null` submissions with a valid token, missing-origin submissions bound to a valid embed token, and rejection of missing/null-origin submissions when the embed token is absent.

### Testing
- `python -m compileall -q hushline/routes/profile.py tests/test_embeddable_forms_settings.py` completed successfully.
- `poetry run ruff format --check` and `poetry run ruff check` on the modified files completed successfully.
- `poetry run mypy` on the modified files completed successfully.
- Targeted `pytest` runs that exercise the new tests were attempted but errored during test setup because the container could not resolve the PostgreSQL host (`postgres`) and thus could not run DB-backed fixtures.
- `make lint`, `make test`, and dependency audit targets were attempted but blocked in this environment because `docker` is unavailable, so full CI checks must run in upstream CI before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2abb7e8f2c83308af9a13ed43ac1e5)