### PR TITLE
Bound DKIM lookups in email header analysis

### DIFF
--- a/hushline/email_headers.py
+++ b/hushline/email_headers.py
@@ -14,6 +14,9 @@ import dns.flags
 import dns.resolver
 
 _AUTH_RESULTS_RE = re.compile(r"\b(dkim|spf|dmarc)\s*=\s*([a-zA-Z0-9_-]+)")
+_MAX_EMAIL_HEADER_COUNT = 250
+_MAX_DKIM_SIGNATURE_HEADERS = 20
+_MAX_DKIM_KEY_LOOKUPS = 10
 
 
 def _parse_tag_value_pairs(value: str) -> dict[str, str]:
@@ -70,7 +73,11 @@ def _lookup_dkim_key(
             "dnssec_validated": False,
             "error": "No DKIM key found at this DNS name.",
         }
-    except (dns.resolver.NoAnswer, dns.resolver.NoNameservers, dns.exception.Timeout) as e:
+    except (
+        dns.resolver.NoAnswer,
+        dns.resolver.NoNameservers,
+        dns.exception.Timeout,
+    ) as e:
         return {
             "selector": selector,
             "domain": domain,
@@ -393,11 +400,24 @@ def analyze_raw_email_headers(raw_headers: str) -> dict[str, Any]:
     return_path_domain = _domain_from_address(return_path_header)
     reply_to_domain = _domain_from_address(reply_to_header)
 
+    header_count = len(message.items())
+    if header_count > _MAX_EMAIL_HEADER_COUNT:
+        raise ValueError(
+            "Too many email headers detected. Paste a smaller header block and try again."
+        )
+
     auth_results = _extract_authentication_results(message.get_all("Authentication-Results", []))
     dkim_headers = message.get_all("DKIM-Signature", [])
+    if len(dkim_headers) > _MAX_DKIM_SIGNATURE_HEADERS:
+        raise ValueError(
+            "Too many DKIM-Signature headers detected. Paste a smaller header block and try again."
+        )
 
     dkim_signatures: list[dict[str, Any]] = []
     dkim_key_lookups: list[dict[str, Any]] = []
+    dkim_lookup_cache: dict[tuple[str, str], dict[str, Any]] = {}
+    resolver: dns.resolver.Resolver | None = None
+    dkim_lookup_limit_reached = False
     for dkim_header in dkim_headers:
         tags = _parse_tag_value_pairs(dkim_header)
         selector = tags.get("s", "")
@@ -407,7 +427,7 @@ def analyze_raw_email_headers(raw_headers: str) -> dict[str, Any]:
             "canonicalization": tags.get("c", ""),
             "selector": selector,
             "domain": domain,
-            "query_name": f"{selector}._domainkey.{domain}" if selector and domain else None,
+            "query_name": (f"{selector}._domainkey.{domain}" if selector and domain else None),
             "body_hash_present": bool(tags.get("bh")),
             "signature_present": bool(tags.get("b")),
             "signed_headers": [
@@ -416,7 +436,18 @@ def analyze_raw_email_headers(raw_headers: str) -> dict[str, Any]:
         }
         dkim_signatures.append(signature)
         if selector and domain:
-            dkim_key_lookups.append(_lookup_dkim_key(selector=selector, domain=domain))
+            cache_key = (selector.lower(), domain.lower())
+            if cache_key in dkim_lookup_cache:
+                continue
+            if len(dkim_lookup_cache) >= _MAX_DKIM_KEY_LOOKUPS:
+                dkim_lookup_limit_reached = True
+                continue
+            if resolver is None:
+                resolver = dns.resolver.Resolver()
+            dkim_lookup_cache[cache_key] = _lookup_dkim_key(
+                selector=selector, domain=domain, resolver=resolver
+            )
+            dkim_key_lookups.append(dkim_lookup_cache[cache_key])
 
     alignment = {
         "from_matches_return_path": bool(
@@ -433,6 +464,10 @@ def analyze_raw_email_headers(raw_headers: str) -> dict[str, Any]:
         warnings.append("From header does not contain a parseable email domain.")
     if dkim_headers and not dkim_key_lookups:
         warnings.append("DKIM signature found, but selector/domain tags were incomplete.")
+    if dkim_lookup_limit_reached:
+        warnings.append(
+            "DKIM key lookup limit reached; additional signatures were parsed without DNS lookups."
+        )
     if auth_results.get("dkim") not in {"pass", "bestguesspass"} and dkim_headers:
         warnings.append("DKIM did not show a pass result in Authentication-Results.")
     if auth_results.get("spf") and auth_results["spf"] != "pass":

--- a/tests/test_email_headers.py
+++ b/tests/test_email_headers.py
@@ -34,6 +34,17 @@ class _FakeResolver:
         return [_FakeTXTRecord("v=DKIM1; k=rsa; p=MIIB12345")]
 
 
+class _CountingResolver:
+    def __init__(self) -> None:
+        self.timeout = 0.0
+        self.lifetime = 0.0
+        self.queries: list[tuple[str, str]] = []
+
+    def resolve(self, qname: str, rdtype: str) -> list[_FakeTXTRecord]:
+        self.queries.append((qname, rdtype))
+        return [_FakeTXTRecord("v=DKIM1; k=rsa; p=MIIB12345")]
+
+
 class _RaisingResolver:
     def __init__(self, exc: Exception) -> None:
         self._exc = exc
@@ -46,7 +57,9 @@ class _RaisingResolver:
         raise self._exc
 
 
-def test_analyze_raw_email_headers_extracts_auth_results_and_dkim_key(mocker: MockFixture) -> None:
+def test_analyze_raw_email_headers_extracts_auth_results_and_dkim_key(
+    mocker: MockFixture,
+) -> None:
     mocker.patch("hushline.email_headers.dns.resolver.Resolver", return_value=_FakeResolver())
     raw_headers = (
         "From: Alerts <alerts@example.org>\n"
@@ -69,7 +82,11 @@ def test_analyze_raw_email_headers_extracts_auth_results_and_dkim_key(mocker: Mo
     assert report["dkim_key_lookups"][0]["has_public_key"] is True
     assert report["dkim_key_lookups"][0]["dnssec_validated"] is False
     assert report["dkim_overview"]["key_advertised_in_dns"] is True
-    assert report["dkim_signatures"][0]["signed_headers"] == ["from", "subject", "sender"]
+    assert report["dkim_signatures"][0]["signed_headers"] == [
+        "from",
+        "subject",
+        "sender",
+    ]
     assert report["executive_summary"]["verdict"] == "looks valid"
 
 
@@ -192,6 +209,69 @@ def test_analyze_raw_email_headers_with_header_body_mix_parses_headers_only() ->
     assert report["auth_results"]["dkim"] == "pass"
 
 
+def test_analyze_raw_email_headers_rejects_excessive_header_count() -> None:
+    raw_headers = "From: Alerts <alerts@example.org>\n" + "".join(
+        f"X-Filler-{index}: value\n" for index in range(251)
+    )
+
+    with pytest.raises(ValueError, match="Too many email headers detected"):
+        analyze_raw_email_headers(raw_headers)
+
+
+def test_analyze_raw_email_headers_rejects_excessive_dkim_signature_count() -> None:
+    raw_headers = "From: Alerts <alerts@example.org>\n" + "".join(
+        "DKIM-Signature: v=1; a=rsa-sha256; d=example.org; " f"s=selector{index}; bh=abc=; b=def=\n"
+        for index in range(21)
+    )
+
+    with pytest.raises(ValueError, match="Too many DKIM-Signature headers detected"):
+        analyze_raw_email_headers(raw_headers)
+
+
+def test_analyze_raw_email_headers_caches_duplicate_dkim_key_lookups(
+    mocker: MockFixture,
+) -> None:
+    resolver = _CountingResolver()
+    resolver_factory = mocker.patch(
+        "hushline.email_headers.dns.resolver.Resolver", return_value=resolver
+    )
+    raw_headers = (
+        "From: Alerts <alerts@example.org>\n"
+        "DKIM-Signature: v=1; a=rsa-sha256; d=example.org; "
+        "s=selector1; bh=abc=; b=def=\n"
+        "DKIM-Signature: v=1; a=rsa-sha256; d=example.org; "
+        "s=selector1; bh=abc=; b=def=\n"
+    )
+
+    report = analyze_raw_email_headers(raw_headers)
+
+    resolver_factory.assert_called_once_with()
+    assert resolver.queries == [("selector1._domainkey.example.org", "TXT")]
+    assert len(report["dkim_signatures"]) == 2
+    assert len(report["dkim_key_lookups"]) == 1
+
+
+def test_analyze_raw_email_headers_caps_unique_dkim_key_lookups(
+    mocker: MockFixture,
+) -> None:
+    resolver = _CountingResolver()
+    mocker.patch("hushline.email_headers.dns.resolver.Resolver", return_value=resolver)
+    raw_headers = "From: Alerts <alerts@example.org>\n" + "".join(
+        "DKIM-Signature: v=1; a=rsa-sha256; d=example.org; " f"s=selector{index}; bh=abc=; b=def=\n"
+        for index in range(11)
+    )
+
+    report = analyze_raw_email_headers(raw_headers)
+
+    assert len(resolver.queries) == 10
+    assert len(report["dkim_signatures"]) == 11
+    assert len(report["dkim_key_lookups"]) == 10
+    assert (
+        "DKIM key lookup limit reached; additional signatures were parsed without DNS lookups."
+        in report["warnings"]
+    )
+
+
 def test_analyze_raw_email_headers_warns_on_unparseable_from_and_incomplete_dkim() -> None:
     raw_headers = (
         "From: not-an-address\n"
@@ -216,10 +296,14 @@ def test_analyze_raw_email_headers_warns_on_unparseable_from_and_incomplete_dkim
     ],
 )
 def test_analyze_raw_email_headers_handles_dns_lookup_errors(
-    mocker: MockFixture, raised: Exception, expected_status: str, expected_error_snippet: str
+    mocker: MockFixture,
+    raised: Exception,
+    expected_status: str,
+    expected_error_snippet: str,
 ) -> None:
     mocker.patch(
-        "hushline.email_headers.dns.resolver.Resolver", return_value=_RaisingResolver(raised)
+        "hushline.email_headers.dns.resolver.Resolver",
+        return_value=_RaisingResolver(raised),
     )
     raw_headers = (
         "From: Alerts <alerts@example.org>\n"
@@ -232,7 +316,9 @@ def test_analyze_raw_email_headers_handles_dns_lookup_errors(
     assert expected_error_snippet in (lookup["error"] or "")
 
 
-def test_create_evidence_zip_contains_pdf_json_and_valid_checksums(mocker: MockFixture) -> None:
+def test_create_evidence_zip_contains_pdf_json_and_valid_checksums(
+    mocker: MockFixture,
+) -> None:
     mocker.patch("hushline.email_headers.dns.resolver.Resolver", return_value=_FakeResolver())
     raw_headers = (
         "From: Alerts <alerts@example.org>\n"
@@ -292,7 +378,9 @@ def test_email_headers_export_zip_contains_evidence_artifacts(
 
 
 @pytest.mark.usefixtures("_authenticated_user")
-def test_email_headers_post_invalid_form_shows_validation_flash(client: FlaskClient) -> None:
+def test_email_headers_post_invalid_form_shows_validation_flash(
+    client: FlaskClient,
+) -> None:
     response = client.post(
         url_for("email_headers"),
         data={"raw_headers": ""},
@@ -349,7 +437,9 @@ def test_email_headers_missing_csrf_preserves_invalid_post_behavior(
 
 
 @pytest.mark.usefixtures("_authenticated_user")
-def test_email_headers_export_invalid_form_redirects_with_flash(client: FlaskClient) -> None:
+def test_email_headers_export_invalid_form_redirects_with_flash(
+    client: FlaskClient,
+) -> None:
     response = client.post(
         url_for("email_headers_evidence_zip"),
         data={"raw_headers": ""},
@@ -476,7 +566,10 @@ def test_render_report_pdf_includes_none_sections_and_warnings_block() -> None:
         "from_domain": None,
         "return_path_domain": None,
         "reply_to_domain": None,
-        "alignment": {"from_matches_return_path": False, "from_matches_any_dkim_domain": False},
+        "alignment": {
+            "from_matches_return_path": False,
+            "from_matches_any_dkim_domain": False,
+        },
         "auth_results": {},
         "dkim_signatures": [],
         "dkim_key_lookups": [],


### PR DESCRIPTION
### Motivation
- Prevent request-time denial-of-service by capping attacker-controlled synchronous DNS TXT lookups triggered from user-supplied raw email headers. 
- Keep header analysis behavior intact while bounding work per-request to preserve availability of Flask/Gunicorn workers. 

### Description
- Add limits and constants: `_MAX_EMAIL_HEADER_COUNT = 250`, `_MAX_DKIM_SIGNATURE_HEADERS = 20`, and `_MAX_DKIM_KEY_LOOKUPS = 10` to bound parsed headers and DNS lookups. 
- Enforce input limits by raising `ValueError` when header count or DKIM-Signature header count exceeds caps. 
- Cache duplicate selector+domain lookups and reuse a single `dns.resolver.Resolver` instance to avoid repeating identical synchronous DNS calls, and stop issuing new unique lookups once the unique-lookup cap is reached. 
- Surface a warning (`DKIM key lookup limit reached; additional signatures were parsed without DNS lookups.`) when the lookup cap truncates DNS processing, and add regression tests covering excessive headers, DKIM signature caps, duplicate-cache behavior, and unique-lookup limiting. 

### Testing
- Ran formatting and lint checks with `poetry run ruff format` and `poetry run ruff check` on the changed files, and they passed. 
- Ran static typing with `poetry run mypy hushline/email_headers.py`, and it passed. 
- Ran the unit test subset with `poetry run pytest tests/test_email_headers.py -q` (filtered to exclude DB-backed/integration tests) where the modified and new unit tests passed (`22 passed, 11 deselected`). 
- A full `pytest` run in this environment showed 22 passing tests and 11 setup errors caused by inability to resolve the local Postgres host (environment DNS/DB unavailable), and Docker-based checks (`make lint`, `make test`, CI-style coverage and audit targets) could not be executed here because Docker is unavailable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b5e99408c8330a6d9fd7f31205f0f)