### PR TITLE
Pin Poetry export plugin in dependency audit

### DIFF
--- a/.github/workflows/dependency-security-audit.yml
+++ b/.github/workflows/dependency-security-audit.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Python dependency audit
         run: |
           docker compose run --rm app bash -lc \
-            'poetry self add poetry-plugin-export && poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt && python -m pip install --disable-pip-version-check pip-audit==2.10.0 && pip-audit -r /tmp/requirements.txt'
+            'poetry self add "poetry-plugin-export==1.10.0" && poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt && python -m pip install --disable-pip-version-check pip-audit==2.10.0 && pip-audit -r /tmp/requirements.txt'
 
   node-runtime-audit:
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ refresh-newsroom-listings: ## Refresh newsroom directory artifact from public so
 
 .PHONY: audit-python
 audit-python: ## Run Python dependency audit (CI-equivalent)
-	$(CMD) bash -lc 'poetry self add poetry-plugin-export && poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt && python -m pip install --disable-pip-version-check pip-audit==2.10.0 && pip-audit -r /tmp/requirements.txt'
+	$(CMD) bash -lc 'poetry self add "poetry-plugin-export==1.10.0" && poetry export -f requirements.txt --without-hashes -o /tmp/requirements.txt && python -m pip install --disable-pip-version-check pip-audit==2.10.0 && pip-audit -r /tmp/requirements.txt'
 
 .PHONY: audit-node-runtime
 audit-node-runtime: ## Run Node runtime dependency audit (CI-equivalent)

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -312,6 +312,18 @@ def test_dependency_audit_workflow_only_runs_python_audit_when_poetry_lock_chang
     )
 
 
+def test_dependency_audit_pins_poetry_export_plugin_install() -> None:
+    workflow_text = _workflow_text(".github/workflows/dependency-security-audit.yml")
+    make_text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+
+    expected_install = 'poetry self add "poetry-plugin-export==1.10.0"'
+
+    assert expected_install in workflow_text
+    assert expected_install in make_text
+    assert "poetry self add poetry-plugin-export &&" not in workflow_text
+    assert "poetry self add poetry-plugin-export &&" not in make_text
+
+
 def test_securedrop_refresh_summary_uses_checked_random_github_output_delimiter() -> None:
     workflow_text = _workflow_text(".github/workflows/securedrop-directory-refresh.yml")
     summary_section = workflow_text.split("      - name: Read refresh summary", 1)[1].split(


### PR DESCRIPTION
### Motivation
- The dependency-audit workflow installed `poetry-plugin-export` without a version, which allows mutable external package state to run code in CI before audit checks execute. Pinning the plugin makes the install deterministic and reduces CI supply-chain risk.

### Description
- Pin `poetry-plugin-export` to an exact version by changing the install to `poetry self add "poetry-plugin-export==1.10.0"` in `.github/workflows/dependency-security-audit.yml` so Poetry cannot pull a mutable latest release during the audit job.
- Apply the same exact-version install to the local CI-equivalent target in `Makefile` (`audit-python`) so local and CI audit behavior are aligned.
- Add a regression test `test_dependency_audit_pins_poetry_export_plugin_install` to `tests/test_workflow_pr_head_qualification.py` that asserts the workflow and Makefile use the pinned install and that the unversioned command is not present.

### Testing
- Ran `python -m pytest tests/test_workflow_pr_head_qualification.py -q` and the targeted tests passed (regression test included) so the assertion coverage for the change is present and green.
- Ran style and workflow checks (`prettier` check on the workflow file, `poetry run ruff format --check` and `poetry run ruff check` for the changed test) and `scripts/check_workflow_pr_head_qualification.py`, all of which passed for the modified files.
- `make lint`, `make test`, `make audit-python`, and `make audit-node-runtime` could not be completed in this environment because Docker is unavailable or external package access (PyPI/npm audit) is blocked, so CI must run the canonical Docker-backed lint/tests/audit jobs before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b60c0ec688330844c1177d2912594)