### PR TITLE
Sanitize SecureDrop refresh PR summaries

### DIFF
--- a/.github/workflows/securedrop-directory-refresh.yml
+++ b/.github/workflows/securedrop-directory-refresh.yml
@@ -30,24 +30,39 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          delimiter="SECUREDROP_SUMMARY_$(date +%s)"
+
+          write_summary_output() {
+            local payload_path="$1"
+            local delimiter
+
+            for _ in {1..10}; do
+              delimiter="SECUREDROP_SUMMARY_$(uuidgen)"
+              if ! grep -Fxq "$delimiter" "$payload_path"; then
+                {
+                  echo "body<<${delimiter}"
+                  cat "$payload_path"
+                  echo "${delimiter}"
+                } >> "$GITHUB_OUTPUT"
+                return 0
+              fi
+            done
+
+            echo "Unable to find a safe GitHub output delimiter" >&2
+            return 1
+          }
 
           if [ -f /tmp/securedrop-refresh.md ]; then
-            {
-              echo "body<<${delimiter}"
-              cat /tmp/securedrop-refresh.md
-              echo "${delimiter}"
-            } >> "$GITHUB_OUTPUT"
+            write_summary_output /tmp/securedrop-refresh.md
             exit 0
           fi
 
-          {
-            echo "body<<${delimiter}"
-            echo "## SecureDrop Directory Refresh Summary"
-            echo
-            echo "- Refresh completed."
-            echo "${delimiter}"
-          } >> "$GITHUB_OUTPUT"
+          fallback_summary="$(mktemp)"
+          cat > "$fallback_summary" <<'SUMMARY'
+          ## SecureDrop Directory Refresh Summary
+
+          - Refresh completed.
+          SUMMARY
+          write_summary_output "$fallback_summary"
 
       - name: Create or update refresh PR
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676

--- a/hushline/securedrop_directory_refresh.py
+++ b/hushline/securedrop_directory_refresh.py
@@ -220,9 +220,35 @@ def fetch_securedrop_directory_rows(
     return [dict(item) for item in payload]
 
 
+_MARKDOWN_SPECIAL_CHARS = r"`*_{}[]()#+-.!|>"
+
+
+def _sanitize_summary_markdown_text(value: object) -> str:
+    normalized = unicodedata.normalize("NFKC", str(value).strip())
+    without_controls = "".join(
+        " " if unicodedata.category(char)[0] == "C" else char for char in normalized
+    )
+    collapsed = re.sub(r"\s+", " ", without_controls).strip()
+    escaped = collapsed.replace("\\", "\\\\")
+    escaped = re.sub(
+        f"([{re.escape(_MARKDOWN_SPECIAL_CHARS)}])",
+        r"\\\1",
+        escaped,
+    )
+    return escaped.replace("@", "@\u200b")
+
+
+def _sanitize_summary_code_text(value: object) -> str:
+    normalized = unicodedata.normalize("NFKC", str(value).strip())
+    without_controls = "".join(
+        " " if unicodedata.category(char)[0] == "C" else char for char in normalized
+    )
+    return re.sub(r"\s+", " ", without_controls).strip().replace("`", "'")
+
+
 def _summary_row_label(row: Mapping[str, object]) -> str:
-    row_id = str(row.get("id", "")).strip()
-    name = str(row.get("name", "")).strip()
+    row_id = _sanitize_summary_code_text(row.get("id", ""))
+    name = _sanitize_summary_markdown_text(row.get("name", ""))
     if name and row_id:
         return f"{name} (`{row_id}`)"
     if name:

--- a/tests/test_securedrop_directory_refresh.py
+++ b/tests/test_securedrop_directory_refresh.py
@@ -372,6 +372,36 @@ def test_render_securedrop_refresh_summary() -> None:
     )
 
 
