### PR TITLE
Fix docs screenshot publish recovery

### DIFF
--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -41,12 +41,14 @@ jobs:
         run: |
           set -euo pipefail
           RUN_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}")"
-          RUN_JSON="$RUN_JSON" CURRENT_RUN_ID="$CURRENT_RUN_ID" python3 - <<'PY'
+          JOBS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs")"
+          RUN_JSON="$RUN_JSON" JOBS_JSON="$JOBS_JSON" CURRENT_RUN_ID="$CURRENT_RUN_ID" python3 - <<'PY'
           import json
           import os
           import sys
 
           run = json.loads(os.environ["RUN_JSON"])
+          jobs = json.loads(os.environ["JOBS_JSON"])
           current_run_id = os.environ["CURRENT_RUN_ID"]
           errors = []
 
@@ -62,8 +64,16 @@ jobs:
                   "source run repository must match "
                   f"{os.environ['GITHUB_REPOSITORY']}, got {head_repository.get('full_name')!r}"
               )
-          if str(run.get("id")) != current_run_id and run.get("conclusion") != "success":
-              errors.append("completed source runs must have a successful conclusion")
+          is_current_run = str(run.get("id")) == current_run_id
+          capture_succeeded = any(
+              job.get("name") == "capture" and job.get("conclusion") == "success"
+              for job in jobs.get("jobs", [])
+          )
+          if not is_current_run and run.get("conclusion") != "success" and not capture_succeeded:
+              errors.append(
+                  "completed source runs must have a successful conclusion or a successful "
+                  "capture job"
+              )
 
           if errors:
               for error in errors:
@@ -114,6 +124,7 @@ jobs:
               Path("release_key.txt"),
               Path("capture_files.json"),
               Path("screenshots/README.md"),
+              Path("screenshots/release/README.md"),
           }
 
           def fail(message: str) -> None:
@@ -152,6 +163,8 @@ jobs:
                   "releases",
                   release_key,
               )
+              if relative == Path("screenshots", "releases", release_key, "README.md"):
+                  continue
               if (is_current_image or is_release_image or is_legacy_release_image) and (
                   path.suffix.lower() in image_extensions
               ):

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -76,9 +76,18 @@ def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> No
     assert 'run.get("event") != "release"' in source_section
     assert 'run.get("path") != ".github/workflows/docs-screenshots.yml"' in source_section
     assert 'head_repository.get("full_name") != os.environ["GITHUB_REPOSITORY"]' in source_section
-    assert 'run.get("conclusion") != "success"' in source_section
+    assert (
+        'JOBS_JSON="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${RUN_ID}/jobs")"'
+        in source_section
+    )
+    assert "capture_succeeded = any(" in source_section
+    assert 'job.get("name") == "capture"' in source_section
+    assert 'job.get("conclusion") == "success"' in source_section
+    assert 'run.get("conclusion") != "success" and not capture_succeeded' in source_section
     assert "rm -f /tmp/docs-screenshots-artifact/artifact.zip" in artifact_section
     assert "path.is_symlink()" in artifact_section
+    assert 'Path("screenshots/release/README.md")' in artifact_section
+    assert 'Path("screenshots", "releases", release_key, "README.md")' in artifact_section
     assert 'is_current_image = relative.parts[:2] == ("screenshots", "current")' in artifact_section
     assert 'is_release_image = relative.parts[:2] == ("screenshots", "release")' in artifact_section
     assert "is_legacy_release_image = relative.parts[:3]" in artifact_section


### PR DESCRIPTION
## What changed

- Allow generated `screenshots/release/README.md` files in the docs screenshot artifact validator.
- Allow manual publish recovery from a failed docs screenshot source run when that source run is still the trusted release workflow and its `capture` job succeeded.
- Updated the workflow qualification test to lock both behaviors.

## Why

The `v0.6.82` docs screenshot capture succeeded and uploaded an artifact, but the publish job failed while validating the artifact because the artifact contained `screenshots/release/README.md`. A manual rerun of the fixed publish workflow was then blocked because the source run's overall conclusion was `failure`, even though the failure was in publish after capture.

## Validation

- `TESTS=tests/test_workflow_pr_head_qualification.py make test`
- `make lint`

## Manual testing

Not applicable beyond workflow log inspection and targeted workflow tests; this change only adjusts GitHub Actions workflow validation/recovery behavior.

## Risk

The recovery path remains constrained to the same repository, the release-triggered docs screenshots workflow path, and a source run with a successful `capture` job.