### PR TITLE
#2181 Extend client-side encryption for conversation messages

### DIFF
--- a/assets/js/client-side-encryption.js
+++ b/assets/js/client-side-encryption.js
@@ -1,5 +1,7 @@
 import * as openpgp from "openpgp";
 
+const textEncoder = new TextEncoder();
+
 function assertClientCryptoSupport() {
   // OpenPGP.js v6 requires secure context + SubtleCrypto + Web Streams + BigInt.
   if (!window.isSecureContext) {
@@ -90,6 +92,91 @@ function isArmoredMessage(value) {
   );
 }
 
+function bytesToBase64(bytes) {
+  let binary = "";
+  bytes.forEach((byte) => {
+    binary += String.fromCharCode(byte);
+  });
+  return btoa(binary);
+}
+
+function jsonFromScript(id, fallback) {
+  const script = document.getElementById(id);
+  if (!script?.textContent) {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(script.textContent);
+  } catch (error) {
+    return fallback;
+  }
+}
+
+async function importChatPublicKey(publicKeyValue) {
+  const publicJwk =
+    typeof publicKeyValue === "string"
+      ? JSON.parse(publicKeyValue)
+      : publicKeyValue;
+  return window.crypto.subtle.importKey(
+    "jwk",
+    publicJwk,
+    {
+      name: "ECDH",
+      namedCurve: publicJwk.crv || "P-256",
+    },
+    false,
+    [],
+  );
+}
+
+async function encryptForChatPublicKey(plaintext, publicKeyValue) {
+  const recipientPublicKey = await importChatPublicKey(publicKeyValue);
+  const ephemeralKeyPair = await window.crypto.subtle.generateKey(
+    {
+      name: "ECDH",
+      namedCurve: "P-256",
+    },
+    true,
+    ["deriveKey"],
+  );
+  const messageKey = await window.crypto.subtle.deriveKey(
+    {
+      name: "ECDH",
+      public: recipientPublicKey,
+    },
+    ephemeralKeyPair.privateKey,
+    {
+      name: "AES-GCM",
+      length: 256,
+    },
+    false,
+    ["encrypt"],
+  );
+  const iv = window.crypto.getRandomValues(new Uint8Array(12));
+  const ciphertext = new Uint8Array(
+    await window.crypto.subtle.encrypt(
+      {
+        name: "AES-GCM",
+        iv,
+      },
+      messageKey,
+      textEncoder.encode(plaintext),
+    ),
+  );
+  const ephemeralPublicJwk = await window.crypto.subtle.exportKey(
+    "jwk",
+    ephemeralKeyPair.publicKey,
+  );
+
+  return JSON.stringify({
+    algorithm: "ECDH-P256-AES-GCM",
+    ephemeral_public_key: JSON.stringify(ephemeralPublicJwk),
+    iv: bytesToBase64(iv),
+    ciphertext: bytesToBase64(ciphertext),
+  });
+}
+
 function getFieldValue(field) {
   if (
     field.tagName === "INPUT" ||
@@ -164,6 +251,11 @@ function getRecipientPublicKeyEntries() {
   }
 }
 
+function getChatPublicKey(id) {
+  const publicKey = jsonFromScript(id, null);
+  return typeof publicKey === "string" && publicKey.trim() ? publicKey : null;
+}
+
 function getMessageFields() {
   return Array.from(document.querySelectorAll(".form-field")).map((field) => ({
     name: field.name || field.querySelector("input")?.name,
@@ -171,6 +263,41 @@ function getMessageFields() {
     value: getFieldValue(field),
     encrypted: field.classList.contains("encrypted-field"),
   }));
+}
+
+function conversationBodyFromFields(messageFields) {
+  return messageFields
+    .map((field) => `${field.label}\n\n${field.value}\n\n==============`)
+    .join("\n\n")
+    .trim();
+}
+
+async function buildEncryptedConversationCopies(messageFields) {
+  const recipientChatPublicKey = getChatPublicKey("recipientChatPublicKey");
+  if (!recipientChatPublicKey) {
+    return {};
+  }
+
+  try {
+    const conversationBody = conversationBodyFromFields(messageFields);
+    const encryptedCopies = {
+      recipient: await encryptForChatPublicKey(
+        conversationBody,
+        recipientChatPublicKey,
+      ),
+    };
+    const senderChatPublicKey = getChatPublicKey("senderChatPublicKey");
+    if (senderChatPublicKey) {
+      encryptedCopies.sender = await encryptForChatPublicKey(
+        conversationBody,
+        senderChatPublicKey,
+      );
+    }
+    return encryptedCopies;
+  } catch (error) {
+    console.error("Chat transcript encryption failed.");
+    return {};
+  }
 }
 
 document.addEventListener("DOMContentLoaded", function () {
@@ -255,6 +382,15 @@ document.addEventListener("DOMContentLoaded", function () {
       if (encryptedEmailFieldsEl) {
         encryptedEmailFieldsEl.value = JSON.stringify(
           encryptedEmailFieldsByRecipient,
+        );
+      }
+
+      const encryptedConversationCopiesEl = document.getElementById(
+        "encrypted_conversation_copies",
+      );
+      if (encryptedConversationCopiesEl) {
+        encryptedConversationCopiesEl.value = JSON.stringify(
+          await buildEncryptedConversationCopies(messageFields),
         );
       }
 

--- a/hushline/routes/forms.py
+++ b/hushline/routes/forms.py
@@ -183,6 +183,10 @@ class DynamicMessageForm:
                 "Encrypted Email Fields By Recipient",
                 validators=[Optional(), Length(max=10240 * len(fields) * 100)],
             )
+            encrypted_conversation_copies = HiddenField(
+                "Encrypted Conversation Copies",
+                validators=[Optional(), Length(max=400000)],
+            )
             owner_guard_nonce = StringField("Owner Guard Nonce", validators=[Optional()])
             owner_guard_signature = StringField("Owner Guard Signature", validators=[Optional()])
             embed_captcha_token = StringField("Embed CAPTCHA Token", validators=[Optional()])

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -59,6 +59,7 @@ from hushline.routes.common import (
     validate_captcha,
 )
 from hushline.routes.forms import DynamicMessageForm
+from hushline.routes.message import _is_chat_ciphertext_envelope
 from hushline.safe_template import safe_render_template
 
 EMBED_CAPTCHA_MAX_AGE_SECONDS = 60 * 60
@@ -129,6 +130,27 @@ def register_profile_routes(app: Flask) -> None:
                 and _is_armored_pgp_message(field_value)
             }
         return encrypted_fields
+
+    def _client_encrypted_conversation_copies(value: str) -> dict[str, str]:
+        if not value:
+            return {}
+
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+
+        if not isinstance(parsed, dict):
+            return {}
+
+        encrypted_copies: dict[str, str] = {}
+        for role in ("sender", "recipient"):
+            encrypted_payload = parsed.get(role)
+            if isinstance(encrypted_payload, str) and _is_chat_ciphertext_envelope(
+                encrypted_payload
+            ):
+                encrypted_copies[role] = encrypted_payload
+        return encrypted_copies
 
     def _new_math_problem() -> tuple[str, str]:
         num1 = secrets.randbelow(10) + 1
@@ -242,21 +264,27 @@ def register_profile_routes(app: Flask) -> None:
         message: Message,
         sender: User,
         recipient: User,
-        raw_extracted_fields: list[tuple[str, str]],
+        encrypted_conversation_copies: dict[str, str],
     ) -> Conversation | None:
         if sender.id == recipient.id:
             return None
 
-        recipient_encryption_target = recipient.message_encryption_target
-        if not recipient_encryption_target:
+        if not recipient.chat_public_key:
             return None
 
-        sender_encryption_target = sender.message_encryption_target
+        recipient_payload = encrypted_conversation_copies.get("recipient")
+        if not recipient_payload:
+            return None
+
+        sender_payload = encrypted_conversation_copies.get("sender")
+        if sender.chat_public_key and not sender_payload:
+            return None
+
         conversation = Conversation()
         sender_participant = ConversationParticipant()
         sender_participant.conversation = conversation
         sender_participant.user = sender
-        sender_participant.has_usable_public_key = False
+        sender_participant.has_usable_public_key = sender_payload is not None
         recipient_participant = ConversationParticipant()
         recipient_participant.conversation = conversation
         recipient_participant.user = recipient
@@ -264,19 +292,11 @@ def register_profile_routes(app: Flask) -> None:
         conversation_message = ConversationMessage()
         conversation_message.conversation = conversation
         conversation_message.sender_participant = sender_participant
-        body = format_message_email_fields(raw_extracted_fields)
-        if sender_encryption_target:
-            try:
-                encrypted_payload = encrypt_message(body, sender_encryption_target)
-            except (RuntimeError, TypeError, ValueError):
-                current_app.logger.warning("Failed to encrypt conversation copy for sender.")
-            else:
-                sender_copy = ConversationMessageCopy()
-                sender_copy.recipient_participant = sender_participant
-                sender_copy.encrypted_payload = encrypted_payload
-                sender_participant.has_usable_public_key = True
-                conversation_message.encrypted_copies.append(sender_copy)
-        recipient_payload = encrypt_message(body, recipient_encryption_target)
+        if sender_payload:
+            sender_copy = ConversationMessageCopy()
+            sender_copy.recipient_participant = sender_participant
+            sender_copy.encrypted_payload = sender_payload
+            conversation_message.encrypted_copies.append(sender_copy)
         recipient_copy = ConversationMessageCopy()
         recipient_copy.recipient_participant = recipient_participant
         recipient_copy.encrypted_payload = recipient_payload
@@ -330,6 +350,7 @@ def register_profile_routes(app: Flask) -> None:
 
         def _render_profile(status_code: int | None = None) -> Response | str | tuple[str, int]:
             message_submission_block_reason = _message_submission_block_reason(uname)
+            sender = _authenticated_sender()
             owner_guard_nonce = secrets.token_urlsafe(16)
             owner_guard_signature = _owner_guard_signature(
                 uname.username,
@@ -353,6 +374,11 @@ def register_profile_routes(app: Flask) -> None:
                 current_user_id=session.get("user_id"),
                 recipient_public_keys=uname.user.message_recipient_keys,
                 recipient_chat_public_key=uname.user.chat_public_key,
+                sender_chat_public_key=(
+                    sender.chat_public_key
+                    if sender is not None and sender.id != uname.user_id
+                    else None
+                ),
                 recipient_public_key_entries=(
                     notification_recipient_public_key_entries(uname.user)
                     if (
@@ -533,7 +559,9 @@ def register_profile_routes(app: Flask) -> None:
                         message=message,
                         sender=sender,
                         recipient=uname.user,
-                        raw_extracted_fields=raw_extracted_fields,
+                        encrypted_conversation_copies=_client_encrypted_conversation_copies(
+                            form.encrypted_conversation_copies.data or ""
+                        ),
                     )
 
                 db.session.commit()

--- a/hushline/templates/embed_profile.html
+++ b/hushline/templates/embed_profile.html
@@ -212,6 +212,7 @@
         <script id="recipientPublicKeys" type="application/json">{{ recipient_public_keys | tojson }}</script>
         <script id="recipientPublicKeyEntries" type="application/json">{{ recipient_public_key_entries | tojson }}</script>
         <script id="recipientChatPublicKey" type="application/json">{{ recipient_chat_public_key | tojson }}</script>
+        <script id="senderChatPublicKey" type="application/json">{{ sender_chat_public_key | tojson }}</script>
 
         {% if not message_submission_block_reason %}
           <div class="captcha">

--- a/hushline/templates/profile.html
+++ b/hushline/templates/profile.html
@@ -157,6 +157,7 @@
     <script id="recipientPublicKeys" type="application/json">{{ recipient_public_keys | tojson }}</script>
     <script id="recipientPublicKeyEntries" type="application/json">{{ recipient_public_key_entries | tojson }}</script>
     <script id="recipientChatPublicKey" type="application/json">{{ recipient_chat_public_key | tojson }}</script>
+    <script id="senderChatPublicKey" type="application/json">{{ sender_chat_public_key | tojson }}</script>
 
     {% if not message_submission_block_reason %}
       <div class="captcha">

--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -283,5 +283,6 @@ def test_profile_exposes_public_chat_key_only(client: FlaskClient, user: User) -
 
     assert response.status_code == 200
     assert 'id="recipientChatPublicKey"' in response.text
+    assert 'id="senderChatPublicKey"' in response.text
     assert "public-chat-key" in response.text
     assert "wrapped-private-chat-key" not in response.text

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -104,6 +104,24 @@ def test_client_side_encryption_has_platform_guards() -> None:
     assert "assertClientCryptoSupport();" in js
 
 
+def test_client_side_encryption_prepares_chat_conversation_copies() -> None:
+    js = (ROOT / "assets/js/client-side-encryption.js").read_text(encoding="utf-8")
+    profile_template = (ROOT / "hushline/templates/profile.html").read_text(encoding="utf-8")
+    embed_template = (ROOT / "hushline/templates/embed_profile.html").read_text(encoding="utf-8")
+
+    assert "function encryptForChatPublicKey(plaintext, publicKeyValue)" in js
+    assert 'algorithm: "ECDH-P256-AES-GCM"' in js
+    assert 'getChatPublicKey("recipientChatPublicKey")' in js
+    assert 'getChatPublicKey("senderChatPublicKey")' in js
+    assert "recipient: await encryptForChatPublicKey(" in js
+    assert "encryptedCopies.sender = await encryptForChatPublicKey(" in js
+    assert "encrypted_conversation_copies" in js
+    assert "private_key" not in js
+    assert "derived wrapping key" not in js.lower()
+    assert 'id="senderChatPublicKey"' in profile_template
+    assert 'id="senderChatPublicKey"' in embed_template
+
+
 def test_profile_template_avoids_inline_submit_handlers() -> None:
     template = (ROOT / "hushline/templates/profile.html").read_text(encoding="utf-8")
     scss = (ROOT / "assets/scss/style.scss").read_text(encoding="utf-8")

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 from uuid import uuid4
@@ -14,6 +15,7 @@ from werkzeug.exceptions import NotFound
 from hushline.db import db
 from hushline.model import (
     AccountCategory,
+    ChatKey,
     Conversation,
     ConversationMessageCopy,
     Message,
@@ -29,10 +31,37 @@ msg_content = "This is a test message."
 suspended_message = "This account is suspended. New messages cannot be sent at this time."
 
 pgp_message_sig = "-----BEGIN PGP MESSAGE-----\n\n"
+chat_message_algorithm = "ECDH-P256-AES-GCM"
 
 
 def _set_pgp_key(user: User) -> None:
     user.pgp_key = Path("tests/test_pgp_key.txt").read_text()
+
+
+def _add_chat_key(user: User, public_key: str) -> None:
+    db.session.add(
+        ChatKey(
+            user=user,
+            key_version=1,
+            public_key=public_key,
+            encrypted_private_key="wrapped-private-chat-key",
+            kdf_algorithm="PBKDF2-SHA-256",
+            kdf_params={"iterations": 310000, "hash": "SHA-256"},
+            kdf_salt="salt",
+            wrapping_algorithm="AES-GCM",
+        )
+    )
+
+
+def _chat_ciphertext(label: str) -> str:
+    return json.dumps(
+        {
+            "algorithm": chat_message_algorithm,
+            "ephemeral_public_key": '{"kty":"EC","crv":"P-256","x":"ephemeral","y":"key"}',
+            "iv": f"iv-{label}",
+            "ciphertext": f"ciphertext-{label}",
+        }
+    )
 
 
 def _authenticate_as(client: FlaskClient, user: User) -> None:
@@ -272,6 +301,8 @@ def test_logged_in_profile_submit_message_creates_conversation_for_distinct_reci
 ) -> None:
     _set_pgp_key(user)
     _set_pgp_key(user2)
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
     db.session.commit()
 
     response = client.post(
@@ -279,6 +310,12 @@ def test_logged_in_profile_submit_message_creates_conversation_for_distinct_reci
         data={
             "field_0": msg_contact_method,
             "field_1": msg_content,
+            "encrypted_conversation_copies": json.dumps(
+                {
+                    "sender": _chat_ciphertext("sender-initial"),
+                    "recipient": _chat_ciphertext("recipient-initial"),
+                }
+            ),
             **get_profile_submission_data(client, user2.primary_username.username),
         },
         follow_redirects=False,
@@ -306,7 +343,10 @@ def test_logged_in_profile_submit_message_creates_conversation_for_distinct_reci
     assert conversation_message.sender_participant.user_id == user.id
     assert len(conversation_message.encrypted_copies) == 2
     for encrypted_copy in conversation_message.encrypted_copies:
-        assert pgp_message_sig in encrypted_copy.encrypted_payload
+        assert chat_message_algorithm in encrypted_copy.encrypted_payload
+        assert msg_contact_method not in encrypted_copy.encrypted_payload
+        assert msg_content not in encrypted_copy.encrypted_payload
+        assert "wrapped-private-chat-key" not in encrypted_copy.encrypted_payload
 
     sender_response = client.get(
         url_for("conversation", conversation_id=conversation.id), follow_redirects=True
@@ -333,6 +373,7 @@ def test_logged_in_profile_submit_message_creates_conversation_without_sender_ke
     client: FlaskClient, user: User, user2: User
 ) -> None:
     _set_pgp_key(user2)
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
     db.session.commit()
 
     response = client.post(
@@ -340,6 +381,9 @@ def test_logged_in_profile_submit_message_creates_conversation_without_sender_ke
         data={
             "field_0": msg_contact_method,
             "field_1": msg_content,
+            "encrypted_conversation_copies": json.dumps(
+                {"recipient": _chat_ciphertext("recipient-initial")}
+            ),
             **get_profile_submission_data(client, user2.primary_username.username),
         },
         follow_redirects=True,
@@ -364,13 +408,54 @@ def test_logged_in_profile_submit_message_creates_conversation_without_sender_ke
     copies = db.session.scalars(db.select(ConversationMessageCopy)).all()
     assert len(copies) == 1
     assert copies[0].recipient_participant.user_id == user2.id
-    assert pgp_message_sig in copies[0].encrypted_payload
+    assert chat_message_algorithm in copies[0].encrypted_payload
+    assert msg_contact_method not in copies[0].encrypted_payload
+    assert msg_content not in copies[0].encrypted_payload
 
     _authenticate_as(client, user2)
     recipient_response = client.get(url_for("conversation", conversation_id=conversation.id))
     assert recipient_response.status_code == 200
     assert "Unlock your Hush Line chat key" in recipient_response.text
     assert "Locked until your chat key is unlocked." in recipient_response.text
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_logged_in_profile_submit_message_with_invalid_chat_ciphertext_skips_conversation(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    _set_pgp_key(user)
+    _set_pgp_key(user2)
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+
+    response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            "encrypted_conversation_copies": json.dumps(
+                {
+                    "recipient": msg_content,
+                    "private_key": "plain-private-key",
+                    "derived_wrapping_key": "plain-derived-key",
+                }
+            ),
+            **get_profile_submission_data(client, user2.primary_username.username),
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200, response.text
+    assert "Message submitted successfully." in response.text
+    message = db.session.scalars(
+        db.select(Message).filter_by(username_id=user2.primary_username.id)
+    ).one()
+    assert message.conversation is None
+    assert db.session.scalars(db.select(Conversation)).all() == []
+    assert db.session.scalars(db.select(ConversationMessageCopy)).all() == []
+    assert "plain-private-key" not in response.text
+    assert "plain-derived-key" not in response.text
 
 
 @pytest.mark.usefixtures("_authenticated_user")


### PR DESCRIPTION
This PR implements child issue #2181 (`Extend client-side encryption for conversation messages`) under epic #2177 (`Feasibility: two-way encrypted conversations between accounts`).
It is intended to merge into the epic branch first, not directly into `main`.

This PR addresses the issue "Extend client-side encryption for conversation messages" by updating supporting files in `assets/js`, request-handling code in `hushline/routes`, and user-facing page templates in `hushline/templates`.
The change includes both implementation work and automated tests, showing the intended behavior and how it is verified.
It touches 8 non-log file(s) (8 total including runner artifacts), primarily in assets/js, hushline/routes, and hushline/templates.

## Summary
- Automated code agent update for child issue #2181.
- Part of epic #2177: Feasibility: two-way encrypted conversations between accounts
- This PR targets the epic integration branch `codex/epic-2177`.
- The child issue is closed explicitly by workflow after this PR merges into the epic branch.

Linked issue: #2181

## Context
- Epic: https://github.com/scidsg/hushline/issues/2177
- Child issue: https://github.com/scidsg/hushline/issues/2181
- Branch: codex/daily-issue-2181
- Base branch: codex/epic-2177
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `assets/js/client-side-encryption.js`
- `hushline/routes/forms.py`
- `hushline/routes/profile.py`
- `hushline/templates/embed_profile.html`
- `hushline/templates/profile.html`
- `tests/test_chat_keys.py`
- `tests/test_frontend_compat.py`
- `tests/test_profile.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
