### PR TITLE
Harden workflow PR head qualification guard

### DIFF
--- a/scripts/check_workflow_pr_head_qualification.py
+++ b/scripts/check_workflow_pr_head_qualification.py
@@ -4,12 +4,18 @@
 from __future__ import annotations
 
 import re
+import shlex
 import sys
 from pathlib import Path
 
 WORKFLOW_DIR = Path(".github/workflows")
 COMMAND_RE = re.compile(r"\bgh pr (list|create)\b")
-HEAD_RE = re.compile(r"--head\s+(?P<token>\"[^\"]+\"|'[^']+'|\S+)")
+FLAG_TOKEN_RE = re.compile(
+    r"(?<!\S)(?P<flag>--head|--repo|-H|-R)(?:(?P<equals>=)|\s+)"
+    r'(?P<token>"[^"]*"|\'[^\']*\'|\S+)',
+)
+HEAD_FLAG_RE = re.compile(r"(?<!\S)(?:--head|-H)(?:=|\s|$)")
+REPO_FLAG_RE = re.compile(r"(?<!\S)(?:--repo|-R)(?:=|\s|$)")
 
 
 def iter_command_blocks(text: str) -> list[tuple[int, str]]:
@@ -39,16 +45,28 @@ def iter_command_blocks(text: str) -> list[tuple[int, str]]:
     return blocks
 
 
+def extract_flag_values(command: str, flags: set[str]) -> list[str]:
+    values: list[str] = []
+    for match in FLAG_TOKEN_RE.finditer(command):
+        if match.group("flag") not in flags:
+            continue
+        token = match.group("token")
+        try:
+            values.append(shlex.split(token)[0])
+        except ValueError:
+            values.append(token.strip("\"'"))
+    return values
+
+
 def is_unqualified_head(command: str) -> bool:
-    if "--repo" not in command or "--head" not in command:
+    if not REPO_FLAG_RE.search(command) or not HEAD_FLAG_RE.search(command):
         return False
 
-    match = HEAD_RE.search(command)
-    if match is None:
-        return False
+    head_values = extract_flag_values(command, {"--head", "-H"})
+    if not head_values:
+        return True
 
-    token = match.group("token").strip("\"'")
-    return ":" not in token
+    return any(":" not in token for token in head_values)
 
 
 def main() -> int:

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -1,6 +1,13 @@
+import importlib.util
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = REPO_ROOT / "scripts" / "check_workflow_pr_head_qualification.py"
+spec = importlib.util.spec_from_file_location("check_workflow_pr_head_qualification", SCRIPT_PATH)
+assert spec is not None
+workflow_guard = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(workflow_guard)
 
 
 def _workflow_text(relative_path: str) -> str:
@@ -272,3 +279,33 @@ def test_epic_child_close_workflow_uses_trusted_head_branch_not_pr_body() -> Non
     assert "const issueNumber = Number(headMatch[1]);" in workflow_text
     assert "context.payload.pull_request.body" not in workflow_text
     assert "Linked issue:" not in workflow_text
+
+
+def test_workflow_pr_head_guard_rejects_unqualified_long_head_with_equals() -> None:
+    command = "gh pr list --repo owner/repo --head=feature-branch"
+
+    assert workflow_guard.is_unqualified_head(command) is True
+
+
+def test_workflow_pr_head_guard_allows_qualified_long_head_with_equals() -> None:
+    command = "gh pr list --repo owner/repo --head=owner:feature-branch"
+
+    assert workflow_guard.is_unqualified_head(command) is False
+
+
+def test_workflow_pr_head_guard_rejects_unqualified_short_head() -> None:
+    command = "gh pr create --repo owner/repo -H feature-branch"
+
+    assert workflow_guard.is_unqualified_head(command) is True
+
+
+def test_workflow_pr_head_guard_allows_qualified_short_head_with_equals() -> None:
+    command = "gh pr create --repo owner/repo -H=owner:feature-branch"
+
+    assert workflow_guard.is_unqualified_head(command) is False
+
+
+def test_workflow_pr_head_guard_rejects_missing_head_value_with_repo() -> None:
+    command = "gh pr create --repo owner/repo --head"
+
+    assert workflow_guard.is_unqualified_head(command) is True


### PR DESCRIPTION
### Motivation
- A static workflow-security guard intended to reject ambiguous `gh pr` usages missed valid flag syntaxes such as `--head=value` and the short `-H` form, producing false negatives. 
- The check must conservatively detect all forms of head/repo flags used by GitHub CLI so workflows cannot accidentally reintroduce unqualified PR-head usage.

### Description
- Replace the single `HEAD_RE` with `FLAG_TOKEN_RE`, and add `HEAD_FLAG_RE` and `REPO_FLAG_RE` to recognize both long (`--head`, `--repo`) and short (`-H`, `-R`) flag forms and `--flag=value` syntax. 
- Add `extract_flag_values()` (using `shlex`) to robustly parse flag values including quoted tokens and preserve the existing owner-qualified requirement. 
- Update `is_unqualified_head()` to conservatively treat presence of a repo flag and an unparseable/missing head value as a violation and to check all discovered head values for owner qualification. 
- Add regression unit tests exercising `--head=value`, `-H value`, `-H=owner:branch`, owner-qualified values, and a malformed `--head` without a value.

### Testing
- Ran the checker directly with `python3 scripts/check_workflow_pr_head_qualification.py` and it completed with no violations on current workflows. 
- Executed the new unit tests with `pytest -q tests/test_workflow_pr_head_qualification.py` and all tests passed. 
- Ran static checks `python3 -m ruff format --check` / `python3 -m ruff check` and `python3 -m mypy` against the modified files and they passed. 
- Environment-limited checks `make lint`, `make test`, `make workflow-security-checks`, and dependency audits could not be executed here because `docker` (and `gh` in this environment) is unavailable and should be run in CI prior to merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b3f5e11a083309fc96cd5f28a7bfd)