### PR TITLE
Do not trust DNS resolver AD flag for DKIM DNSSEC status

### DIFF
--- a/hushline/email_headers.py
+++ b/hushline/email_headers.py
@@ -10,7 +10,6 @@ from email.utils import parseaddr
 from typing import Any
 
 import dns.exception
-import dns.flags
 import dns.resolver
 
 _AUTH_RESULTS_RE = re.compile(r"\b(dkim|spf|dmarc)\s*=\s*([a-zA-Z0-9_-]+)")
@@ -102,8 +101,10 @@ def _lookup_dkim_key(
         if tags.get("p"):
             has_public_key = True
 
-    response = getattr(records, "response", None)
-    dnssec_validated = bool(response and (response.flags & dns.flags.AD))
+    # A recursive resolver's AD bit is only a claim from that resolver. Because this
+    # application does not perform its own DNSSEC chain validation or authenticate the
+    # resolver transport, do not report DNSSEC validation for DKIM key lookups here.
+    dnssec_validated = False
 
     return {
         "selector": selector,
@@ -217,7 +218,10 @@ def _build_interpretation(report: dict[str, Any]) -> dict[str, list[str]]:
         auth_chain_lines.append(
             "Without DNSSEC validation, treat DNS-based evidence as lower-confidence."
         )
-    auth_chain_lines.append("Technical note: DNSSEC status is based on the resolver AD flag.")
+    auth_chain_lines.append(
+        "Technical note: Hush Line does not independently validate DNSSEC for DKIM DNS "
+        "lookups; resolver AD flags are not treated as proof of validation."
+    )
     interpretation["auth_chain"] = auth_chain_lines
 
     align_rp = alignment["from_matches_return_path"]
@@ -601,7 +605,7 @@ def _render_report_pdf(report: dict[str, Any], created_at: datetime) -> bytes:
                 f"{'yes' if report['dkim_overview']['key_advertised_in_dns'] else 'no'}"
             ),
             (
-                "  DKIM key validated via DNSSEC: "
+                "  DKIM key independently validated via DNSSEC: "
                 f"{'yes' if report['dkim_overview']['dnssec_validated'] else 'no'}"
             ),
             "  Summary:",
@@ -670,7 +674,7 @@ def _render_report_pdf(report: dict[str, Any], created_at: datetime) -> bytes:
             lines.append(
                 f"  {lookup['query_name']} status={lookup['status']} "
                 f"has_public_key={lookup['has_public_key']} "
-                f"dnssec_validated={lookup['dnssec_validated']}"
+                f"dnssec_independently_validated={lookup['dnssec_validated']}"
             )
     else:
         lines.append("  None")

--- a/hushline/templates/email_headers.html
+++ b/hushline/templates/email_headers.html
@@ -53,7 +53,7 @@
           <code>{{ "yes" if report.dkim_overview.key_advertised_in_dns else "no" }}</code>
         </li>
         <li>
-          DNSSEC-validated DNS answer:
+          DNSSEC independently validated by Hush Line:
           <code>{{ "yes" if report.dkim_overview.dnssec_validated else "no" }}</code>
         </li>
       </ul>
@@ -138,7 +138,7 @@
               {% if item.has_public_key %}
                 (public key present)
               {% endif %}
-              (dnssec validated: <code>{{ "yes" if item.dnssec_validated else "no" }}</code>)
+              (dnssec independently validated: <code>{{ "yes" if item.dnssec_validated else "no" }}</code>)
               {% if item.error %}
                 - {{ item.error }}
               {% endif %}

--- a/tests/test_email_headers.py
+++ b/tests/test_email_headers.py
@@ -4,6 +4,7 @@ import zipfile
 from datetime import UTC, datetime
 
 import dns.exception
+import dns.flags
 import dns.resolver
 import pytest
 from bs4 import BeautifulSoup
@@ -23,15 +24,22 @@ class _FakeTXTRecord:
         return f'"{self._text}"'
 
 
+class _FakeAnswer(list[_FakeTXTRecord]):
+    def __init__(self, records: list[_FakeTXTRecord], flags: int = 0) -> None:
+        super().__init__(records)
+        self.response = type("FakeResponse", (), {"flags": flags})()
+
+
 class _FakeResolver:
-    def __init__(self) -> None:
+    def __init__(self, flags: int = 0) -> None:
+        self._flags = flags
         self.timeout = 0.0
         self.lifetime = 0.0
 
-    def resolve(self, qname: str, rdtype: str) -> list[_FakeTXTRecord]:
+    def resolve(self, qname: str, rdtype: str) -> _FakeAnswer:
         assert qname == "selector1._domainkey.example.org"
         assert rdtype == "TXT"
-        return [_FakeTXTRecord("v=DKIM1; k=rsa; p=MIIB12345")]
+        return _FakeAnswer([_FakeTXTRecord("v=DKIM1; k=rsa; p=MIIB12345")], self._flags)
 
 
 class _RaisingResolver:
@@ -71,6 +79,35 @@ def test_analyze_raw_email_headers_extracts_auth_results_and_dkim_key(mocker: Mo
     assert report["dkim_overview"]["key_advertised_in_dns"] is True
     assert report["dkim_signatures"][0]["signed_headers"] == ["from", "subject", "sender"]
     assert report["executive_summary"]["verdict"] == "looks valid"
+
+
+def test_analyze_raw_email_headers_does_not_trust_resolver_ad_flag(
+    mocker: MockFixture,
+) -> None:
+    mocker.patch(
+        "hushline.email_headers.dns.resolver.Resolver",
+        return_value=_FakeResolver(flags=dns.flags.AD),
+    )
+    raw_headers = (
+        "From: Alerts <alerts@example.org>\n"
+        "Authentication-Results: mx.example.net; dkim=pass header.d=example.org\n"
+        "DKIM-Signature: v=1; a=rsa-sha256; d=example.org; s=selector1; "
+        "h=from:subject; bh=abc123=; b=def456=\n"
+    )
+
+    report = analyze_raw_email_headers(raw_headers)
+
+    assert report["dkim_key_lookups"][0]["status"] == "found"
+    assert report["dkim_key_lookups"][0]["has_public_key"] is True
+    assert report["dkim_key_lookups"][0]["dnssec_validated"] is False
+    assert report["dkim_overview"]["dnssec_validated"] is False
+    assert any(
+        "resolver AD flags are not treated as proof of validation" in line
+        for line in report["interpretation"]["auth_chain"]
+    )
+    assert not any(
+        "This DNS evidence is strong" in line for line in report["interpretation"]["auth_chain"]
+    )
 
 
 def test_email_headers_page_renders(client: FlaskClient) -> None:
@@ -411,7 +448,7 @@ def test_parse_tag_value_pairs_ignores_invalid_parts_and_empty_keys() -> None:
     assert tags == {"s": "selector1", "d": "example.org"}
 
 
-def test_build_interpretation_includes_strong_chain_multiple_signatures_and_strong_keys() -> None:
+def test_build_interpretation_includes_dnssec_chain_multiple_signatures_and_strong_keys() -> None:
     interpretation = email_headers._build_interpretation(
         {
             "auth_results": {"dkim": "pass", "spf": "pass", "dmarc": "pass"},


### PR DESCRIPTION
### Motivation
- Prevent misleading DNSSEC assertions in DKIM key lookups by avoiding reliance on a recursive resolver's AD bit as proof of DNSSEC validation.
- Preserve report integrity and user trust in the email validation tool without implementing full DNSSEC chain validation or requiring a trusted resolver transport.
- Maintain existing DKIM lookup functionality while removing an unsafe, over-confident trust signal from UI/PDF reports.

### Description
- Stop deriving `dnssec_validated` from `response.flags & dns.flags.AD` in `_lookup_dkim_key()` and instead set `dnssec_validated = False` unless independent DNSSEC validation is implemented.
- Update interpretation text to explicitly state that Hush Line does not independently validate DNSSEC for DKIM lookups and that resolver AD flags are not treated as proof of validation.
- Change UI and PDF wording to clarify DNSSEC status as “independently validated by Hush Line” and rename per-lookup PDF field to `dnssec_independently_validated` for clarity.
- Add a regression test that simulates a resolver returning an AD-flagged response and asserts the report still treats `dnssec_validated` as `False` and does not label DNS evidence as strong.

### Testing
- Ran unit test subset with `poetry run pytest tests/test_email_headers.py -q -k 'not page and not export and not post and not csrf'` and the selected tests passed (`19 passed, 11 deselected`).
- Ran full `poetry run pytest tests/test_email_headers.py -q` where pure/unit tests passed, but DB-backed Flask tests errored due to inability to resolve the `postgres` host in this environment (`psycopg.OperationalError`), so full local test run is blocked by environment networking.
- Static checks `poetry run ruff format --check` and `poetry run ruff check` passed and `poetry run mypy` passed for the modified files.
- Repository-wide `make lint`, `make test`, `make audit-python`, and `make audit-node-runtime` could not be run here because Docker is unavailable in the current environment (`docker: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b60c0eda48330932a7bef5a0b18de)