### PR TITLE
Harden directory caution badge normalization

### DIFF
--- a/hushline/routes/common.py
+++ b/hushline/routes/common.py
@@ -37,8 +37,65 @@ def _dir_sort_key(u: Username) -> str:
     return s.casefold()
 
 
+_DIRECTORY_CONFUSABLE_ASCII = str.maketrans(
+    {
+        # The caution badge only protects names resembling these ASCII terms:
+        # "admin" and "hushline". Normalize common Unicode homoglyphs for
+        # those letters before transliteration so spoofed names are not missed.
+        "Α": "a",
+        "А": "a",
+        "а": "a",
+        "Ꭺ": "a",
+        "ꓮ": "a",
+        "ԁ": "d",
+        "Ꭰ": "d",
+        "Η": "h",
+        "Н": "h",
+        "н": "h",
+        "Һ": "h",
+        "һ": "h",
+        "Ꮋ": "h",
+        "Ꮒ": "h",
+        "Ι": "i",
+        "І": "i",
+        "і": "i",
+        "Ӏ": "l",
+        "ӏ": "l",
+        "ı": "i",
+        "Ꭵ": "i",
+        "ⅼ": "l",
+        "Ⲓ": "l",
+        "ⲓ": "l",
+        "Μ": "m",
+        "М": "m",
+        "м": "m",
+        "Ꮇ": "m",
+        "ꓟ": "m",
+        "Ν": "n",
+        "п": "n",
+        "ո": "n",
+        "Ꮑ": "n",
+        "Ѕ": "s",
+        "ѕ": "s",
+        "Ꮪ": "s",
+        "ꓢ": "s",
+        "υ": "u",
+        "Ս": "u",
+        "ս": "u",
+        "⋃": "u",
+        "Ε": "e",
+        "Е": "e",
+        "е": "e",
+        "Ꭼ": "e",
+    }
+)
+
+
 def normalized_directory_display_name(value: str | None) -> str:
