### PR TITLE
#2183 Implement unread conversation indicators and mark-read behavior

### DIFF
--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2239,6 +2239,17 @@ a.logoutLink {
   transform: scale(0.9);
 }
 
+.message .conversation-unread-dot {
+  position: absolute;
+  right: 1.125rem;
+  top: 0.925rem;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: var(--color-brand);
+  box-shadow: 0 0 0 0.1875rem var(--color-highlight);
+}
+
 footer {
   font-size: var(--font-size-smaller);
   padding-right: 1rem;

--- a/hushline/routes/inbox.py
+++ b/hushline/routes/inbox.py
@@ -14,6 +14,7 @@ from hushline.auth import authentication_required
 from hushline.db import db
 from hushline.model import (
     Conversation,
+    ConversationMessage,
     ConversationParticipant,
     Message,
     MessageStatus,
@@ -32,11 +33,19 @@ class InboxConversation:
     has_available_copy: bool
 
 
-def _conversation_latest_at(conversation: Conversation) -> datetime:
+def _conversation_latest_message(conversation: Conversation) -> ConversationMessage | None:
+    if not conversation.messages:
+        return None
+
     return max(
-        (message.created_at for message in conversation.messages),
-        default=conversation.created_at,
+        conversation.messages,
+        key=lambda message: (message.created_at, message.id),
     )
+
+
+def _conversation_latest_at(conversation: Conversation) -> datetime:
+    latest_message = _conversation_latest_message(conversation)
+    return latest_message.created_at if latest_message else conversation.created_at
 
 
 def _participant_has_available_copies(
@@ -56,10 +65,13 @@ def _conversation_has_unread(
     conversation: Conversation,
     participant: ConversationParticipant,
 ) -> bool:
-    return any(
-        message.sender_participant_id != participant.id
-        and (participant.last_read_at is None or message.created_at > participant.last_read_at)
-        for message in conversation.messages
+    latest_message = _conversation_latest_message(conversation)
+    return bool(
+        latest_message
+        and latest_message.sender_participant_id != participant.id
+        and (
+            participant.last_read_at is None or latest_message.created_at > participant.last_read_at
+        )
     )
 
 

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -46,6 +46,16 @@ _ARMORED_PGP_MESSAGE_PATTERN = re.compile(
 )
 
 
+def _conversation_latest_message(thread: Conversation) -> ConversationMessage | None:
+    if not thread.messages:
+        return None
+
+    return max(
+        thread.messages,
+        key=lambda message: (message.created_at, message.id),
+    )
+
+
 def _is_armored_pgp_message(value: str) -> bool:
     return bool(_ARMORED_PGP_MESSAGE_PATTERN.fullmatch(value))
 
@@ -124,6 +134,13 @@ def register_message_routes(app: Flask) -> None:
         participant = thread.participant_for_user_id(user.id)
         if not participant:
             abort(404)
+
+        latest_message = _conversation_latest_message(thread)
+        if latest_message and (
+            participant.last_read_at is None or latest_message.created_at > participant.last_read_at
+        ):
+            participant.last_read_at = latest_message.created_at
+            db.session.commit()
 
         message_copies = []
         message_copy_payloads = []

--- a/hushline/templates/inbox.html
+++ b/hushline/templates/inbox.html
@@ -41,7 +41,12 @@
               aria-labelledby="{{ title_id }}"
             >
               {% if item.has_unread %}
-                <span class="badge" aria-label="Unread conversation">Unread</span>
+                <span
+                  class="conversation-unread-dot"
+                  role="img"
+                  aria-label="Unread conversation"
+                  title="Unread conversation"
+                ></span>
               {% endif %}
               <h4 id="{{ title_id }}">
                 Conversation with

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -236,7 +236,7 @@ def test_inbox_conversation_rows_have_accessible_status_and_unread_state(
     conversation_section = soup.find("section", {"aria-labelledby": "conversation-list-heading"})
     conversation_heading = soup.find(id="conversation-list-heading")
     conversation_rows = soup.select("article.conversation-summary")
-    unread_badge = soup.select_one("article.conversation-summary .badge")
+    unread_indicator = soup.select_one("article.conversation-summary .conversation-unread-dot")
     status_messages = [
         status.get_text(" ", strip=True)
         for status in soup.select("article.conversation-summary p[role='status']")
@@ -251,9 +251,10 @@ def test_inbox_conversation_rows_have_accessible_status_and_unread_state(
         assert title_id
         assert soup.find(id=title_id) is not None
 
-    assert unread_badge is not None
-    assert unread_badge.get("aria-label") == "Unread conversation"
-    assert unread_badge.get_text(" ", strip=True) == "Unread"
+    assert unread_indicator is not None
+    assert unread_indicator.get("role") == "img"
+    assert unread_indicator.get("aria-label") == "Unread conversation"
+    assert unread_indicator.get_text(" ", strip=True) == ""
     assert "Locked: unlock your Hush Line chat key to read this thread." in status_messages
     assert "Key unavailable: no encrypted copy is available for this account." in status_messages
     assert (

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime, timedelta, timezone
 
 from flask import Flask, url_for
 from flask.testing import FlaskClient
@@ -89,6 +90,38 @@ def _copies_for(conversation: Conversation, label: str) -> dict[str, str]:
         str(participant.id): _ciphertext(f"{label}-{participant.id}")
         for participant in conversation.participants
     }
+
+
+def _participant_for(conversation: Conversation, user: User) -> ConversationParticipant:
+    participant = conversation.participant_for_user_id(user.id)
+    assert participant is not None
+    return participant
+
+
+def _set_initial_message_created_at(conversation: Conversation, created_at: datetime) -> None:
+    conversation.messages[0].created_at = created_at
+    db.session.commit()
+
+
+def _add_conversation_message(
+    conversation: Conversation,
+    sender_participant: ConversationParticipant,
+    *,
+    created_at: datetime,
+    label: str,
+) -> ConversationMessage:
+    conversation_message = ConversationMessage()
+    conversation_message.conversation = conversation
+    conversation_message.sender_participant = sender_participant
+    conversation_message.created_at = created_at
+    for recipient_participant in conversation.participants:
+        encrypted_copy = ConversationMessageCopy()
+        encrypted_copy.recipient_participant = recipient_participant
+        encrypted_copy.encrypted_payload = _ciphertext(f"{label}-{recipient_participant.id}")
+        conversation_message.encrypted_copies.append(encrypted_copy)
+    db.session.add(conversation_message)
+    db.session.commit()
+    return conversation_message
 
 
 def test_conversation_route_authorizes_only_participants(
@@ -263,3 +296,79 @@ def test_append_conversation_message_redirects_unauthenticated_user(
     assert response.headers["Location"].endswith(url_for("login"))
     message_count = db.session.scalar(db.select(db.func.count()).select_from(ConversationMessage))
     assert message_count == 1
+
+
+def test_recipient_unread_indicator_clears_when_locked_thread_loads(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    sender_participant = _participant_for(conversation, user)
+    recipient_participant = _participant_for(conversation, user2)
+    initial_created_at = datetime(2026, 1, 1, 12, tzinfo=timezone.utc)
+    _set_initial_message_created_at(conversation, initial_created_at)
+    recipient_participant.last_read_at = initial_created_at
+    db.session.commit()
+    latest_message = _add_conversation_message(
+        conversation,
+        sender_participant,
+        created_at=initial_created_at + timedelta(minutes=5),
+        label="recipient-unread",
+    )
+    _authenticate_as(client, user2)
+
+    unread_response = client.get(url_for("inbox"))
+
+    assert unread_response.status_code == 200
+    assert 'aria-label="Unread conversation"' in unread_response.text
+
+    thread_response = client.get(url_for("conversation", conversation_id=conversation.id))
+
+    assert thread_response.status_code == 200
+    assert "Transcript content is hidden until your chat key is unlocked" in thread_response.text
+    db.session.refresh(recipient_participant)
+    assert recipient_participant.last_read_at == latest_message.created_at
+
+    read_response = client.get(url_for("inbox"))
+    assert read_response.status_code == 200
+    assert 'aria-label="Unread conversation"' not in read_response.text
+
+
+def test_inbox_unread_indicator_uses_latest_message_for_each_participant(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    user_participant = _participant_for(conversation, user)
+    user2_participant = _participant_for(conversation, user2)
+    initial_created_at = datetime(2026, 1, 1, 12, tzinfo=timezone.utc)
+    _set_initial_message_created_at(conversation, initial_created_at)
+    user_participant.last_read_at = initial_created_at
+    user2_participant.last_read_at = initial_created_at
+    db.session.commit()
+    _add_conversation_message(
+        conversation,
+        user2_participant,
+        created_at=initial_created_at + timedelta(minutes=5),
+        label="incoming",
+    )
+    _add_conversation_message(
+        conversation,
+        user_participant,
+        created_at=initial_created_at + timedelta(minutes=10),
+        label="own-latest",
+    )
+
+    _authenticate_as(client, user)
+    sender_response = client.get(url_for("inbox"))
+
+    assert sender_response.status_code == 200
+    assert 'aria-label="Unread conversation"' not in sender_response.text
+
+    _authenticate_as(client, user2)
+    recipient_response = client.get(url_for("inbox"))
+
+    assert recipient_response.status_code == 200
+    assert 'aria-label="Unread conversation"' in recipient_response.text


### PR DESCRIPTION
This PR implements child issue #2183 (`Implement unread conversation indicators and mark-read behavior`) under epic #2177 (`Feasibility: two-way encrypted conversations between accounts`).
It is intended to merge into the epic branch first, not directly into `main`.

This PR addresses the issue "Implement unread conversation indicators and mark-read behavior" by updating supporting files in `assets/scss`, request-handling code in `hushline/routes`, and user-facing page templates in `hushline/templates`.
The change includes both implementation work and automated tests, showing the intended behavior and how it is verified.
It touches 6 non-log file(s) (6 total including runner artifacts), primarily in assets/scss, hushline/routes, and hushline/templates.

## Summary
- Automated code agent update for child issue #2183.
- Part of epic #2177: Feasibility: two-way encrypted conversations between accounts
- This PR targets the epic integration branch `codex/epic-2177`.
- The child issue is closed explicitly by workflow after this PR merges into the epic branch.

Linked issue: #2183

## Context
- Epic: https://github.com/scidsg/hushline/issues/2177
- Child issue: https://github.com/scidsg/hushline/issues/2183
- Branch: codex/daily-issue-2183
- Base branch: codex/epic-2177
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `assets/scss/style.scss`
- `hushline/routes/inbox.py`
- `hushline/routes/message.py`
- `hushline/templates/inbox.html`
- `tests/test_accessibility.py`
- `tests/test_conversation.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
