### PR TITLE
#2189 Add client-generated Hush Line chat keys for in-app conversations

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -219,3 +219,126 @@ document.addEventListener("DOMContentLoaded", function () {
     });
   });
 });
+
+function bytesToBase64(bytes) {
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}
+
+async function provisionChatKey(form) {
+  const passwordInput = form.querySelector("#chat-key-password");
+  const status = document.getElementById("chat-key-provision-status");
+  const submitButton = form.querySelector('button[type="submit"]');
+  if (!passwordInput || !status || !submitButton) return;
+
+  if (!window.crypto?.subtle) {
+    status.textContent = "This browser cannot create a chat key.";
+    return;
+  }
+
+  submitButton.disabled = true;
+  status.textContent = "Creating chat key...";
+  let privateJwk = null;
+
+  try {
+    const textEncoder = new TextEncoder();
+    const salt = window.crypto.getRandomValues(new Uint8Array(16));
+    const iv = window.crypto.getRandomValues(new Uint8Array(12));
+    const keyPair = await window.crypto.subtle.generateKey(
+      {
+        name: "ECDH",
+        namedCurve: "P-256",
+      },
+      true,
+      ["deriveBits"],
+    );
+    const publicJwk = await window.crypto.subtle.exportKey(
+      "jwk",
+      keyPair.publicKey,
+    );
+    privateJwk = await window.crypto.subtle.exportKey("jwk", keyPair.privateKey);
+    const passwordKey = await window.crypto.subtle.importKey(
+      "raw",
+      textEncoder.encode(passwordInput.value),
+      "PBKDF2",
+      false,
+      ["deriveKey"],
+    );
+    const wrappingKey = await window.crypto.subtle.deriveKey(
+      {
+        name: "PBKDF2",
+        salt,
+        iterations: 310000,
+        hash: "SHA-256",
+      },
+      passwordKey,
+      {
+        name: "AES-GCM",
+        length: 256,
+      },
+      false,
+      ["encrypt"],
+    );
+    const encryptedBytes = new Uint8Array(
+      await window.crypto.subtle.encrypt(
+        {
+          name: "AES-GCM",
+          iv,
+        },
+        wrappingKey,
+        textEncoder.encode(JSON.stringify(privateJwk)),
+      ),
+    );
+    const payload = {
+      public_key: JSON.stringify(publicJwk),
+      encrypted_private_key: JSON.stringify({
+        algorithm: "AES-GCM",
+        iv: bytesToBase64(iv),
+        ciphertext: bytesToBase64(encryptedBytes),
+      }),
+      kdf_algorithm: "PBKDF2-SHA-256",
+      kdf_params: {
+        iterations: 310000,
+        hash: "SHA-256",
+      },
+      kdf_salt: bytesToBase64(salt),
+      wrapping_algorithm: "AES-GCM",
+    };
+    const headers = {
+      Accept: "application/json",
+      "Content-Type": "application/json",
+    };
+    if (form.dataset.csrfToken) {
+      headers["X-CSRFToken"] = form.dataset.csrfToken;
+    }
+
+    const response = await fetch(form.dataset.chatKeyUrl, {
+      method: "POST",
+      credentials: "same-origin",
+      headers,
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      throw new Error("Chat key creation failed");
+    }
+    status.textContent = "Chat key created.";
+    form.hidden = true;
+  } catch (error) {
+    status.textContent = "Chat key creation failed.";
+  } finally {
+    privateJwk = null;
+    passwordInput.value = "";
+    submitButton.disabled = false;
+  }
+}
+
+document.addEventListener("DOMContentLoaded", function () {
+  const chatKeyForm = document.getElementById("chat-key-provision-form");
+  chatKeyForm?.addEventListener("submit", function (event) {
+    event.preventDefault();
+    provisionChatKey(event.currentTarget);
+  });
+});

--- a/hushline/model/__init__.py
+++ b/hushline/model/__init__.py
@@ -1,6 +1,7 @@
 # ruff: noqa: F401
 
 from hushline.model.authentication_log import AuthenticationLog
+from hushline.model.chat_key import ChatKey
 from hushline.model.conversation import (
     Conversation,
     ConversationMessage,

--- a/hushline/model/chat_key.py
+++ b/hushline/model/chat_key.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import Index, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from hushline.db import db
+
+if TYPE_CHECKING:
+    from flask_sqlalchemy.model import Model
+
+    from hushline.model.user import User
+else:
+    Model = db.Model
+
+
+class ChatKey(Model):
+    __tablename__ = "chat_keys"
+    __table_args__ = (
+        UniqueConstraint("user_id", "key_version"),
+        Index("ix_chat_keys_user_id_disabled_at", "user_id", "disabled_at"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    user_id: Mapped[int] = mapped_column(
+        db.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    key_version: Mapped[int] = mapped_column(nullable=False)
+    public_key: Mapped[str] = mapped_column(db.Text, nullable=False)
+    encrypted_private_key: Mapped[str] = mapped_column(db.Text, nullable=False)
+    kdf_algorithm: Mapped[str] = mapped_column(db.String(128), nullable=False)
+    kdf_params: Mapped[dict[str, Any]] = mapped_column(db.JSON, nullable=False)
+    kdf_salt: Mapped[str] = mapped_column(db.Text, nullable=False)
+    wrapping_algorithm: Mapped[str] = mapped_column(db.String(128), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        db.DateTime(timezone=True), server_default=text("NOW()"), nullable=False
+    )
+    rotated_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))
+    disabled_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))
+    recovery_state: Mapped[str | None] = mapped_column(db.String(64))
+
+    user: Mapped["User"] = relationship(back_populates="chat_keys")
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+    @classmethod
+    def active_for_user_id(cls, user_id: int) -> "ChatKey | None":
+        return db.session.scalars(
+            db.select(cls)
+            .where(cls.user_id == user_id, cls.disabled_at.is_(None))
+            .order_by(cls.key_version.desc())
+            .limit(1)
+        ).one_or_none()

--- a/hushline/model/user.py
+++ b/hushline/model/user.py
@@ -27,6 +27,7 @@ from hushline.password_hasher import hash_password, verify_password
 if TYPE_CHECKING:
     from flask_sqlalchemy.model import Model
 
+    from hushline.model.chat_key import ChatKey
     from hushline.model.conversation import ConversationParticipant
     from hushline.model.message import Message
     from hushline.model.notification_recipient import NotificationRecipient
@@ -94,6 +95,12 @@ class User(Model):
     conversation_participants: Mapped[list["ConversationParticipant"]] = relationship(
         back_populates="user",
         order_by="ConversationParticipant.id.asc()",
+        passive_deletes=True,
+    )
+    chat_keys: Mapped[list["ChatKey"]] = relationship(
+        back_populates="user",
+        cascade="all, delete-orphan",
+        order_by="ChatKey.key_version.desc(), ChatKey.id.desc()",
         passive_deletes=True,
     )
     messages: Mapped[list["Message"]] = relationship(
@@ -453,6 +460,18 @@ class User(Model):
         if len(keys) == 1:
             return keys[0]
         return keys
+
+    @property
+    def active_chat_key(self) -> "ChatKey | None":
+        return next(
+            (chat_key for chat_key in self.chat_keys if chat_key.disabled_at is None),
+            None,
+        )
+
+    @property
+    def chat_public_key(self) -> str | None:
+        active_key = self.active_chat_key
+        return active_key.public_key if active_key is not None else None
 
     @property
     def next_notification_recipient_position(self) -> int:

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -352,6 +352,7 @@ def register_profile_routes(app: Flask) -> None:
                 ),
                 current_user_id=session.get("user_id"),
                 recipient_public_keys=uname.user.message_recipient_keys,
+                recipient_chat_public_key=uname.user.chat_public_key,
                 recipient_public_key_entries=(
                     notification_recipient_public_key_entries(uname.user)
                     if (

--- a/hushline/settings/encryption.py
+++ b/hushline/settings/encryption.py
@@ -1,16 +1,22 @@
-from typing import Tuple
+import json
+from datetime import UTC, datetime
+from typing import Any, Tuple
 
 from flask import (
     Blueprint,
+    current_app,
+    jsonify,
     render_template,
     request,
     session,
 )
+from flask_wtf.csrf import generate_csrf, validate_csrf
 from werkzeug.wrappers.response import Response
+from wtforms.validators import ValidationError
 
 from hushline.auth import authentication_required
 from hushline.db import db
-from hushline.model import User
+from hushline.model import ChatKey, User
 from hushline.settings.common import (
     form_error,
     handle_pgp_key_form,
@@ -20,11 +26,162 @@ from hushline.settings.forms import (
     PGPProtonForm,
 )
 
+CHAT_KEY_STRING_MAX_LENGTH = 200_000
+CHAT_KEY_METADATA_MAX_LENGTH = 20_000
+CHAT_KEY_RECOVERY_STATE_MAX_LENGTH = 64
+CHAT_KEY_FORBIDDEN_SECRET_FIELDS = {
+    "decrypted_message_text",
+    "decrypted_private_key",
+    "derived_key",
+    "password",
+    "plaintext_private_key",
+    "private_key",
+    "unlock_key",
+    "wrapping_key",
+}
+
 
 def _submitted_encryption_form(pgp_key_form: PGPKeyForm) -> PGPKeyForm | None:
     if pgp_key_form.submit.name in request.form:
         return pgp_key_form
     return None
+
+
+def _validate_json_csrf() -> str | None:
+    if current_app.config.get("WTF_CSRF_ENABLED") is False:
+        return None
+
+    token = request.headers.get("X-CSRFToken") or request.headers.get("X-CSRF-Token")
+    try:
+        validate_csrf(token)
+    except ValidationError:
+        return "Invalid CSRF token."
+    return None
+
+
+def _normalized_payload_key(value: str) -> str:
+    return value.strip().lower().replace("-", "_")
+
+
+def _payload_contains_forbidden_secret_field(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            if (
+                isinstance(key, str)
+                and _normalized_payload_key(key) in CHAT_KEY_FORBIDDEN_SECRET_FIELDS
+            ):
+                return True
+            if _payload_contains_forbidden_secret_field(nested_value):
+                return True
+    elif isinstance(value, list):
+        return any(_payload_contains_forbidden_secret_field(item) for item in value)
+    return False
+
+
+def _payload_text(payload: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+def _validate_chat_key_payload(payload: Any, *, current_user_id: int) -> tuple[dict[str, Any], str]:
+    if not isinstance(payload, dict):
+        return {}, "Expected a JSON object."
+
+    if _payload_contains_forbidden_secret_field(payload):
+        return {}, "Plaintext chat key material is not accepted."
+
+    payload_user_id = payload.get("user_id")
+    if payload_user_id is not None and payload_user_id != current_user_id:
+        return {}, "Chat keys can only be provisioned for the authenticated user."
+
+    public_key = _payload_text(payload, "public_key", "chat_public_key")
+    encrypted_private_key = _payload_text(
+        payload,
+        "encrypted_private_key",
+        "encrypted_private_key_blob",
+    )
+    kdf_algorithm = _payload_text(payload, "kdf_algorithm")
+    kdf_salt = _payload_text(payload, "kdf_salt", "salt")
+    wrapping_algorithm = _payload_text(payload, "wrapping_algorithm") or "AES-GCM"
+    kdf_params = payload.get("kdf_params")
+
+    kdf = payload.get("kdf")
+    if isinstance(kdf, dict):
+        if kdf_algorithm is None:
+            kdf_algorithm = _payload_text(kdf, "algorithm")
+        if kdf_salt is None:
+            kdf_salt = _payload_text(kdf, "salt")
+        if kdf_params is None:
+            kdf_params = kdf.get("params")
+
+    if not public_key:
+        return {}, "public_key is required."
+    if not encrypted_private_key:
+        return {}, "encrypted_private_key is required."
+    if not kdf_algorithm:
+        return {}, "kdf_algorithm is required."
+    if not kdf_salt:
+        return {}, "kdf_salt is required."
+    if not isinstance(kdf_params, dict) or not kdf_params:
+        return {}, "kdf_params must be a non-empty object."
+
+    string_fields = {
+        "public_key": public_key,
+        "encrypted_private_key": encrypted_private_key,
+        "kdf_algorithm": kdf_algorithm,
+        "kdf_salt": kdf_salt,
+        "wrapping_algorithm": wrapping_algorithm,
+    }
+    if any(len(value) > CHAT_KEY_STRING_MAX_LENGTH for value in string_fields.values()):
+        return {}, "Chat key payload is too large."
+
+    try:
+        serialized_kdf_params = json.dumps(kdf_params, sort_keys=True)
+    except (TypeError, ValueError):
+        return {}, "kdf_params must be JSON serializable."
+    if len(serialized_kdf_params) > CHAT_KEY_METADATA_MAX_LENGTH:
+        return {}, "kdf_params is too large."
+
+    recovery_state = _payload_text(payload, "recovery_state")
+    if recovery_state is not None and len(recovery_state) > CHAT_KEY_RECOVERY_STATE_MAX_LENGTH:
+        return {}, "recovery_state is too large."
+
+    return {
+        "public_key": public_key,
+        "encrypted_private_key": encrypted_private_key,
+        "kdf_algorithm": kdf_algorithm,
+        "kdf_params": kdf_params,
+        "kdf_salt": kdf_salt,
+        "wrapping_algorithm": wrapping_algorithm,
+        "recovery_state": recovery_state,
+    }, ""
+
+
+def _chat_key_response(chat_key: ChatKey | None) -> dict[str, Any]:
+    if chat_key is None:
+        return {"chat_key": None}
+
+    return {
+        "chat_key": {
+            "id": chat_key.id,
+            "key_version": chat_key.key_version,
+            "public_key": chat_key.public_key,
+            "encrypted_private_key": chat_key.encrypted_private_key,
+            "kdf_algorithm": chat_key.kdf_algorithm,
+            "kdf_params": chat_key.kdf_params,
+            "kdf_salt": chat_key.kdf_salt,
+            "wrapping_algorithm": chat_key.wrapping_algorithm,
+            "created_at": chat_key.created_at.isoformat(),
+            "rotated_at": chat_key.rotated_at.isoformat() if chat_key.rotated_at else None,
+            "disabled_at": chat_key.disabled_at.isoformat() if chat_key.disabled_at else None,
+            "recovery_state": chat_key.recovery_state,
+        }
+    }
 
 
 def register_encryption_routes(bp: Blueprint) -> None:
@@ -50,4 +207,48 @@ def register_encryption_routes(bp: Blueprint) -> None:
             user=user,
             pgp_proton_form=pgp_proton_form,
             pgp_key_form=pgp_key_form,
+            chat_key=user.active_chat_key,
+            chat_key_csrf_token=generate_csrf(),
         ), status_code
+
+    @bp.route("/chat-key.json", methods=["GET", "POST"])
+    @authentication_required
+    def chat_key() -> Response | tuple[Response, int]:
+        user = db.session.scalars(db.select(User).filter_by(id=session["user_id"])).one()
+
+        if request.method == "GET":
+            return jsonify(_chat_key_response(user.active_chat_key))
+
+        csrf_error = _validate_json_csrf()
+        if csrf_error:
+            return jsonify({"error": csrf_error}), 400
+
+        payload = request.get_json(silent=True)
+        cleaned_payload, error = _validate_chat_key_payload(payload, current_user_id=user.id)
+        if error:
+            status_code = 403 if error.startswith("Chat keys can only") else 400
+            return jsonify({"error": error}), status_code
+
+        now = datetime.now(UTC)
+        active_key = user.active_chat_key
+        next_version = max((chat_key.key_version for chat_key in user.chat_keys), default=0) + 1
+        if active_key is not None:
+            active_key.disabled_at = now
+            active_key.recovery_state = "rotated"
+
+        new_chat_key = ChatKey(
+            user=user,
+            key_version=next_version,
+            public_key=cleaned_payload["public_key"],
+            encrypted_private_key=cleaned_payload["encrypted_private_key"],
+            kdf_algorithm=cleaned_payload["kdf_algorithm"],
+            kdf_params=cleaned_payload["kdf_params"],
+            kdf_salt=cleaned_payload["kdf_salt"],
+            wrapping_algorithm=cleaned_payload["wrapping_algorithm"],
+            rotated_at=now if active_key is not None else None,
+            recovery_state=cleaned_payload["recovery_state"],
+        )
+        db.session.add(new_chat_key)
+        db.session.commit()
+
+        return jsonify(_chat_key_response(new_chat_key)), 201

--- a/hushline/templates/embed_profile.html
+++ b/hushline/templates/embed_profile.html
@@ -211,6 +211,7 @@
 
         <script id="recipientPublicKeys" type="application/json">{{ recipient_public_keys | tojson }}</script>
         <script id="recipientPublicKeyEntries" type="application/json">{{ recipient_public_key_entries | tojson }}</script>
+        <script id="recipientChatPublicKey" type="application/json">{{ recipient_chat_public_key | tojson }}</script>
 
         {% if not message_submission_block_reason %}
           <div class="captcha">

--- a/hushline/templates/profile.html
+++ b/hushline/templates/profile.html
@@ -156,6 +156,7 @@
 
     <script id="recipientPublicKeys" type="application/json">{{ recipient_public_keys | tojson }}</script>
     <script id="recipientPublicKeyEntries" type="application/json">{{ recipient_public_key_entries | tojson }}</script>
+    <script id="recipientChatPublicKey" type="application/json">{{ recipient_chat_public_key | tojson }}</script>
 
     {% if not message_submission_block_reason %}
       <div class="captcha">

--- a/hushline/templates/settings/encryption.html
+++ b/hushline/templates/settings/encryption.html
@@ -4,6 +4,35 @@
   <h3>Encryption</h3>
   <p class="meta">This public key is used on your tip line. Manage notification recipient addresses and recipient-specific keys on the Notifications page.</p>
 
+  <h4>Hush Line Chat Key</h4>
+  {% if chat_key %}
+    <p class="meta">Chat key version {{ chat_key.key_version }} is provisioned.</p>
+  {% else %}
+    <form
+      id="chat-key-provision-form"
+      class="formBody"
+      method="POST"
+      action="{{ url_for('settings.encryption') }}"
+      data-chat-key-url="{{ url_for('settings.chat_key') }}"
+      data-csrf-token="{{ chat_key_csrf_token }}"
+    >
+      <label for="chat-key-password">Current Password</label>
+      <input
+        id="chat-key-password"
+        type="password"
+        autocomplete="current-password"
+        required
+      />
+      <button type="submit">Create Chat Key</button>
+      <p
+        id="chat-key-provision-status"
+        class="meta"
+        role="status"
+        aria-live="polite"
+      ></p>
+    </form>
+  {% endif %}
+
   <h4>Proton Key Import</h4>
   <p>🔒 Do you use Proton Mail? We can automatically retrieve your PGP key from Proton's key server.</p>
   <form

--- a/migrations/versions/f6c1e2d3a4b5_add_chat_keys.py
+++ b/migrations/versions/f6c1e2d3a4b5_add_chat_keys.py
@@ -1,0 +1,62 @@
+"""add chat keys
+
+Revision ID: f6c1e2d3a4b5
+Revises: a9d8c7b6e5f4
+Create Date: 2026-06-11 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "f6c1e2d3a4b5"
+down_revision = "a9d8c7b6e5f4"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_keys",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("key_version", sa.Integer(), nullable=False),
+        sa.Column("public_key", sa.Text(), nullable=False),
+        sa.Column("encrypted_private_key", sa.Text(), nullable=False),
+        sa.Column("kdf_algorithm", sa.String(length=128), nullable=False),
+        sa.Column("kdf_params", sa.JSON(), nullable=False),
+        sa.Column("kdf_salt", sa.Text(), nullable=False),
+        sa.Column("wrapping_algorithm", sa.String(length=128), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column("rotated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("disabled_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("recovery_state", sa.String(length=64), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["user_id"],
+            ["users.id"],
+            name=op.f("fk_chat_keys_user_id_users"),
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("id", name=op.f("pk_chat_keys")),
+        sa.UniqueConstraint("user_id", "key_version", name=op.f("uq_chat_keys_user_id")),
+    )
+    op.create_index(op.f("ix_chat_keys_user_id"), "chat_keys", ["user_id"], unique=False)
+    op.create_index(
+        "ix_chat_keys_user_id_disabled_at",
+        "chat_keys",
+        ["user_id", "disabled_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_chat_keys_user_id_disabled_at", table_name="chat_keys")
+    op.drop_index(op.f("ix_chat_keys_user_id"), table_name="chat_keys")
+    op.drop_table("chat_keys")

--- a/tests/migrations/revision_f6c1e2d3a4b5.py
+++ b/tests/migrations/revision_f6c1e2d3a4b5.py
@@ -1,0 +1,78 @@
+from sqlalchemy import text
+
+from hushline.db import db
+
+NEW_TABLES = ["chat_keys"]
+NEW_INDEXES = ["ix_chat_keys_user_id_disabled_at"]
+FORBIDDEN_COLUMNS = [
+    "private_key",
+    "plaintext_private_key",
+    "derived_key",
+    "unlock_key",
+    "decrypted_message_text",
+]
+
+
+class UpgradeTester:
+    def load_data(self) -> None:
+        pass
+
+    def check_upgrade(self) -> None:
+        table_names = db.session.scalars(
+            text(
+                """
+                SELECT table_name
+                FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name = ANY(:table_names)
+                """
+            ),
+            {"table_names": NEW_TABLES},
+        ).all()
+        assert table_names == NEW_TABLES
+
+        indexes = db.session.scalars(
+            text(
+                """
+                SELECT indexname
+                FROM pg_indexes
+                WHERE schemaname = 'public'
+                  AND indexname = ANY(:index_names)
+                """
+            ),
+            {"index_names": NEW_INDEXES},
+        ).all()
+        assert indexes == NEW_INDEXES
+
+        plaintext_columns = db.session.scalars(
+            text(
+                """
+                SELECT column_name
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'chat_keys'
+                  AND column_name = ANY(:column_names)
+                """
+            ),
+            {"column_names": FORBIDDEN_COLUMNS},
+        ).all()
+        assert plaintext_columns == []
+
+
+class DowngradeTester:
+    def load_data(self) -> None:
+        pass
+
+    def check_downgrade(self) -> None:
+        table_count = db.session.scalar(
+            text(
+                """
+                SELECT count(*)
+                FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name = ANY(:table_names)
+                """
+            ),
+            {"table_names": NEW_TABLES},
+        )
+        assert table_count == 0

--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -1,0 +1,215 @@
+import re
+
+import pytest
+from flask import Flask, url_for
+from flask.testing import FlaskClient
+
+from hushline.db import db
+from hushline.model import ChatKey, User
+
+
+def _chat_key_payload(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "public_key": '{"kty":"EC","crv":"P-256","x":"public-x","y":"public-y"}',
+        "encrypted_private_key": (
+            '{"algorithm":"AES-GCM","iv":"nonce","ciphertext":"wrapped-private-key"}'
+        ),
+        "kdf_algorithm": "PBKDF2-SHA-256",
+        "kdf_params": {"iterations": 310000, "hash": "SHA-256"},
+        "kdf_salt": "salt",
+        "wrapping_algorithm": "AES-GCM",
+    }
+    payload.update(overrides)
+    return payload
+
+
+def _chat_key_columns() -> set[str]:
+    return {column.name for column in db.metadata.tables["chat_keys"].columns}
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_settings_encryption_shows_chat_key_provisioner(client: FlaskClient) -> None:
+    response = client.get(url_for("settings.encryption"))
+
+    assert response.status_code == 200
+    assert 'id="chat-key-provision-form"' in response.text
+    assert f'data-chat-key-url="{url_for("settings.chat_key")}"' in response.text
+    assert 'id="chat-key-password"' in response.text
+    assert 'autocomplete="current-password"' in response.text
+    assert 'name="chat_key_password"' not in response.text
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_authenticated_user_can_provision_chat_key(client: FlaskClient, user: User) -> None:
+    response = client.post(url_for("settings.chat_key"), json=_chat_key_payload())
+
+    assert response.status_code == 201
+    created_key = db.session.scalars(db.select(ChatKey).filter_by(user_id=user.id)).one()
+    assert created_key.key_version == 1
+    assert created_key.public_key == _chat_key_payload()["public_key"]
+    assert created_key.encrypted_private_key == _chat_key_payload()["encrypted_private_key"]
+    assert created_key.kdf_algorithm == "PBKDF2-SHA-256"
+    assert created_key.kdf_params == {"iterations": 310000, "hash": "SHA-256"}
+    assert created_key.kdf_salt == "salt"
+    assert created_key.wrapping_algorithm == "AES-GCM"
+    assert created_key.disabled_at is None
+
+    response_payload = response.get_json()
+    assert response_payload is not None
+    assert response_payload["chat_key"]["public_key"] == created_key.public_key
+    assert response_payload["chat_key"]["encrypted_private_key"] == (
+        created_key.encrypted_private_key
+    )
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_chat_key_payload_rejects_plaintext_private_key_material(
+    client: FlaskClient,
+) -> None:
+    response = client.post(
+        url_for("settings.chat_key"),
+        json=_chat_key_payload(private_key="plain-private-key"),
+    )
+
+    assert response.status_code == 400
+    assert "Plaintext chat key material is not accepted." in response.text
+    assert db.session.scalars(db.select(ChatKey)).all() == []
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_chat_key_cannot_be_provisioned_for_another_user(client: FlaskClient, user2: User) -> None:
+    response = client.post(
+        url_for("settings.chat_key"),
+        json=_chat_key_payload(user_id=user2.id),
+    )
+
+    assert response.status_code == 403
+    assert db.session.scalars(db.select(ChatKey)).all() == []
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_chat_key_post_requires_csrf_when_enabled(app: Flask, client: FlaskClient) -> None:
+    prior_setting = app.config.get("WTF_CSRF_ENABLED")
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        response = client.post(url_for("settings.chat_key"), json=_chat_key_payload())
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = prior_setting
+
+    assert response.status_code == 400
+    assert "Invalid CSRF token." in response.text
+    assert db.session.scalars(db.select(ChatKey)).all() == []
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_chat_key_post_accepts_csrf_header_when_enabled(app: Flask, client: FlaskClient) -> None:
+    prior_setting = app.config.get("WTF_CSRF_ENABLED")
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        settings_response = client.get(url_for("settings.encryption"))
+        token_match = re.search(r'data-csrf-token="([^"]+)"', settings_response.text)
+        assert token_match is not None
+
+        response = client.post(
+            url_for("settings.chat_key"),
+            json=_chat_key_payload(),
+            headers={"X-CSRFToken": token_match.group(1)},
+        )
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = prior_setting
+
+    assert response.status_code == 201
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_chat_key_rotation_versions_new_key_and_disables_old_key(
+    client: FlaskClient, user: User
+) -> None:
+    first_response = client.post(url_for("settings.chat_key"), json=_chat_key_payload())
+    second_response = client.post(
+        url_for("settings.chat_key"),
+        json=_chat_key_payload(public_key='{"kty":"EC","x":"rotated"}'),
+    )
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 201
+    keys = db.session.scalars(
+        db.select(ChatKey).filter_by(user_id=user.id).order_by(ChatKey.key_version.asc())
+    ).all()
+    assert [key.key_version for key in keys] == [1, 2]
+    assert keys[0].disabled_at is not None
+    assert keys[0].recovery_state == "rotated"
+    assert keys[1].disabled_at is None
+    assert keys[1].rotated_at is not None
+    assert user.chat_public_key == '{"kty":"EC","x":"rotated"}'
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_chat_key_get_returns_only_authenticated_users_key(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    owned_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="owned-public",
+        encrypted_private_key="owned-wrapped-private",
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000},
+        kdf_salt="salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    other_key = ChatKey(
+        user=user2,
+        key_version=1,
+        public_key="other-public",
+        encrypted_private_key="other-wrapped-private",
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000},
+        kdf_salt="salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    db.session.add_all([owned_key, other_key])
+    db.session.commit()
+
+    response = client.get(url_for("settings.chat_key"))
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload is not None
+    assert payload["chat_key"]["public_key"] == "owned-public"
+    assert "other-public" not in response.text
+
+
+def test_chat_key_schema_has_no_plaintext_private_key_columns(app: Flask) -> None:
+    assert _chat_key_columns().isdisjoint(
+        {
+            "private_key",
+            "plaintext_private_key",
+            "derived_key",
+            "unlock_key",
+            "decrypted_message_text",
+        }
+    )
+
+
+@pytest.mark.usefixtures("_pgp_user")
+def test_profile_exposes_public_chat_key_only(client: FlaskClient, user: User) -> None:
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="public-chat-key",
+        encrypted_private_key="wrapped-private-chat-key",
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000},
+        kdf_salt="salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    db.session.add(chat_key)
+    db.session.commit()
+
+    response = client.get(url_for("profile", username=user.primary_username.username))
+
+    assert response.status_code == 200
+    assert 'id="recipientChatPublicKey"' in response.text
+    assert "public-chat-key" in response.text
+    assert "wrapped-private-chat-key" not in response.text


### PR DESCRIPTION
This PR implements child issue #2189 (`Add client-generated Hush Line chat keys for in-app conversations`) under epic #2177 (`Feasibility: two-way encrypted conversations between accounts`).
It is intended to merge into the epic branch first, not directly into `main`.

This PR addresses the issue "Add client-generated Hush Line chat keys for in-app conversations" by updating supporting files in `assets/js`, data and model code in `hushline/model`, and request-handling code in `hushline/routes`.
The change includes both implementation work and automated tests, showing the intended behavior and how it is verified.
It touches 12 non-log file(s) (12 total including runner artifacts), primarily in assets/js, hushline/model, and hushline/routes.

## Summary
- Automated code agent update for child issue #2189.
- Part of epic #2177: Feasibility: two-way encrypted conversations between accounts
- This PR targets the epic integration branch `codex/epic-2177`.
- The child issue is closed explicitly by workflow after this PR merges into the epic branch.

Linked issue: #2189

## Context
- Epic: https://github.com/scidsg/hushline/issues/2177
- Child issue: https://github.com/scidsg/hushline/issues/2189
- Branch: codex/daily-issue-2189
- Base branch: codex/epic-2177
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `assets/js/settings.js`
- `hushline/model/__init__.py`
- `hushline/model/chat_key.py`
- `hushline/model/user.py`
- `hushline/routes/profile.py`
- `hushline/settings/encryption.py`
- `hushline/templates/embed_profile.html`
- `hushline/templates/profile.html`
- `hushline/templates/settings/encryption.html`
- `migrations/versions/f6c1e2d3a4b5_add_chat_keys.py`
- `tests/migrations/revision_f6c1e2d3a4b5.py`
- `tests/test_chat_keys.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
