### PR TITLE
Prevent alias directory location disclosure

### DIFF
--- a/hushline/routes/directory.py
+++ b/hushline/routes/directory.py
@@ -380,6 +380,9 @@ def _geography_fields(
 
 
 def _username_geography(username: Username) -> DirectoryListingGeography:
+    if not username.is_primary:
+        return build_directory_geography()
+
     user = username.user
     return build_directory_geography(
         city=getattr(user, "city", None),

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -21,6 +21,7 @@ from hushline.model import (
     PublicRecordListing,
     SecureDropDirectoryListing,
     User,
+    Username,
     get_globaleaks_directory_listings,
     get_newsroom_directory_listings,
     get_public_record_listings,
@@ -988,6 +989,29 @@ def test_directory_users_json_includes_normalized_user_location(
     assert row["subdivision"] == "Illinois"
     assert row["subdivision_code"] == "IL"
     assert row["countries"] == ["United States"]
+
+
+def test_directory_users_json_excludes_account_location_from_alias_rows(
+    client: FlaskClient, user: User, user_alias: Username
+) -> None:
+    user.country = "US"
+    user.city = "Chicago"
+    user.subdivision = "IL"
+    user.primary_username.show_in_directory = False
+    user_alias.show_in_directory = True
+    db.session.commit()
+
+    response = client.get(url_for("directory_users"))
+    assert response.status_code == 200
+
+    rows = response.json or []
+    assert all(row["primary_username"] != user.primary_username.username for row in rows)
+    row = next(row for row in rows if row["primary_username"] == user_alias.username)
+    assert row["city"] is None
+    assert row["country"] is None
+    assert row["subdivision"] is None
+    assert row["subdivision_code"] is None
+    assert row["countries"] == []
 
 
 def test_directory_users_json_includes_legacy_account_category_label(


### PR DESCRIPTION
### Motivation
- The public directory builder previously copied account-level `User` location fields into every returned `Username` row, which allowed a public alias to leak the primary account's city/country/subdivision via `/directory/users.json`.
- This is a privacy-sensitive metadata disclosure affecting unauthenticated public directory rows and location filter metadata derived from visible `Username` objects.

### Description
- Stop exposing account geography for non-primary usernames by changing `_username_geography` to return an empty geography when `username.is_primary` is false in `hushline/routes/directory.py`.
- Add a regression test `test_directory_users_json_excludes_account_location_from_alias_rows` in `tests/test_directory.py` and import `Username` to assert that a public alias does not include account location when the primary username is hidden.
- Preserve existing behavior for primary usernames so normalized location and filter metadata continue to work for primary accounts.

### Testing
- `poetry run ruff format --check` and `poetry run ruff check` passed for the modified files and `poetry run mypy` reported no issues for the changed modules.
- Attempted `poetry run pytest tests/test_directory.py -q -k 'normalized_user_location or excludes_account_location_from_alias_rows'` but the run could not complete due to a test database host resolution error (`psycopg.OperationalError: Temporary failure in name resolution`) in this environment. 
- `make lint`, `make test`, and dependency audit targets were blocked in this environment because Docker is not available, so full CI-style checks must be run by maintainers before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b356921ec8330b439d9c955ff0798)