### PR TITLE
#2180 Add participant-authorized conversation routes and chat composer

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -165,6 +165,104 @@
     }
   }
 
+  async function importPublicKey(publicKeyValue) {
+    const publicJwk = typeof publicKeyValue === "string"
+      ? JSON.parse(publicKeyValue)
+      : publicKeyValue;
+    return window.crypto.subtle.importKey(
+      "jwk",
+      publicJwk,
+      {
+        name: "ECDH",
+        namedCurve: publicJwk.crv || "P-256",
+      },
+      false,
+      [],
+    );
+  }
+
+  async function deriveChatMessageKey(publicKey, privateKey, usages) {
+    return window.crypto.subtle.deriveKey(
+      {
+        name: "ECDH",
+        public: publicKey,
+      },
+      privateKey,
+      {
+        name: "AES-GCM",
+        length: 256,
+      },
+      false,
+      usages,
+    );
+  }
+
+  async function encryptForPublicKey(plaintext, publicKeyValue) {
+    assertCryptoSupport();
+    const recipientPublicKey = await importPublicKey(publicKeyValue);
+    const ephemeralKeyPair = await window.crypto.subtle.generateKey(
+      {
+        name: "ECDH",
+        namedCurve: "P-256",
+      },
+      true,
+      ["deriveKey"],
+    );
+    const messageKey = await deriveChatMessageKey(
+      recipientPublicKey,
+      ephemeralKeyPair.privateKey,
+      ["encrypt"],
+    );
+    const iv = window.crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = new Uint8Array(
+      await window.crypto.subtle.encrypt(
+        {
+          name: "AES-GCM",
+          iv,
+        },
+        messageKey,
+        textEncoder.encode(plaintext),
+      ),
+    );
+    const ephemeralPublicJwk = await window.crypto.subtle.exportKey(
+      "jwk",
+      ephemeralKeyPair.publicKey,
+    );
+
+    return JSON.stringify({
+      algorithm: "ECDH-P256-AES-GCM",
+      ephemeral_public_key: JSON.stringify(ephemeralPublicJwk),
+      iv: bytesToBase64(iv),
+      ciphertext: bytesToBase64(ciphertext),
+    });
+  }
+
+  async function decryptChatCiphertext(encryptedPayload) {
+    if (!unlockedChatPrivateKey) {
+      throw new Error("Chat key is locked.");
+    }
+    assertCryptoSupport();
+    const envelope = JSON.parse(encryptedPayload);
+    if (envelope.algorithm !== "ECDH-P256-AES-GCM") {
+      throw new Error("Unsupported chat ciphertext.");
+    }
+    const ephemeralPublicKey = await importPublicKey(envelope.ephemeral_public_key);
+    const messageKey = await deriveChatMessageKey(
+      ephemeralPublicKey,
+      unlockedChatPrivateKey,
+      ["decrypt"],
+    );
+    const plaintextBytes = await window.crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: base64ToBytes(envelope.iv),
+      },
+      messageKey,
+      base64ToBytes(envelope.ciphertext),
+    );
+    return textDecoder.decode(plaintextBytes);
+  }
+
   async function fetchChatKey(chatKeyUrl) {
     const response = await fetch(chatKeyUrl, {
       credentials: "same-origin",
@@ -200,6 +298,164 @@
 
   function chatKeyUrlFromCurrentOrigin() {
     return new URL("/settings/chat-key.json", window.location.origin).toString();
+  }
+
+  function jsonFromScript(id, fallback) {
+    const script = document.getElementById(id);
+    if (!script?.textContent) {
+      return fallback;
+    }
+
+    try {
+      return JSON.parse(script.textContent);
+    } catch (error) {
+      return fallback;
+    }
+  }
+
+  function setConversationStatus(message) {
+    const status = document.getElementById("conversation-chat-status");
+    if (status) {
+      status.textContent = message;
+    }
+  }
+
+  async function decryptConversationMessages() {
+    const copies = jsonFromScript("conversationMessageCopies", []);
+    for (const copy of copies) {
+      if (!copy.encrypted_payload) {
+        continue;
+      }
+
+      const messageElement = document.querySelector(
+        `[data-conversation-message-id="${copy.message_id}"] .conversation-message-body`,
+      );
+      if (!messageElement) {
+        continue;
+      }
+
+      try {
+        messageElement.textContent = await decryptChatCiphertext(copy.encrypted_payload);
+      } catch (error) {
+        messageElement.textContent = "This message cannot be decrypted in this browser.";
+      }
+    }
+  }
+
+  function setConversationComposeEnabled(enabled) {
+    const form = document.getElementById("conversation-compose-form");
+    const body = document.getElementById("conversation-compose-body");
+    const submit = document.getElementById("conversation-compose-submit");
+    if (!form) {
+      return;
+    }
+
+    if (body) {
+      body.disabled = !enabled;
+    }
+    if (submit) {
+      submit.disabled = !enabled;
+    }
+  }
+
+  async function unlockConversationFromPassword() {
+    const passwordInput = document.getElementById("conversation-chat-password");
+    if (!passwordInput?.value) {
+      setConversationStatus("Enter your account password to unlock your chat key.");
+      return;
+    }
+
+    setConversationStatus("Unlocking chat key...");
+    try {
+      const chatKey = await fetchChatKey(chatKeyUrlFromCurrentOrigin());
+      if (!chatKey) {
+        setConversationStatus("Create a Hush Line chat key before reading this conversation.");
+        return;
+      }
+      const unlocked = await unlockFromPassword(chatKey, passwordInput.value);
+      if (!unlocked) {
+        setConversationStatus("Chat key unlock failed.");
+        return;
+      }
+      await decryptConversationMessages();
+      const root = document.getElementById("conversation-chat");
+      setConversationComposeEnabled(root?.dataset.canCompose === "true");
+      setConversationStatus("Chat key unlocked in this browser.");
+      passwordInput.value = "";
+    } catch (error) {
+      setConversationStatus("Chat key unlock failed.");
+    }
+  }
+
+  async function handleConversationSubmit(event) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const root = document.getElementById("conversation-chat");
+    const body = document.getElementById("conversation-compose-body");
+    const plaintext = body?.value.trim();
+    const participantKeys = jsonFromScript("conversationParticipantPublicKeys", []);
+    if (!root?.dataset.messageUrl || !plaintext) {
+      return;
+    }
+    if (state.status !== "unlocked") {
+      setConversationStatus("Unlock your chat key before replying.");
+      return;
+    }
+
+    setConversationStatus("Encrypting reply...");
+    try {
+      const encryptedCopies = {};
+      for (const participantKey of participantKeys) {
+        encryptedCopies[String(participantKey.participant_id)] = await encryptForPublicKey(
+          plaintext,
+          participantKey.public_key,
+        );
+      }
+      const csrfToken = form.querySelector("input[name='csrf_token']")?.value;
+      const response = await fetch(root.dataset.messageUrl, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "X-CSRFToken": csrfToken || "",
+        },
+        body: JSON.stringify({
+          encrypted_copies: encryptedCopies,
+        }),
+      });
+      if (!response.ok) {
+        setConversationStatus("Reply could not be saved.");
+        return;
+      }
+      body.value = "";
+      window.location.reload();
+    } catch (error) {
+      setConversationStatus("Reply could not be encrypted.");
+    }
+  }
+
+  function bindConversation() {
+    const root = document.getElementById("conversation-chat");
+    if (!root) {
+      return;
+    }
+
+    document
+      .getElementById("conversation-chat-unlock")
+      ?.addEventListener("click", unlockConversationFromPassword);
+
+    const form = document.getElementById("conversation-compose-form");
+    if (form && form.dataset.bound !== "true") {
+      form.dataset.bound = "true";
+      form.addEventListener("submit", handleConversationSubmit);
+    }
+
+    if (state.status === "unlocked") {
+      decryptConversationMessages();
+      setConversationComposeEnabled(root.dataset.canCompose === "true");
+      setConversationStatus("Chat key unlocked in this browser.");
+    }
   }
 
   async function handleLoginSubmit(event) {
@@ -301,6 +557,7 @@
       .querySelector("form[action*='password-reset']")
       ?.addEventListener("submit", clearChatKeyMaterial);
     bindLogoutCleanup();
+    bindConversation();
   }
 
   window.HushLineChatKeys = {
@@ -309,6 +566,8 @@
     get state() {
       return { ...state };
     },
+    decryptChatCiphertext,
+    encryptForPublicKey,
     rewrapForPasswordChange,
     unlockFromPassword,
   };

