### PR TITLE
Reject null/missing-origin embed submissions

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -201,21 +201,6 @@ def register_profile_routes(app: Flask) -> None:
 
         return True
 
-    def _embed_form_token_belongs_to_profile(uname: Username, token: str) -> bool:
-        try:
-            payload: dict[str, Any] = _embed_captcha_serializer().loads(
-                token,
-                max_age=EMBED_CAPTCHA_MAX_AGE_SECONDS,
-            )
-        except (BadData, SignatureExpired):
-            return False
-
-        return (
-            payload.get("v") == 1
-            and payload.get("username") == uname.username
-            and payload.get("user_id") == uname.user_id
-        )
-
     def _embed_post_origin_is_valid(uname: Username) -> bool:
         origin = request.headers.get("Origin", "").strip()
         if not origin:
@@ -225,10 +210,7 @@ def register_profile_routes(app: Flask) -> None:
                 origin = f"{parsed_referer.scheme}://{parsed_referer.netloc}"
 
         if not origin or origin == "null":
-            return _embed_form_token_belongs_to_profile(
-                uname,
-                request.form.get("embed_captcha_token", ""),
-            )
+            return False
 
         parsed_origin = urlsplit(origin)
         parsed_host = urlsplit(request.host_url)

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -704,7 +704,7 @@ def test_embed_profile_submission_rejects_invalid_csrf_token(
     assert _first_message_for(user.primary_username) is None
 
 
-def test_embed_profile_submission_allows_sandboxed_null_origin(
+def test_embed_profile_submission_rejects_sandboxed_null_origin(
     client: FlaskClient, user: User
 ) -> None:
     _enable_embeds_globally()
@@ -725,13 +725,12 @@ def test_embed_profile_submission_allows_sandboxed_null_origin(
         headers={"Origin": "null"},
     )
 
-    assert post_response.status_code == 200, post_response.text
-    assert _first_message_for(user.primary_username) is not None
+    assert post_response.status_code == 400
+    assert "Invalid embed request origin" in post_response.text
+    assert _first_message_for(user.primary_username) is None
 
 
-def test_embed_profile_submission_allows_token_bound_missing_origin(
-    client: FlaskClient, user: User
-) -> None:
+def test_embed_profile_submission_rejects_missing_origin(client: FlaskClient, user: User) -> None:
     _enable_embeds_globally()
     _make_message_capable(user)
     _configure_embed(user.primary_username)
@@ -749,8 +748,9 @@ def test_embed_profile_submission_allows_token_bound_missing_origin(
         },
     )
 
-    assert post_response.status_code == 200, post_response.text
-    assert _first_message_for(user.primary_username) is not None
+    assert post_response.status_code == 400
+    assert "Invalid embed request origin" in post_response.text
+    assert _first_message_for(user.primary_username) is None
 
 
 def test_embed_profile_submission_rejects_missing_origin_without_embed_form_token(


### PR DESCRIPTION
### Motivation
- Fix a security regression where publicly mintable embed CAPTCHA tokens could be harvested and replayed from sandboxed/null-origin contexts to bypass the embed origin allowlist and create unwanted messages.
- The embed token only proves profile/CAPTCHA metadata and is not bound to an embedding parent origin, browser session, or one-time request context, so it must not be used to authorize requests with no verifiable Origin.

### Description
- Remove the profile-bound origin-bypass helper and stop treating a present embed token as sufficient proof when the POST `Origin` is missing or `null` by making `_embed_post_origin_is_valid()` return `False` for missing/`null` origins.
- Preserve same-origin validation for concrete `Origin` headers derived from `Origin` or `Referer` as before.
- Update regression tests in `tests/test_embeddable_forms_settings.py` so that harvested/embed GET tokens replayed with `Origin: null` or with no `Origin` now assert a 400 rejection and no message is created.
- Keep existing CAPTCHA and owner-guard verification logic unchanged; this is a minimal behavioral tightening for embed origin checks.

### Testing
- Ran formatting and static checks on modified files with `poetry run ruff format` and `poetry run ruff check` which passed for the changed files (`hushline/routes/profile.py` and `tests/test_embeddable_forms_settings.py`).
- Attempted to run `poetry run pytest tests/test_embeddable_forms_settings.py -q` but the test run could not complete in this environment because the test harness requires a PostgreSQL service started via Docker and the host `postgres` could not be resolved, so full pytest validation is blocked here.
- Attempted `make lint`, `make test`, and `docker compose up -d postgres blob-storage` but these were blocked because `docker` is not available in this environment; full CI-style checks should be run in the Docker-enabled CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b154942ac8330b0b647c98c2c9a84)