-    return re.sub(r"[^a-z0-9]+", "", (value or "").casefold())
+    normalized_value = unicodedata.normalize("NFKC", value or "")
+    skeleton = normalized_value.translate(_DIRECTORY_CONFUSABLE_ASCII)
+    transliterated = unidecode(skeleton)
+    return re.sub(r"[^a-z0-9]+", "", transliterated.casefold())
 
 
 def show_directory_caution_badge(

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -766,6 +766,12 @@ def test_directory_users_json_includes_display_name_fallback_and_flags(
         "hush line admin",
         "admin of hush line",
         "The Hush-Line Admin",
+        "Ｈｕｓｈ Ｌｉｎｅ",
+        "Ａｄｍｉｎ",
+        "𝙃𝙪𝙨𝙝 𝙇𝙞𝙣𝙚",
+        "Αdmin",
+        "Нush Line",
+        "һuѕһ ӏіոе",
     ],
 )
 def test_directory_users_json_flags_suspicious_non_verified_non_admin_display_names_for_caution(
@@ -4077,6 +4083,13 @@ def test_directory_all_tab_moves_caution_accounts_to_bottom(
             is_verified=False,
             user=SimpleNamespace(is_admin=False, pgp_key="pgp-key"),
         ),
+        SimpleNamespace(
+            username="unicode-spoof",
+            display_name="Ｈｕｓｈ Ｌｉｎｅ",
+            bio="unicode spoof bio",
+            is_verified=False,
+            user=SimpleNamespace(is_admin=False, pgp_key="pgp-key"),
+        ),
     )
 
     monkeypatch.setattr(
@@ -4095,6 +4108,7 @@ def test_directory_all_tab_moves_caution_accounts_to_bottom(
         "Alpha Witness",
         "Zulu Witness",
         "Admin of Hush Line",
+        "Ｈｕｓｈ Ｌｉｎｅ",
     ]
 
 

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -106,10 +106,11 @@ def test_profile_accepts_case_insensitive_username(
     assert user_alias.username in response.text
 
 
+@pytest.mark.parametrize("display_name", ["Admin of Hush Line", "Ｈｕｓｈ Ｌｉｎｅ"])
 def test_profile_shows_caution_badge_for_suspicious_non_admin_display_name(
-    client: FlaskClient, user: User
+    client: FlaskClient, user: User, display_name: str
 ) -> None:
-    user.primary_username.display_name = "Admin of Hush Line"
+    user.primary_username.display_name = display_name
     user.primary_username.is_verified = False
     user.is_admin = False
     db.session.commit()

--- a/tests/test_routes_common.py
+++ b/tests/test_routes_common.py
@@ -80,6 +80,31 @@ def test_show_directory_caution_badge_honors_explicit_cautious_override() -> Non
     )
 
 
+@pytest.mark.parametrize(
+    ("display_name", "expected"),
+    [
+        ("Ｈｕｓｈ Ｌｉｎｅ", "hushline"),
+        ("Ａｄｍｉｎ", "admin"),
+        ("𝙃𝙪𝙨𝙝 𝙇𝙞𝙣𝙚", "hushline"),
+        ("Αdmin", "admin"),
+        ("Нush Line", "hushline"),
+        ("һuѕһ ӏіոе", "hushline"),
+    ],
+)
+def test_normalized_directory_display_name_handles_unicode_confusables(
+    display_name: str, expected: str
+) -> None:
+    assert routes_common.normalized_directory_display_name(display_name) == expected
+    assert (
+        routes_common.show_directory_caution_badge(
+            display_name,
+            is_admin=False,
+            is_verified=False,
+        )
+        is True
+    )
+
+
 def test_do_send_email_returns_early_without_enabled_notifications(
     user: User, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
### Motivation
- Close a Unicode confusable bypass where visually spoofed display names (fullwidth, mathematical, Cyrillic/Greek, etc.) could evade the new caution-badge and directory demotion logic. 
- Preserve the existing behavior while strengthening the normalization used to decide whether non-admin, non-verified entries look like `admin` or `Hush Line`.

### Description
- Replace the simplistic ASCII-only casefold/strip with NFKC normalization, a targeted confusable-to-ASCII skeleton translate map (`_DIRECTORY_CONFUSABLE_ASCII`), then `unidecode` transliteration and final ASCII stripping in `normalized_directory_display_name` in `hushline/routes/common.py`.
- Keep `show_directory_caution_badge` semantics but feed it the hardened normalization output so confusable Unicode names are flagged correctly.
- Add regression/unit tests to cover spoofed names (fullwidth, mathematical bold, Greek/Cyrillic/mixed homoglyphs) and ensure directory JSON rows and the "All" tab ordering demote flagged entries; tests modified/added in `tests/test_routes_common.py`, `tests/test_directory.py`, and `tests/test_profile.py`.

### Testing
- Ran `poetry run pytest tests/test_routes_common.py::test_normalized_directory_display_name_handles_unicode_confusables -q` and it passed.
- Ran formatting/lint/type checks: `poetry run ruff format ...`, `poetry run ruff check ...`, and `poetry run mypy ...` and they passed for the changed files.
- Attempted to run DB-backed pytest scenarios (for example `poetry run pytest tests/test_directory.py::test_directory_users_json_flags_suspicious_non_verified_non_admin_display_names_for_caution tests/test_directory.py::test_directory_all_tab_moves_caution_accounts_to_bottom tests/test_profile.py::test_profile_shows_caution_badge_for_suspicious_non_admin_display_name -q`) but these were blocked locally because Docker/postgres was unavailable and the `postgres` hostname could not resolve; therefore full integration test runs and `make test`/`make lint` that depend on Docker could not complete in this environment.
- Notes: non-DB unit tests that do not require a running Postgres instance passed; DB-backed tests must be validated in CI (or a local environment with `docker compose up -d postgres blob-storage`) before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aef52378c833097bd33f4a15705ec)