### PR TITLE
#2179 Create conversations from logged-in tip submissions

### DIFF
--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -18,6 +18,7 @@ from hushline.crypto import encrypt_message
 from hushline.db import db
 from hushline.forms import DeleteMessageForm, ResendMessageForm, UpdateMessageStatusForm
 from hushline.model import (
+    Conversation,
     FieldValue,
     Message,
     User,
@@ -59,6 +60,42 @@ def register_message_routes(app: Flask) -> None:
             update_status_form=update_status_form,
             delete_message_form=delete_message_form,
             resend_message_form=resend_message_form,
+        )
+
+    @app.route("/conversation/<int:conversation_id>")
+    @authentication_required
+    def conversation(conversation_id: int) -> str:
+        user = db.session.get(User, session["user_id"])
+        if not user:
+            abort(404)
+
+        thread = db.session.scalars(
+            Conversation.for_user_id(user.id).where(Conversation.id == conversation_id)
+        ).one_or_none()
+        if not thread:
+            abort(404)
+
+        participant = thread.participant_for_user_id(user.id)
+        if not participant:
+            abort(404)
+
+        message_copies = []
+        for conversation_message in thread.messages:
+            copy = next(
+                (
+                    encrypted_copy
+                    for encrypted_copy in conversation_message.encrypted_copies
+                    if encrypted_copy.recipient_participant_id == participant.id
+                ),
+                None,
+            )
+            message_copies.append((conversation_message, copy))
+
+        return render_template(
+            "conversation.html",
+            conversation=thread,
+            participant=participant,
+            message_copies=message_copies,
         )
 
     @app.route("/reply/<slug>")

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -23,6 +23,7 @@ from sqlalchemy import func
 from sqlalchemy.exc import MultipleResultsFound
 from werkzeug.wrappers.response import Response
 
