### PR TITLE
Harden bump-personal-server-after-release workflow to prevent tampered branch merges

### DIFF
--- a/.github/workflows/bump-personal-server-after-release.yml
+++ b/.github/workflows/bump-personal-server-after-release.yml
@@ -62,7 +62,7 @@ jobs:
           token: ${{ secrets.PERSONAL_SERVER_VERSION_BUMP }}
           path: hushline-personal-server
 
-      - name: Check out or create release branch in hushline-personal-server
+      - name: Create clean release branch in hushline-personal-server
         working-directory: hushline-personal-server
         shell: bash
         run: |
@@ -70,10 +70,9 @@ jobs:
 
           if git ls-remote --exit-code --heads origin "$PERSONAL_SERVER_BRANCH" >/dev/null 2>&1; then
             git fetch origin "$PERSONAL_SERVER_BRANCH":"refs/remotes/origin/$PERSONAL_SERVER_BRANCH"
-            git checkout -B "$PERSONAL_SERVER_BRANCH" "origin/$PERSONAL_SERVER_BRANCH"
-          else
-            git checkout -B "$PERSONAL_SERVER_BRANCH"
           fi
+
+          git checkout -B "$PERSONAL_SERVER_BRANCH" "origin/$PERSONAL_SERVER_BASE_REF"
 
       - name: Update personal server package and image references
         id: update_personal_server
@@ -129,16 +128,8 @@ jobs:
           PY
 
           if git diff --quiet -- "$PERSONAL_SERVER_PACKAGE_FILE" "$PERSONAL_SERVER_COMPOSE_FILE"; then
-            if git diff --quiet "origin/$PERSONAL_SERVER_BASE_REF...HEAD" -- \
-              "$PERSONAL_SERVER_PACKAGE_FILE" \
-              "$PERSONAL_SERVER_COMPOSE_FILE"; then
-              echo "changed=false" >> "$GITHUB_OUTPUT"
-              echo "Personal server already points at $RELEASE_TAG"
-              exit 0
-            fi
-
-            echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Personal server branch already contains the $RELEASE_TAG bump; continuing with PR and merge checks"
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Personal server already points at $RELEASE_TAG"
             exit 0
           fi
 
@@ -146,6 +137,7 @@ jobs:
 
       - name: Commit and push personal server branch
         if: steps.update_personal_server.outputs.changed == 'true'
+        id: commit_personal_server
         working-directory: hushline-personal-server
         shell: bash
         run: |
@@ -160,8 +152,9 @@ jobs:
           fi
           git commit -m "Bump personal server to $RELEASE_TAG"
           git push --force-with-lease=refs/heads/"$PERSONAL_SERVER_BRANCH" origin "$PERSONAL_SERVER_BRANCH"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-      - name: Verify only the personal server version files changed
+      - name: Verify only the generated personal server version diff changed
         if: steps.update_personal_server.outputs.changed == 'true'
         working-directory: hushline-personal-server
         shell: bash
@@ -238,6 +231,7 @@ jobs:
             --repo "$PERSONAL_SERVER_REPOSITORY" \
             --squash \
             --delete-branch \
+            --match-head-commit "${{ steps.commit_personal_server.outputs.head_sha }}" \
             "$PR_URL" >"$merge_output_file" 2>&1; then
             cat "$merge_output_file"
             exit 0

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -43,6 +43,43 @@ def test_cross_repo_auto_merge_workflows_use_owner_qualified_pr_heads() -> None:
         assert workflow_text.count(head_filter) == expected_count
 
 
