### PR TITLE
Sanitize screenshot email header samples

### DIFF
--- a/docs/screenshots/scenes.json
+++ b/docs/screenshots/scenes.json
@@ -89,7 +89,7 @@
         {
           "type": "fill",
           "selector": "#raw_headers",
-          "value": "Return-Path: <notifications@hushline.app>\nX-Original-To: glenn@scidsg.org\nDelivered-To: glenn@scidsg.org\nAuthentication-Results: mail.protonmail.ch; dmarc=pass (p=none dis=none) header.from=hushline.app\nAuthentication-Results: mail.protonmail.ch; spf=pass smtp.mailfrom=hushline.app\nAuthentication-Results: mail.protonmail.ch; arc=none smtp.remote-ip=198.252.153.129\nAuthentication-Results: mail.protonmail.ch; dkim=none\nContent-Type: text/plain\nMime-Version: 1.0\nFrom: notifications@hushline.app\nTo: glenn@scidsg.org\nSubject: New Hush Line Message Received\nReply-To: notifications@hushline.app\nDate: Mon, 16 Feb 2026 00:31:10 +0000\n"
+          "value": "Return-Path: <notifications@example.org>\nX-Original-To: recipient@example.org\nDelivered-To: recipient@example.org\nAuthentication-Results: mx.example.net; dmarc=pass (p=none dis=none) header.from=example.org\nAuthentication-Results: mx.example.net; spf=pass smtp.mailfrom=example.org\nAuthentication-Results: mx.example.net; arc=none smtp.remote-ip=192.0.2.10\nAuthentication-Results: mx.example.net; dkim=none\nContent-Type: text/plain\nMime-Version: 1.0\nFrom: notifications@example.org\nTo: recipient@example.org\nSubject: New Hush Line Message Received\nReply-To: notifications@example.org\nDate: Mon, 16 Feb 2026 00:31:10 +0000\n"
         },
         {
           "type": "click",
@@ -467,7 +467,7 @@
         {
           "type": "fill",
           "selector": "#raw_headers",
-          "value": "Return-Path: <notifications@hushline.app>\nX-Original-To: glenn@scidsg.org\nDelivered-To: glenn@scidsg.org\nAuthentication-Results: mail.protonmail.ch; dmarc=pass (p=none dis=none) header.from=hushline.app\nAuthentication-Results: mail.protonmail.ch; spf=pass smtp.mailfrom=hushline.app\nAuthentication-Results: mail.protonmail.ch; arc=none smtp.remote-ip=198.252.153.129\nAuthentication-Results: mail.protonmail.ch; dkim=none\nContent-Type: text/plain\nMime-Version: 1.0\nFrom: notifications@hushline.app\nTo: glenn@scidsg.org\nSubject: New Hush Line Message Received\nReply-To: notifications@hushline.app\nDate: Mon, 16 Feb 2026 00:31:10 +0000\n"
+          "value": "Return-Path: <notifications@example.org>\nX-Original-To: recipient@example.org\nDelivered-To: recipient@example.org\nAuthentication-Results: mx.example.net; dmarc=pass (p=none dis=none) header.from=example.org\nAuthentication-Results: mx.example.net; spf=pass smtp.mailfrom=example.org\nAuthentication-Results: mx.example.net; arc=none smtp.remote-ip=192.0.2.10\nAuthentication-Results: mx.example.net; dkim=none\nContent-Type: text/plain\nMime-Version: 1.0\nFrom: notifications@example.org\nTo: recipient@example.org\nSubject: New Hush Line Message Received\nReply-To: notifications@example.org\nDate: Mon, 16 Feb 2026 00:31:10 +0000\n"
         },
         {
           "type": "click",

--- a/tests/test_screenshot_manifest_privacy.py
+++ b/tests/test_screenshot_manifest_privacy.py
@@ -1,0 +1,39 @@
+import ipaddress
+import json
+import re
+from pathlib import Path
+
+SCREENSHOT_MANIFESTS = sorted(Path("docs/screenshots").glob("scenes*.json"))
+EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]+@([A-Za-z0-9.-]+\.[A-Za-z]{2,})")
+IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+RESERVED_EMAIL_DOMAINS = {"example.com", "example.net", "example.org"}
+DOCUMENTATION_NETWORKS = tuple(
+    ipaddress.ip_network(network)
+    for network in ("192.0.2.0/24", "198.51.100.0/24", "203.0.113.0/24")
+)
+
+
+def _raw_header_samples(manifest_path: Path) -> list[str]:
+    manifest = json.loads(manifest_path.read_text())
+    scenes = manifest.get("scenes", manifest)
+    samples: list[str] = []
+    for scene in scenes:
+        for action in scene.get("actions", []):
+            if action.get("type") == "fill" and action.get("selector") == "#raw_headers":
+                samples.append(action.get("value", ""))
+    return samples
+
+
+def test_email_validation_screenshot_headers_use_documentation_addresses() -> None:
+    for manifest_path in SCREENSHOT_MANIFESTS:
+        for sample in _raw_header_samples(manifest_path):
+            domains = {match.group(1).lower() for match in EMAIL_RE.finditer(sample)}
+            assert domains <= RESERVED_EMAIL_DOMAINS
+
+
+def test_email_validation_screenshot_headers_use_documentation_ips() -> None:
+    for manifest_path in SCREENSHOT_MANIFESTS:
+        for sample in _raw_header_samples(manifest_path):
+            for match in IPV4_RE.finditer(sample):
+                address = ipaddress.ip_address(match.group(0))
+                assert any(address in network for network in DOCUMENTATION_NETWORKS)


### PR DESCRIPTION
### Motivation

- The screenshot manifest in `docs/screenshots/scenes.json` contained real-looking recipient email and mail-routing metadata which can be rendered and published by the docs screenshot automation, creating an avoidable privacy disclosure.

### Description

- Replaced sensitive raw-header samples in `docs/screenshots/scenes.json` with reserved documentation addresses (`example.org`/`example.com`/`example.net`) and documentation IPv4 ranges (`192.0.2.0/24`), preserving the original example semantics.
- Added `tests/test_screenshot_manifest_privacy.py` which scans screenshot manifests and asserts that `#raw_headers` fill actions only use reserved example domains and documentation IP networks.
- Made only minimal JSON formatting adjustments to the manifest so the change is focused on sanitizing data and adding regression coverage.

### Testing

- Ran `python -m pytest tests/test_screenshot_manifest_privacy.py -q` and the new privacy tests passed (2 passed).
- Ran `python -m ruff format --check tests/test_screenshot_manifest_privacy.py && python -m ruff check tests/test_screenshot_manifest_privacy.py` and formatting/lint checks for the new test file passed locally.
- Verified programmatic behavior by invoking `analyze_raw_email_headers` on the updated valid-status scenes and confirmed both still produce the `looks valid` verdict.
- Docker-backed project-wide checks (`make lint`, `make test`, `make audit-python`, `make audit-node-runtime`) were not executed here because Docker is not available in the current environment and must be run in CI or a Docker-enabled developer environment before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b60c14fc08330b67b2d6f99a15737)