### PR TITLE
Harden staging infra release branch handling

### DIFF
--- a/.github/workflows/bump-staging-after-release.yml
+++ b/.github/workflows/bump-staging-after-release.yml
@@ -60,7 +60,7 @@ jobs:
           token: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT }}
           path: hushline-infra
 
-      - name: Check out or create release branch in hushline-infra
+      - name: Reset release branch to trusted infra base
         working-directory: hushline-infra
         shell: bash
         run: |
@@ -68,10 +68,9 @@ jobs:
 
           if git ls-remote --exit-code --heads origin "$INFRA_BRANCH" >/dev/null 2>&1; then
             git fetch origin "$INFRA_BRANCH":"refs/remotes/origin/$INFRA_BRANCH"
-            git checkout -B "$INFRA_BRANCH" "origin/$INFRA_BRANCH"
-          else
-            git checkout -B "$INFRA_BRANCH"
           fi
+
+          git checkout -B "$INFRA_BRANCH" "origin/$INFRA_BASE_REF"
 
       - name: Update staging version branch reference
         id: update_infra
@@ -113,7 +112,7 @@ jobs:
 
           echo "changed=true" >> "$GITHUB_OUTPUT"
 
-      - name: Commit and push infra branch
+      - name: Commit infra branch
         if: steps.update_infra.outputs.changed == 'true'
         working-directory: hushline-infra
         shell: bash
@@ -128,21 +127,69 @@ jobs:
             exit 0
           fi
           git commit -m "Bump staging to $RELEASE_TAG"
-          git push --force-with-lease=refs/heads/"$INFRA_BRANCH" origin "$INFRA_BRANCH"
 
-      - name: Verify only the staging tag file changed
+      - name: Verify only the staging tag changed
         if: steps.update_infra.outputs.changed == 'true'
         working-directory: hushline-infra
         shell: bash
         run: |
           set -euo pipefail
 
-          changed_files="$(git diff --name-only "origin/$INFRA_BASE_REF...HEAD")"
+          python3 - <<'PY'
+          import os
+          import re
+          import subprocess
 
-          if [ "$changed_files" != "$INFRA_FILE" ]; then
-            echo "::error title=Unexpected infra diff::Expected only $INFRA_FILE to change, got: $changed_files"
-            exit 1
-          fi
+          base_ref = os.environ["INFRA_BASE_REF"]
+          infra_file = os.environ["INFRA_FILE"]
+          release_tag = os.environ["RELEASE_TAG"]
+
+          diff = subprocess.run(
+              ["git", "diff", f"origin/{base_ref}...HEAD", "--", infra_file],
+              check=True,
+              stdout=subprocess.PIPE,
+              text=True,
+          ).stdout
+          changed_files = subprocess.run(
+              ["git", "diff", "--name-only", f"origin/{base_ref}...HEAD"],
+              check=True,
+              stdout=subprocess.PIPE,
+              text=True,
+          ).stdout.splitlines()
+
+          tag_line_pattern = re.compile(r'^[+-]\s*tag\s*=\s*"v\d+\.\d+\.\d+"$')
+          changed_lines = [
+              line
+              for line in diff.splitlines()
+              if line.startswith(("+", "-")) and not line.startswith(("+++", "---"))
+          ]
+          tag_changes = [line for line in changed_lines if tag_line_pattern.match(line)]
+          expected_added_tag = re.compile(
+              rf'^\+\s*tag\s*=\s*"{re.escape(release_tag)}"$',
+          )
+
+          if (
+              changed_files != [infra_file]
+              or changed_lines != tag_changes
+              or len(tag_changes) != 2
+              or not tag_changes[0].startswith("-")
+              or not expected_added_tag.match(tag_changes[1])
+          ):
+              raise SystemExit(
+                  "Expected exactly one staging tag replacement in "
+                  f"{infra_file}, got files {changed_files} "
+                  f"and diff lines {changed_lines}.",
+              )
+          PY
+
+      - name: Push infra branch
+        if: steps.update_infra.outputs.changed == 'true'
+        working-directory: hushline-infra
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          git push --force-with-lease=refs/heads/"$INFRA_BRANCH" origin "$INFRA_BRANCH"
 
       - name: Create or update staging PR
         if: steps.update_infra.outputs.changed == 'true'

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -329,3 +329,38 @@ def test_workflow_pr_head_guard_rejects_missing_head_value_with_repo() -> None:
     command = "gh pr create --repo owner/repo --head"
 
     assert workflow_guard.is_unqualified_head(command) is True
