### PR TITLE
Resolve directory 'Request a correction' links to verified admin profile

### DIFF
--- a/hushline/routes/directory.py
+++ b/hushline/routes/directory.py
@@ -14,6 +14,7 @@ from flask import (
 from unidecode import unidecode
 from werkzeug.wrappers.response import Response
 
+from hushline.db import db
 from hushline.model import (
     AccountCategory,
     GlobaLeaksDirectoryListing,
@@ -21,6 +22,7 @@ from hushline.model import (
     OrganizationSetting,
     PublicRecordListing,
     SecureDropDirectoryListing,
+    User,
     Username,
     get_globaleaks_directory_listing,
     get_globaleaks_directory_listings,
@@ -453,6 +455,25 @@ def _directory_user_row(username: Username) -> dict[str, object | None]:
     }
 
 
+def _directory_correction_contact_username() -> Username | None:
+    admin_usernames = db.session.scalars(
+        db.select(Username)
+        .join(User)
+        .where(
+            User.is_admin.is_(True),
+            User.is_suspended.is_(False),
+            Username.is_primary.is_(True),
+        )
+        .order_by(Username.id)
+    ).all()
+
+    for username in admin_usernames:
+        if _user_message_capable(username.user):
+            return username
+
+    return None
+
+
 def _shuffle_featured_directory_items(items: Sequence[_FeaturedItem]) -> list[_FeaturedItem]:
     shuffled_items = list(items)
     random.shuffle(shuffled_items)
@@ -863,6 +884,12 @@ def register_directory_routes(app: Flask) -> None:
                 *[_directory_user_row(username) for username in usernames],
             ]
         filtered_all_directory_entries.sort(key=_all_directory_entry_sort_key)
+        correction_contact_username = _directory_correction_contact_username()
+        correction_contact_url = (
+            url_for("profile", username=correction_contact_username.username)
+            if correction_contact_username is not None
+            else None
+        )
         return render_template(
             "directory.html",
             intro_text=OrganizationSetting.fetch_one(OrganizationSetting.DIRECTORY_INTRO_TEXT),
@@ -902,6 +929,7 @@ def register_directory_routes(app: Flask) -> None:
             truncate_directory_bio=_directory_card_bio,
             user_message_capable=_user_message_capable,
             logged_in=logged_in,
+            correction_contact_url=correction_contact_url,
         )
 
     @app.route("/directory/public-records/<slug>")

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -676,7 +676,7 @@
     >
       <p class="meta dirMeta">
         🧪 Beta: This tab includes self-reported attorneys and automated listings pulled from public records.
-        <a href="/to/admin">Request a correction</a>.
+        {% if correction_contact_url %}<a href="{{ correction_contact_url }}">Request a correction</a>.{% endif %}
       </p>
 
       {% if attorney_usernames or public_record_all_listings %}
@@ -737,7 +737,7 @@
   {% if directory_verified_tab_enabled %}
     <div id="newsrooms" class="tab-content" role="tabpanel" aria-labelledby="newsrooms-tab">
       <p class="meta dirMeta">
-        🧪 Beta: This tab includes self-reported journalists, self-reported newsrooms, and automated listings from public journalism directories{% if newsroom_automated_sources %}, including {% for source in newsroom_automated_sources %}<a href="{{ source.url }}" target="_blank" rel="noopener noreferrer">{{ source.label }}</a>{% if not loop.last %}{% if loop.revindex0 == 1 %} and {% else %}, {% endif %}{% endif %}{% endfor %}{% endif %}. <a href="/to/admin">Request a correction</a>.
+        🧪 Beta: This tab includes self-reported journalists, self-reported newsrooms, and automated listings from public journalism directories{% if newsroom_automated_sources %}, including {% for source in newsroom_automated_sources %}<a href="{{ source.url }}" target="_blank" rel="noopener noreferrer">{{ source.label }}</a>{% if not loop.last %}{% if loop.revindex0 == 1 %} and {% else %}, {% endif %}{% endif %}{% endfor %}{% endif %}. {% if correction_contact_url %}<a href="{{ correction_contact_url }}">Request a correction</a>.{% endif %}
       </p>
 
       {% if journalism_usernames or newsroom_listings %}
@@ -799,7 +799,7 @@
     <div id="globaleaks" class="tab-content" role="tabpanel" aria-labelledby="globaleaks-tab">
       <p class="meta dirMeta">
         🧪 Beta: This list contains manual and automated entries and should not be considered exhaustive or authoritative.
-        <a href="/to/admin">Request a correction</a>.
+        {% if correction_contact_url %}<a href="{{ correction_contact_url }}">Request a correction</a>.{% endif %}
       </p>
 
       {% if globaleaks_listings %}
@@ -830,7 +830,7 @@
       <p class="meta dirMeta">
         🧪 Beta: These listings are automated from the Freedom of the Press Foundation's public
         <a href="https://securedrop.org/api/v1/directory/?format=json">SecureDrop API</a>.
-        <a href="/to/admin">Request a correction</a>.
+        {% if correction_contact_url %}<a href="{{ correction_contact_url }}">Request a correction</a>.{% endif %}
       </p>
 
       {% if securedrop_listings %}
@@ -866,7 +866,7 @@
     {% if directory_verified_tab_enabled %}
       <p class="meta dirMeta">
         🧪 Beta: This list contains automated entries.
-        <a href="/to/admin">Request a correction</a>.
+        {% if correction_contact_url %}<a href="{{ correction_contact_url }}">Request a correction</a>.{% endif %}
       </p>
     {% endif %}
     {% if not directory_verified_tab_enabled %}

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -40,6 +40,13 @@ _JOURNALISM_ACCOUNT_CATEGORIES = {
 }
 
 
+def _configure_directory_correction_admin(admin_user: User, username: str = "site-admin") -> str:
+    admin_user.primary_username.username = username
+    admin_user.pgp_key = Path("tests/test_pgp_key.txt").read_text()
+    db.session.commit()
+    return url_for("profile", username=username)
+
+
 def _first_public_record_listing_or_skip() -> PublicRecordListing:
     listings = _strict_public_record_listings()
     if not listings:
@@ -552,7 +559,10 @@ def test_directory_randomizes_featured_user_order(
     assert usernames[:3] == ["second-featured-user", "featured-user", "admin-user"]
 
 
-def test_directory_public_record_banner_links_to_admin(client: FlaskClient) -> None:
+def test_directory_public_record_banner_links_to_admin(
+    client: FlaskClient, admin_user: User
+) -> None:
+    correction_url = _configure_directory_correction_admin(admin_user)
     response = client.get(url_for("directory"))
     assert response.status_code == 200
 
@@ -565,7 +575,7 @@ def test_directory_public_record_banner_links_to_admin(client: FlaskClient) -> N
     banner_link = banner.select_one("a")
     assert banner_link is not None
     assert banner_link.text.strip() == "Request a correction"
-    assert banner_link.get("href") == "/to/admin"
+    assert banner_link.get("href") == correction_url
     banner_text = " ".join(banner.get_text(" ", strip=True).split())
     assert (
         "Beta: This tab includes self-reported attorneys and automated listings pulled from "
@@ -575,8 +585,9 @@ def test_directory_public_record_banner_links_to_admin(client: FlaskClient) -> N
 
 
 def test_directory_securedrop_banner_links_to_admin_without_tor_copy(
-    client: FlaskClient,
+    client: FlaskClient, admin_user: User
 ) -> None:
+    correction_url = _configure_directory_correction_admin(admin_user)
     response = client.get(url_for("directory"))
     assert response.status_code == 200
 
@@ -589,7 +600,7 @@ def test_directory_securedrop_banner_links_to_admin_without_tor_copy(
     banner_links = banner.select("a")
     links_by_text = {link.text.strip().rstrip("."): link.get("href") for link in banner_links}
     assert links_by_text["SecureDrop API"] == "https://securedrop.org/api/v1/directory/?format=json"
-    assert links_by_text["Request a correction"] == "/to/admin"
+    assert links_by_text["Request a correction"] == correction_url
     banner_text = " ".join(banner.get_text(" ", strip=True).split())
     assert banner_text.startswith("🧪 Beta:")
     assert (
@@ -603,8 +614,9 @@ def test_directory_securedrop_banner_links_to_admin_without_tor_copy(
 
 
 def test_directory_globaleaks_banner_links_to_admin_without_tor_copy(
-    client: FlaskClient,
+    client: FlaskClient, admin_user: User
 ) -> None:
+    correction_url = _configure_directory_correction_admin(admin_user)
     response = client.get(url_for("directory"))
     assert response.status_code == 200
 
@@ -619,7 +631,7 @@ def test_directory_globaleaks_banner_links_to_admin_without_tor_copy(
         link.text.replace("\u2060", "").strip().rstrip("."): link.get("href")
         for link in banner_links
     }
-    assert links_by_text["Request a correction"] == "/to/admin"
+    assert links_by_text["Request a correction"] == correction_url
     assert "Tor Browser" not in links_by_text
     banner_text = " ".join(banner.get_text(" ", strip=True).split())
     assert banner_text.startswith("🧪 Beta:")
@@ -632,8 +644,9 @@ def test_directory_globaleaks_banner_links_to_admin_without_tor_copy(
 
 
 def test_directory_newsrooms_banner_links_to_admin(
-    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch, admin_user: User
 ) -> None:
+    correction_url = _configure_directory_correction_admin(admin_user)
     monkeypatch.setattr(
         "hushline.routes.directory.get_newsroom_directory_listings",
         lambda: (_sample_newsroom_listing(), _sample_european_network_listing()),
@@ -658,7 +671,7 @@ def test_directory_newsrooms_banner_links_to_admin(
         links_by_text["Directory of European Journalism Networks"]
         == "https://journalismdirectory.org/search-networks/"
     )
-    assert links_by_text["Request a correction"] == "/to/admin"
+    assert links_by_text["Request a correction"] == correction_url
     banner_text = " ".join(banner.get_text(" ", strip=True).split())
     assert banner_text.startswith("🧪 Beta:")
     assert "self-reported journalists, self-reported newsrooms, and automated listings" in (
@@ -677,7 +690,8 @@ def test_directory_newsrooms_banner_links_to_admin(
     assert "Find Your News directory . Request a correction." not in rendered_banner_text
 
 
-def test_directory_all_tab_banner_links_to_admin(client: FlaskClient) -> None:
+def test_directory_all_tab_banner_links_to_admin(client: FlaskClient, admin_user: User) -> None:
+    correction_url = _configure_directory_correction_admin(admin_user)
     response = client.get(url_for("directory"))
     assert response.status_code == 200
 
@@ -690,11 +704,32 @@ def test_directory_all_tab_banner_links_to_admin(client: FlaskClient) -> None:
     banner_link = banner.select_one("a")
     assert banner_link is not None
     assert banner_link.text.strip() == "Request a correction"
-    assert banner_link.get("href") == "/to/admin"
+    assert banner_link.get("href") == correction_url
     banner_text = " ".join(banner.get_text(" ", strip=True).split())
     assert banner_text.startswith("🧪 Beta:")
     assert "This list contains automated entries." in banner_text
     assert "Request a correction" in banner_text
+
+
+def test_directory_correction_links_ignore_non_admin_admin_username(
+    client: FlaskClient, user: User, admin_user: User
+) -> None:
+    user.primary_username.username = "admin"
+    user.pgp_key = Path("tests/test_pgp_key.txt").read_text()
+    correction_url = _configure_directory_correction_admin(admin_user, "verified-site-admin")
+
+    response = client.get(url_for("directory"))
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    correction_links = [
+        link.get("href")
+        for link in soup.select(".dirMeta a")
+        if link.get_text(strip=True) == "Request a correction"
+    ]
+    assert correction_links
+    assert set(correction_links) == {correction_url}
+    assert "/to/admin" not in correction_links
 
 
 def test_directory_hides_tab_bar_when_verified_tabs_disabled(client: FlaskClient) -> None:

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -44,7 +44,7 @@ def _configure_directory_correction_admin(admin_user: User, username: str = "sit
     admin_user.primary_username.username = username
     admin_user.pgp_key = Path("tests/test_pgp_key.txt").read_text()
     db.session.commit()
-    return url_for("profile", username=username)
+    return url_for("profile", username=username, _external=False)
 
 
 def _first_public_record_listing_or_skip() -> PublicRecordListing:


### PR DESCRIPTION
### Motivation
- Prevent trust/misdirection where hardcoded `/to/admin` links in directory banners could resolve to a non-admin username or a 404 instead of a verified administrator contact.

### Description
- Add `_directory_correction_contact_username()` which finds the first non-suspended primary admin username that is message-capable and returns its `Username` record.
- Compute `correction_contact_url` in `register_directory_routes` and pass it into the `directory.html` template so banners link to a verified admin profile rather than the literal `/to/admin` path.
- Replace literal `/to/admin` anchors in the public-records, newsrooms, GlobaLeaks, SecureDrop, and All tab banners with conditional rendering of the resolved `correction_contact_url`.
- Update `tests/test_directory.py` to configure a real admin correction contact and add a test that ensures a normal user claiming the `admin` username does not become the correction target.

### Testing
- `python -m ruff format --check` passed for the modified files.
- `python -m ruff check` passed for the modified files.
- `python -m mypy` passed for the modified files.
- `pytest` runs in the local environment were blocked by an inability to connect to the configured Postgres host (DNS resolution failure for `postgres`), so the new/modified directory tests were added but could not be executed here; CI should run the full test suite and the added tests are expected to pass there.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b3f5e14f483308124c94140bc6c0a)