### PR TITLE
Keep transient public-record link failures non-definitive

### DIFF
--- a/hushline/public_record_refresh.py
+++ b/hushline/public_record_refresh.py
@@ -601,13 +601,13 @@ def build_requests_link_checker(
             return LinkCheckResult(
                 ok=False,
                 reason=f"HTTP {last_status_code}",
-                definitive_failure=True,
+                definitive_failure=False,
             )
         if last_error is not None and last_status_code is None:
             return LinkCheckResult(
                 ok=False,
                 reason=str(last_error),
-                definitive_failure=True,
+                definitive_failure=False,
             )
         return LinkCheckResult(ok=True)
 

--- a/tests/test_public_record_refresh.py
+++ b/tests/test_public_record_refresh.py
@@ -940,7 +940,7 @@ def test_refresh_public_record_rows_flags_and_drops_link_failures() -> None:
     assert checked_urls
 
 
-def test_refresh_public_record_rows_drops_exhausted_link_failures() -> None:
+def test_refresh_public_record_rows_keeps_transient_link_failures() -> None:
     rows = [
         _row(
             id_value="seed-healthy",
@@ -960,7 +960,7 @@ def test_refresh_public_record_rows_drops_exhausted_link_failures() -> None:
 
     def checker(url: str) -> LinkCheckResult:
         if url == "https://transient.example":
-            return LinkCheckResult(ok=False, reason="HTTP 503", definitive_failure=True)
+            return LinkCheckResult(ok=False, reason="HTTP 503", definitive_failure=False)
         return LinkCheckResult(ok=True)
 
     result = refresh_public_record_rows(
@@ -972,10 +972,10 @@ def test_refresh_public_record_rows_drops_exhausted_link_failures() -> None:
         drop_failed_links=True,
     )
 
-    assert [row["id"] for row in result.rows] == ["seed-healthy"]
+    assert [row["id"] for row in result.rows] == ["seed-healthy", "seed-transient"]
     assert len(result.link_failures) == 1
     assert result.link_failures[0].listing_id == "seed-transient"
-    assert result.dropped_record_ids == ["seed-transient"]
+    assert result.dropped_record_ids == []
 
 
 def test_refresh_public_record_rows_rejects_legacy_self_reported_source_label() -> None:
@@ -1290,7 +1290,7 @@ def test_build_requests_link_checker_rejects_invalid_arguments() -> None:
         build_requests_link_checker(timeout_seconds=0)
 
 
-def test_build_requests_link_checker_returns_last_server_error_after_retries() -> None:
+def test_build_requests_link_checker_returns_last_server_error_as_transient() -> None:
     class _FakeResponse:
         def __init__(self, status_code: int) -> None:
             self.status_code = status_code
@@ -1315,10 +1315,10 @@ def test_build_requests_link_checker_returns_last_server_error_after_retries() -
 
     assert result.ok is False
     assert result.reason == "HTTP 500"
-    assert result.definitive_failure is True
+    assert result.definitive_failure is False
 
 
-def test_build_requests_link_checker_returns_last_request_exception_reason() -> None:
+def test_build_requests_link_checker_returns_last_request_exception_as_transient() -> None:
     class _FakeSession:
         def __init__(self) -> None:
             self.headers: dict[str, str] = {}
@@ -1336,7 +1336,7 @@ def test_build_requests_link_checker_returns_last_request_exception_reason() -> 
 
     assert result.ok is False
     assert result.reason == "network timeout"
-    assert result.definitive_failure is True
+    assert result.definitive_failure is False
 
 
 def test_render_refresh_summary_includes_dropped_ids_and_link_failures() -> None:


### PR DESCRIPTION
### Motivation
- Prevent transient upstream/network/server errors from being treated as definitive link failures that can cause automated deletion of public-record listings when `--drop-failing-records` is used.
- Preserve integrity and availability of the public attorney directory by only allowing clear permanent broken-link statuses to be eligible for dropping.

### Description
- Change `build_requests_link_checker` in `hushline/public_record_refresh.py` to report exhausted HTTP 5xx responses and `requests.RequestException` results as link failures but with `definitive_failure=False` instead of `True`.
- Keep existing behavior that treats explicit broken status codes (e.g., 404/410) as `definitive_failure=True` so permanent failures continue to be removable.
- Update `tests/test_public_record_refresh.py` to expect transient 5xx and exception outcomes to be non-definitive and to retain affected rows when `drop_failed_links=True`.
- Preserve reporting of link failures so transient issues are visible in the refresh output without causing automated drops.

### Testing
- Ran targeted unit tests with `poetry run pytest` for the affected scenarios and workflow checks, and the invoked tests passed (targeted subset: `test_refresh_public_record_rows_flags_and_drops_link_failures`, `test_refresh_public_record_rows_keeps_transient_link_failures`, `test_build_requests_link_checker_retries_then_succeeds`, `test_build_requests_link_checker_marks_404_as_definitive_failure`, `test_build_requests_link_checker_returns_last_server_error_as_transient`, `test_build_requests_link_checker_returns_last_request_exception_as_transient`, and `test_refresh_script_drop_failing_records_rejects_unresolved_failures` all passed).
- Ran the refresh-related test suites with `poetry run pytest -q tests/test_public_record_refresh.py tests/test_public_record_refresh_workflow.py` and all tests passed (`352 passed`).
- Ran formatting/checks with `poetry run ruff format --check ...` and `poetry run ruff check ...` which reported no issues.
- Note: `make lint`, `make test`, `make audit-python`, and `make audit-node-runtime` could not be executed in the current environment because `docker` is not available here, and a Dependabot pre-check via the GitHub API was blocked by network restrictions, so those CI-backed checks should be verified in CI before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b49427190833090d50ec00769acf4)