### PR TITLE
#2178 Add conversation data model and migrations

### DIFF
--- a/hushline/model/__init__.py
+++ b/hushline/model/__init__.py
@@ -1,6 +1,12 @@
 # ruff: noqa: F401
 
 from hushline.model.authentication_log import AuthenticationLog
+from hushline.model.conversation import (
+    Conversation,
+    ConversationMessage,
+    ConversationMessageCopy,
+    ConversationParticipant,
+)
 from hushline.model.embed_rate_limit_attempt import EmbedRateLimitAttempt
 from hushline.model.enums import (
     AccountCategory,

--- a/hushline/model/conversation.py
+++ b/hushline/model/conversation.py
@@ -1,0 +1,154 @@
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import Index, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from hushline.db import db
+
+if TYPE_CHECKING:
+    from flask_sqlalchemy.model import Model
+    from sqlalchemy import Select
+
+    from hushline.model.message import Message
+    from hushline.model.user import User
+else:
+    Model = db.Model
+
+
+class Conversation(Model):
+    __tablename__ = "conversations"
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    created_at: Mapped[datetime] = mapped_column(
+        db.DateTime(timezone=True), server_default=text("NOW()"), nullable=False
+    )
+
+    participants: Mapped[list["ConversationParticipant"]] = relationship(
+        back_populates="conversation",
+        cascade="all, delete-orphan",
+        order_by="ConversationParticipant.id.asc()",
+    )
+    messages: Mapped[list["ConversationMessage"]] = relationship(
+        back_populates="conversation",
+        cascade="all, delete-orphan",
+        order_by="ConversationMessage.id.asc()",
+    )
+    initial_message: Mapped["Message | None"] = relationship(
+        "Message",
+        back_populates="conversation",
+        uselist=False,
+    )
+
+    @classmethod
+    def for_user_id(cls, user_id: int) -> "Select[tuple[Conversation]]":
+        return (
+            db.select(cls)
+            .join(ConversationParticipant)
+            .where(ConversationParticipant.user_id == user_id)
+        )
+
+    def participant_for_user_id(self, user_id: int) -> "ConversationParticipant | None":
+        return next(
+            (participant for participant in self.participants if participant.user_id == user_id),
+            None,
+        )
+
+
+class ConversationParticipant(Model):
+    __tablename__ = "conversation_participants"
+    __table_args__ = (
+        UniqueConstraint("conversation_id", "user_id"),
+        Index("ix_conversation_participants_user_id_conversation_id", "user_id", "conversation_id"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    conversation_id: Mapped[int] = mapped_column(
+        db.ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    user_id: Mapped[int] = mapped_column(
+        db.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        db.DateTime(timezone=True), server_default=text("NOW()"), nullable=False
+    )
+    last_read_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))
+    has_usable_public_key: Mapped[bool] = mapped_column(
+        db.Boolean,
+        nullable=False,
+        default=False,
+        server_default=text("false"),
+    )
+
+    conversation: Mapped["Conversation"] = relationship(back_populates="participants")
+    user: Mapped["User"] = relationship(back_populates="conversation_participants")
+    sent_messages: Mapped[list["ConversationMessage"]] = relationship(
+        back_populates="sender_participant",
+        passive_deletes=True,
+    )
+    encrypted_copies: Mapped[list["ConversationMessageCopy"]] = relationship(
+        back_populates="recipient_participant",
+        passive_deletes=True,
+    )
+
+
+class ConversationMessage(Model):
+    __tablename__ = "conversation_messages"
+    __table_args__ = (
+        Index(
+            "ix_conversation_messages_conversation_id_created_at",
+            "conversation_id",
+            "created_at",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    conversation_id: Mapped[int] = mapped_column(
+        db.ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    sender_participant_id: Mapped[int] = mapped_column(
+        db.ForeignKey("conversation_participants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        db.DateTime(timezone=True), server_default=text("NOW()"), nullable=False
+    )
+
+    conversation: Mapped["Conversation"] = relationship(back_populates="messages")
+    sender_participant: Mapped["ConversationParticipant"] = relationship(
+        back_populates="sent_messages"
+    )
+    encrypted_copies: Mapped[list["ConversationMessageCopy"]] = relationship(
+        back_populates="message",
+        cascade="all, delete-orphan",
+        order_by="ConversationMessageCopy.id.asc()",
+    )
+
+
+class ConversationMessageCopy(Model):
+    __tablename__ = "conversation_message_copies"
+    __table_args__ = (
+        UniqueConstraint("conversation_message_id", "recipient_participant_id"),
+        Index(
+            "ix_conversation_message_copies_participant_message",
+            "recipient_participant_id",
+            "conversation_message_id",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    conversation_message_id: Mapped[int] = mapped_column(
+        db.ForeignKey("conversation_messages.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    recipient_participant_id: Mapped[int] = mapped_column(
+        db.ForeignKey("conversation_participants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    encrypted_payload: Mapped[str] = mapped_column(db.Text, nullable=False)
+
+    message: Mapped["ConversationMessage"] = relationship(back_populates="encrypted_copies")
+    recipient_participant: Mapped["ConversationParticipant"] = relationship(
+        back_populates="encrypted_copies"
+    )

--- a/hushline/model/message.py
+++ b/hushline/model/message.py
@@ -15,7 +15,7 @@ from hushline.model.message_status_text import MessageStatusText
 if TYPE_CHECKING:
     from flask_sqlalchemy.model import Model
 
-    from hushline.model import FieldValue, Username
+    from hushline.model import Conversation, FieldValue, Username
 else:
     Model = db.Model
 
@@ -36,6 +36,13 @@ class Message(Model):
     )
     username_id: Mapped[int] = mapped_column(db.ForeignKey("usernames.id"), nullable=False)
     username: Mapped["Username"] = relationship(uselist=False)
+    conversation_id: Mapped[int | None] = mapped_column(
+        db.ForeignKey("conversations.id", ondelete="SET NULL"), unique=True
+    )
+    conversation: Mapped["Conversation | None"] = relationship(
+        "Conversation",
+        back_populates="initial_message",
+    )
     reply_slug: Mapped[str] = mapped_column(index=True, nullable=False)
     status: Mapped[MessageStatus] = mapped_column(
         SQLAlchemyEnum(MessageStatus), default=MessageStatus.PENDING, nullable=False

--- a/hushline/model/user.py
+++ b/hushline/model/user.py
@@ -27,6 +27,7 @@ from hushline.password_hasher import hash_password, verify_password
 if TYPE_CHECKING:
     from flask_sqlalchemy.model import Model
 
+    from hushline.model.conversation import ConversationParticipant
     from hushline.model.message import Message
     from hushline.model.notification_recipient import NotificationRecipient
     from hushline.model.password_reset_token import PasswordResetToken
@@ -89,6 +90,11 @@ class User(Model):
         back_populates="user",
         cascade="all, delete-orphan",
         order_by="PasswordResetToken.id.desc()",
+    )
+    conversation_participants: Mapped[list["ConversationParticipant"]] = relationship(
+        back_populates="user",
+        order_by="ConversationParticipant.id.asc()",
+        passive_deletes=True,
     )
     messages: Mapped[list["Message"]] = relationship(
         secondary="usernames",

--- a/migrations/versions/a9d8c7b6e5f4_add_conversation_tables.py
+++ b/migrations/versions/a9d8c7b6e5f4_add_conversation_tables.py
@@ -1,0 +1,241 @@
+"""add conversation tables
+
+Revision ID: a9d8c7b6e5f4
+Revises: e3b7c1a9d2f4
+Create Date: 2026-06-11 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "a9d8c7b6e5f4"
+down_revision = "e3b7c1a9d2f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "conversations",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_conversations")),
+    )
+    op.create_table(
+        "conversation_participants",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("conversation_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column("last_read_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "has_usable_public_key",
+            sa.Boolean(),
+            server_default=sa.text("false"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"],
+            ["conversations.id"],
+            name=op.f("fk_conversation_participants_conversation_id_conversations"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_conversation_participants_user_id_users"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_conversation_participants")),
+        sa.UniqueConstraint(
+            "conversation_id",
+            "user_id",
+            name=op.f("uq_conversation_participants_conversation_id"),
+        ),
+    )
+    op.create_index(
+        op.f("ix_conversation_participants_conversation_id"),
+        "conversation_participants",
+        ["conversation_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_conversation_participants_user_id"),
+        "conversation_participants",
+        ["user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_conversation_participants_user_id_conversation_id",
+        "conversation_participants",
+        ["user_id", "conversation_id"],
+        unique=False,
+    )
+    op.create_table(
+        "conversation_messages",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("conversation_id", sa.Integer(), nullable=False),
+        sa.Column("sender_participant_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["conversation_id"],
+            ["conversations.id"],
+            name=op.f("fk_conversation_messages_conversation_id_conversations"),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["sender_participant_id"],
+            ["conversation_participants.id"],
+            name=op.f("fk_conversation_messages_sender_participant_id_conversation_participants"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_conversation_messages")),
+    )
+    op.create_index(
+        op.f("ix_conversation_messages_conversation_id"),
+        "conversation_messages",
+        ["conversation_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_conversation_messages_conversation_id_created_at",
+        "conversation_messages",
+        ["conversation_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_conversation_messages_sender_participant_id"),
+        "conversation_messages",
+        ["sender_participant_id"],
+        unique=False,
+    )
+    op.create_table(
+        "conversation_message_copies",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("conversation_message_id", sa.Integer(), nullable=False),
+        sa.Column("recipient_participant_id", sa.Integer(), nullable=False),
+        sa.Column("encrypted_payload", sa.Text(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["conversation_message_id"],
+            ["conversation_messages.id"],
+            name=op.f(
+                "fk_conversation_message_copies_conversation_message_id_conversation_messages"
+            ),
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(
+            ["recipient_participant_id"],
+            ["conversation_participants.id"],
+            name=op.f(
+                "fk_conversation_message_copies_recipient_participant_id_conversation_participants"
+            ),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_conversation_message_copies")),
+        sa.UniqueConstraint(
+            "conversation_message_id",
+            "recipient_participant_id",
+            name=op.f("uq_conversation_message_copies_conversation_message_id"),
+        ),
+    )
+    op.create_index(
+        op.f("ix_conversation_message_copies_conversation_message_id"),
+        "conversation_message_copies",
+        ["conversation_message_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_conversation_message_copies_participant_message",
+        "conversation_message_copies",
+        ["recipient_participant_id", "conversation_message_id"],
+        unique=False,
+    )
+    op.create_index(
+        op.f("ix_conversation_message_copies_recipient_participant_id"),
+        "conversation_message_copies",
+        ["recipient_participant_id"],
+        unique=False,
+    )
+
+    with op.batch_alter_table("messages", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("conversation_id", sa.Integer(), nullable=True))
+        batch_op.create_foreign_key(
+            batch_op.f("fk_messages_conversation_id_conversations"),
+            "conversations",
+            ["conversation_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        batch_op.create_unique_constraint(
+            batch_op.f("uq_messages_conversation_id"),
+            ["conversation_id"],
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("messages", schema=None) as batch_op:
+        batch_op.drop_constraint(batch_op.f("uq_messages_conversation_id"), type_="unique")
+        batch_op.drop_constraint(
+            batch_op.f("fk_messages_conversation_id_conversations"),
+            type_="foreignkey",
+        )
+        batch_op.drop_column("conversation_id")
+
+    op.drop_index(
+        op.f("ix_conversation_message_copies_recipient_participant_id"),
+        table_name="conversation_message_copies",
+    )
+    op.drop_index(
+        "ix_conversation_message_copies_participant_message",
+        table_name="conversation_message_copies",
+    )
+    op.drop_index(
+        op.f("ix_conversation_message_copies_conversation_message_id"),
+        table_name="conversation_message_copies",
+    )
+    op.drop_table("conversation_message_copies")
+    op.drop_index(
+        op.f("ix_conversation_messages_sender_participant_id"),
+        table_name="conversation_messages",
+    )
+    op.drop_index(
+        "ix_conversation_messages_conversation_id_created_at",
+        table_name="conversation_messages",
+    )
+    op.drop_index(
+        op.f("ix_conversation_messages_conversation_id"),
+        table_name="conversation_messages",
+    )
+    op.drop_table("conversation_messages")
+    op.drop_index(
+        "ix_conversation_participants_user_id_conversation_id",
+        table_name="conversation_participants",
+    )
+    op.drop_index(
+        op.f("ix_conversation_participants_user_id"),
+        table_name="conversation_participants",
+    )
+    op.drop_index(
+        op.f("ix_conversation_participants_conversation_id"),
+        table_name="conversation_participants",
+    )
+    op.drop_table("conversation_participants")
+    op.drop_table("conversations")

--- a/tests/migrations/revision_a9d8c7b6e5f4.py
+++ b/tests/migrations/revision_a9d8c7b6e5f4.py
@@ -1,0 +1,111 @@
+from sqlalchemy import text
+
+from hushline.db import db
+
+NEW_TABLES = [
+    "conversations",
+    "conversation_participants",
+    "conversation_messages",
+    "conversation_message_copies",
+]
+
+NEW_INDEXES = [
+    "ix_conversation_participants_user_id_conversation_id",
+    "ix_conversation_messages_conversation_id_created_at",
+    "ix_conversation_message_copies_participant_message",
+]
+
+
+class UpgradeTester:
+    def load_data(self) -> None:
+        pass
+
+    def check_upgrade(self) -> None:
+        table_names = db.session.scalars(
+            text(
+                """
+                SELECT table_name
+                FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name = ANY(:table_names)
+                """
+            ),
+            {"table_names": NEW_TABLES},
+        ).all()
+        assert sorted(table_names) == sorted(NEW_TABLES)
+
+        indexes = db.session.scalars(
+            text(
+                """
+                SELECT indexname
+                FROM pg_indexes
+                WHERE schemaname = 'public'
+                  AND indexname = ANY(:index_names)
+                """
+            ),
+            {"index_names": NEW_INDEXES},
+        ).all()
+        assert sorted(indexes) == sorted(NEW_INDEXES)
+
+        assert (
+            db.session.scalar(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'messages'
+                      AND column_name = 'conversation_id'
+                    """
+                )
+            )
+            == 1
+        )
+
+        plaintext_columns = db.session.scalars(
+            text(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name IN ('conversation_messages', 'conversation_message_copies')
+                  AND column_name = ANY(:column_names)
+                """
+            ),
+            {"column_names": ["body", "content", "plaintext", "message_body"]},
+        ).all()
+        assert plaintext_columns == []
+
+
+class DowngradeTester:
+    def load_data(self) -> None:
+        pass
+
+    def check_downgrade(self) -> None:
+        table_count = db.session.scalar(
+            text(
+                """
+                SELECT count(*)
+                FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name = ANY(:table_names)
+                """
+            ),
+            {"table_names": NEW_TABLES},
+        )
+        assert table_count == 0
+
+        assert (
+            db.session.scalar(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'messages'
+                      AND column_name = 'conversation_id'
+                    """
+                )
+            )
+            == 0
+        )

--- a/tests/test_conversation_model.py
+++ b/tests/test_conversation_model.py
@@ -1,0 +1,113 @@
+from datetime import datetime, timezone
+
+from flask import Flask
+
+from hushline.db import db
+from hushline.model import (
+    Conversation,
+    ConversationMessage,
+    ConversationMessageCopy,
+    ConversationParticipant,
+    Message,
+    User,
+)
+
+
+def _make_conversation(
+    user: User, user2: User
+) -> tuple[
+    Conversation,
+    ConversationParticipant,
+    ConversationParticipant,
+]:
+    conversation = Conversation()
+    participant = ConversationParticipant()
+    participant.conversation = conversation
+    participant.user = user
+    participant.has_usable_public_key = True
+    participant2 = ConversationParticipant()
+    participant2.conversation = conversation
+    participant2.user = user2
+    db.session.add(conversation)
+    db.session.commit()
+    return conversation, participant, participant2
+
+
+def test_conversation_membership_is_user_id_based(app: Flask, user: User, user2: User) -> None:
+    conversation, participant, participant2 = _make_conversation(user, user2)
+
+    user_conversations = db.session.scalars(Conversation.for_user_id(user.id)).all()
+    user2_conversations = db.session.scalars(Conversation.for_user_id(user2.id)).all()
+    missing_conversations = db.session.scalars(Conversation.for_user_id(999_999)).all()
+
+    assert user_conversations == [conversation]
+    assert user2_conversations == [conversation]
+    assert missing_conversations == []
+    assert conversation.participant_for_user_id(user.id) == participant
+    assert conversation.participant_for_user_id(user2.id) == participant2
+    assert conversation.participant_for_user_id(999_999) is None
+
+
+def test_conversation_message_has_encrypted_copies(
+    app: Flask,
+    user: User,
+    user2: User,
+) -> None:
+    conversation, participant, participant2 = _make_conversation(user, user2)
+    conversation_message = ConversationMessage()
+    conversation_message.conversation = conversation
+    conversation_message.sender_participant = participant
+    copy = ConversationMessageCopy()
+    copy.message = conversation_message
+    copy.recipient_participant = participant
+    copy.encrypted_payload = "encrypted-for-sender"
+    copy2 = ConversationMessageCopy()
+    copy2.message = conversation_message
+    copy2.recipient_participant = participant2
+    copy2.encrypted_payload = "encrypted-for-recipient"
+    db.session.add(conversation_message)
+    db.session.commit()
+
+    assert conversation.messages == [conversation_message]
+    assert conversation_message.sender_participant == participant
+    assert conversation_message.encrypted_copies == [copy, copy2]
+    assert participant.encrypted_copies == [copy]
+    assert participant2.encrypted_copies == [copy2]
+    assert {
+        column.name for column in db.metadata.tables["conversation_messages"].columns
+    }.isdisjoint({"body", "content", "plaintext", "message_body"})
+    assert {
+        column.name for column in db.metadata.tables["conversation_message_copies"].columns
+    }.isdisjoint({"body", "content", "plaintext", "message_body"})
+
+
+def test_participant_read_state_and_key_defaults(app: Flask, user: User, user2: User) -> None:
+    conversation, participant, participant2 = _make_conversation(user, user2)
+
+    assert participant.has_usable_public_key is True
+    assert participant.last_read_at is None
+    assert participant2.has_usable_public_key is False
+    assert participant2.last_read_at is None
+
+    read_at = datetime.now(timezone.utc)
+    participant2.last_read_at = read_at
+    db.session.add(conversation)
+    db.session.commit()
+
+    assert participant2.last_read_at == read_at
+
+
+def test_initial_message_can_link_to_conversation(
+    app: Flask,
+    user: User,
+    user2: User,
+    message: Message,
+) -> None:
+    conversation, _, _ = _make_conversation(user, user2)
+
+    message.conversation = conversation
+    db.session.add(message)
+    db.session.commit()
+
+    assert message.conversation == conversation
+    assert conversation.initial_message == message


### PR DESCRIPTION
This PR implements child issue #2178 (`Add conversation data model and migrations`) under epic #2177 (`Feasibility: two-way encrypted conversations between accounts`).
It is intended to merge into the epic branch first, not directly into `main`.

This PR addresses the issue "Add conversation data model and migrations" by updating data and model code in `hushline/model`, database migrations in `migrations`, and automated tests in `tests/migrations/revision_a9d8c7b6e5f4.py`.
The change includes both implementation work and automated tests, showing the intended behavior and how it is verified.
It touches 7 non-log file(s) (7 total including runner artifacts), primarily in hushline/model, migrations/versions, and tests/migrations.

## Summary
- Automated code agent update for child issue #2178.
- Part of epic #2177: Feasibility: two-way encrypted conversations between accounts
- This PR targets the epic integration branch `codex/epic-2177`.
- The child issue is closed explicitly by workflow after this PR merges into the epic branch.

Linked issue: #2178

## Context
- Epic: https://github.com/scidsg/hushline/issues/2177
- Child issue: https://github.com/scidsg/hushline/issues/2178
- Branch: codex/daily-issue-2178
- Base branch: codex/epic-2177
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `hushline/model/__init__.py`
- `hushline/model/conversation.py`
- `hushline/model/message.py`
- `hushline/model/user.py`
- `migrations/versions/a9d8c7b6e5f4_add_conversation_tables.py`
- `tests/migrations/revision_a9d8c7b6e5f4.py`
- `tests/test_conversation_model.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
