### PR TITLE
Fix provenance roadmap baseline sync

### DIFF
--- a/scripts/refresh_public_record_law_firms.py
+++ b/scripts/refresh_public_record_law_firms.py
@@ -439,10 +439,11 @@ def _sync_provenance_roadmap(
     adapter_count = len(OFFICIAL_US_STATE_DISCOVERY_ADAPTERS)
     updated = re.sub(
         r"## Current Baseline \([^)]+\)\n"
+        r"(?:[ \t]*\n)*"
         r"- Active strict listings: `[^`]+`\n"
         r"- States with strict listings: .+\n",
         (
-            f"## Current Baseline ({generated_on})\n"
+            f"## Current Baseline ({generated_on})\n\n"
             f"- Active strict listings: `{report['total_strict_listings']}`\n"
             f"- States with strict listings: {state_list or 'none'}\n"
         ),

--- a/tests/test_public_record_refresh_workflow.py
+++ b/tests/test_public_record_refresh_workflow.py
@@ -159,6 +159,7 @@ def test_sync_provenance_roadmap_updates_baseline_and_adapter_count(tmp_path: Pa
                 "# Public Record Provenance Roadmap (U.S.)",
                 "",
                 "## Current Baseline (March 10, 2026)",
+                "",
                 "- Active strict listings: `58`",
                 "- States with strict listings: `AK`",
                 "",
@@ -180,6 +181,7 @@ def test_sync_provenance_roadmap_updates_baseline_and_adapter_count(tmp_path: Pa
 
     updated = roadmap_path.read_text(encoding="utf-8")
     assert "## Current Baseline (2026-03-11)" in updated
+    assert "## Current Baseline (2026-03-11)\n\n- Active strict listings" in updated
     assert "- Active strict listings: `2`" in updated
     assert "- States with strict listings: `CA`, `WA`" in updated
     assert "- Explicit state adapter entries in discovery code: 50 / 50." in updated
@@ -194,6 +196,7 @@ def test_sync_provenance_roadmap_preserves_eu_planning_section(tmp_path: Path) -
                 "# Public Record Provenance Roadmap (U.S.)",
                 "",
                 "## Current Baseline (March 10, 2026)",
+                "",
                 "- Active strict listings: `58`",
                 "- States with strict listings: `AK`",
                 "",


### PR DESCRIPTION
### Motivation
- The roadmap sync logic expected the `## Current Baseline (...)` heading to be immediately followed by list items, but the real document contains a blank line there causing the baseline date, listing count, and state list to remain stale while adapter counts could still update.
- The change ensures the provenance roadmap writer reliably matches and updates the existing baseline block in the canonical `docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md` format.

### Description
- Relax the `_sync_provenance_roadmap` regex in `scripts/refresh_public_record_law_firms.py` to accept optional blank lines between the `Current Baseline` heading and the following list items. 
- Preserve a single blank line when writing the updated baseline block so the file spacing matches the existing roadmap format. 
- Update `tests/test_public_record_refresh_workflow.py` fixtures to use the real roadmap spacing and add an assertion that the rewritten baseline includes the blank line before `- Active strict listings`.

### Testing
- Ran targeted reproduction using a temporary copy of `docs/PUBLIC-RECORD-PROVENANCE-ROADMAP.md` via `python` which confirmed `## Current Baseline (YYYY-MM-DD)

- Active strict listings` and the state list were updated. 
- Ran formatting and static checks with `poetry run ruff format --check` and `poetry run ruff check` on the modified files with success. 
- Ran type checks with `poetry run mypy` on the modified files with success. 
- Ran the refresh workflow tests with `poetry run pytest -q tests/test_public_record_refresh_workflow.py` and the targeted tests passed (`9 passed` for that suite); the full `make test` / Docker-backed checks could not be executed here because Docker is not available in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b3f5df1c083309f7aa408f3c5b0f2)