### PR TITLE
Escape public directory report listing fields

### DIFF
--- a/scripts/public_directory_snapshot_report.py
+++ b/scripts/public_directory_snapshot_report.py
@@ -167,6 +167,44 @@ def _snapshot_map(rows: list[dict[str, object]]) -> dict[str, dict[str, object]]
     return {str(row["primary_username"]): row for row in rows}
 
 
+def _single_line_text(value: object, fallback: str = "") -> str:
+    if not isinstance(value, str):
+        return fallback
+    normalized = " ".join(value.split())
+    return normalized or fallback
+
+
+def _markdown_escape_text(value: object, fallback: str = "") -> str:
+    text = _single_line_text(value, fallback)
+    return "".join(f"\\{char}" if char in r"\`*_{}[]()#+-.!:|<>" else char for char in text)
+
+
+def _markdown_code_span(value: object, fallback: str = "") -> str:
+    text = _single_line_text(value, fallback)
+    if not text:
+        return ""
+
+    longest_backtick_run = 0
+    current_run = 0
+    for char in text:
+        if char == "`":
+            current_run += 1
+            longest_backtick_run = max(longest_backtick_run, current_run)
+        else:
+            current_run = 0
+    delimiter = "`" * (longest_backtick_run + 1)
+    if text.startswith("`") or text.endswith("`"):
+        text = f" {text} "
+    return f"{delimiter}{text}{delimiter}"
+
+
+def _format_report_listing(row: Mapping[str, object]) -> str:
+    username = _markdown_code_span(row.get("primary_username"), "unknown")
+    display_name = _markdown_escape_text(row.get("display_name"), "unknown")
+    profile_url = _markdown_escape_text(row.get("profile_url"), "profile URL unavailable")
+    return f"- {username} ({display_name}) - {profile_url}"
+
+
 def _build_diff_summary(
     current_snapshot: list[dict[str, object]],
     baseline_snapshot: list[dict[str, object]],
@@ -251,11 +289,7 @@ def _append_diff_section(
     if diff["new_usernames"]:
         for username in cast(list[str], diff["new_usernames"]):
             row = current_map[str(username)]
-            lines.append(
-                f"- `{username}`"
-                f" ({row['display_name']})"
-                f" - {row['profile_url'] or 'profile URL unavailable'}"
-            )
+            lines.append(_format_report_listing(row))
     else:
         lines.append("- none")
 
@@ -263,11 +297,7 @@ def _append_diff_section(
     if diff["removed_usernames"]:
         for username in cast(list[str], diff["removed_usernames"]):
             row = baseline_map[str(username)]
-            lines.append(
-                f"- `{username}`"
-                f" ({row['display_name']})"
-                f" - {row['profile_url'] or 'profile URL unavailable'}"
-            )
+            lines.append(_format_report_listing(row))
     else:
         lines.append("- none")
     return diff

--- a/tests/test_public_directory_snapshot_report.py
+++ b/tests/test_public_directory_snapshot_report.py
@@ -172,6 +172,32 @@ def test_build_markdown_report_reports_added_and_removed_usernames() -> None:
     }
 
 
+def test_build_markdown_report_escapes_user_controlled_listing_markdown() -> None:
+    module = _load_module()
+
+    current_snapshot = [
+        {
+            "primary_username": "newuser",
+            "display_name": "Trusted User\n## Forged Heading [track](https://example.test)",
+            "profile_url": "/to/newuser\n![pixel](https://example.test/pixel.png)",
+            "is_verified": False,
+            "has_pgp_key": True,
+        },
+    ]
+
+    report, _summary = module.build_markdown_report(current_snapshot, [], [])
+
+    assert "## Forged Heading" not in report
+    assert "[track](https://example.test)" not in report
+    assert "![pixel](https://example.test/pixel.png)" not in report
+    assert (
+        r"- `newuser` "
+        r"(Trusted User \#\# Forged Heading "
+        r"\[track\]\(https\://example\.test\)) - "
+        r"/to/newuser \!\[pixel\]\(https\://example\.test/pixel\.png\)"
+    ) in report
+
+
 def test_build_readme_report_renders_natural_language_and_history_table() -> None:
     module = _load_module()
 


### PR DESCRIPTION
### Motivation
- A security scan flagged that user-controlled `display_name` and `profile_url` values were interpolated directly into generated Markdown reports, allowing Markdown injection (headings, links, images) in the published report.
- The weekly report pipeline renders generated Markdown into GitHub step summaries and a stats repo, so the integrity of those artifacts must be preserved.

### Description
- Added Markdown-safe rendering helpers to `scripts/public_directory_snapshot_report.py`: `_single_line_text`, `_markdown_escape_text`, `_markdown_code_span`, and `_format_report_listing` to normalize values to a single line and escape Markdown metacharacters.
- Replaced direct string interpolation of `display_name` and `profile_url` in the new/removed listing rows with `_format_report_listing(row)` to ensure safe rendering of username, display name, and profile URL.
- Added a regression unit test `test_build_markdown_report_escapes_user_controlled_listing_markdown` in `tests/test_public_directory_snapshot_report.py` to assert that newlines, headings, links, and image-like Markdown in user fields are escaped and cannot break the report.
- Files changed: `scripts/public_directory_snapshot_report.py`, `tests/test_public_directory_snapshot_report.py`.

### Testing
- Ran `pytest -q tests/test_public_directory_snapshot_report.py` and observed `6 passed` (unit tests covering snapshot build, markdown/report/readme rendering, and the new regression test).
- Ran formatting and static checks: `poetry run ruff format` (applied) and `poetry run ruff check` (passed), and `poetry run mypy` (passed).
- `make lint`, `make test`, `make audit-python`, and `make audit-node-runtime` could not be executed in this environment because Docker is unavailable (`docker: not found`), so CI-style lint/test/audit must be run in a Docker-enabled environment or CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b41e5013c83308534e9c07b8ef4ae)