### PR TITLE
Harden docs screenshots workflow release_key handling

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -140,11 +140,14 @@ jobs:
       - name: Resolve release key
         id: vars
         if: steps.manifest.outputs.enabled == 'true'
+        env:
+          INPUT_RELEASE_KEY: ${{ inputs.release_key }}
+          RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
         run: |
           set -euo pipefail
-          RELEASE_KEY="${{ inputs.release_key }}"
+          RELEASE_KEY="$INPUT_RELEASE_KEY"
           if [ -z "$RELEASE_KEY" ]; then
-            RELEASE_KEY="${{ github.event.release.tag_name }}"
+            RELEASE_KEY="$RELEASE_TAG_NAME"
           fi
           if [ -z "$RELEASE_KEY" ]; then
             RELEASE_KEY="$(git tag --points-at HEAD | rg '^v[0-9]+\.[0-9]+\.[0-9]+$' | head -n1 || true)"

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -190,6 +190,20 @@ def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> 
     assert "${WEBSITE_SCREENSHOT_ROOT}/releases" not in website_section
 
 
+def test_docs_screenshots_release_key_input_is_passed_through_environment() -> None:
+    workflow_text = _workflow_text(".github/workflows/docs-screenshots.yml")
+    resolve_section = workflow_text.split("      - name: Resolve release key", 1)[1].split(
+        "      - name: Resolve screenshot capture manifest", 1
+    )[0]
+
+    assert "INPUT_RELEASE_KEY: ${{ inputs.release_key }}" in resolve_section
+    assert "RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}" in resolve_section
+    assert 'RELEASE_KEY="$INPUT_RELEASE_KEY"' in resolve_section
+    assert 'RELEASE_KEY="$RELEASE_TAG_NAME"' in resolve_section
+    assert 'RELEASE_KEY="${{ inputs.release_key }}"' not in resolve_section
+    assert 'RELEASE_KEY="${{ github.event.release.tag_name }}"' not in resolve_section
+
+
 def test_docs_screenshot_capture_manifest_does_not_persist_read_tokens() -> None:
     workflow_text = _workflow_text(".github/workflows/docs-screenshots.yml")
     manifest_section = workflow_text.split("      - name: Resolve screenshot capture manifest", 1)[


### PR DESCRIPTION
### Motivation
- Prevent command-injection from a manually supplied `workflow_dispatch` `release_key` input that was previously interpolated directly into a shell assignment and could persist a PATH/git-wrapper to exfiltrate the website push PAT.
- Preserve the existing release-key resolution and validation behavior while removing unsafe GitHub expression-to-shell interpolation.

### Description
- Pass untrusted values into the `Resolve release key` step via environment variables (`INPUT_RELEASE_KEY` and `EVENT_RELEASE_TAG`) and use those env vars in the shell instead of embedding `${{ ... }}` directly into assignments in `/.github/workflows/docs-screenshots.yml`.
- Retain the original fallback order and validation, including the `vX.Y.Z` regex check and emitting `release_key` to `GITHUB_OUTPUT`.
- Resolve conflicts with current `main`, preserving the release-tag validation step and the regression coverage for env-based release-key handling.

### Testing
- `make test CMD="docker compose run --rm app" TESTS=tests/test_workflow_pr_head_qualification.py` passed (`16 passed`).
- `docker compose run --rm app poetry run ruff format --check tests/test_workflow_pr_head_qualification.py` passed.
- `docker compose run --rm app poetry run ruff check tests/test_workflow_pr_head_qualification.py` passed.
- `git diff --check` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b45406cf08330ba8965ab415c723e)