### PR TITLE
Drop exhausted public record link failures

### DIFF
--- a/hushline/public_record_refresh.py
+++ b/hushline/public_record_refresh.py
@@ -598,9 +598,17 @@ def build_requests_link_checker(
                 definitive_failure=True,
             )
         if last_status_code is not None and last_status_code >= _HTTP_SERVER_ERROR_MIN_STATUS:
-            return LinkCheckResult(ok=False, reason=f"HTTP {last_status_code}")
+            return LinkCheckResult(
+                ok=False,
+                reason=f"HTTP {last_status_code}",
+                definitive_failure=True,
+            )
         if last_error is not None and last_status_code is None:
-            return LinkCheckResult(ok=False, reason=str(last_error))
+            return LinkCheckResult(
+                ok=False,
+                reason=str(last_error),
+                definitive_failure=True,
+            )
         return LinkCheckResult(ok=True)
 
     return check_url

--- a/scripts/refresh_public_record_law_firms.py
+++ b/scripts/refresh_public_record_law_firms.py
@@ -538,8 +538,17 @@ def main() -> int:
             generated_on=datetime.now().astimezone().date().isoformat(),
         )
 
+    unresolved_link_failures = [
+        failure
+        for failure in refresh_result.link_failures
+        if failure.listing_id not in refresh_result.dropped_record_ids
+    ]
     link_failures_detected = bool(refresh_result.link_failures)
