### PR TITLE
Fix runner automation documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ If local audit commands are blocked by network/tooling availability, document th
 - Local contributor onboarding prompt: [`docs/LOCAL-CONTRIBUTOR-ONBOARDING-PROMPT.md`](./docs/LOCAL-CONTRIBUTOR-ONBOARDING-PROMPT.md)
 - Developer notes: [`docs/DEV.md`](./docs/DEV.md)
 - Architecture: [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)
-- Runner automation: [`docs/AGENT_RUNNER.md`](./docs/AGENT_RUNNER.md)
+- Runner automation: [Agent automation and policy](https://github.com/scidsg/hushline-agents)
 - Terms: [`docs/TERMS.md`](./docs/TERMS.md)
 
 ## Latest Screenshots


### PR DESCRIPTION
### Motivation
- The agent runner documentation file was renamed from `docs/AGENT_RUNNER.md` to `docs/AGENT-RUNNER.md`, leaving a stale local link in the repository root `README.md` that would 404 for readers. 
- The docs index (`docs/README.md`) already refers readers to the external automation repository, so the root README should match that destination to avoid broken navigation.

### Description
- Replaced the `README.md` documentation map entry for runner automation to point to `https://github.com/scidsg/hushline-agents` instead of the removed local `docs/AGENT_RUNNER.md` path. 
- This is a documentation-only change with no runtime, authentication, encryption, or behavioral impact. 
- The commit was GPG-signed in this environment; maintainers should confirm signature policy expectations when merging.

### Testing
- Ran a targeted local Markdown link resolver (`python` script) to validate links in `README.md` and `docs/README.md`, and the check passed. 
- Ran `git diff --check` to ensure no stray whitespace/link errors, and it passed. 
- `make lint`, `make test`, `make audit-python`, and `make audit-node-runtime` could not be executed in this environment because Docker is not available (`/bin/sh: 1: docker: not found`), so those CI checks must be run in CI or a Docker-capable environment before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2afb499db48330bbd45e52e16e7732)