--- a/hushline/forms.py
+++ b/hushline/forms.py
@@ -114,6 +114,10 @@ class ResendMessageForm(FlaskForm):
     submit = SubmitField("Resend to Email", widget=Button())
 
 
+class ConversationMessageForm(FlaskForm):
+    submit = SubmitField("Send Reply", widget=Button())
+
+
 class ValidTemplate:
     def __init__(self, variables: Mapping[str, str]) -> None:
         self._variables = variables

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -1,24 +1,36 @@
 import re
 from datetime import UTC, datetime
+from typing import Any
 
 from flask import (
     Flask,
     abort,
     current_app,
     flash,
+    jsonify,
     redirect,
     render_template,
+    request,
     session,
     url_for,
 )
+from flask_wtf.csrf import validate_csrf
 from werkzeug.wrappers.response import Response
+from wtforms.validators import ValidationError
 
 from hushline.auth import authentication_required
 from hushline.crypto import encrypt_message
 from hushline.db import db
-from hushline.forms import DeleteMessageForm, ResendMessageForm, UpdateMessageStatusForm
+from hushline.forms import (
+    ConversationMessageForm,
+    DeleteMessageForm,
+    ResendMessageForm,
+    UpdateMessageStatusForm,
+)
 from hushline.model import (
     Conversation,
+    ConversationMessage,
+    ConversationMessageCopy,
     FieldValue,
     Message,
     User,
@@ -26,6 +38,7 @@ from hushline.model import (
 )
 from hushline.routes.common import do_send_email, notification_email_encryption_target
 
+_CHAT_CIPHERTEXT_MAX_LENGTH = 200_000
 _ARMORED_PGP_MESSAGE_PATTERN = re.compile(
     r"^\s*-----BEGIN PGP MESSAGE-----\r?\n"
     r"(?:[!-~]+: .*\r?\n)*\r?\n?[\s\S]*\r?\n"
@@ -35,6 +48,39 @@ _ARMORED_PGP_MESSAGE_PATTERN = re.compile(
 
 def _is_armored_pgp_message(value: str) -> bool:
     return bool(_ARMORED_PGP_MESSAGE_PATTERN.fullmatch(value))
+
+
+def _validate_json_csrf() -> str | None:
+    if current_app.config.get("WTF_CSRF_ENABLED") is False:
+        return None
+
+    token = request.headers.get("X-CSRFToken") or request.headers.get("X-CSRF-Token")
+    try:
+        validate_csrf(token)
+    except ValidationError:
+        return "Invalid CSRF token."
+    return None
+
+
+def _is_chat_ciphertext_envelope(value: object) -> bool:
+    if not isinstance(value, str) or not value or len(value) > _CHAT_CIPHERTEXT_MAX_LENGTH:
+        return False
+
+    try:
+        envelope = current_app.json.loads(value)
+    except ValueError:
+        return False
+
+    if not isinstance(envelope, dict):
+        return False
+
+    return (
+        all(
+            isinstance(envelope.get(field), str) and envelope[field]
+            for field in ("algorithm", "ephemeral_public_key", "iv", "ciphertext")
+        )
+        and envelope["algorithm"] == "ECDH-P256-AES-GCM"
+    )
 
 
 def register_message_routes(app: Flask) -> None:
@@ -80,6 +126,7 @@ def register_message_routes(app: Flask) -> None:
             abort(404)
 
         message_copies = []
+        message_copy_payloads = []
         for conversation_message in thread.messages:
             copy = next(
                 (
@@ -90,12 +137,99 @@ def register_message_routes(app: Flask) -> None:
                 None,
             )
             message_copies.append((conversation_message, copy))
+            message_copy_payloads.append(
+                {
+                    "message_id": conversation_message.id,
+                    "created_at": conversation_message.created_at.isoformat(),
+                    "sender_participant_id": conversation_message.sender_participant_id,
+                    "encrypted_payload": copy.encrypted_payload if copy else None,
+                }
+            )
+
+        participant_public_keys = [
+            {
+                "participant_id": thread_participant.id,
+                "public_key": thread_participant.user.chat_public_key,
+            }
+            for thread_participant in thread.participants
+            if thread_participant.user and thread_participant.user.chat_public_key
+        ]
+        can_compose = len(participant_public_keys) == len(thread.participants)
+        conversation_message_form = ConversationMessageForm()
 
         return render_template(
             "conversation.html",
             conversation=thread,
             participant=participant,
             message_copies=message_copies,
+            message_copy_payloads=message_copy_payloads,
+            participant_public_keys=participant_public_keys,
+            can_compose=can_compose,
+            conversation_message_form=conversation_message_form,
+        )
+
+    @app.route("/conversation/<int:conversation_id>/messages", methods=["POST"])
+    @authentication_required
+    def append_conversation_message(conversation_id: int) -> tuple[Response, int]:
+        user = db.session.get(User, session["user_id"])
+        if not user:
+            abort(404)
+
+        thread = db.session.scalars(
+            Conversation.for_user_id(user.id).where(Conversation.id == conversation_id)
+        ).one_or_none()
+        if not thread:
+            abort(404)
+
+        participant = thread.participant_for_user_id(user.id)
+        if not participant:
+            abort(404)
+
+        csrf_error = _validate_json_csrf()
+        if csrf_error:
+            return jsonify({"error": csrf_error}), 400
+
+        payload: Any = request.get_json(silent=True)
+        if not isinstance(payload, dict):
+            return jsonify({"error": "Invalid encrypted message payload."}), 400
+
+        encrypted_copies = payload.get("encrypted_copies")
+        if not isinstance(encrypted_copies, dict):
+            return jsonify({"error": "Invalid encrypted message payload."}), 400
+
+        participant_public_keys = {
+            str(thread_participant.id): thread_participant.user.chat_public_key
+            for thread_participant in thread.participants
+            if thread_participant.user and thread_participant.user.chat_public_key
+        }
+        if len(participant_public_keys) != len(thread.participants):
+            return jsonify({"error": "Conversation replies are unavailable."}), 400
+
+        if set(encrypted_copies.keys()) != set(participant_public_keys.keys()):
+            return jsonify({"error": "Invalid encrypted message payload."}), 400
+
+        if not all(_is_chat_ciphertext_envelope(value) for value in encrypted_copies.values()):
+            return jsonify({"error": "Invalid encrypted message payload."}), 400
+
+        conversation_message = ConversationMessage()
+        conversation_message.conversation = thread
+        conversation_message.sender_participant = participant
+        for recipient_participant in thread.participants:
+            encrypted_copy = ConversationMessageCopy()
+            encrypted_copy.recipient_participant = recipient_participant
+            encrypted_copy.encrypted_payload = encrypted_copies[str(recipient_participant.id)]
+            conversation_message.encrypted_copies.append(encrypted_copy)
+        db.session.add(conversation_message)
+        db.session.commit()
+
+        return (
+            jsonify(
+                {
+                    "message_id": conversation_message.id,
+                    "created_at": conversation_message.created_at.isoformat(),
+                }
+            ),
+            201,
         )
 
     @app.route("/reply/<slug>")

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -165,6 +165,104 @@
     }
   }
 
+  async function importPublicKey(publicKeyValue) {
+    const publicJwk = typeof publicKeyValue === "string"
+      ? JSON.parse(publicKeyValue)
+      : publicKeyValue;
+    return window.crypto.subtle.importKey(
+      "jwk",
+      publicJwk,
+      {
+        name: "ECDH",
+        namedCurve: publicJwk.crv || "P-256",
+      },
+      false,
+      [],
+    );
+  }
+
+  async function deriveChatMessageKey(publicKey, privateKey, usages) {
+    return window.crypto.subtle.deriveKey(
+      {
+        name: "ECDH",
+        public: publicKey,
+      },
+      privateKey,
+      {
+        name: "AES-GCM",
+        length: 256,
+      },
+      false,
+      usages,
+    );
+  }
+
+  async function encryptForPublicKey(plaintext, publicKeyValue) {
+    assertCryptoSupport();
+    const recipientPublicKey = await importPublicKey(publicKeyValue);
+    const ephemeralKeyPair = await window.crypto.subtle.generateKey(
+      {
+        name: "ECDH",
+        namedCurve: "P-256",
+      },
+      true,
+      ["deriveKey"],
+    );
+    const messageKey = await deriveChatMessageKey(
+      recipientPublicKey,
+      ephemeralKeyPair.privateKey,
+      ["encrypt"],
+    );
+    const iv = window.crypto.getRandomValues(new Uint8Array(12));
+    const ciphertext = new Uint8Array(
+      await window.crypto.subtle.encrypt(
+        {
+          name: "AES-GCM",
+          iv,
+        },
+        messageKey,
+        textEncoder.encode(plaintext),
+      ),
+    );
+    const ephemeralPublicJwk = await window.crypto.subtle.exportKey(
+      "jwk",
+      ephemeralKeyPair.publicKey,
+    );
+
+    return JSON.stringify({
+      algorithm: "ECDH-P256-AES-GCM",
+      ephemeral_public_key: JSON.stringify(ephemeralPublicJwk),
+      iv: bytesToBase64(iv),
+      ciphertext: bytesToBase64(ciphertext),
+    });
+  }
+
+  async function decryptChatCiphertext(encryptedPayload) {
+    if (!unlockedChatPrivateKey) {
+      throw new Error("Chat key is locked.");
+    }
+    assertCryptoSupport();
+    const envelope = JSON.parse(encryptedPayload);
+    if (envelope.algorithm !== "ECDH-P256-AES-GCM") {
+      throw new Error("Unsupported chat ciphertext.");
+    }
+    const ephemeralPublicKey = await importPublicKey(envelope.ephemeral_public_key);
+    const messageKey = await deriveChatMessageKey(
+      ephemeralPublicKey,
+      unlockedChatPrivateKey,
+      ["decrypt"],
+    );
+    const plaintextBytes = await window.crypto.subtle.decrypt(
+      {
+        name: "AES-GCM",
+        iv: base64ToBytes(envelope.iv),
+      },
+      messageKey,
+      base64ToBytes(envelope.ciphertext),
+    );
+    return textDecoder.decode(plaintextBytes);
+  }
+
   async function fetchChatKey(chatKeyUrl) {
     const response = await fetch(chatKeyUrl, {
       credentials: "same-origin",
@@ -200,6 +298,164 @@
 
   function chatKeyUrlFromCurrentOrigin() {
     return new URL("/settings/chat-key.json", window.location.origin).toString();
+  }
+
+  function jsonFromScript(id, fallback) {
+    const script = document.getElementById(id);
+    if (!script?.textContent) {
+      return fallback;
+    }
+
+    try {
+      return JSON.parse(script.textContent);
+    } catch (error) {
+      return fallback;
+    }
+  }
+
+  function setConversationStatus(message) {
+    const status = document.getElementById("conversation-chat-status");
+    if (status) {
+      status.textContent = message;
+    }
+  }
+
+  async function decryptConversationMessages() {
+    const copies = jsonFromScript("conversationMessageCopies", []);
+    for (const copy of copies) {
+      if (!copy.encrypted_payload) {
+        continue;
+      }
+
+      const messageElement = document.querySelector(
+        `[data-conversation-message-id="${copy.message_id}"] .conversation-message-body`,
+      );
+      if (!messageElement) {
+        continue;
+      }
+
+      try {
+        messageElement.textContent = await decryptChatCiphertext(copy.encrypted_payload);
+      } catch (error) {
+        messageElement.textContent = "This message cannot be decrypted in this browser.";
+      }
+    }
+  }
+
+  function setConversationComposeEnabled(enabled) {
+    const form = document.getElementById("conversation-compose-form");
+    const body = document.getElementById("conversation-compose-body");
+    const submit = document.getElementById("conversation-compose-submit");
+    if (!form) {
+      return;
+    }
+
+    if (body) {
+      body.disabled = !enabled;
+    }
+    if (submit) {
+      submit.disabled = !enabled;
+    }
+  }
+
+  async function unlockConversationFromPassword() {
+    const passwordInput = document.getElementById("conversation-chat-password");
+    if (!passwordInput?.value) {
+      setConversationStatus("Enter your account password to unlock your chat key.");
+      return;
+    }
+
+    setConversationStatus("Unlocking chat key...");
+    try {
+      const chatKey = await fetchChatKey(chatKeyUrlFromCurrentOrigin());
+      if (!chatKey) {
+        setConversationStatus("Create a Hush Line chat key before reading this conversation.");
+        return;
+      }
+      const unlocked = await unlockFromPassword(chatKey, passwordInput.value);
+      if (!unlocked) {
+        setConversationStatus("Chat key unlock failed.");
+        return;
+      }
+      await decryptConversationMessages();
+      const root = document.getElementById("conversation-chat");
+      setConversationComposeEnabled(root?.dataset.canCompose === "true");
+      setConversationStatus("Chat key unlocked in this browser.");
+      passwordInput.value = "";
+    } catch (error) {
+      setConversationStatus("Chat key unlock failed.");
+    }
+  }
+
+  async function handleConversationSubmit(event) {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const root = document.getElementById("conversation-chat");
+    const body = document.getElementById("conversation-compose-body");
+    const plaintext = body?.value.trim();
+    const participantKeys = jsonFromScript("conversationParticipantPublicKeys", []);
+    if (!root?.dataset.messageUrl || !plaintext) {
+      return;
+    }
+    if (state.status !== "unlocked") {
+      setConversationStatus("Unlock your chat key before replying.");
+      return;
+    }
+
+    setConversationStatus("Encrypting reply...");
+    try {
+      const encryptedCopies = {};
+      for (const participantKey of participantKeys) {
+        encryptedCopies[String(participantKey.participant_id)] = await encryptForPublicKey(
+          plaintext,
+          participantKey.public_key,
+        );
+      }
+      const csrfToken = form.querySelector("input[name='csrf_token']")?.value;
+      const response = await fetch(root.dataset.messageUrl, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+          "X-CSRFToken": csrfToken || "",
+        },
+        body: JSON.stringify({
+          encrypted_copies: encryptedCopies,
+        }),
+      });
+      if (!response.ok) {
+        setConversationStatus("Reply could not be saved.");
+        return;
+      }
+      body.value = "";
+      window.location.reload();
+    } catch (error) {
+      setConversationStatus("Reply could not be encrypted.");
+    }
+  }
+
+  function bindConversation() {
+    const root = document.getElementById("conversation-chat");
+    if (!root) {
+      return;
+    }
+
+    document
+      .getElementById("conversation-chat-unlock")
+      ?.addEventListener("click", unlockConversationFromPassword);
+
+    const form = document.getElementById("conversation-compose-form");
+    if (form && form.dataset.bound !== "true") {
+      form.dataset.bound = "true";
+      form.addEventListener("submit", handleConversationSubmit);
+    }
+
+    if (state.status === "unlocked") {
+      decryptConversationMessages();
+      setConversationComposeEnabled(root.dataset.canCompose === "true");
+      setConversationStatus("Chat key unlocked in this browser.");
+    }
   }
 
   async function handleLoginSubmit(event) {
@@ -301,6 +557,7 @@
       .querySelector("form[action*='password-reset']")
       ?.addEventListener("submit", clearChatKeyMaterial);
     bindLogoutCleanup();
+    bindConversation();
   }
 
   window.HushLineChatKeys = {
@@ -309,6 +566,8 @@
     get state() {
       return { ...state };
     },
+    decryptChatCiphertext,
+    encryptForPublicKey,
     rewrapForPasswordChange,
     unlockFromPassword,
   };

--- a/hushline/templates/conversation.html
+++ b/hushline/templates/conversation.html
@@ -21,19 +21,75 @@
       </p>
     {% endif %}
   </div>
-  <article class="message">
-    {% for conversation_message, encrypted_copy in message_copies %}
-      <div class="field-value encrypted">
-        <div class="label">
-          {{ conversation_message.created_at.date() }}
+
+  {% set append_message_url = url_for('append_conversation_message', conversation_id=conversation.id) %}
+  <section
+    id="conversation-chat"
+    data-message-url="{{ append_message_url }}"
+    data-can-compose="{{ 'true' if can_compose else 'false' }}"
+  >
+    <div id="conversation-key-locked" class="message">
+      <h2>Chat Key Locked</h2>
+      <p>
+        Unlock your Hush Line chat key with your account password to read and reply.
+        Do not upload or paste any external private key.
+      </p>
+      <label for="conversation-chat-password">Account Password</label>
+      <input
+        id="conversation-chat-password"
+        name="conversation_chat_password"
+        type="password"
+        autocomplete="current-password"
+      />
+      <button id="conversation-chat-unlock" type="button">Unlock Chat</button>
+      <p id="conversation-chat-status" class="meta" role="status">
+        Transcript content is hidden until your chat key is unlocked in this browser.
+      </p>
+    </div>
+
+    <script id="conversationParticipantPublicKeys" type="application/json">
+      {{ participant_public_keys | tojson }}
+    </script>
+    <script id="conversationMessageCopies" type="application/json">
+      {{ message_copy_payloads | tojson }}
+    </script>
+
+    <article class="message" aria-live="polite">
+      {% for conversation_message, encrypted_copy in message_copies %}
+        <div
+          class="field-value encrypted"
+          data-conversation-message-id="{{ conversation_message.id }}"
+        >
+          <div class="label">
+            {{ conversation_message.created_at.date() }}
+          </div>
+          {% if encrypted_copy %}
+            <p class="conversation-message-body">Locked until your chat key is unlocked.</p>
+          {% else %}
+            <p>No encrypted copy is available for your account.</p>
+          {% endif %}
         </div>
-        {% if encrypted_copy %}
-          <pre class="encrypted-value">{{ encrypted_copy.encrypted_payload }}</pre>
-        {% else %}
-          <p>No encrypted copy is available for your account.</p>
-        {% endif %}
-      </div>
-    {% endfor %}
-  </article>
+      {% endfor %}
+    </article>
+
+    <form id="conversation-compose-form">
+      {{ conversation_message_form.hidden_tag() }}
+      <label for="conversation-compose-body">Reply</label>
+      <textarea
+        id="conversation-compose-body"
+        name="message"
+        rows="5"
+        maxlength="50000"
+        disabled="disabled"
+        required
+      ></textarea>
+      {{ conversation_message_form.submit(id="conversation-compose-submit", disabled="disabled") }}
+      {% if not can_compose %}
+        <p class="meta">
+          Replies are unavailable until every participant has an active Hush Line chat key.
+        </p>
+      {% endif %}
+    </form>
+  </section>
 </div>
 {% endblock %}

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,0 +1,265 @@
+import json
+
+from flask import Flask, url_for
+from flask.testing import FlaskClient
+
+from hushline.db import db
+from hushline.model import (
+    ChatKey,
+    Conversation,
+    ConversationMessage,
+    ConversationMessageCopy,
+    ConversationParticipant,
+    User,
+)
+
+
+def _authenticate_as(client: FlaskClient, user: User) -> None:
+    with client.session_transaction() as session:
+        session["user_id"] = user.id
+        session["session_id"] = user.session_id
+        session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
+
+
+def _add_chat_key(user: User, public_key: str) -> None:
+    db.session.add(
+        ChatKey(
+            user=user,
+            key_version=1,
+            public_key=public_key,
+            encrypted_private_key="wrapped-private-chat-key",
+            kdf_algorithm="PBKDF2-SHA-256",
+            kdf_params={"iterations": 310000},
+            kdf_salt="salt",
+            wrapping_algorithm="AES-GCM",
+        )
+    )
+
+
+def _ciphertext(label: str) -> str:
+    return json.dumps(
+        {
+            "algorithm": "ECDH-P256-AES-GCM",
+            "ephemeral_public_key": '{"kty":"EC","crv":"P-256","x":"ephemeral","y":"key"}',
+            "iv": f"iv-{label}",
+            "ciphertext": f"ciphertext-{label}",
+        }
+    )
+
+
+def _make_conversation(
+    sender: User,
+    recipient: User,
+    *,
+    include_initial_copy: bool = True,
+) -> Conversation:
+    conversation = Conversation()
+    sender_participant = ConversationParticipant()
+    sender_participant.conversation = conversation
+    sender_participant.user = sender
+    sender_participant.has_usable_public_key = True
+    recipient_participant = ConversationParticipant()
+    recipient_participant.conversation = conversation
+    recipient_participant.user = recipient
+    recipient_participant.has_usable_public_key = True
+    conversation_message = ConversationMessage()
+    conversation_message.conversation = conversation
+    conversation_message.sender_participant = sender_participant
+    if include_initial_copy:
+        sender_copy = ConversationMessageCopy()
+        sender_copy.recipient_participant = sender_participant
+        sender_copy.encrypted_payload = _ciphertext("sender-initial")
+        recipient_copy = ConversationMessageCopy()
+        recipient_copy.recipient_participant = recipient_participant
+        recipient_copy.encrypted_payload = _ciphertext("recipient-initial")
+        conversation_message.encrypted_copies.extend(
+            [
+                sender_copy,
+                recipient_copy,
+            ]
+        )
+    db.session.add(conversation)
+    db.session.commit()
+    return conversation
+
+
+def _copies_for(conversation: Conversation, label: str) -> dict[str, str]:
+    return {
+        str(participant.id): _ciphertext(f"{label}-{participant.id}")
+        for participant in conversation.participants
+    }
+
+
+def test_conversation_route_authorizes_only_participants(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    admin_user: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+
+    _authenticate_as(client, user)
+    sender_response = client.get(url_for("conversation", conversation_id=conversation.id))
+    assert sender_response.status_code == 200
+    assert "Unlock your Hush Line chat key" in sender_response.text
+
+    _authenticate_as(client, user2)
+    recipient_response = client.get(url_for("conversation", conversation_id=conversation.id))
+    assert recipient_response.status_code == 200
+    assert "Unlock your Hush Line chat key" in recipient_response.text
+
+    _authenticate_as(client, admin_user)
+    unrelated_response = client.get(url_for("conversation", conversation_id=conversation.id))
+    assert unrelated_response.status_code == 404
+
+    with client.session_transaction() as session:
+        session.clear()
+    unauthenticated_response = client.get(url_for("conversation", conversation_id=conversation.id))
+    assert unauthenticated_response.status_code == 302
+    assert unauthenticated_response.headers["Location"].endswith(url_for("login"))
+
+
+def test_conversation_view_shows_locked_chat_key_state(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    response = client.get(url_for("conversation", conversation_id=conversation.id))
+
+    assert response.status_code == 200
+    assert "Transcript content is hidden until your chat key is unlocked" in response.text
+    assert (
+        "Replies are unavailable until every participant has an active Hush Line chat key."
+        in response.text
+    )
+    assert "Do not upload or paste any external private key." in response.text
+    assert "Proton" not in response.text
+    assert "PGP" not in response.text
+
+
+def test_participant_can_append_encrypted_conversation_message(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    conversation = _make_conversation(user, user2)
+    plaintext = "plaintext follow-up must not be stored"
+    _authenticate_as(client, user)
+
+    response = client.post(
+        url_for("append_conversation_message", conversation_id=conversation.id),
+        json={"encrypted_copies": _copies_for(conversation, "follow-up")},
+    )
+
+    assert response.status_code == 201
+    messages = db.session.scalars(
+        db.select(ConversationMessage)
+        .where(ConversationMessage.conversation_id == conversation.id)
+        .order_by(ConversationMessage.id.asc())
+    ).all()
+    assert len(messages) == 2
+    assert messages[-1].sender_participant.user_id == user.id
+    assert len(messages[-1].encrypted_copies) == 2
+    for encrypted_copy in messages[-1].encrypted_copies:
+        assert "ECDH-P256-AES-GCM" in encrypted_copy.encrypted_payload
+        assert plaintext not in encrypted_copy.encrypted_payload
+
+
+def test_append_conversation_message_rejects_invalid_payload_without_leaking_content(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+    leaked_content = "plaintext disclosure"
+
+    response = client.post(
+        url_for("append_conversation_message", conversation_id=conversation.id),
+        json={
+            "encrypted_copies": {
+                str(participant.id): leaked_content for participant in conversation.participants
+            }
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Invalid encrypted message payload." in response.text
+    assert leaked_content not in response.text
+    message_count = db.session.scalar(db.select(db.func.count()).select_from(ConversationMessage))
+    assert message_count == 1
+
+
+def test_append_conversation_message_requires_csrf_when_enabled(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+    prior_setting = app.config.get("WTF_CSRF_ENABLED")
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        response = client.post(
+            url_for("append_conversation_message", conversation_id=conversation.id),
+            json={"encrypted_copies": _copies_for(conversation, "csrf")},
+        )
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = prior_setting
+
+    assert response.status_code == 400
+    assert "Invalid CSRF token." in response.text
+    message_count = db.session.scalar(db.select(db.func.count()).select_from(ConversationMessage))
+    assert message_count == 1
+
+
+def test_append_conversation_message_rejects_non_participant(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    admin_user: User,
+) -> None:
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, admin_user)
+
+    response = client.post(
+        url_for("append_conversation_message", conversation_id=conversation.id),
+        json={"encrypted_copies": _copies_for(conversation, "unrelated")},
+    )
+
+    assert response.status_code == 404
+    message_count = db.session.scalar(db.select(db.func.count()).select_from(ConversationMessage))
+    assert message_count == 1
+
+
+def test_append_conversation_message_redirects_unauthenticated_user(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    conversation = _make_conversation(user, user2)
+
+    response = client.post(
+        url_for("append_conversation_message", conversation_id=conversation.id),
+        json={"encrypted_copies": _copies_for(conversation, "unauthenticated")},
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(url_for("login"))
+    message_count = db.session.scalar(db.select(db.func.count()).select_from(ConversationMessage))
+    assert message_count == 1

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -312,12 +312,14 @@ def test_logged_in_profile_submit_message_creates_conversation_for_distinct_reci
         url_for("conversation", conversation_id=conversation.id), follow_redirects=True
     )
     assert sender_response.status_code == 200
-    assert pgp_message_sig in sender_response.text
+    assert "Unlock your Hush Line chat key" in sender_response.text
+    assert "Locked until your chat key is unlocked." in sender_response.text
 
     _authenticate_as(client, user2)
     recipient_response = client.get(url_for("conversation", conversation_id=conversation.id))
     assert recipient_response.status_code == 200
-    assert pgp_message_sig in recipient_response.text
+    assert "Unlock your Hush Line chat key" in recipient_response.text
+    assert "Locked until your chat key is unlocked." in recipient_response.text
     message_response = client.get(url_for("message", public_id=message.public_id))
     assert url_for("conversation", conversation_id=conversation.id) in message_response.text
 
@@ -367,7 +369,8 @@ def test_logged_in_profile_submit_message_creates_conversation_without_sender_ke
     _authenticate_as(client, user2)
     recipient_response = client.get(url_for("conversation", conversation_id=conversation.id))
     assert recipient_response.status_code == 200
-    assert pgp_message_sig in recipient_response.text
+    assert "Unlock your Hush Line chat key" in recipient_response.text
+    assert "Locked until your chat key is unlocked." in recipient_response.text
 
 
 @pytest.mark.usefixtures("_authenticated_user")


### PR DESCRIPTION
This PR implements child issue #2180 (`Add participant-authorized conversation routes and chat composer`) under epic #2177 (`Feasibility: two-way encrypted conversations between accounts`).
It is intended to merge into the epic branch first, not directly into `main`.

This PR addresses the issue "Add participant-authorized conversation routes and chat composer" by updating supporting files in `assets/js`, application code in `hushline/forms.py`, and request-handling code in `hushline/routes`.
The change includes both implementation work and automated tests, showing the intended behavior and how it is verified.
It touches 7 non-log file(s) (7 total including runner artifacts), primarily in assets/js, hushline/forms.py, and hushline/routes.

## Summary
- Automated code agent update for child issue #2180.
- Part of epic #2177: Feasibility: two-way encrypted conversations between accounts
- This PR targets the epic integration branch `codex/epic-2177`.
- The child issue is closed explicitly by workflow after this PR merges into the epic branch.

Linked issue: #2180

## Context
- Epic: https://github.com/scidsg/hushline/issues/2177
- Child issue: https://github.com/scidsg/hushline/issues/2180
- Branch: codex/daily-issue-2180
- Base branch: codex/epic-2177
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `assets/js/chat-key-lifecycle.js`
- `hushline/forms.py`
- `hushline/routes/message.py`
- `hushline/static/js/chat-key-lifecycle.js`
- `hushline/templates/conversation.html`
- `tests/test_conversation.py`
- `tests/test_profile.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