+def test_personal_server_bump_workflow_rebuilds_release_branch_from_main() -> None:
+    workflow_text = _workflow_text(".github/workflows/bump-personal-server-after-release.yml")
+    branch_section = workflow_text.split(
+        "      - name: Create clean release branch in hushline-personal-server", 1
+    )[1].split("      - name: Update personal server package and image references", 1)[0]
+    update_section = workflow_text.split(
+        "      - name: Update personal server package and image references", 1
+    )[1].split("      - name: Commit and push personal server branch", 1)[0]
+    commit_section = workflow_text.split("      - name: Commit and push personal server branch", 1)[
+        1
+    ].split("      - name: Verify only the generated personal server version diff changed", 1)[0]
+    merge_section = workflow_text.split(
+        "      - name: Merge personal server PR if immediately allowed", 1
+    )[1]
+
+    assert 'git ls-remote --exit-code --heads origin "$PERSONAL_SERVER_BRANCH"' in branch_section
+    assert (
+        'git fetch origin "$PERSONAL_SERVER_BRANCH":'
+        '"refs/remotes/origin/$PERSONAL_SERVER_BRANCH"' in branch_section
+    )
+    assert (
+        'git checkout -B "$PERSONAL_SERVER_BRANCH" "origin/$PERSONAL_SERVER_BASE_REF"'
+        in branch_section
+    )
+    assert (
+        'git checkout -B "$PERSONAL_SERVER_BRANCH" "origin/$PERSONAL_SERVER_BRANCH"'
+        not in branch_section
+    )
+    assert "origin/$PERSONAL_SERVER_BASE_REF...HEAD" not in update_section
+    assert "branch already contains" not in update_section
+    assert 'echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"' in commit_section
+    assert (
+        '--match-head-commit "${{ steps.commit_personal_server.outputs.head_sha }}"'
+        in merge_section
+    )
+
+
 def test_public_directory_weekly_report_refreshes_stats_branch_lease_before_push() -> None:
     workflow_text = _workflow_text(".github/workflows/public-directory-weekly-report.yml")
     build_section = workflow_text.split("      - name: Build weekly directory report", 1)[1].split(


### PR DESCRIPTION
### Motivation
- A security scan identified a critical supply-chain vulnerability where the release bump workflow trusted pre-existing release-named branches in `scidsg/hushline-personal-server`, allowing malicious edits confined to `hushline-personal-server/DEBIAN/control` or `hushline-personal-server/var/lib/hushline/docker-compose.yaml` to be included in an automated PR and merged. 
- The intent of the change is to ensure the automated bump only ever merges the workflow-generated version/image bump derived from `origin/main` and to prevent a privileged PAT from merging attacker-controlled branch contents.

### Description
- Rebuild the personal-server release branch from `origin/main` on every run instead of checking out and trusting a pre-existing release-named branch, while still fetching any existing release branch only to refresh the `--force-with-lease` expectation. (`.github/workflows/bump-personal-server-after-release.yml`).
- Simplify the rerun/changed detection so the workflow no longer treats an existing branch diff as an accepted rerun path and only marks `changed=true` when the workflow-generated bump actually produces modified target files. (`PERSONAL_SERVER_PACKAGE_FILE` and `PERSONAL_SERVER_COMPOSE_FILE`).
- Record the generated bump commit SHA as an output (`head_sha`) after push and pin the auto-merge call with `gh pr merge --match-head-commit` so the workflow will refuse to merge if the remote head was changed after verification. (`--match-head-commit "${{ steps.commit_personal_server.outputs.head_sha }}"`).
- Add workflow-guard test coverage asserting the clean-branch behavior and head-SHA merge pinning in `tests/test_workflow_pr_head_qualification.py` (added `test_personal_server_bump_workflow_rebuilds_release_branch_from_main`).

### Testing
- Ran `poetry run pytest tests/test_workflow_pr_head_qualification.py -q` and the modified test suite passed (16 passed). 
- Ran `poetry run ruff format --check` and `poetry run ruff check --output-format full` on the modified test file and formatting/lint checks passed locally for the edited files. 
- Performed targeted static assertions that the workflow no longer checks out a pre-existing release branch, no longer accepts the old rerun path, emits `head_sha`, and uses `--match-head-commit`, and those assertions passed. 
- Full `make lint`, `make test`, and dependency audit targets could not be run in this environment because Docker is not available, and a local YAML parse check failed due to `PyYAML` not being installed; CI must run the Docker-backed checks and dependency audits before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b4639fc6c8330af481c14c884a3e1)