### PR TITLE
Validate docs screenshot release tags before shell use

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -43,6 +43,22 @@ jobs:
   capture:
     runs-on: ubuntu-latest
     steps:
+      - name: Validate release tag
+        if: ${{ github.event_name == 'release' }}
+        env:
+          EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          set -euo pipefail
+          python - <<'PY'
+          import os
+          import re
+          import sys
+
+          release_tag = os.environ["EVENT_RELEASE_TAG"].strip()
+          if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+", release_tag):
+              sys.exit(f"Unexpected docs screenshot release tag: {release_tag!r}")
+          PY
+
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
         with:
           ref: ${{ inputs.release_ref != '' && inputs.release_ref || github.event_name == 'release' && github.event.release.tag_name || inputs.release_key != '' && inputs.release_key || github.sha }}
@@ -140,11 +156,14 @@ jobs:
       - name: Resolve release key
         id: vars
         if: steps.manifest.outputs.enabled == 'true'
+        env:
+          INPUT_RELEASE_KEY: ${{ inputs.release_key }}
+          EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          RELEASE_KEY="${{ inputs.release_key }}"
+          RELEASE_KEY="${INPUT_RELEASE_KEY:-}"
           if [ -z "$RELEASE_KEY" ]; then
-            RELEASE_KEY="${{ github.event.release.tag_name }}"
+            RELEASE_KEY="${EVENT_RELEASE_TAG:-}"
           fi
           if [ -z "$RELEASE_KEY" ]; then
             RELEASE_KEY="$(git tag --points-at HEAD | rg '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -190,6 +190,24 @@ def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> 
     assert "${WEBSITE_SCREENSHOT_ROOT}/releases" not in website_section
 
 
+def test_docs_screenshot_release_tag_is_validated_before_shell_use() -> None:
+    workflow_text = _workflow_text(".github/workflows/docs-screenshots.yml")
+    validate_section = workflow_text.split("      - name: Validate release tag", 1)[1].split(
+        "      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5", 1
+    )[0]
+    resolve_section = workflow_text.split("      - name: Resolve release key", 1)[1].split(
+        "      - name: Resolve screenshot capture manifest", 1
+    )[0]
+
+    assert "EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}" in validate_section
+    assert 'os.environ["EVENT_RELEASE_TAG"].strip()' in validate_section
+    assert 're.fullmatch(r"v[0-9]+\\.[0-9]+\\.[0-9]+", release_tag)' in validate_section
+    assert 'RELEASE_KEY="${{ github.event.release.tag_name }}"' not in resolve_section
+    assert 'RELEASE_KEY="${EVENT_RELEASE_TAG:-}"' in resolve_section
+    assert "INPUT_RELEASE_KEY: ${{ inputs.release_key }}" in resolve_section
+    assert "EVENT_RELEASE_TAG: ${{ github.event.release.tag_name }}" in resolve_section
+
+
 def test_docs_screenshot_capture_manifest_does_not_persist_read_tokens() -> None:
     workflow_text = _workflow_text(".github/workflows/docs-screenshots.yml")
     manifest_section = workflow_text.split("      - name: Resolve screenshot capture manifest", 1)[


### PR DESCRIPTION
### Motivation
- A release-triggered workflow previously interpolated `github.event.release.tag_name` directly into a Bash assignment, allowing crafted tag names to inject shell commands before later validation.
- The change hardens the docs screenshot workflow to prevent command injection from maliciously-crafted release tags while preserving existing screenshot capture and publish behavior.

### Description
- Added an early `Validate release tag` step that copies `github.event.release.tag_name` into `EVENT_RELEASE_TAG` and enforces `vMAJOR.MINOR.PATCH` with a strict regex before proceeding.
- Avoided direct expression interpolation in shell by passing `inputs.release_key` and `github.event.release.tag_name` via step `env:` and using `INPUT_RELEASE_KEY`/`EVENT_RELEASE_TAG` inside the `Resolve release key` script.
- Kept the final `release_key` runtime validation and output behavior intact and unchanged except for sourcing the values from safe env vars. 
- Added a regression test `test_docs_screenshot_release_tag_is_validated_before_shell_use` in `tests/test_workflow_pr_head_qualification.py` that locks the safer env-transfer pattern and rejects direct release-tag interpolation in the shell step.

### Testing
- Ran `python -m pytest tests/test_workflow_pr_head_qualification.py -q` and the test suite for that file passed (`11 passed`).
- Ran formatting/lint checks for the changed test file with `python -m ruff format --check` and `python -m ruff check` and they passed for the modified file. 
- Ran `prettier --ignore-path /dev/null --check .github/workflows/docs-screenshots.yml` which passed formatting checks. 
- Performed local shell validations including `bash -n` on synthesized step scripts and an automated PoC replay that confirmed a crafted tag is rejected and does not execute injected commands (checks reported `release_tag_injection_checks_ok`).
- Note: full `make lint`, `make test`, and dependency audits could not run in this environment because Docker is unavailable, and `actionlint` was not installed here; these checks should run in CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b423c4b088330bb366e395906ea83)