### PR TITLE
Restrict epic child issue auto-close workflow

### DIFF
--- a/.github/workflows/close-epic-child-issue-on-merge.yml
+++ b/.github/workflows/close-epic-child-issue-on-merge.yml
@@ -18,24 +18,39 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea
         with:
           script: |
-            const body = String(context.payload.pull_request.body || "");
-            const match = body.match(/(?:^|\n)Linked issue:\s*#(\d+)\b/i);
-
-            if (!match) {
-              core.info("No linked child issue marker found in PR body.");
-              return;
-            }
-
-            const issueNumber = Number(match[1]);
-            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
-              core.info("Linked child issue marker did not contain a valid issue number.");
-              return;
-            }
-
+            const pullRequest = context.payload.pull_request;
             const owner = context.repo.owner;
             const repo = context.repo.repo;
-            const prNumber = context.payload.pull_request.number;
-            const baseRef = String(context.payload.pull_request.base.ref || "");
+            const prNumber = pullRequest.number;
+            const baseRef = String(pullRequest.base.ref || "");
+            const headRef = String(pullRequest.head.ref || "");
+            const headRepo = String(pullRequest.head.repo?.full_name || "");
+            const expectedRepo = `${owner}/${repo}`;
+
+            if (headRepo !== expectedRepo) {
+              core.info(`Skipping PR #${prNumber}: head repository ${headRepo} is not ${expectedRepo}.`);
+              return;
+            }
+
+            const baseMatch = baseRef.match(/^codex\/epic-(\d+)$/);
+            if (!baseMatch) {
+              core.info(`Skipping PR #${prNumber}: base branch ${baseRef} is not an epic branch.`);
+              return;
+            }
+
+            // Do not trust mutable PR body text to choose an issue to close.
+            // Agent-created child PRs use same-repository heads named codex/daily-issue-<issue>.
+            const headMatch = headRef.match(/^codex\/daily-issue-(\d+)$/);
+            if (!headMatch) {
+              core.info(`Skipping PR #${prNumber}: head branch ${headRef} is not an agent child branch.`);
+              return;
+            }
+
+            const issueNumber = Number(headMatch[1]);
+            if (!Number.isInteger(issueNumber) || issueNumber <= 0) {
+              core.info("Agent child branch did not contain a valid issue number.");
+              return;
+            }
             const issue = await github.rest.issues.get({
               owner,
               repo,

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -249,3 +249,17 @@ def test_securedrop_refresh_summary_uses_checked_random_github_output_delimiter(
     assert 'delimiter="SECUREDROP_SUMMARY_$(uuidgen)"' in summary_section
     assert 'grep -Fxq "$delimiter" "$payload_path"' in summary_section
     assert 'delimiter="SECUREDROP_SUMMARY_$(date +%s)"' not in summary_section
+
+
+def test_epic_child_close_workflow_uses_trusted_head_branch_not_pr_body() -> None:
+    workflow_text = _workflow_text(".github/workflows/close-epic-child-issue-on-merge.yml")
+
+    assert "pull_request_target:" in workflow_text
+    assert "issues: write" in workflow_text
+    assert "pullRequest.head.repo?.full_name" in workflow_text
+    assert "headRepo !== expectedRepo" in workflow_text
+    assert "baseRef.match(/^codex\\/epic-(\\d+)$/)" in workflow_text
+    assert "headRef.match(/^codex\\/daily-issue-(\\d+)$/)" in workflow_text
+    assert "const issueNumber = Number(headMatch[1]);" in workflow_text
+    assert "context.payload.pull_request.body" not in workflow_text
+    assert "Linked issue:" not in workflow_text


### PR DESCRIPTION
### Motivation
- A pull_request_target workflow previously parsed an attacker-controllable `Linked issue: #<n>` marker from PR bodies and used the repository token to comment and close that issue, allowing forked PR authors to influence which issue was closed.
- The change removes reliance on mutable PR body text and instead ensures only trusted same-repository agent child PRs can trigger automated issue closure.

### Description
- Replace parsing of `context.payload.pull_request.body` with checks that `pull_request.head.repo.full_name` equals the current repo and that `pull_request.head.ref` matches `^codex/daily-issue-(\d+)$` to derive the issue number.
- Require the base branch to match `^codex/epic-(\d+)$` and skip action for forked or non-agent branches.
- Preserve the existing behavior of creating a comment and closing the derived issue when validations pass.
- Add a regression test `test_epic_child_close_workflow_uses_trusted_head_branch_not_pr_body` to assert the workflow uses trusted head metadata and does not reference PR body text.
- Rebase onto current `main` and preserve the SecureDrop refresh delimiter regression test added after this branch was opened.

### Testing
- Ran `docker compose run --rm app poetry run pytest -q tests/test_workflow_pr_head_qualification.py` and it passed (10 tests, all green).
- Ran `python3 scripts/check_workflow_pr_head_qualification.py` and it succeeded, confirming owner-qualified PR head usage checks.
- Ran `npx prettier --ignore-path /dev/null --check .github/workflows/close-epic-child-issue-on-merge.yml` and formatting matched Prettier.
- Bare local `pytest`, `python`, and `poetry` commands were unavailable in this shell, so validation used the repository Docker path plus `python3`.

### Manual testing
- Not applicable; this is a GitHub Actions workflow hardening change covered by static workflow regression tests.

### Risks / follow-ups
- Low behavioral risk for trusted same-repository agent child PRs using the expected `codex/daily-issue-<issue>` branch naming convention.
- Forked PRs and non-agent branch names are intentionally skipped by the auto-close workflow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2af992b314833091805362557fdcc9)