### PR TITLE
#2182 Show conversations in both participants' inboxes

### DIFF
--- a/hushline/routes/inbox.py
+++ b/hushline/routes/inbox.py
@@ -1,3 +1,6 @@
+from dataclasses import dataclass
+from datetime import datetime
+
 from flask import (
     Flask,
     abort,
@@ -10,11 +13,82 @@ from werkzeug.wrappers.response import Response
 from hushline.auth import authentication_required
 from hushline.db import db
 from hushline.model import (
+    Conversation,
+    ConversationParticipant,
     Message,
     MessageStatus,
     User,
     Username,
 )
+
+
+@dataclass(frozen=True)
+class InboxConversation:
+    conversation: Conversation
+    other_participant_names: list[str]
+    latest_at: datetime
+    message_count: int
+    has_unread: bool
+    has_available_copy: bool
+
+
+def _conversation_latest_at(conversation: Conversation) -> datetime:
+    return max(
+        (message.created_at for message in conversation.messages),
+        default=conversation.created_at,
+    )
+
+
+def _participant_has_available_copies(
+    conversation: Conversation,
+    participant: ConversationParticipant,
+) -> bool:
+    return all(
+        any(
+            encrypted_copy.recipient_participant_id == participant.id
+            for encrypted_copy in message.encrypted_copies
+        )
+        for message in conversation.messages
+    )
+
+
+def _conversation_has_unread(
+    conversation: Conversation,
+    participant: ConversationParticipant,
+) -> bool:
+    return any(
+        message.sender_participant_id != participant.id
+        and (participant.last_read_at is None or message.created_at > participant.last_read_at)
+        for message in conversation.messages
+    )
+
+
+def _inbox_conversation_summary(
+    conversation: Conversation,
+    user: User,
+) -> InboxConversation | None:
+    participant = conversation.participant_for_user_id(user.id)
+    if participant is None:
+        return None
+
+    other_participant_names = []
+    for thread_participant in conversation.participants:
+        if thread_participant.user_id == user.id:
+            continue
+        username = thread_participant.user.primary_username
+        other_participant_names.append(f"@{username.username}")
+
+    return InboxConversation(
+        conversation=conversation,
+        other_participant_names=other_participant_names,
+        latest_at=_conversation_latest_at(conversation),
+        message_count=len(conversation.messages),
+        has_unread=_conversation_has_unread(conversation, participant),
+        has_available_copy=(
+            participant.has_usable_public_key
+            and _participant_has_available_copies(conversation, participant)
+        ),
+    )
 
 
 def register_inbox_routes(app: Flask) -> None:
@@ -55,10 +129,18 @@ def register_inbox_routes(app: Flask) -> None:
         status_counts_map = {x[0]: x[1] for x in status_count_results}
         message_statuses = [(x, status_counts_map.get(x, 0)) for x in MessageStatus]
 
+        conversations = [
+            summary
+            for conversation in db.session.scalars(Conversation.for_user_id(user.id))
+            if (summary := _inbox_conversation_summary(conversation, user)) is not None
+        ]
+        conversations.sort(key=lambda conversation: conversation.latest_at, reverse=True)
+
         return render_template(
             "inbox.html",
             user=user,
             messages=messages,
+            conversations=conversations,
             status_filter=status_filter,
             total_messages=sum(x[1] for x in message_statuses),
             message_statuses=message_statuses,

--- a/hushline/templates/inbox.html
+++ b/hushline/templates/inbox.html
@@ -18,27 +18,89 @@
             {% set count = total_messages %}
             {% set url = url_for('inbox') %}
           {% endif %}
-          {% set is_active = (pair and pair[0] == status_filter) or (pair is none and not status_filter) %}
+          {% set is_active =
+            (pair and pair[0] == status_filter) or (pair is none and not status_filter)
+          %}
           <li class="tab{% if is_active %} active{% endif %}">
-            <a href="{{ url }}"{% if is_active %} aria-current="page"{% endif %}>{{ display_str }}</a>
+            <a href="{{ url }}"{% if is_active %} aria-current="page"{% endif %}>
+              {{ display_str }}
+            </a>
             <span class="badge">{{ count }}</span>
           </li>
         {% endfor %}
       </ul>
     </nav>
     <div class="message-list">
+      {% if conversations %}
+        <section class="conversation-list" aria-labelledby="conversation-list-heading">
+          <h3 id="conversation-list-heading">Conversations</h3>
+          {% for item in conversations %}
+            {% set title_id = "conversation-title-" ~ item.conversation.id %}
+            <article
+              class="message encrypted conversation-summary"
+              aria-labelledby="{{ title_id }}"
+            >
+              {% if item.has_unread %}
+                <span class="badge" aria-label="Unread conversation">Unread</span>
+              {% endif %}
+              <h4 id="{{ title_id }}">
+                Conversation with
+                {% if item.other_participant_names %}
+                  {{ item.other_participant_names | join(", ") }}
+                {% else %}
+                  your account
+                {% endif %}
+              </h4>
+              {% if item.conversation.initial_message %}
+                <p>To: @{{ item.conversation.initial_message.username.username }}</p>
+              {% endif %}
+              <p>{{ item.latest_at.date() }}</p>
+              <p>
+                {{ item.message_count }} encrypted
+                {{ "message" if item.message_count == 1 else "messages" }}
+              </p>
+              {% if item.has_available_copy %}
+                <p class="meta" role="status">
+                  Locked: unlock your Hush Line chat key to read this thread.
+                </p>
+              {% else %}
+                <p class="meta" role="status">
+                  Key unavailable: no encrypted copy is available for this account.
+                </p>
+              {% endif %}
+              <p>
+                <a
+                  class="stretched-link"
+                  href="{{ url_for('conversation', conversation_id=item.conversation.id) }}"
+                >
+                  Open conversation
+                </a>
+              </p>
+            </article>
+          {% endfor %}
+        </section>
+      {% endif %}
       {% if messages %}
         {% for message in messages %}
           <article
             class="message encrypted"
-            aria-label="Message with {{ message.username.display_name or message.username.username }}"
+            aria-label="Message with {{
+              message.username.display_name or message.username.username
+            }}"
           >
             <p>To: @{{ message.username.username }}</p>
             <p>{{ message.created_at.date() }}</p>
