### PR TITLE
Defer 2FA session rotation until verification

### DIFF
--- a/hushline/routes/auth.py
+++ b/hushline/routes/auth.py
@@ -400,7 +400,6 @@ def register_auth_routes(app: Flask) -> None:
                     form.password.data,
                     password_rehash_source_hash,
                 )
-                rotate_user_session_id(user)
 
                 # 2FA enabled?
                 if user.totp_secret:
@@ -418,6 +417,7 @@ def register_auth_routes(app: Flask) -> None:
                         raise
                     return redirect(url_for("verify_2fa_login"))
 
+                rotate_user_session_id(user)
                 set_session_user(user=user, username=username.username, is_authenticated=True)
 
                 auth_log = AuthenticationLog(user_id=user.id, successful=True)
@@ -568,6 +568,8 @@ def register_auth_routes(app: Flask) -> None:
                     user_id=user.id, successful=True, otp_code=verification_code, timecode=timecode
                 )
                 db.session.add(auth_log)
+                rotate_user_session_id(user)
+                session["session_id"] = user.session_id
                 session["is_authenticated"] = True
                 password_rehash_source_hash = user.password_hash
                 has_pending_password_rehash = PENDING_PASSWORD_REHASH_SESSION_KEY in session

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -301,6 +301,38 @@ def test_login_redirects_to_original_protected_page(
         assert POST_AUTH_REDIRECT_SESSION_KEY not in sess
 
 
+def test_login_password_step_for_2fa_does_not_revoke_existing_sessions(
+    app: Flask, client: FlaskClient, user: User, user_password: str
+) -> None:
+    user.totp_secret = TOTP_SECRET
+    db.session.commit()
+    original_session_id = user.session_id
+
+    with client.session_transaction() as sess:
+        sess["user_id"] = user.id
+        sess["session_id"] = original_session_id
+        sess["username"] = user.primary_username.username
+        sess["is_authenticated"] = True
+
+    with app.test_client() as password_only_client:
+        response = password_only_client.post(
+            url_for("login"),
+            data={"username": user.primary_username.username, "password": user_password},
+            follow_redirects=False,
+        )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(url_for("verify_2fa_login"))
+    db.session.refresh(user)
+    assert user.session_id == original_session_id
+
+    response = client.get(url_for("settings.profile"), follow_redirects=False)
+    assert response.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess["session_id"] == original_session_id
+        assert sess["is_authenticated"] is True
+
+
 def _enable_password_reset_email(user: User) -> None:
     user.enable_email_notifications = True
     user.email = "recipient@example.com"
@@ -751,6 +783,7 @@ def test_verify_2fa_login_redirects_to_original_protected_page(
     totp_secret = pyotp.random_base32()
     user.totp_secret = totp_secret
     db.session.commit()
+    original_session_id = user.session_id
 
     response = client.get(url_for("settings.profile"), follow_redirects=False)
     assert response.status_code == 302
@@ -775,8 +808,11 @@ def test_verify_2fa_login_redirects_to_original_protected_page(
     assert response.status_code == 302
     assert response.headers["Location"].endswith(url_for("settings.profile"))
 
+    db.session.refresh(user)
+    assert user.session_id != original_session_id
     with client.session_transaction() as sess:
         assert POST_AUTH_REDIRECT_SESSION_KEY not in sess
+        assert sess["session_id"] == user.session_id
 
 
 def test_verify_2fa_login_failed_rehash_commit_clears_auth_session(

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -322,7 +322,7 @@ def test_login_password_step_for_2fa_does_not_revoke_existing_sessions(
         )
 
     assert response.status_code == 302
-    assert response.headers["Location"].endswith(url_for("verify_2fa_login"))
+    assert response.headers["Location"] == url_for("verify_2fa_login", _external=False)
     db.session.refresh(user)
     assert user.session_id == original_session_id
 


### PR DESCRIPTION
### Motivation
- Fix a security regression where the per-user `session_id` was rotated immediately after password verification, allowing a password-only attacker to revoke all existing sessions for 2FA-enabled accounts. 
- The second factor must gate account-level session revocation so password-only challenges cannot produce a denial-of-service against active authenticated browsers.

### Description
- Stop rotating the global `User.session_id` during the password step for 2FA-enabled logins by removing the call to `rotate_user_session_id` before redirecting to `verify_2fa_login` in `hushline/routes/auth.py`.
- Rotate `User.session_id` only after successful TOTP verification and write the new token into the authenticated session (`session["session_id"] = user.session_id`) within `verify_2fa_login` in `hushline/routes/auth.py`.
- Ensure non-2FA full logins still rotate the session id on full authentication and update the session accordingly by rotating before setting the authenticated session.
- Add regression tests in `tests/test_routes_auth.py` to assert that a password-only 2FA login challenge does not revoke an already-authenticated session and that successful 2FA completion rotates the token and updates the session.

### Testing
- Ran linters and static checks: `poetry run ruff format --check` and `poetry run ruff check` succeeded, and `poetry run mypy` passed, and `python -m py_compile` succeeded for the modified files. 
- Attempted to run targeted pytest for the new/affected tests, but the test run could not complete because the local environment could not resolve the required `postgres` host (Postgres/Docker is not available here), causing pytest to error; full test suite could not be executed locally. 
- `make lint`, `make test`, `make audit-python`, and `make audit-node-runtime` were not run because Docker is not installed in the current environment; these must be run in CI or a local environment with Docker to validate end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b54dbe8848330b622d86b69d391fd)