### PR TITLE
Allow same-origin iframe submissions for embeds

### DIFF
--- a/hushline/embeds.py
+++ b/hushline/embeds.py
@@ -19,7 +19,7 @@ EMBED_SUBMISSION_REJECTED_COUNTER = "embed_form_submission_rejected_total"
 EMBED_SUBMISSION_RATE_LIMITED_COUNTER = "embed_form_submission_rate_limited_total"
 EMBED_IFRAME_SANDBOX = (
     "allow-forms allow-popups allow-popups-to-escape-sandbox "
-    "allow-scripts allow-top-navigation-by-user-activation"
+    "allow-same-origin allow-scripts allow-top-navigation-by-user-activation"
 )
 EMBED_IFRAME_HEIGHT = 1300
 EMBED_IFRAME_MIN_HEIGHT = 320

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -1481,6 +1481,7 @@ def test_primary_embed_settings_update_origins_and_render_iframe_snippet(
         "allow-forms",
         "allow-popups",
         "allow-popups-to-escape-sandbox",
+        "allow-same-origin",
         "allow-scripts",
         "allow-top-navigation-by-user-activation",
     ]

--- a/tests/test_embeds.py
+++ b/tests/test_embeds.py
@@ -1,0 +1,9 @@
+from hushline.embeds import EMBED_IFRAME_SANDBOX
+
+
+def test_embed_iframe_sandbox_preserves_same_origin_form_origin() -> None:
+    sandbox_tokens = EMBED_IFRAME_SANDBOX.split()
+
+    assert "allow-forms" in sandbox_tokens
+    assert "allow-same-origin" in sandbox_tokens
+    assert "allow-scripts" in sandbox_tokens


### PR DESCRIPTION
### Motivation
- The embed POST origin validator rejects missing or `null` Origins while the official generated iframe snippet was sandboxed without `allow-same-origin` (and sets `referrerpolicy="no-referrer"`), which causes legitimate submissions from the official snippet to arrive as `Origin: null` and be rejected, breaking embed availability.

### Description
- Add `allow-same-origin` to the generated iframe sandbox token (`EMBED_IFRAME_SANDBOX`) so browser form submissions from the official snippet use the Hush Line origin instead of `null`.
- Update the existing snippet-rendering assertion in `tests/test_embeddable_forms_settings.py` to expect the additional sandbox token.
- Add a focused unit test `tests/test_embeds.py` that asserts the required sandbox tokens (including `allow-same-origin`) are present to lock this behavior.

### Testing
- Ran the new focused unit test `pytest -q tests/test_embeds.py`, which passed.
- Ran formatting/lint checks for the modified files with `poetry run ruff format --check` and `poetry run ruff check --output-format full`, which succeeded for the changed files, and `poetry run mypy` for the same files, which reported no issues.
- Attempted to run integration tests `pytest -q tests/test_embeddable_forms_settings.py::test_primary_embed_settings_update_origins_and_render_iframe_snippet tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_sandboxed_null_origin` but they were blocked by the local test environment because the test database host `postgres` failed DNS resolution and could not be reached.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b366212e48330b35899fa56ef45ac)