### PR TITLE
Render caution badge for cautious users in Verified directory tab

### DIFF
--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -10,7 +10,8 @@
       <p class="meta">@{{ username.username }}</p>
     {% endif %}
     {% set is_featured = username.is_featured | default(false) %}
-    {% if is_featured or username.is_verified or username.user.is_admin %}
+    {% set is_cautious = username.user.is_cautious | default(false) %}
+    {% if is_featured or username.is_verified or username.user.is_admin or is_cautious %}
       <div class="badgeContainer">
         {% if is_featured %}
           <span class="badge" role="img" aria-label="Featured account">💎 Featured</span>
@@ -20,6 +21,9 @@
         {% endif %}
         {% if username.is_verified %}
           <span class="badge" role="img" aria-label="Verified account">⭐️ Verified</span>
+        {% endif %}
+        {% if is_cautious %}
+          <span class="badge badgeCaution" role="img" aria-label="Caution: display name may be mistaken for admin">⚠️ Caution</span>
         {% endif %}
       </div>
     {% endif %}
@@ -43,7 +47,8 @@
       <p class="meta">@{{ username.username }}</p>
     {% endif %}
     {% set is_featured = username.is_featured | default(false) %}
-    {% if is_featured or username.is_verified or username.user.is_admin %}
+    {% set is_cautious = username.user.is_cautious | default(false) %}
+    {% if is_featured or username.is_verified or username.user.is_admin or is_cautious %}
       <div class="badgeContainer">
         {% if is_featured %}
           <span class="badge" role="img" aria-label="Featured account">💎 Featured</span>
@@ -53,6 +58,9 @@
         {% endif %}
         {% if username.is_verified %}
           <span class="badge" role="img" aria-label="Verified account">⭐️ Verified</span>
+        {% endif %}
+        {% if is_cautious %}
+          <span class="badge badgeCaution" role="img" aria-label="Caution: display name may be mistaken for admin">⚠️ Caution</span>
         {% endif %}
       </div>
     {% endif %}

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -152,6 +152,7 @@ def _directory_username(  # noqa: PLR0913
     is_verified: bool = False,
     is_featured: bool = False,
     is_admin: bool = False,
+    is_cautious: bool = False,
     pgp_key: str = "pgp-key",
     account_category: str | None = None,
     country: str | None = None,
@@ -166,7 +167,7 @@ def _directory_username(  # noqa: PLR0913
         is_featured=is_featured,
         user=SimpleNamespace(
             is_admin=is_admin,
-            is_cautious=False,
+            is_cautious=is_cautious,
             pgp_key=pgp_key,
             account_category=account_category,
             account_category_label=None,
@@ -373,6 +374,61 @@ def test_directory_verified_tab_promotes_featured_users_first(
     normal_card_heading = normal_cards[0].select_one("h3")
     assert normal_card_heading is not None
     assert normal_card_heading.get_text(strip=True) == "Admin User"
+
+
+def test_directory_verified_tab_shows_caution_badges_for_cautious_accounts(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    featured_user = _directory_username(
+        username="featured-cautious-user",
+        display_name="Featured Cautious User",
+        is_verified=True,
+        is_featured=True,
+        is_cautious=True,
+    )
+    pgp_user = _directory_username(
+        username="pgp-cautious-user",
+        display_name="PGP Cautious User",
+        is_verified=True,
+        is_cautious=True,
+    )
+    info_only_user = _directory_username(
+        username="info-cautious-user",
+        display_name="Info Cautious User",
+        is_verified=True,
+        is_cautious=True,
+        pgp_key="",
+    )
+    monkeypatch.setattr(
+        "hushline.routes.directory.get_directory_usernames",
+        lambda: (featured_user, pgp_user, info_only_user),
+    )
+    monkeypatch.setattr("hushline.routes.directory.get_public_record_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_securedrop_directory_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_globaleaks_directory_listings", lambda: ())
+    monkeypatch.setattr("hushline.routes.directory.get_newsroom_directory_listings", lambda: ())
+    monkeypatch.setattr(
+        directory_routes,
+        "_shuffle_featured_directory_items",
+        lambda items: list(items),
+    )
+
+    response = client.get(url_for("directory"))
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+    verified_panel = soup.find(id="verified")
+
+    for display_name in (
+        "Featured Cautious User",
+        "PGP Cautious User",
+        "Info Cautious User",
+    ):
+        card = _find_directory_card(verified_panel, display_name)
+        caution_badge = card.select_one(
+            '.badge.badgeCaution[aria-label="Caution: display name may be mistaken for admin"]'
+        )
+        assert caution_badge is not None
+        assert caution_badge.get_text(strip=True) == "⚠️ Caution"
 
 
 def test_directory_verified_tab_keeps_featured_info_only_accounts_in_info_only_section(


### PR DESCRIPTION
### Motivation
- The `is_cautious` account flag was added but the server-rendered Verified directory view did not display the caution badge, allowing admin-marked cautious verified accounts to appear without the intended warning. 
- That inconsistency weakens a public trust/safety signal and could mislead visitors into interacting with an account administrators intended to warn about.

### Description
- Updated `hushline/templates/directory.html` to compute `is_cautious = username.user.is_cautious | default(false)` in both `verified_user_card` and `featured_user_card` macros and to render the existing caution badge when `is_cautious` is true. 
- Extended the test helper in `tests/test_directory.py` so `_directory_username` accepts `is_cautious` and propagates it into the mocked `user` object. 
- Added `test_directory_verified_tab_shows_caution_badges_for_cautious_accounts` to verify the caution badge is shown for featured, PGP-capable, and info-only verified cards in the Verified tab.

### Testing
- Ran formatting and static checks on the modified test file with `poetry run ruff format tests/test_directory.py` and `poetry run ruff check tests/test_directory.py --output-format full`, which passed. 
- Attempted the new unit test with `poetry run pytest tests/test_directory.py::test_directory_verified_tab_shows_caution_badges_for_cautious_accounts -q`, but the run was blocked in this environment due to an unresolved test database host (`postgres`) and therefore did not complete. 
- `make lint`, `make test`, and the dependency audit targets could not be executed here because Docker is unavailable in this environment and must be run in CI or a local environment with the full stack before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ac603342883309c644d72169a232f)