### PR TITLE
#2190 Handle chat key unlock, password changes, and recovery limits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ htmlcov
 
 # generated
 hushline/static/js/*
+!hushline/static/js/chat-key-lifecycle.js
 !hushline/static/js/directory_verified.js
 !hushline/static/js/settings-location.js
 hushline/static/css/

--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -1,0 +1,319 @@
+(function () {
+  const textEncoder = new TextEncoder();
+  const textDecoder = new TextDecoder();
+  let unlockedChatPrivateKey = null;
+  const state = {
+    status: "empty",
+    keyVersion: null,
+    lastError: null,
+  };
+
+  function bytesToBase64(bytes) {
+    let binary = "";
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary);
+  }
+
+  function base64ToBytes(value) {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  }
+
+  function assertCryptoSupport() {
+    if (!window.crypto?.subtle) {
+      throw new Error("Web Crypto is unavailable.");
+    }
+  }
+
+  async function deriveWrappingKey(password, salt, kdfParams, usages) {
+    const passwordKey = await window.crypto.subtle.importKey(
+      "raw",
+      textEncoder.encode(password),
+      "PBKDF2",
+      false,
+      ["deriveKey"],
+    );
+    return window.crypto.subtle.deriveKey(
+      {
+        name: "PBKDF2",
+        salt,
+        iterations: Number(kdfParams?.iterations || 310000),
+        hash: kdfParams?.hash || "SHA-256",
+      },
+      passwordKey,
+      {
+        name: "AES-GCM",
+        length: 256,
+      },
+      false,
+      usages,
+    );
+  }
+
+  async function decryptPrivateJwk(chatKey, password) {
+    const encryptedPrivateKey = JSON.parse(chatKey.encrypted_private_key);
+    const wrappingKey = await deriveWrappingKey(
+      password,
+      base64ToBytes(chatKey.kdf_salt),
+      chatKey.kdf_params,
+      ["decrypt"],
+    );
+    const privateJwkBytes = await window.crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: base64ToBytes(encryptedPrivateKey.iv),
+      },
+      wrappingKey,
+      base64ToBytes(encryptedPrivateKey.ciphertext),
+    );
+    return JSON.parse(textDecoder.decode(privateJwkBytes));
+  }
+
+  async function importPrivateKey(privateJwk) {
+    return window.crypto.subtle.importKey(
+      "jwk",
+      privateJwk,
+      {
+        name: "ECDH",
+        namedCurve: privateJwk.crv || "P-256",
+      },
+      false,
+      ["deriveBits"],
+    );
+  }
+
+  async function unlockFromPassword(chatKey, password) {
+    if (!chatKey) {
+      clearChatKeyMaterial();
+      state.status = "no-key";
+      return true;
+    }
+
+    assertCryptoSupport();
+    let privateJwk = null;
+    try {
+      privateJwk = await decryptPrivateJwk(chatKey, password);
+      unlockedChatPrivateKey = await importPrivateKey(privateJwk);
+      state.status = "unlocked";
+      state.keyVersion = chatKey.key_version;
+      state.lastError = null;
+      return true;
+    } catch (error) {
+      clearChatKeyMaterial();
+      state.status = "locked";
+      state.keyVersion = chatKey.key_version || null;
+      state.lastError = "Chat key unlock failed.";
+      return false;
+    } finally {
+      privateJwk = null;
+    }
+  }
+
+  async function encryptPrivateJwk(privateJwk, password) {
+    const salt = window.crypto.getRandomValues(new Uint8Array(16));
+    const iv = window.crypto.getRandomValues(new Uint8Array(12));
+    const wrappingKey = await deriveWrappingKey(password, salt, {
+      iterations: 310000,
+      hash: "SHA-256",
+    }, ["encrypt"]);
+    const encryptedBytes = new Uint8Array(
+      await window.crypto.subtle.encrypt(
+        {
+          name: "AES-GCM",
+          iv,
+        },
+        wrappingKey,
+        textEncoder.encode(JSON.stringify(privateJwk)),
+      ),
+    );
+
+    return {
+      encrypted_private_key: JSON.stringify({
+        algorithm: "AES-GCM",
+        iv: bytesToBase64(iv),
+        ciphertext: bytesToBase64(encryptedBytes),
+      }),
+      kdf_algorithm: "PBKDF2-SHA-256",
+      kdf_params: {
+        iterations: 310000,
+        hash: "SHA-256",
+      },
+      kdf_salt: bytesToBase64(salt),
+      wrapping_algorithm: "AES-GCM",
+    };
+  }
+
+  async function rewrapForPasswordChange(chatKey, oldPassword, newPassword) {
+    assertCryptoSupport();
+    let privateJwk = null;
+    try {
+      privateJwk = await decryptPrivateJwk(chatKey, oldPassword);
+      const wrapped = await encryptPrivateJwk(privateJwk, newPassword);
+      return {
+        public_key: chatKey.public_key,
+        recovery_state: "available",
+        ...wrapped,
+      };
+    } finally {
+      privateJwk = null;
+    }
+  }
+
+  async function fetchChatKey(chatKeyUrl) {
+    const response = await fetch(chatKeyUrl, {
+      credentials: "same-origin",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    if (!response.ok) {
+      throw new Error("Chat key lookup failed.");
+    }
+    const payload = await response.json();
+    return payload.chat_key || null;
+  }
+
+  function clearChatKeyMaterial() {
+    unlockedChatPrivateKey = null;
+    state.status = "empty";
+    state.keyVersion = null;
+    state.lastError = null;
+  }
+
+  function replaceDocument(responseText, responseUrl) {
+    const parsedDocument = new DOMParser().parseFromString(
+      responseText,
+      "text/html",
+    );
+    document.title = parsedDocument.title;
+    document.head.replaceWith(document.importNode(parsedDocument.head, true));
+    document.body.replaceWith(document.importNode(parsedDocument.body, true));
+    window.history.replaceState({}, "", responseUrl);
+    bindPage();
+  }
+
+  function chatKeyUrlFromCurrentOrigin() {
+    return new URL("/settings/chat-key.json", window.location.origin).toString();
+  }
+
+  async function handleLoginSubmit(event) {
+    const form = event.currentTarget;
+    const passwordInput = form.querySelector("input[name='password']");
+    if (!passwordInput?.value || !window.fetch || !window.FormData) {
+      return;
+    }
+
+    event.preventDefault();
+    const password = passwordInput.value;
+    try {
+      const response = await fetch(form.action, {
+        method: "POST",
+        credentials: "same-origin",
+        body: new FormData(form),
+      });
+      const responseUrl = new URL(response.url);
+      const responseText = await response.text();
+      if (response.redirected && responseUrl.pathname !== "/login") {
+        if (responseUrl.pathname !== "/verify-2fa-login") {
+          const chatKey = await fetchChatKey(chatKeyUrlFromCurrentOrigin());
+          await unlockFromPassword(chatKey, password);
+        }
+        replaceDocument(responseText, response.url);
+        return;
+      }
+      replaceDocument(responseText, response.url);
+    } catch (error) {
+      HTMLFormElement.prototype.submit.call(form);
+    }
+  }
+
+  async function handlePasswordChangeSubmit(event) {
+    const form = event.currentTarget;
+    const chatKeyUrl = form.dataset.chatKeyUrl;
+    const rewrappedInput = form.querySelector("#rewrapped_chat_key");
+    const oldPasswordInput = form.querySelector("#old_password");
+    const newPasswordInput = form.querySelector("#new_password");
+    const submitButton = form.querySelector("[name='change_password']");
+    const status = document.getElementById("chat-key-rewrap-status");
+    if (
+      !chatKeyUrl ||
+      rewrappedInput?.value ||
+      !oldPasswordInput?.value ||
+      !newPasswordInput?.value
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    if (status) {
+      status.textContent = "Unlocking chat key...";
+    }
+
+    try {
+      const chatKey = await fetchChatKey(chatKeyUrl);
+      if (chatKey) {
+        const rewrappedPayload = await rewrapForPasswordChange(
+          chatKey,
+          oldPasswordInput.value,
+          newPasswordInput.value,
+        );
+        rewrappedInput.value = JSON.stringify(rewrappedPayload);
+        if (status) {
+          status.textContent = "Chat key rewrapped.";
+        }
+      }
+      if (submitButton?.click) {
+        submitButton.click();
+      } else {
+        HTMLFormElement.prototype.submit.call(form);
+      }
+    } catch (error) {
+      if (status) {
+        status.textContent = "Chat key unlock failed. Password was not changed.";
+      }
+    }
+  }
+
+  function bindLogoutCleanup() {
+    document.querySelectorAll("a[href$='/logout']").forEach((link) => {
+      link.addEventListener("click", clearChatKeyMaterial);
+    });
+  }
+
+  function bindPage() {
+    if (document.body?.dataset.authenticated !== "true") {
+      clearChatKeyMaterial();
+    }
+
+    document
+      .querySelector("form[action$='/login']")
+      ?.addEventListener("submit", handleLoginSubmit);
+    document
+      .getElementById("change-password-form")
+      ?.addEventListener("submit", handlePasswordChangeSubmit);
+    document
+      .querySelector("form[action*='password-reset']")
+      ?.addEventListener("submit", clearChatKeyMaterial);
+    bindLogoutCleanup();
+  }
+
+  window.HushLineChatKeys = {
+    clear: clearChatKeyMaterial,
+    fetchChatKey,
+    get state() {
+      return { ...state };
+    },
+    rewrapForPasswordChange,
+    unlockFromPassword,
+  };
+
+  document.addEventListener("DOMContentLoaded", function () {
+    bindPage();
+  });
+})();

--- a/hushline/chat_key_lifecycle.py
+++ b/hushline/chat_key_lifecycle.py
@@ -1,0 +1,163 @@
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+from hushline.db import db
+from hushline.model import ChatKey, User
+
+CHAT_KEY_STRING_MAX_LENGTH = 200_000
+CHAT_KEY_METADATA_MAX_LENGTH = 20_000
+CHAT_KEY_RECOVERY_STATE_MAX_LENGTH = 64
+CHAT_KEY_FORBIDDEN_SECRET_FIELDS = {
+    "decrypted_message_text",
+    "decrypted_private_key",
+    "derived_key",
+    "password",
+    "plaintext_private_key",
+    "private_key",
+    "unlock_key",
+    "wrapping_key",
+}
+
+
+def normalized_payload_key(value: str) -> str:
+    return value.strip().lower().replace("-", "_")
+
+
+def payload_contains_forbidden_secret_field(value: Any) -> bool:
+    if isinstance(value, dict):
+        for key, nested_value in value.items():
+            if (
+                isinstance(key, str)
+                and normalized_payload_key(key) in CHAT_KEY_FORBIDDEN_SECRET_FIELDS
+            ):
+                return True
+            if payload_contains_forbidden_secret_field(nested_value):
+                return True
+    elif isinstance(value, list):
+        return any(payload_contains_forbidden_secret_field(item) for item in value)
+    return False
+
+
+def payload_text(payload: dict[str, Any], *keys: str) -> str | None:
+    for key in keys:
+        value = payload.get(key)
+        if isinstance(value, str):
+            stripped = value.strip()
+            if stripped:
+                return stripped
+    return None
+
+
+def validate_chat_key_payload(payload: Any, *, current_user_id: int) -> tuple[dict[str, Any], str]:
+    if not isinstance(payload, dict):
+        return {}, "Expected a JSON object."
+
+    if payload_contains_forbidden_secret_field(payload):
+        return {}, "Plaintext chat key material is not accepted."
+
+    payload_user_id = payload.get("user_id")
+    if payload_user_id is not None and payload_user_id != current_user_id:
+        return {}, "Chat keys can only be provisioned for the authenticated user."
+
+    public_key = payload_text(payload, "public_key", "chat_public_key")
+    encrypted_private_key = payload_text(
+        payload,
+        "encrypted_private_key",
+        "encrypted_private_key_blob",
+    )
+    kdf_algorithm = payload_text(payload, "kdf_algorithm")
+    kdf_salt = payload_text(payload, "kdf_salt", "salt")
+    wrapping_algorithm = payload_text(payload, "wrapping_algorithm") or "AES-GCM"
+    kdf_params = payload.get("kdf_params")
+
+    kdf = payload.get("kdf")
+    if isinstance(kdf, dict):
+        if kdf_algorithm is None:
+            kdf_algorithm = payload_text(kdf, "algorithm")
+        if kdf_salt is None:
+            kdf_salt = payload_text(kdf, "salt")
+        if kdf_params is None:
+            kdf_params = kdf.get("params")
+
+    if not public_key:
+        return {}, "public_key is required."
+    if not encrypted_private_key:
+        return {}, "encrypted_private_key is required."
+    if not kdf_algorithm:
+        return {}, "kdf_algorithm is required."
+    if not kdf_salt:
+        return {}, "kdf_salt is required."
+    if not isinstance(kdf_params, dict) or not kdf_params:
+        return {}, "kdf_params must be a non-empty object."
+
+    string_fields = {
+        "public_key": public_key,
+        "encrypted_private_key": encrypted_private_key,
+        "kdf_algorithm": kdf_algorithm,
+        "kdf_salt": kdf_salt,
+        "wrapping_algorithm": wrapping_algorithm,
+    }
+    if any(len(value) > CHAT_KEY_STRING_MAX_LENGTH for value in string_fields.values()):
+        return {}, "Chat key payload is too large."
+
+    try:
+        serialized_kdf_params = json.dumps(kdf_params, sort_keys=True)
+    except (TypeError, ValueError):
+        return {}, "kdf_params must be JSON serializable."
+    if len(serialized_kdf_params) > CHAT_KEY_METADATA_MAX_LENGTH:
+        return {}, "kdf_params is too large."
+
+    recovery_state = payload_text(payload, "recovery_state")
+    if recovery_state is not None and len(recovery_state) > CHAT_KEY_RECOVERY_STATE_MAX_LENGTH:
+        return {}, "recovery_state is too large."
+
+    return {
+        "public_key": public_key,
+        "encrypted_private_key": encrypted_private_key,
+        "kdf_algorithm": kdf_algorithm,
+        "kdf_params": kdf_params,
+        "kdf_salt": kdf_salt,
+        "wrapping_algorithm": wrapping_algorithm,
+        "recovery_state": recovery_state,
+    }, ""
+
+
+def retire_active_chat_key(
+    user: User, *, recovery_state: str, when: datetime | None = None
+) -> bool:
+    active_key = user.active_chat_key
+    if active_key is None:
+        return False
+
+    active_key.disabled_at = when or datetime.now(UTC)
+    active_key.recovery_state = recovery_state
+    return True
+
+
+def rewrap_active_chat_key(
+    user: User, payload: dict[str, Any], *, when: datetime | None = None
+) -> ChatKey | None:
+    active_key = user.active_chat_key
+    if active_key is None:
+        return None
+
+    now = when or datetime.now(UTC)
+    active_key.disabled_at = now
+    active_key.recovery_state = "rewrapped"
+
+    next_version = max((chat_key.key_version for chat_key in user.chat_keys), default=0) + 1
+    new_chat_key = ChatKey(
+        user=user,
+        key_version=next_version,
+        public_key=payload["public_key"],
+        encrypted_private_key=payload["encrypted_private_key"],
+        kdf_algorithm=payload["kdf_algorithm"],
+        kdf_params=payload["kdf_params"],
+        kdf_salt=payload["kdf_salt"],
+        wrapping_algorithm=payload["wrapping_algorithm"],
+        rotated_at=now,
+        recovery_state=payload["recovery_state"],
+    )
+    db.session.add(new_chat_key)
+    return new_chat_key

--- a/hushline/routes/auth.py
+++ b/hushline/routes/auth.py
@@ -29,6 +29,7 @@ from hushline.auth import (
     rotate_user_session_id,
     set_session_user,
 )
+from hushline.chat_key_lifecycle import retire_active_chat_key
 from hushline.db import db
 from hushline.model import (
     AuthenticationLog,
@@ -494,6 +495,11 @@ def register_auth_routes(app: Flask) -> None:
                     return render_template("password_reset.html", form=form), 400
 
                 now = _now()
+                retire_active_chat_key(
+                    user,
+                    recovery_state="password_reset_locked",
+                    when=datetime.now(UTC),
+                )
                 user.password_hash = new_password
                 rotate_user_session_id(user)
                 _invalidate_password_reset_tokens(user, used_at=now)

--- a/hushline/settings/auth.py
+++ b/hushline/settings/auth.py
@@ -63,6 +63,7 @@ def register_auth_routes(bp: Blueprint) -> None:
         return render_template(
             "settings/auth.html",
             user=user,
+            chat_key=user.active_chat_key,
             change_username_form=change_username_form,
             change_password_form=change_password_form,
         ), status_code

--- a/hushline/settings/common.py
+++ b/hushline/settings/common.py
@@ -1,5 +1,6 @@
 import asyncio
 import ipaddress
+import json
 import socket
 import urllib.parse
 from dataclasses import dataclass
@@ -25,6 +26,7 @@ from werkzeug.wrappers.response import Response
 from wtforms import Field
 
 from hushline.auth import rotate_user_session_id
+from hushline.chat_key_lifecycle import rewrap_active_chat_key, validate_chat_key_payload
 from hushline.crypto import can_encrypt_with_pgp_key, is_valid_pgp_key
 from hushline.db import db
 from hushline.external_urls import canonical_external_url
@@ -476,6 +478,30 @@ def handle_change_password_form(
     ):
         change_password_form.new_password.errors.append("Cannot choose a repeat password.")
         return None
+
+    if user.active_chat_key is not None:
+        rewrapped_chat_key = request.form.get("rewrapped_chat_key", "")
+        if not rewrapped_chat_key:
+            change_password_form.new_password.errors.append(
+                "Unlock your chat key before changing your password."
+            )
+            return None
+
+        try:
+            rewrapped_payload = json.loads(rewrapped_chat_key)
+        except json.JSONDecodeError:
+            change_password_form.new_password.errors.append("Chat key rewrap payload is invalid.")
+            return None
+
+        cleaned_payload, error = validate_chat_key_payload(
+            rewrapped_payload,
+            current_user_id=user.id,
+        )
+        if error:
+            change_password_form.new_password.errors.append(error)
+            return None
+
+        rewrap_active_chat_key(user, cleaned_payload)
 
     user.password_hash = change_password_form.new_password.data
     rotate_user_session_id(user)

--- a/hushline/settings/encryption.py
+++ b/hushline/settings/encryption.py
@@ -1,4 +1,3 @@
-import json
 from datetime import UTC, datetime
 from typing import Any, Tuple
 
@@ -15,6 +14,10 @@ from werkzeug.wrappers.response import Response
 from wtforms.validators import ValidationError
 
 from hushline.auth import authentication_required
+from hushline.chat_key_lifecycle import (
+    rewrap_active_chat_key,
+    validate_chat_key_payload,
+)
 from hushline.db import db
 from hushline.model import ChatKey, User
 from hushline.settings.common import (
@@ -25,20 +28,6 @@ from hushline.settings.forms import (
     PGPKeyForm,
     PGPProtonForm,
 )
-
-CHAT_KEY_STRING_MAX_LENGTH = 200_000
-CHAT_KEY_METADATA_MAX_LENGTH = 20_000
-CHAT_KEY_RECOVERY_STATE_MAX_LENGTH = 64
-CHAT_KEY_FORBIDDEN_SECRET_FIELDS = {
-    "decrypted_message_text",
-    "decrypted_private_key",
-    "derived_key",
-    "password",
-    "plaintext_private_key",
-    "private_key",
-    "unlock_key",
-    "wrapping_key",
-}
 
 
 def _submitted_encryption_form(pgp_key_form: PGPKeyForm) -> PGPKeyForm | None:
@@ -57,109 +46,6 @@ def _validate_json_csrf() -> str | None:
     except ValidationError:
         return "Invalid CSRF token."
     return None
-
-
-def _normalized_payload_key(value: str) -> str:
-    return value.strip().lower().replace("-", "_")
-
-
-def _payload_contains_forbidden_secret_field(value: Any) -> bool:
-    if isinstance(value, dict):
-        for key, nested_value in value.items():
-            if (
-                isinstance(key, str)
-                and _normalized_payload_key(key) in CHAT_KEY_FORBIDDEN_SECRET_FIELDS
-            ):
-                return True
-            if _payload_contains_forbidden_secret_field(nested_value):
-                return True
-    elif isinstance(value, list):
-        return any(_payload_contains_forbidden_secret_field(item) for item in value)
-    return False
-
-
-def _payload_text(payload: dict[str, Any], *keys: str) -> str | None:
-    for key in keys:
-        value = payload.get(key)
-        if isinstance(value, str):
-            stripped = value.strip()
-            if stripped:
-                return stripped
-    return None
-
-
-def _validate_chat_key_payload(payload: Any, *, current_user_id: int) -> tuple[dict[str, Any], str]:
-    if not isinstance(payload, dict):
-        return {}, "Expected a JSON object."
-
-    if _payload_contains_forbidden_secret_field(payload):
-        return {}, "Plaintext chat key material is not accepted."
-
-    payload_user_id = payload.get("user_id")
-    if payload_user_id is not None and payload_user_id != current_user_id:
-        return {}, "Chat keys can only be provisioned for the authenticated user."
-
-    public_key = _payload_text(payload, "public_key", "chat_public_key")
-    encrypted_private_key = _payload_text(
-        payload,
-        "encrypted_private_key",
-        "encrypted_private_key_blob",
-    )
-    kdf_algorithm = _payload_text(payload, "kdf_algorithm")
-    kdf_salt = _payload_text(payload, "kdf_salt", "salt")
-    wrapping_algorithm = _payload_text(payload, "wrapping_algorithm") or "AES-GCM"
-    kdf_params = payload.get("kdf_params")
-
-    kdf = payload.get("kdf")
-    if isinstance(kdf, dict):
-        if kdf_algorithm is None:
-            kdf_algorithm = _payload_text(kdf, "algorithm")
-        if kdf_salt is None:
-            kdf_salt = _payload_text(kdf, "salt")
-        if kdf_params is None:
-            kdf_params = kdf.get("params")
-
-    if not public_key:
-        return {}, "public_key is required."
-    if not encrypted_private_key:
-        return {}, "encrypted_private_key is required."
-    if not kdf_algorithm:
-        return {}, "kdf_algorithm is required."
-    if not kdf_salt:
-        return {}, "kdf_salt is required."
-    if not isinstance(kdf_params, dict) or not kdf_params:
-        return {}, "kdf_params must be a non-empty object."
-
-    string_fields = {
-        "public_key": public_key,
-        "encrypted_private_key": encrypted_private_key,
-        "kdf_algorithm": kdf_algorithm,
-        "kdf_salt": kdf_salt,
-        "wrapping_algorithm": wrapping_algorithm,
-    }
-    if any(len(value) > CHAT_KEY_STRING_MAX_LENGTH for value in string_fields.values()):
-        return {}, "Chat key payload is too large."
-
-    try:
-        serialized_kdf_params = json.dumps(kdf_params, sort_keys=True)
-    except (TypeError, ValueError):
-        return {}, "kdf_params must be JSON serializable."
-    if len(serialized_kdf_params) > CHAT_KEY_METADATA_MAX_LENGTH:
-        return {}, "kdf_params is too large."
-
-    recovery_state = _payload_text(payload, "recovery_state")
-    if recovery_state is not None and len(recovery_state) > CHAT_KEY_RECOVERY_STATE_MAX_LENGTH:
-        return {}, "recovery_state is too large."
-
-    return {
-        "public_key": public_key,
-        "encrypted_private_key": encrypted_private_key,
-        "kdf_algorithm": kdf_algorithm,
-        "kdf_params": kdf_params,
-        "kdf_salt": kdf_salt,
-        "wrapping_algorithm": wrapping_algorithm,
-        "recovery_state": recovery_state,
-    }, ""
 
 
 def _chat_key_response(chat_key: ChatKey | None) -> dict[str, Any]:
@@ -208,6 +94,14 @@ def register_encryption_routes(bp: Blueprint) -> None:
             pgp_proton_form=pgp_proton_form,
             pgp_key_form=pgp_key_form,
             chat_key=user.active_chat_key,
+            locked_chat_key=next(
+                (
+                    chat_key
+                    for chat_key in user.chat_keys
+                    if chat_key.recovery_state == "password_reset_locked"
+                ),
+                None,
+            ),
             chat_key_csrf_token=generate_csrf(),
         ), status_code
 
@@ -224,30 +118,29 @@ def register_encryption_routes(bp: Blueprint) -> None:
             return jsonify({"error": csrf_error}), 400
 
         payload = request.get_json(silent=True)
-        cleaned_payload, error = _validate_chat_key_payload(payload, current_user_id=user.id)
+        cleaned_payload, error = validate_chat_key_payload(payload, current_user_id=user.id)
         if error:
             status_code = 403 if error.startswith("Chat keys can only") else 400
             return jsonify({"error": error}), status_code
 
         now = datetime.now(UTC)
         active_key = user.active_chat_key
-        next_version = max((chat_key.key_version for chat_key in user.chat_keys), default=0) + 1
-        if active_key is not None:
-            active_key.disabled_at = now
+        new_chat_key = rewrap_active_chat_key(user, cleaned_payload, when=now)
+        if new_chat_key is None:
+            next_version = max((chat_key.key_version for chat_key in user.chat_keys), default=0) + 1
+            new_chat_key = ChatKey(
+                user=user,
+                key_version=next_version,
+                public_key=cleaned_payload["public_key"],
+                encrypted_private_key=cleaned_payload["encrypted_private_key"],
+                kdf_algorithm=cleaned_payload["kdf_algorithm"],
+                kdf_params=cleaned_payload["kdf_params"],
+                kdf_salt=cleaned_payload["kdf_salt"],
+                wrapping_algorithm=cleaned_payload["wrapping_algorithm"],
+                recovery_state=cleaned_payload["recovery_state"],
+            )
+        elif active_key is not None:
             active_key.recovery_state = "rotated"
-
-        new_chat_key = ChatKey(
-            user=user,
-            key_version=next_version,
-            public_key=cleaned_payload["public_key"],
-            encrypted_private_key=cleaned_payload["encrypted_private_key"],
-            kdf_algorithm=cleaned_payload["kdf_algorithm"],
-            kdf_params=cleaned_payload["kdf_params"],
-            kdf_salt=cleaned_payload["kdf_salt"],
-            wrapping_algorithm=cleaned_payload["wrapping_algorithm"],
-            rotated_at=now if active_key is not None else None,
-            recovery_state=cleaned_payload["recovery_state"],
-        )
         db.session.add(new_chat_key)
         db.session.commit()
 

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -1,0 +1,319 @@
+(function () {
+  const textEncoder = new TextEncoder();
+  const textDecoder = new TextDecoder();
+  let unlockedChatPrivateKey = null;
+  const state = {
+    status: "empty",
+    keyVersion: null,
+    lastError: null,
+  };
+
+  function bytesToBase64(bytes) {
+    let binary = "";
+    bytes.forEach((byte) => {
+      binary += String.fromCharCode(byte);
+    });
+    return btoa(binary);
+  }
+
+  function base64ToBytes(value) {
+    const binary = atob(value);
+    const bytes = new Uint8Array(binary.length);
+    for (let index = 0; index < binary.length; index += 1) {
+      bytes[index] = binary.charCodeAt(index);
+    }
+    return bytes;
+  }
+
+  function assertCryptoSupport() {
+    if (!window.crypto?.subtle) {
+      throw new Error("Web Crypto is unavailable.");
+    }
+  }
+
+  async function deriveWrappingKey(password, salt, kdfParams, usages) {
+    const passwordKey = await window.crypto.subtle.importKey(
+      "raw",
+      textEncoder.encode(password),
+      "PBKDF2",
+      false,
+      ["deriveKey"],
+    );
+    return window.crypto.subtle.deriveKey(
+      {
+        name: "PBKDF2",
+        salt,
+        iterations: Number(kdfParams?.iterations || 310000),
+        hash: kdfParams?.hash || "SHA-256",
+      },
+      passwordKey,
+      {
+        name: "AES-GCM",
+        length: 256,
+      },
+      false,
+      usages,
+    );
+  }
+
+  async function decryptPrivateJwk(chatKey, password) {
+    const encryptedPrivateKey = JSON.parse(chatKey.encrypted_private_key);
+    const wrappingKey = await deriveWrappingKey(
+      password,
+      base64ToBytes(chatKey.kdf_salt),
+      chatKey.kdf_params,
+      ["decrypt"],
+    );
+    const privateJwkBytes = await window.crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: base64ToBytes(encryptedPrivateKey.iv),
+      },
+      wrappingKey,
+      base64ToBytes(encryptedPrivateKey.ciphertext),
+    );
+    return JSON.parse(textDecoder.decode(privateJwkBytes));
+  }
+
+  async function importPrivateKey(privateJwk) {
+    return window.crypto.subtle.importKey(
+      "jwk",
+      privateJwk,
+      {
+        name: "ECDH",
+        namedCurve: privateJwk.crv || "P-256",
+      },
+      false,
+      ["deriveBits"],
+    );
+  }
+
+  async function unlockFromPassword(chatKey, password) {
+    if (!chatKey) {
+      clearChatKeyMaterial();
+      state.status = "no-key";
+      return true;
+    }
+
+    assertCryptoSupport();
+    let privateJwk = null;
+    try {
+      privateJwk = await decryptPrivateJwk(chatKey, password);
+      unlockedChatPrivateKey = await importPrivateKey(privateJwk);
+      state.status = "unlocked";
+      state.keyVersion = chatKey.key_version;
+      state.lastError = null;
+      return true;
+    } catch (error) {
+      clearChatKeyMaterial();
+      state.status = "locked";
+      state.keyVersion = chatKey.key_version || null;
+      state.lastError = "Chat key unlock failed.";
+      return false;
+    } finally {
+      privateJwk = null;
+    }
+  }
+
+  async function encryptPrivateJwk(privateJwk, password) {
+    const salt = window.crypto.getRandomValues(new Uint8Array(16));
+    const iv = window.crypto.getRandomValues(new Uint8Array(12));
+    const wrappingKey = await deriveWrappingKey(password, salt, {
+      iterations: 310000,
+      hash: "SHA-256",
+    }, ["encrypt"]);
+    const encryptedBytes = new Uint8Array(
+      await window.crypto.subtle.encrypt(
+        {
+          name: "AES-GCM",
+          iv,
+        },
+        wrappingKey,
+        textEncoder.encode(JSON.stringify(privateJwk)),
+      ),
+    );
+
+    return {
+      encrypted_private_key: JSON.stringify({
+        algorithm: "AES-GCM",
+        iv: bytesToBase64(iv),
+        ciphertext: bytesToBase64(encryptedBytes),
+      }),
+      kdf_algorithm: "PBKDF2-SHA-256",
+      kdf_params: {
+        iterations: 310000,
+        hash: "SHA-256",
+      },
+      kdf_salt: bytesToBase64(salt),
+      wrapping_algorithm: "AES-GCM",
+    };
+  }
+
+  async function rewrapForPasswordChange(chatKey, oldPassword, newPassword) {
+    assertCryptoSupport();
+    let privateJwk = null;
+    try {
+      privateJwk = await decryptPrivateJwk(chatKey, oldPassword);
+      const wrapped = await encryptPrivateJwk(privateJwk, newPassword);
+      return {
+        public_key: chatKey.public_key,
+        recovery_state: "available",
+        ...wrapped,
+      };
+    } finally {
+      privateJwk = null;
+    }
+  }
+
+  async function fetchChatKey(chatKeyUrl) {
+    const response = await fetch(chatKeyUrl, {
+      credentials: "same-origin",
+      headers: {
+        Accept: "application/json",
+      },
+    });
+    if (!response.ok) {
+      throw new Error("Chat key lookup failed.");
+    }
+    const payload = await response.json();
+    return payload.chat_key || null;
+  }
+
+  function clearChatKeyMaterial() {
+    unlockedChatPrivateKey = null;
+    state.status = "empty";
+    state.keyVersion = null;
+    state.lastError = null;
+  }
+
+  function replaceDocument(responseText, responseUrl) {
+    const parsedDocument = new DOMParser().parseFromString(
+      responseText,
+      "text/html",
+    );
+    document.title = parsedDocument.title;
+    document.head.replaceWith(document.importNode(parsedDocument.head, true));
+    document.body.replaceWith(document.importNode(parsedDocument.body, true));
+    window.history.replaceState({}, "", responseUrl);
+    bindPage();
+  }
+
+  function chatKeyUrlFromCurrentOrigin() {
+    return new URL("/settings/chat-key.json", window.location.origin).toString();
+  }
+
+  async function handleLoginSubmit(event) {
+    const form = event.currentTarget;
+    const passwordInput = form.querySelector("input[name='password']");
+    if (!passwordInput?.value || !window.fetch || !window.FormData) {
+      return;
+    }
+
+    event.preventDefault();
+    const password = passwordInput.value;
+    try {
+      const response = await fetch(form.action, {
+        method: "POST",
+        credentials: "same-origin",
+        body: new FormData(form),
+      });
+      const responseUrl = new URL(response.url);
+      const responseText = await response.text();
+      if (response.redirected && responseUrl.pathname !== "/login") {
+        if (responseUrl.pathname !== "/verify-2fa-login") {
+          const chatKey = await fetchChatKey(chatKeyUrlFromCurrentOrigin());
+          await unlockFromPassword(chatKey, password);
+        }
+        replaceDocument(responseText, response.url);
+        return;
+      }
+      replaceDocument(responseText, response.url);
+    } catch (error) {
+      HTMLFormElement.prototype.submit.call(form);
+    }
+  }
+
+  async function handlePasswordChangeSubmit(event) {
+    const form = event.currentTarget;
+    const chatKeyUrl = form.dataset.chatKeyUrl;
+    const rewrappedInput = form.querySelector("#rewrapped_chat_key");
+    const oldPasswordInput = form.querySelector("#old_password");
+    const newPasswordInput = form.querySelector("#new_password");
+    const submitButton = form.querySelector("[name='change_password']");
+    const status = document.getElementById("chat-key-rewrap-status");
+    if (
+      !chatKeyUrl ||
+      rewrappedInput?.value ||
+      !oldPasswordInput?.value ||
+      !newPasswordInput?.value
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    if (status) {
+      status.textContent = "Unlocking chat key...";
+    }
+
+    try {
+      const chatKey = await fetchChatKey(chatKeyUrl);
+      if (chatKey) {
+        const rewrappedPayload = await rewrapForPasswordChange(
+          chatKey,
+          oldPasswordInput.value,
+          newPasswordInput.value,
+        );
+        rewrappedInput.value = JSON.stringify(rewrappedPayload);
+        if (status) {
+          status.textContent = "Chat key rewrapped.";
+        }
+      }
+      if (submitButton?.click) {
+        submitButton.click();
+      } else {
+        HTMLFormElement.prototype.submit.call(form);
+      }
+    } catch (error) {
+      if (status) {
+        status.textContent = "Chat key unlock failed. Password was not changed.";
+      }
+    }
+  }
+
+  function bindLogoutCleanup() {
+    document.querySelectorAll("a[href$='/logout']").forEach((link) => {
+      link.addEventListener("click", clearChatKeyMaterial);
+    });
+  }
+
+  function bindPage() {
+    if (document.body?.dataset.authenticated !== "true") {
+      clearChatKeyMaterial();
+    }
+
+    document
+      .querySelector("form[action$='/login']")
+      ?.addEventListener("submit", handleLoginSubmit);
+    document
+      .getElementById("change-password-form")
+      ?.addEventListener("submit", handlePasswordChangeSubmit);
+    document
+      .querySelector("form[action*='password-reset']")
+      ?.addEventListener("submit", clearChatKeyMaterial);
+    bindLogoutCleanup();
+  }
+
+  window.HushLineChatKeys = {
+    clear: clearChatKeyMaterial,
+    fetchChatKey,
+    get state() {
+      return { ...state };
+    },
+    rewrapForPasswordChange,
+    unlockFromPassword,
+  };
+
+  document.addEventListener("DOMContentLoaded", function () {
+    bindPage();
+  });
+})();

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -153,6 +153,7 @@
     />
     <script src="{{ url_for('static', filename='no-js.js') }}"></script>
     {% block scripts %}{% endblock %}
+    <script defer src="{{ url_for('static', filename='js/chat-key-lifecycle.js') }}"></script>
     <script defer src="{{ url_for('static', filename='js/time-shadows.js') }}"></script>
     <script defer src="{{ url_for('static', filename='js/global.js') }}"></script>
     <style>
@@ -169,7 +170,10 @@
     </style>
   </head>
 
-  <body class="{% block body_class %}{% endblock %}">
+  <body
+    class="{% block body_class %}{% endblock %}"
+    data-authenticated="{{ 'true' if 'user_id' in session and session.get('is_authenticated', False) else 'false' }}"
+  >
     {% if splash_screen_enabled %}
       <div
         id="first-load-splash"

--- a/hushline/templates/settings/auth.html
+++ b/hushline/templates/settings/auth.html
@@ -11,6 +11,8 @@
   <form
     method="POST"
     class="formBody"
+    id="change-password-form"
+    data-chat-key-url="{{ url_for('settings.chat_key') if chat_key else '' }}"
   >
     {% set username_field = change_username_form.new_username %}
     {{ change_username_form.hidden_tag() }}
@@ -59,6 +61,13 @@
     {% for error in new_password_field.errors %}
       <span class="error">{{ error }}</span>
     {% endfor %}
+    <input type="hidden" name="rewrapped_chat_key" id="rewrapped_chat_key" />
+    <p
+      id="chat-key-rewrap-status"
+      class="meta"
+      role="status"
+      aria-live="polite"
+    ></p>
     {{ change_password_form.submit }}
   </form>
 {% endblock %}

--- a/hushline/templates/settings/encryption.html
+++ b/hushline/templates/settings/encryption.html
@@ -8,6 +8,12 @@
   {% if chat_key %}
     <p class="meta">Chat key version {{ chat_key.key_version }} is provisioned.</p>
   {% else %}
+    {% if locked_chat_key %}
+      <p class="meta">
+        Chat history encrypted to key version {{ locked_chat_key.key_version }} is locked because
+        the password was reset without the old password. Hush Line cannot recover the private key.
+      </p>
+    {% endif %}
     <form
       id="chat-key-provision-form"
       class="formBody"

--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -1,4 +1,6 @@
 import re
+from datetime import UTC, datetime
+from pathlib import Path
 
 import pytest
 from flask import Flask, url_for
@@ -6,6 +8,8 @@ from flask.testing import FlaskClient
 
 from hushline.db import db
 from hushline.model import ChatKey, User
+
+ROOT = Path(__file__).resolve().parents[1]
 
 
 def _chat_key_payload(**overrides: object) -> dict[str, object]:
@@ -37,6 +41,32 @@ def test_settings_encryption_shows_chat_key_provisioner(client: FlaskClient) -> 
     assert 'id="chat-key-password"' in response.text
     assert 'autocomplete="current-password"' in response.text
     assert 'name="chat_key_password"' not in response.text
+    assert url_for("static", filename="js/chat-key-lifecycle.js") in response.text
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_settings_encryption_shows_locked_chat_key_state(client: FlaskClient, user: User) -> None:
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="public-chat-key",
+        encrypted_private_key="wrapped-private-chat-key",
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000},
+        kdf_salt="salt",
+        wrapping_algorithm="AES-GCM",
+        disabled_at=datetime.now(UTC),
+        recovery_state="password_reset_locked",
+    )
+    db.session.add(chat_key)
+    db.session.commit()
+
+    response = client.get(url_for("settings.encryption"))
+
+    assert response.status_code == 200
+    assert "Chat history encrypted to key version 1 is locked" in response.text
+    assert "Hush Line cannot recover the private key." in response.text
+    assert 'id="chat-key-provision-form"' in response.text
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -60,6 +90,37 @@ def test_authenticated_user_can_provision_chat_key(client: FlaskClient, user: Us
     assert response_payload["chat_key"]["encrypted_private_key"] == (
         created_key.encrypted_private_key
     )
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_authenticated_user_can_provision_new_chat_key_after_locked_key(
+    client: FlaskClient, user: User
+) -> None:
+    locked_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="locked-public",
+        encrypted_private_key="locked-wrapped-private",
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000},
+        kdf_salt="locked-salt",
+        wrapping_algorithm="AES-GCM",
+        disabled_at=datetime.now(UTC),
+        recovery_state="password_reset_locked",
+    )
+    db.session.add(locked_key)
+    db.session.commit()
+
+    response = client.post(url_for("settings.chat_key"), json=_chat_key_payload())
+
+    assert response.status_code == 201
+    keys = db.session.scalars(
+        db.select(ChatKey).filter_by(user_id=user.id).order_by(ChatKey.key_version.asc())
+    ).all()
+    assert [key.key_version for key in keys] == [1, 2]
+    assert keys[0].recovery_state == "password_reset_locked"
+    assert keys[1].disabled_at is None
+    assert keys[1].public_key == _chat_key_payload()["public_key"]
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -190,6 +251,17 @@ def test_chat_key_schema_has_no_plaintext_private_key_columns(app: Flask) -> Non
             "decrypted_message_text",
         }
     )
+
+
+def test_chat_key_lifecycle_js_exposes_unlock_rewrap_and_cleanup() -> None:
+    lifecycle_js = (ROOT / "hushline/static/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
+
+    assert "window.HushLineChatKeys" in lifecycle_js
+    assert "unlockFromPassword" in lifecycle_js
+    assert "rewrapForPasswordChange" in lifecycle_js
+    assert "clearChatKeyMaterial" in lifecycle_js
+    assert "document.body?.dataset.authenticated" in lifecycle_js
+    assert "Chat key unlock failed." in lifecycle_js
 
 
 @pytest.mark.usefixtures("_pgp_user")

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -20,6 +20,7 @@ from hushline.auth import (
 from hushline.config import PASSWORD_HASH_REHASH_ON_AUTH_ENABLED
 from hushline.db import db
 from hushline.model import (
+    ChatKey,
     InviteCode,
     NotificationRecipient,
     OrganizationSetting,
@@ -413,6 +414,47 @@ def test_password_reset_sets_new_password_and_consumes_token(
     assert reused_response.status_code == 200
     assert PASSWORD_RESET_INVALID_LINK_MESSAGE in reused_response.text
     assert "Reset Password" in reused_response.text
+
+
+def test_password_reset_locks_active_chat_key_without_server_recovery(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="public-chat-key",
+        encrypted_private_key='{"algorithm":"AES-GCM","iv":"old","ciphertext":"old"}',
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000, "hash": "SHA-256"},
+        kdf_salt="old-salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    reset_token, raw_token = PasswordResetToken.create_for_user(
+        user.id,
+        ttl=timedelta(hours=1),
+    )
+    db.session.add_all([chat_key, reset_token])
+    db.session.commit()
+
+    response = client.post(
+        url_for("reset_password", token=raw_token),
+        data={"password": "ResetPassword123!!"},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    db.session.refresh(user)
+    db.session.refresh(chat_key)
+    assert ChatKey.active_for_user_id(user.id) is None
+    assert user.check_password("ResetPassword123!!")
+    assert not user.check_password(user_password)
+    assert chat_key.disabled_at is not None
+    assert chat_key.recovery_state == "password_reset_locked"
+    assert chat_key.encrypted_private_key == (
+        '{"algorithm":"AES-GCM","iv":"old","ciphertext":"old"}'
+    )
+    assert "recovery" not in chat_key.encrypted_private_key
+    assert db.session.scalar(db.select(db.func.count()).select_from(ChatKey)) == 1
 
 
 def test_password_reset_request_never_emails_shared_notification_recipients(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,4 +1,6 @@
+import json
 from base64 import b64decode
+from datetime import UTC, datetime
 from io import BytesIO
 from unittest.mock import ANY, MagicMock, patch
 from uuid import uuid4
@@ -15,6 +17,7 @@ from hushline.db import db
 from hushline.model import (
     AccountCategory,
     AuthenticationLog,
+    ChatKey,
     FieldDefinition,
     FieldType,
     Message,
@@ -434,6 +437,197 @@ def test_change_password_revokes_sibling_session(
     response = sibling_client.get(url_for("inbox"), follow_redirects=False)
     assert response.status_code == 302
     assert response.headers["Location"].endswith(url_for("login"))
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_change_password_requires_chat_key_rewrap_when_active_chat_key_exists(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="public-chat-key",
+        encrypted_private_key='{"algorithm":"AES-GCM","iv":"old","ciphertext":"old"}',
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000, "hash": "SHA-256"},
+        kdf_salt="old-salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    db.session.add(chat_key)
+    db.session.commit()
+    original_password_hash = user.password_hash
+
+    response = client.post(
+        url_for("settings.auth"),
+        data=form_to_data(
+            ChangePasswordForm(
+                data={
+                    "old_password": user_password,
+                    "new_password": "ChangedPassword123!!",
+                }
+            )
+        ),
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 400
+    assert "Unlock your chat key before changing your password." in response.text
+    db.session.refresh(user)
+    assert user.password_hash == original_password_hash
+    db.session.refresh(chat_key)
+    assert chat_key.disabled_at is None
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_change_password_rewraps_active_chat_key(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="public-chat-key",
+        encrypted_private_key='{"algorithm":"AES-GCM","iv":"old","ciphertext":"old"}',
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000, "hash": "SHA-256"},
+        kdf_salt="old-salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    db.session.add(chat_key)
+    db.session.commit()
+    new_password = "ChangedPassword123!!"
+    data = form_to_data(
+        ChangePasswordForm(
+            data={
+                "old_password": user_password,
+                "new_password": new_password,
+            }
+        )
+    )
+    data["rewrapped_chat_key"] = json.dumps(
+        {
+            "public_key": "public-chat-key",
+            "encrypted_private_key": (
+                '{"algorithm":"AES-GCM","iv":"new","ciphertext":"rewrapped"}'
+            ),
+            "kdf_algorithm": "PBKDF2-SHA-256",
+            "kdf_params": {"iterations": 310000, "hash": "SHA-256"},
+            "kdf_salt": "new-salt",
+            "wrapping_algorithm": "AES-GCM",
+            "recovery_state": "available",
+        }
+    )
+
+    response = client.post(
+        url_for("settings.auth"),
+        data=data,
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Password successfully changed. Please log in again." in response.text
+    db.session.refresh(user)
+    assert user.check_password(new_password)
+    keys = db.session.scalars(
+        db.select(ChatKey).filter_by(user_id=user.id).order_by(ChatKey.key_version.asc())
+    ).all()
+    assert [key.key_version for key in keys] == [1, 2]
+    assert keys[0].disabled_at is not None
+    assert keys[0].recovery_state == "rewrapped"
+    assert keys[1].disabled_at is None
+    assert keys[1].public_key == "public-chat-key"
+    assert keys[1].encrypted_private_key == (
+        '{"algorithm":"AES-GCM","iv":"new","ciphertext":"rewrapped"}'
+    )
+    assert keys[1].kdf_salt == "new-salt"
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_change_password_rewrap_rejects_plaintext_chat_key_material(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="public-chat-key",
+        encrypted_private_key='{"algorithm":"AES-GCM","iv":"old","ciphertext":"old"}',
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000, "hash": "SHA-256"},
+        kdf_salt="old-salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    db.session.add(chat_key)
+    db.session.commit()
+    original_password_hash = user.password_hash
+    data = form_to_data(
+        ChangePasswordForm(
+            data={
+                "old_password": user_password,
+                "new_password": "ChangedPassword123!!",
+            }
+        )
+    )
+    data["rewrapped_chat_key"] = json.dumps(
+        {
+            "public_key": "public-chat-key",
+            "encrypted_private_key": (
+                '{"algorithm":"AES-GCM","iv":"new","ciphertext":"rewrapped"}'
+            ),
+            "kdf_algorithm": "PBKDF2-SHA-256",
+            "kdf_params": {"iterations": 310000, "hash": "SHA-256"},
+            "kdf_salt": "new-salt",
+            "private_key": "plaintext-private-key",
+        }
+    )
+
+    response = client.post(url_for("settings.auth"), data=data, follow_redirects=True)
+
+    assert response.status_code == 400
+    assert "Plaintext chat key material is not accepted." in response.text
+    db.session.refresh(user)
+    assert user.password_hash == original_password_hash
+    db.session.refresh(chat_key)
+    assert chat_key.disabled_at is None
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_change_password_allows_account_access_when_chat_key_is_locked(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="public-chat-key",
+        encrypted_private_key='{"algorithm":"AES-GCM","iv":"old","ciphertext":"old"}',
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000, "hash": "SHA-256"},
+        kdf_salt="old-salt",
+        wrapping_algorithm="AES-GCM",
+        disabled_at=datetime.now(UTC),
+        recovery_state="password_reset_locked",
+    )
+    db.session.add(chat_key)
+    db.session.commit()
+    new_password = "ChangedPassword123!!"
+
+    response = client.post(
+        url_for("settings.auth"),
+        data=form_to_data(
+            ChangePasswordForm(
+                data={
+                    "old_password": user_password,
+                    "new_password": new_password,
+                }
+            )
+        ),
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Password successfully changed. Please log in again." in response.text
+    db.session.refresh(user)
+    assert user.check_password(new_password)
+    db.session.refresh(chat_key)
+    assert chat_key.recovery_state == "password_reset_locked"
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,7 @@ const entries = new Object();
 modules = [
   // ours
   "client-side-encryption",
+  "chat-key-lifecycle",
   "diceware-words",
   "directory",
   "directory_verified",


### PR DESCRIPTION
This PR implements child issue #2190 (`Handle chat key unlock, password changes, and recovery limits`) under epic #2177 (`Feasibility: two-way encrypted conversations between accounts`).
It is intended to merge into the epic branch first, not directly into `main`.

This PR addresses the issue "Handle chat key unlock, password changes, and recovery limits" by updating supporting files in `.gitignore`, supporting files in `assets/js`, and application code in `hushline/chat_key_lifecycle.py`.
The change includes both implementation work and automated tests, showing the intended behavior and how it is verified.
It touches 15 non-log file(s) (15 total including runner artifacts), primarily in .gitignore, assets/js, and hushline/chat_key_lifecycle.py.

## Summary
- Automated code agent update for child issue #2190.
- Part of epic #2177: Feasibility: two-way encrypted conversations between accounts
- This PR targets the epic integration branch `codex/epic-2177`.
- The child issue is closed explicitly by workflow after this PR merges into the epic branch.

Linked issue: #2190

## Context
- Epic: https://github.com/scidsg/hushline/issues/2177
- Child issue: https://github.com/scidsg/hushline/issues/2190
- Branch: codex/daily-issue-2190
- Base branch: codex/epic-2177
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `.gitignore`
- `assets/js/chat-key-lifecycle.js`
- `hushline/chat_key_lifecycle.py`
- `hushline/routes/auth.py`
- `hushline/settings/auth.py`
- `hushline/settings/common.py`
- `hushline/settings/encryption.py`
- `hushline/static/js/chat-key-lifecycle.js`
- `hushline/templates/base.html`
- `hushline/templates/settings/auth.html`
- `hushline/templates/settings/encryption.html`
- `tests/test_chat_keys.py`
- `tests/test_routes_auth.py`
- `tests/test_settings.py`
- `webpack.config.js`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