+
+
+def test_staging_release_branch_resets_to_trusted_base_before_auto_merge() -> None:
+    workflow_text = _workflow_text(".github/workflows/bump-staging-after-release.yml")
+    reset_section = workflow_text.split(
+        "      - name: Reset release branch to trusted infra base",
+        1,
+    )[1].split("      - name: Update staging version branch reference", 1)[0]
+    commit_section = workflow_text.split("      - name: Commit infra branch", 1)[1].split(
+        "      - name: Verify only the staging tag changed",
+        1,
+    )[0]
+    verify_section = workflow_text.split(
+        "      - name: Verify only the staging tag changed",
+        1,
+    )[1].split("      - name: Push infra branch", 1)[0]
+    push_section = workflow_text.split("      - name: Push infra branch", 1)[1].split(
+        "      - name: Create or update staging PR",
+        1,
+    )[0]
+
+    assert 'git fetch origin "$INFRA_BRANCH":"refs/remotes/origin/$INFRA_BRANCH"' in reset_section
+    assert 'git checkout -B "$INFRA_BRANCH" "origin/$INFRA_BASE_REF"' in reset_section
+    assert 'git checkout -B "$INFRA_BRANCH" "origin/$INFRA_BRANCH"' not in reset_section
+    assert (
+        'git push --force-with-lease=refs/heads/"$INFRA_BRANCH" origin "$INFRA_BRANCH"'
+        not in commit_section
+    )
+    assert "changed_lines != tag_changes" in verify_section
+    assert "len(tag_changes) != 2" in verify_section
+    assert "expected_added_tag.match(tag_changes[1])" in verify_section
+    assert (
+        'git push --force-with-lease=refs/heads/"$INFRA_BRANCH" origin "$INFRA_BRANCH"'
+        in push_section
+    )


### PR DESCRIPTION
### Motivation
- Prevent attacker-controlled changes from being smuggled into an auto-merged infra PR by reusing an existing release-named branch from the infra repo.  The workflow must operate from a trusted base and verify the exact intended change before using a privileged infra token.  

### Description
- Reset the checked-out release branch to the trusted base `origin/$INFRA_BASE_REF` before applying the staging tag update so untrusted branch history is discarded rather than reused.  
- Split commit, validation, and push so the workflow commits the local change first, validates the committed diff exactly, then pushes the branch only after validation.  
- Replace the path-only validation with an exact diff check implemented in Python that requires exactly one `tag = "vX.Y.Z"` replacement to the release tag in `hushline-env/hushline.tf`.  
- Add a regression test that asserts the workflow contains the trusted-base reset, pre-push validation logic, and the expected push ordering in the staging workflow file.  

### Testing
- Ran the targeted workflow unit tests: `pytest tests/test_workflow_pr_head_qualification.py -q` and they passed (`17 passed`).  
- Ran formatting/lint checks for the changed test file: `python -m ruff format tests/test_workflow_pr_head_qualification.py && python -m ruff check tests/test_workflow_pr_head_qualification.py` and they passed after reformatting.  
- Attempted repository-wide `make lint`, `make test`, and dependency audits but they could not run in this environment because Docker is not available, so CI must run the full Docker-backed checks before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b48fbc1c08330b3cf832f8699e25d)