### PR TITLE
Fix embed origin validation behind proxy

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -213,7 +213,7 @@ def register_profile_routes(app: Flask) -> None:
             return False
 
         parsed_origin = urlsplit(origin)
-        parsed_host = urlsplit(request.host_url)
+        parsed_host = urlsplit(canonical_external_url("embed_profile", username=uname.username))
         return (parsed_origin.scheme, parsed_origin.netloc) == (
             parsed_host.scheme,
             parsed_host.netloc,

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -366,6 +366,35 @@ def test_embed_profile_submission_accepts_client_encrypted_fields(
     ]
 
 
+def test_embed_profile_submission_accepts_canonical_public_origin_behind_proxy(
+    app: Flask, client: FlaskClient, user: User
+) -> None:
+    app.config["PUBLIC_BASE_URL"] = "https://tips.example"
+    _enable_embeds_globally()
+    _make_message_capable(user)
+    _configure_embed(user.primary_username, "https://publisher.example")
+
+    response = client.get(url_for("embed_profile", username=user.primary_username.username))
+    assert response.status_code == 200
+    submission_data = _embed_submission_data(response.text)
+
+    post_response = client.post(
+        url_for("embed_profile", username=user.primary_username.username),
+        data={
+            "field_0": "Embedded Signal contact",
+            "field_1": "Embedded message",
+            **submission_data,
+        },
+        base_url="http://internal-app:8080",
+        headers={"Origin": "https://tips.example"},
+    )
+
+    assert post_response.status_code == 200, post_response.text
+    message = _first_message_for(user.primary_username)
+    assert message is not None
+    assert len(message.field_values) == 2
+
+
 def test_embed_submission_operational_counters_exclude_sensitive_request_data(
     app: Flask, client: FlaskClient, user: User
 ) -> None:


### PR DESCRIPTION
## What changed
- Validate embedded form POST origins against Hush Line's canonical public embed URL instead of `request.host_url`.
- Added a regression test for proxy deployments where the browser origin is the public `PUBLIC_BASE_URL` but the internal request host is different.

## Why
The production embed endpoint can be served behind DigitalOcean/Cloudflare with an internal request scheme/host that does not match `https://tips.hushline.app`. Comparing a valid iframe POST origin to `request.host_url` rejects legitimate embedded form submissions with `Invalid embed request origin`.

This keeps the existing protection against missing, `null`, and cross-site origins intact.

## Validation
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.yaml run --rm --no-deps -e BLOB_STORAGE_PUBLIC_S3_ENDPOINT=http://blob-storage:4566/ app poetry run pytest -q tests/test_embeddable_forms_settings.py::test_embed_profile_submission_accepts_canonical_public_origin_behind_proxy`
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.yaml run --rm --no-deps -e BLOB_STORAGE_PUBLIC_S3_ENDPOINT=http://blob-storage:4566/ app poetry run pytest -q tests/test_embeddable_forms_settings.py` (`59 passed`)
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.yaml run --rm --no-deps app poetry run ruff format --check hushline/routes/profile.py tests/test_embeddable_forms_settings.py`
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.yaml run --rm --no-deps app poetry run ruff check --output-format full hushline/routes/profile.py tests/test_embeddable_forms_settings.py`

Full `make test` was not run locally because the default Compose stack collided with the already-running local Hush Line services on `127.0.0.1:4566`; the affected test file was run successfully with explicit container networking overrides.

## Manual testing
- Performed a live smoke check against `https://tips.hushline.app/embed/to/admin` using a valid form token and intentionally wrong captcha. Before this fix, a POST with `Origin: https://tips.hushline.app` reached the app but returned `Invalid embed request origin`, confirming the proxy-origin mismatch root cause.

## Risks / follow-ups
- After this ships to the app, re-enable the `https://hushline.app` website iframe using the generated embed snippet that includes `allow-same-origin`.