-            <p><a class="stretched-link" href="{{ url_for('message', public_id=message.public_id) }}">Go to message</a></p>
+            <p>
+              <a
+                class="stretched-link"
+                href="{{ url_for('message', public_id=message.public_id) }}"
+              >
+                Go to message
+              </a>
+            </p>
           </article>
         {% endfor %}
-      {% else %}
+      {% elif not conversations %}
         <div class="emptyState">
           <img
             class="empty"

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -4,7 +4,49 @@ from flask import url_for
 from flask.testing import FlaskClient
 
 from hushline.db import db
-from hushline.model import OrganizationSetting
+from hushline.model import (
+    Conversation,
+    ConversationMessage,
+    ConversationMessageCopy,
+    ConversationParticipant,
+    OrganizationSetting,
+    User,
+)
+
+
+def _make_inbox_conversation(
+    user: User,
+    user2: User,
+    *,
+    user_has_copy: bool,
+    sender_is_other_user: bool,
+) -> Conversation:
+    conversation = Conversation()
+    user_participant = ConversationParticipant()
+    user_participant.conversation = conversation
+    user_participant.user = user
+    user_participant.has_usable_public_key = user_has_copy
+    other_participant = ConversationParticipant()
+    other_participant.conversation = conversation
+    other_participant.user = user2
+    other_participant.has_usable_public_key = True
+    conversation_message = ConversationMessage()
+    conversation_message.conversation = conversation
+    conversation_message.sender_participant = (
+        other_participant if sender_is_other_user else user_participant
+    )
+    if user_has_copy:
+        user_copy = ConversationMessageCopy()
+        user_copy.recipient_participant = user_participant
+        user_copy.encrypted_payload = "encrypted-for-current-user"
+        conversation_message.encrypted_copies.append(user_copy)
+    other_copy = ConversationMessageCopy()
+    other_copy.recipient_participant = other_participant
+    other_copy.encrypted_payload = "encrypted-for-other-user"
+    conversation_message.encrypted_copies.append(other_copy)
+    db.session.add(conversation)
+    db.session.commit()
+    return conversation
 
 
 def test_directory_tab_aria_and_controls(client: FlaskClient) -> None:
@@ -166,6 +208,68 @@ def test_inbox_filter_nav_marks_current_page(client: FlaskClient) -> None:
     assert inbox_nav is not None
     assert current is not None
     assert current.text.strip() == "All"
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_inbox_conversation_rows_have_accessible_status_and_unread_state(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    locked_conversation = _make_inbox_conversation(
+        user,
+        user2,
+        user_has_copy=True,
+        sender_is_other_user=False,
+    )
+    unavailable_conversation = _make_inbox_conversation(
+        user,
+        user2,
+        user_has_copy=False,
+        sender_is_other_user=True,
+    )
+
+    response = client.get(url_for("inbox"), follow_redirects=True)
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    conversation_section = soup.find("section", {"aria-labelledby": "conversation-list-heading"})
+    conversation_heading = soup.find(id="conversation-list-heading")
+    conversation_rows = soup.select("article.conversation-summary")
+    unread_badge = soup.select_one("article.conversation-summary .badge")
+    status_messages = [
+        status.get_text(" ", strip=True)
+        for status in soup.select("article.conversation-summary p[role='status']")
+    ]
+
+    assert conversation_section is not None
+    assert conversation_heading is not None
+    assert conversation_heading.get_text(" ", strip=True) == "Conversations"
+    assert len(conversation_rows) == 2
+    for row in conversation_rows:
+        title_id = row.get("aria-labelledby")
+        assert title_id
+        assert soup.find(id=title_id) is not None
+
+    assert unread_badge is not None
+    assert unread_badge.get("aria-label") == "Unread conversation"
+    assert unread_badge.get_text(" ", strip=True) == "Unread"
+    assert "Locked: unlock your Hush Line chat key to read this thread." in status_messages
+    assert "Key unavailable: no encrypted copy is available for this account." in status_messages
+    assert (
+        soup.find(
+            "a",
+            href=url_for("conversation", conversation_id=locked_conversation.id),
+        )
+        is not None
+    )
+    assert (
+        soup.find(
+            "a",
+            href=url_for("conversation", conversation_id=unavailable_conversation.id),
+        )
+        is not None
+    )
 
 
 def test_guidance_modal_has_accessible_attributes(client: FlaskClient) -> None:

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -1,10 +1,55 @@
+import json
+from pathlib import Path
+
 import pytest
 from flask import url_for
 from flask.testing import FlaskClient
+from helpers import get_profile_submission_data
 
 from hushline import auth
 from hushline.db import db
-from hushline.model import FieldValue, Message, MessageStatus, User, Username
+from hushline.model import ChatKey, FieldValue, Message, MessageStatus, User, Username
+
+MSG_CONTACT_METHOD = "I prefer Signal."
+MSG_CONTENT = "This is a test message."
+
+
+def _authenticate_as(client: FlaskClient, user: User) -> None:
+    with client.session_transaction() as session:
+        session["user_id"] = user.id
+        session["session_id"] = user.session_id
+        session["username"] = user.primary_username.username
+        session["is_authenticated"] = True
+
+
+def _set_pgp_key(user: User) -> None:
+    user.pgp_key = Path("tests/test_pgp_key.txt").read_text()
+
+
+def _add_chat_key(user: User, public_key: str) -> None:
+    db.session.add(
+        ChatKey(
+            user=user,
+            key_version=1,
+            public_key=public_key,
+            encrypted_private_key="wrapped-private-chat-key",
+            kdf_algorithm="PBKDF2-SHA-256",
+            kdf_params={"iterations": 310000, "hash": "SHA-256"},
+            kdf_salt="salt",
+            wrapping_algorithm="AES-GCM",
+        )
+    )
+
+
+def _chat_ciphertext(label: str) -> str:
+    return json.dumps(
+        {
+            "algorithm": "ECDH-P256-AES-GCM",
+            "ephemeral_public_key": '{"kty":"EC","crv":"P-256","x":"ephemeral","y":"key"}',
+            "iv": f"iv-{label}",
+            "ciphertext": f"ciphertext-{label}",
+        }
+    )
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -119,6 +164,72 @@ def test_filter_on_status(client: FlaskClient, user: User, user_alias: Username)
                 assert (
                     f'href="{url_for("message", public_id=other_msg.public_id)}"' not in resp.text
                 )
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_inbox_lists_conversation_for_sender_and_recipient_after_submission(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _set_pgp_key(user2)
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+
+    response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data={
+            "field_0": MSG_CONTACT_METHOD,
+            "field_1": MSG_CONTENT,
+            "encrypted_conversation_copies": json.dumps(
+                {
+                    "sender": _chat_ciphertext("sender-initial"),
+                    "recipient": _chat_ciphertext("recipient-initial"),
+                }
+            ),
+            **get_profile_submission_data(client, user2.primary_username.username),
+        },
+        follow_redirects=False,
+    )
+
+    message = db.session.scalars(
+        db.select(Message).filter_by(username_id=user2.primary_username.id)
+    ).one()
+    assert message.conversation is not None
+    conversation_url = url_for("conversation", conversation_id=message.conversation.id)
+    message_url = url_for("message", public_id=message.public_id)
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(conversation_url)
+
+    sender_response = client.get(url_for("inbox"))
+    assert sender_response.status_code == 200
+    assert conversation_url in sender_response.text
+    assert f"@{user2.primary_username.username}" in sender_response.text
+    assert MSG_CONTACT_METHOD not in sender_response.text
+    assert MSG_CONTENT not in sender_response.text
+    assert "Proton" not in sender_response.text
+    assert "PGP" not in sender_response.text
+
+    message.status = MessageStatus.ARCHIVED
+    db.session.commit()
+    _authenticate_as(client, user2)
+    recipient_response = client.get(url_for("inbox"))
+    assert recipient_response.status_code == 200
+    assert conversation_url in recipient_response.text
+    assert f"@{user.primary_username.username}" in recipient_response.text
+    assert MSG_CONTACT_METHOD not in recipient_response.text
+    assert MSG_CONTENT not in recipient_response.text
+
+    pending_response = client.get(url_for("inbox", status=MessageStatus.PENDING.value))
+    assert pending_response.status_code == 200
+    assert conversation_url in pending_response.text
+    assert f'href="{message_url}"' not in pending_response.text
+
+    archived_response = client.get(url_for("inbox", status=MessageStatus.ARCHIVED.value))
+    assert archived_response.status_code == 200
+    assert conversation_url in archived_response.text
+    assert f'href="{message_url}"' in archived_response.text
 
 
 @pytest.mark.usefixtures("_authenticated_user")


### PR DESCRIPTION
This PR implements child issue #2182 (`Show conversations in both participants' inboxes`) under epic #2177 (`Feasibility: two-way encrypted conversations between accounts`).
It is intended to merge into the epic branch first, not directly into `main`.

This PR addresses the issue "Show conversations in both participants' inboxes" by updating request-handling code in `hushline/routes`, user-facing page templates in `hushline/templates`, and automated tests in `tests/test_accessibility.py`.
The change includes both implementation work and automated tests, showing the intended behavior and how it is verified.
It touches 4 non-log file(s) (4 total including runner artifacts), primarily in hushline/routes, hushline/templates, and tests/test_accessibility.py.

## Summary
- Automated code agent update for child issue #2182.
- Part of epic #2177: Feasibility: two-way encrypted conversations between accounts
- This PR targets the epic integration branch `codex/epic-2177`.
- The child issue is closed explicitly by workflow after this PR merges into the epic branch.

Linked issue: #2182

## Context
- Epic: https://github.com/scidsg/hushline/issues/2177
- Child issue: https://github.com/scidsg/hushline/issues/2182
- Branch: codex/daily-issue-2182
- Base branch: codex/epic-2177
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `hushline/routes/inbox.py`
- `hushline/templates/inbox.html`
- `tests/test_accessibility.py`
- `tests/test_inbox.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