+from hushline.auth import get_session_user
 from hushline.crypto import encrypt_message
 from hushline.db import db
 from hushline.embeds import (
@@ -35,11 +36,16 @@ from hushline.embeds import (
 )
 from hushline.external_urls import canonical_external_url
 from hushline.model import (
+    Conversation,
+    ConversationMessage,
+    ConversationMessageCopy,
+    ConversationParticipant,
     FieldDefinition,
     FieldValue,
     Message,
     NotificationRecipient,
     OrganizationSetting,
+    User,
     Username,
 )
 from hushline.routes.common import (
@@ -225,6 +231,59 @@ def register_profile_routes(app: Flask) -> None:
         if not uname.user.message_encryption_target:
             return "missing_recipient_keys"
         return None
+
+    def _authenticated_sender() -> User | None:
+        if not session.get("is_authenticated", False):
+            return None
+        return get_session_user()
+
+    def _create_initial_conversation(
+        *,
+        message: Message,
+        sender: User,
+        recipient: User,
+        raw_extracted_fields: list[tuple[str, str]],
+    ) -> Conversation | None:
+        if sender.id == recipient.id:
+            return None
+
+        recipient_encryption_target = recipient.message_encryption_target
+        if not recipient_encryption_target:
+            return None
+
+        sender_encryption_target = sender.message_encryption_target
+        conversation = Conversation()
+        sender_participant = ConversationParticipant()
+        sender_participant.conversation = conversation
+        sender_participant.user = sender
+        sender_participant.has_usable_public_key = False
+        recipient_participant = ConversationParticipant()
+        recipient_participant.conversation = conversation
+        recipient_participant.user = recipient
+        recipient_participant.has_usable_public_key = True
+        conversation_message = ConversationMessage()
+        conversation_message.conversation = conversation
+        conversation_message.sender_participant = sender_participant
+        body = format_message_email_fields(raw_extracted_fields)
+        if sender_encryption_target:
+            try:
+                encrypted_payload = encrypt_message(body, sender_encryption_target)
+            except (RuntimeError, TypeError, ValueError):
+                current_app.logger.warning("Failed to encrypt conversation copy for sender.")
+            else:
+                sender_copy = ConversationMessageCopy()
+                sender_copy.recipient_participant = sender_participant
+                sender_copy.encrypted_payload = encrypted_payload
+                sender_participant.has_usable_public_key = True
+                conversation_message.encrypted_copies.append(sender_copy)
+        recipient_payload = encrypt_message(body, recipient_encryption_target)
+        recipient_copy = ConversationMessageCopy()
+        recipient_copy.recipient_participant = recipient_participant
+        recipient_copy.encrypted_payload = recipient_payload
+        conversation_message.encrypted_copies.append(recipient_copy)
+        message.conversation = conversation
+        db.session.add(conversation)
+        return conversation
 
     @app.route("/to/<username>", methods=["GET", "POST"])
     def profile(username: str) -> Response | str | tuple[str, int]:
@@ -466,6 +525,16 @@ def register_profile_routes(app: Flask) -> None:
                     db.session.flush()
                     extracted_fields.append((field_definition.label, field_value.value or ""))
 
+                conversation = None
+                sender = _authenticated_sender()
+                if sender:
+                    conversation = _create_initial_conversation(
+                        message=message,
+                        sender=sender,
+                        recipient=uname.user,
+                        raw_extracted_fields=raw_extracted_fields,
+                    )
+
                 db.session.commit()
 
                 plaintext_new_message_body = (
@@ -580,6 +649,9 @@ def register_profile_routes(app: Flask) -> None:
                     )
 
                 flash("👍 Message submitted successfully.")
+                if conversation is not None:
+                    current_app.logger.debug("Message sent and now redirecting to conversation")
+                    return redirect(url_for("conversation", conversation_id=conversation.id))
                 session["reply_slug"] = message.reply_slug
                 current_app.logger.debug("Message sent and now redirecting")
                 return redirect(url_for("submission_success"))

--- a/hushline/templates/conversation.html
+++ b/hushline/templates/conversation.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+
+{% block title %}Conversation{% endblock %}
+
+{% block content %}
+<div class="message-header">
+  <h1>Conversation</h1>
+</div>
+
+<div class="message-container">
+  <div class="message-meta">
+    {% if conversation.initial_message %}
+      <p>
+        To:
+        <a href="{{ url_for('profile', username=conversation.initial_message.username.username) }}">
+          {{
+            conversation.initial_message.username.display_name
+            or conversation.initial_message.username.username
+          }}
+        </a>
+      </p>
+    {% endif %}
+  </div>
+  <article class="message">
+    {% for conversation_message, encrypted_copy in message_copies %}
+      <div class="field-value encrypted">
+        <div class="label">
+          {{ conversation_message.created_at.date() }}
+        </div>
+        {% if encrypted_copy %}
+          <pre class="encrypted-value">{{ encrypted_copy.encrypted_payload }}</pre>
+        {% else %}
+          <p>No encrypted copy is available for your account.</p>
+        {% endif %}
+      </div>
+    {% endfor %}
+  </article>
+</div>
+{% endblock %}

--- a/hushline/templates/message.html
+++ b/hushline/templates/message.html
@@ -37,6 +37,13 @@
     <p class="meta">
       {{ message.created_at.date() }}
     </p>
+    {% if message.conversation %}
+      <p>
+        <a href="{{ url_for('conversation', conversation_id=message.conversation.id) }}">
+          Open conversation
+        </a>
+      </p>
+    {% endif %}
   </div>
   <article class="message">
     {% for field_value in message.field_values %}

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -14,6 +14,8 @@ from werkzeug.exceptions import NotFound
 from hushline.db import db
 from hushline.model import (
     AccountCategory,
+    Conversation,
+    ConversationMessageCopy,
     Message,
     NotificationRecipient,
     OrganizationSetting,
@@ -27,6 +29,18 @@ msg_content = "This is a test message."
 suspended_message = "This account is suspended. New messages cannot be sent at this time."
 
 pgp_message_sig = "-----BEGIN PGP MESSAGE-----\n\n"
+
+
+def _set_pgp_key(user: User) -> None:
+    user.pgp_key = Path("tests/test_pgp_key.txt").read_text()
+
+
+def _authenticate_as(client: FlaskClient, user: User) -> None:
+    with client.session_transaction() as session:
+        session["user_id"] = user.id
+        session["session_id"] = user.session_id
+        session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
 
 
 def _make_current_paid_super_user(user: User) -> None:
@@ -226,6 +240,182 @@ def test_profile_submit_message(client: FlaskClient, user: User) -> None:
     response = client.get(url_for("message", public_id=message.public_id), follow_redirects=True)
     assert response.status_code == 200
     assert pgp_message_sig in response.text, response.text
+
+
+@pytest.mark.usefixtures("_pgp_user")
+def test_anonymous_profile_submit_message_keeps_reply_success_flow(
+    client: FlaskClient, user: User
+) -> None:
+    response = client.post(
+        url_for("profile", username=user.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            **get_profile_submission_data(client, user.primary_username.username),
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200, response.text
+    assert "Message submitted successfully." in response.text
+    assert "Reply Address" in response.text
+
+    message = db.session.scalars(
+        db.select(Message).filter_by(username_id=user.primary_username.id)
+    ).one()
+    assert message.conversation is None
+    assert db.session.scalars(db.select(Conversation)).all() == []
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_logged_in_profile_submit_message_creates_conversation_for_distinct_recipient(
+    client: FlaskClient, user: User, user2: User, admin_user: User
+) -> None:
+    _set_pgp_key(user)
+    _set_pgp_key(user2)
+    db.session.commit()
+
+    response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            **get_profile_submission_data(client, user2.primary_username.username),
+        },
+        follow_redirects=False,
+    )
+
+    message = db.session.scalars(
+        db.select(Message).filter_by(username_id=user2.primary_username.id)
+    ).one()
+    conversation = message.conversation
+    assert conversation is not None
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(
+        url_for("conversation", conversation_id=conversation.id)
+    )
+    assert {participant.user_id for participant in conversation.participants} == {
+        user.id,
+        user2.id,
+    }
+    participants_by_user_id = {
+        participant.user_id: participant for participant in conversation.participants
+    }
+    assert participants_by_user_id[user.id].has_usable_public_key is True
+    assert participants_by_user_id[user2.id].has_usable_public_key is True
+    [conversation_message] = conversation.messages
+    assert conversation_message.sender_participant.user_id == user.id
+    assert len(conversation_message.encrypted_copies) == 2
+    for encrypted_copy in conversation_message.encrypted_copies:
+        assert pgp_message_sig in encrypted_copy.encrypted_payload
+
+    sender_response = client.get(
+        url_for("conversation", conversation_id=conversation.id), follow_redirects=True
+    )
+    assert sender_response.status_code == 200
+    assert pgp_message_sig in sender_response.text
+
+    _authenticate_as(client, user2)
+    recipient_response = client.get(url_for("conversation", conversation_id=conversation.id))
+    assert recipient_response.status_code == 200
+    assert pgp_message_sig in recipient_response.text
+    message_response = client.get(url_for("message", public_id=message.public_id))
+    assert url_for("conversation", conversation_id=conversation.id) in message_response.text
+
+    _authenticate_as(client, admin_user)
+    other_response = client.get(url_for("conversation", conversation_id=conversation.id))
+    assert other_response.status_code == 404
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_logged_in_profile_submit_message_creates_conversation_without_sender_key(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    _set_pgp_key(user2)
+    db.session.commit()
+
+    response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            **get_profile_submission_data(client, user2.primary_username.username),
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200, response.text
+    assert "No encrypted copy is available for your account." in response.text
+
+    message = db.session.scalars(
+        db.select(Message).filter_by(username_id=user2.primary_username.id)
+    ).one()
+    conversation = message.conversation
+    assert conversation is not None
+    assert {participant.user_id for participant in conversation.participants} == {
+        user.id,
+        user2.id,
+    }
+    participants_by_user_id = {
+        participant.user_id: participant for participant in conversation.participants
+    }
+    assert participants_by_user_id[user.id].has_usable_public_key is False
+    assert participants_by_user_id[user2.id].has_usable_public_key is True
+    copies = db.session.scalars(db.select(ConversationMessageCopy)).all()
+    assert len(copies) == 1
+    assert copies[0].recipient_participant.user_id == user2.id
+    assert pgp_message_sig in copies[0].encrypted_payload
+
+    _authenticate_as(client, user2)
+    recipient_response = client.get(url_for("conversation", conversation_id=conversation.id))
+    assert recipient_response.status_code == 200
+    assert pgp_message_sig in recipient_response.text
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+@pytest.mark.usefixtures("_pgp_user")
+def test_self_profile_submit_message_keeps_reply_success_flow(
+    client: FlaskClient, user: User
+) -> None:
+    response = client.post(
+        url_for("profile", username=user.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            **get_profile_submission_data(client, user.primary_username.username),
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 200, response.text
+    assert "Reply Address" in response.text
+
+    message = db.session.scalars(
+        db.select(Message).filter_by(username_id=user.primary_username.id)
+    ).one()
+    assert message.conversation is None
+    assert db.session.scalars(db.select(Conversation)).all() == []
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_logged_in_profile_submit_message_requires_recipient_encryption_target(
+    client: FlaskClient, user2: User
+) -> None:
+    response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            **get_profile_submission_data(client, user2.primary_username.username),
+        },
+        follow_redirects=True,
+    )
+    assert response.status_code == 400
+    assert "do not have any usable recipient PGP keys" in response.text
+    assert (
+        db.session.scalars(
+            db.select(Message).filter_by(username_id=user2.primary_username.id)
+        ).first()
+        is None
+    )
+    assert db.session.scalars(db.select(Conversation)).all() == []
 
 
 @pytest.mark.usefixtures("_authenticated_user")


### PR DESCRIPTION
This PR implements child issue #2179 (`Create conversations from logged-in tip submissions`) under epic #2177 (`Feasibility: two-way encrypted conversations between accounts`).
It is intended to merge into the epic branch first, not directly into `main`.

This PR addresses the issue "Create conversations from logged-in tip submissions" by updating request-handling code in `hushline/routes`, user-facing page templates in `hushline/templates`, and automated tests in `tests/test_profile.py`.
The change includes both implementation work and automated tests, showing the intended behavior and how it is verified.
It touches 5 non-log file(s) (5 total including runner artifacts), primarily in hushline/routes, hushline/templates, and tests/test_profile.py.

## Summary
- Automated code agent update for child issue #2179.
- Part of epic #2177: Feasibility: two-way encrypted conversations between accounts
- This PR targets the epic integration branch `codex/epic-2177`.
- The child issue is closed explicitly by workflow after this PR merges into the epic branch.

Linked issue: #2179

## Context
- Epic: https://github.com/scidsg/hushline/issues/2177
- Child issue: https://github.com/scidsg/hushline/issues/2179
- Branch: codex/daily-issue-2179
- Base branch: codex/epic-2177
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `hushline/routes/message.py`
- `hushline/routes/profile.py`
- `hushline/templates/conversation.html`
- `hushline/templates/message.html`
- `tests/test_profile.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