-    if link_failures_detected and not args.allow_link_failures and not args.drop_failing_records:
+    if (
+        link_failures_detected
+        and not args.allow_link_failures
+        and (not args.drop_failing_records or unresolved_link_failures)
+    ):
         raise PublicRecordRefreshError(
             "Broken links detected during refresh. "
             "Use --allow-link-failures to flag only, or --drop-failing-records to remove them."

--- a/tests/test_public_record_refresh.py
+++ b/tests/test_public_record_refresh.py
@@ -940,7 +940,7 @@ def test_refresh_public_record_rows_flags_and_drops_link_failures() -> None:
     assert checked_urls
 
 
-def test_refresh_public_record_rows_keeps_rows_on_transient_link_failures() -> None:
+def test_refresh_public_record_rows_drops_exhausted_link_failures() -> None:
     rows = [
         _row(
             id_value="seed-healthy",
@@ -960,7 +960,7 @@ def test_refresh_public_record_rows_keeps_rows_on_transient_link_failures() -> N
 
     def checker(url: str) -> LinkCheckResult:
         if url == "https://transient.example":
-            return LinkCheckResult(ok=False, reason="HTTP 503")
+            return LinkCheckResult(ok=False, reason="HTTP 503", definitive_failure=True)
         return LinkCheckResult(ok=True)
 
     result = refresh_public_record_rows(
@@ -972,10 +972,10 @@ def test_refresh_public_record_rows_keeps_rows_on_transient_link_failures() -> N
         drop_failed_links=True,
     )
 
-    assert [row["id"] for row in result.rows] == ["seed-healthy", "seed-transient"]
+    assert [row["id"] for row in result.rows] == ["seed-healthy"]
     assert len(result.link_failures) == 1
     assert result.link_failures[0].listing_id == "seed-transient"
-    assert result.dropped_record_ids == []
+    assert result.dropped_record_ids == ["seed-transient"]
 
 
 def test_refresh_public_record_rows_rejects_legacy_self_reported_source_label() -> None:
@@ -1315,7 +1315,7 @@ def test_build_requests_link_checker_returns_last_server_error_after_retries() -
 
     assert result.ok is False
     assert result.reason == "HTTP 500"
-    assert result.definitive_failure is False
+    assert result.definitive_failure is True
 
 
 def test_build_requests_link_checker_returns_last_request_exception_reason() -> None:
@@ -1336,7 +1336,7 @@ def test_build_requests_link_checker_returns_last_request_exception_reason() -> 
 
     assert result.ok is False
     assert result.reason == "network timeout"
-    assert result.definitive_failure is False
+    assert result.definitive_failure is True
 
 
 def test_render_refresh_summary_includes_dropped_ids_and_link_failures() -> None:

--- a/tests/test_public_record_refresh_workflow.py
+++ b/tests/test_public_record_refresh_workflow.py
@@ -2,8 +2,11 @@ from __future__ import annotations
 
 import importlib.util
 import re
+import sys
 from pathlib import Path
 from typing import Any
+
+import pytest
 
 from hushline.public_record_refresh import (
     LinkValidationFailure,
@@ -89,6 +92,61 @@ def test_refresh_public_record_corrections_make_target_matches_workflow_semantic
     )
     assert "--drop-failing-records" in target_section
     assert "--allow-link-failures" in target_section
+
+
+def test_refresh_script_drop_failing_records_rejects_unresolved_failures(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    refresh_script = _load_refresh_script_module()
+    output_path = tmp_path / "public_record_law_firms.json"
+    output_path.write_text("[]\n", encoding="utf-8")
+    unresolved_row = _public_record_row("seed-unresolved", "CA")
+
+    monkeypatch.setattr(refresh_script, "_load_rows", lambda _path: [])
+
+    def fake_refresh_public_record_rows(*_args: Any, **kwargs: Any) -> PublicRecordRefreshResult:
+        assert kwargs["drop_failed_links"] is True
+        return PublicRecordRefreshResult(
+            rows=[unresolved_row],
+            region_counts={"US": 1},
+            checked_url_count=1,
+            link_failures=[
+                LinkValidationFailure(
+                    listing_id="seed-unresolved",
+                    listing_name="Seed Unresolved",
+                    field="website",
+                    url="https://unresolved.example",
+                    reason="network timeout",
+                )
+            ],
+            dropped_record_ids=[],
+        )
+
+    monkeypatch.setattr(
+        refresh_script,
+        "refresh_public_record_rows",
+        fake_refresh_public_record_rows,
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "refresh_public_record_law_firms.py",
+            "--input",
+            str(output_path),
+            "--output",
+            str(output_path),
+            "--regions",
+            "US",
+            "--region-target",
+            "US=1",
+            "--no-link-validation",
+            "--drop-failing-records",
+        ],
+    )
+
+    with pytest.raises(refresh_script.PublicRecordRefreshError, match="Broken links detected"):
+        refresh_script.main()
 
 
 def test_refresh_report_matches_structured_values() -> None:


### PR DESCRIPTION
### Motivation
- Aardvark found that non-HTTP link failures (DNS/TLS/connection errors) and persistent 5xx responses could survive the weekly `--drop-failing-records` refresh, leaving stale or attacker-controlled external links in the published public-record directory.
- The change restores the provenance policy that listings whose official public record cannot be verified should be removable by the refresh pipeline.
- The fix aims to be minimal and behavior-preserving: only mark exhausted retries as definitive failures and ensure the refresh command fails when unresolved failures remain.

### Description
- Mark exhausted persistent server errors and request exceptions as definitive failures in `build_requests_link_checker` by returning `LinkCheckResult(..., definitive_failure=True)` for 5xx responses and request exceptions after retries in `hushline/public_record_refresh.py`.
- Add a guard in `scripts/refresh_public_record_law_firms.py` so `--drop-failing-records` does not suppress remaining unresolved link failures by computing `unresolved_link_failures` and requiring them to be empty (unless `--allow-link-failures` is used).
- Update and add tests in `tests/test_public_record_refresh.py` and `tests/test_public_record_refresh_workflow.py` to assert that exhausted failures are treated as definitive and dropped, and that the refresh script raises when unresolved failures remain under `--drop-failing-records`.

### Testing
- Ran formatter/lint checks locally: `poetry run ruff format --check` and `poetry run ruff check` on the modified files and they passed.
- Ran static typing: `poetry run mypy` on the modified files and it passed.
- Ran unit/workflow tests: `poetry run pytest -q tests/test_public_record_refresh.py tests/test_public_record_refresh_workflow.py` which returned `352 passed`.
- `make lint`, `make test`, CI-style coverage, and dependency audits could not be executed in this environment because Docker is not available, so those steps should be run in CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b3c9b54588330919faa66c4af2f54)