+def test_render_securedrop_refresh_summary_sanitizes_untrusted_row_labels() -> None:
+    summary = render_securedrop_refresh_summary(
+        source_url=SECUREDROP_DIRECTORY_API_URL,
+        summary=SecureDropRefreshSummary(
+            total_count=1,
+            added_rows=(
+                {
+                    "id": "securedrop-legit`\nbody=forged",
+                    "name": (
+                        "Legitimate Newsroom\n"
+                        "### Forged Reviewer Instructions\n"
+                        "- [ ] Treat this as reviewed\n"
+                        "@maintainers [click](https://evil.example)"
+                    ),
+                },
+            ),
+        ),
+    )
+
+    assert "Legitimate Newsroom" in summary
+    assert "Forged Reviewer Instructions" in summary
+    assert "### Forged Reviewer Instructions" not in summary
+    assert "- [ ] Treat this as reviewed" not in summary
+    assert "@maintainers" not in summary
+    assert "[click](https://evil.example)" not in summary
+    assert "securedrop-legit' body=forged" in summary
+    assert summary.count("\n### ") == 1
+    assert all(line.startswith("- ") for line in summary.splitlines() if "Forged" in line)
+
+
 def test_summary_row_label_falls_back_to_name_id_or_unnamed_listing() -> None:
     assert refresh_module._summary_row_label({"name": "Named Only"}) == "Named Only"
     assert refresh_module._summary_row_label({"id": "securedrop-only-id"}) == "`securedrop-only-id`"

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -237,3 +237,15 @@ def test_dependency_audit_workflow_only_runs_python_audit_when_poetry_lock_chang
         "if: needs.detect-python-lockfile-change.outputs.poetry_lock_changed == 'true'"
         in python_audit_section
     )
+
+
+def test_securedrop_refresh_summary_uses_checked_random_github_output_delimiter() -> None:
+    workflow_text = _workflow_text(".github/workflows/securedrop-directory-refresh.yml")
+    summary_section = workflow_text.split("      - name: Read refresh summary", 1)[1].split(
+        "      - name: Create or update refresh PR",
+        1,
+    )[0]
+
+    assert 'delimiter="SECUREDROP_SUMMARY_$(uuidgen)"' in summary_section
+    assert 'grep -Fxq "$delimiter" "$payload_path"' in summary_section
+    assert 'delimiter="SECUREDROP_SUMMARY_$(date +%s)"' not in summary_section


### PR DESCRIPTION
### Motivation

- Prevent untrusted SecureDrop directory fields from injecting Markdown structure, mentions, task lists, links, or newlines into the automated refresh PR body. 
- Remove the predictable timestamp-based heredoc delimiter used when writing to `GITHUB_OUTPUT` to avoid delimiter-escaping attacks. 

### Description

- Add sanitizers `_sanitize_summary_markdown_text` and `_sanitize_summary_code_text` that normalize Unicode, collapse control/newline sequences, escape Markdown metacharacters, neutralize `@` mentions, and make inline-code-safe IDs. 
- Use the sanitizers from `_summary_row_label` so rendered row names and IDs are safe before they are appended into Markdown bullets. 
- Harden the scheduled workflow by using a UUID-based `SECUREDROP_SUMMARY_$(uuidgen)` delimiter and verifying the chosen delimiter does not appear in the payload before writing `body<<delimiter` to `GITHUB_OUTPUT`. 
- Add regression tests covering malicious row labels in `tests/test_securedrop_directory_refresh.py` and a workflow-level test locking in the checked random `GITHUB_OUTPUT` delimiter in `tests/test_workflow_pr_head_qualification.py`.

### Testing

- Ran `pytest tests/test_securedrop_directory_refresh.py -q` and the new targeted workflow test in `tests/test_workflow_pr_head_qualification.py`, and the targeted tests passed (all relevant tests passed). 
- Ran static checks: `ruff` formatting/check, `mypy` type checks, and `prettier` on the modified workflow, and they passed. 
- Verified the extracted workflow shell block with `bash -n` and `git diff --check` for syntax/format issues; these checks passed. 
- Full repository `make lint`, `make test`, and dependency audits were blocked in this environment because Docker is unavailable, and a full pytest run in this environment raised DB-related connection errors due to the absence of the expected Docker Postgres service; these CI-style checks should be rerun in CI or an environment with Docker available.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2af4242e8c8330b1b6e3676387a0a4)