### PR TITLE
Allow docs screenshot release manifest artifact

### DIFF
--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -125,6 +125,7 @@ jobs:
               Path("capture_files.json"),
               Path("screenshots/README.md"),
               Path("screenshots/release/README.md"),
+              Path("screenshots/release/manifest.json"),
           }
 
           def fail(message: str) -> None:

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -131,6 +131,7 @@ def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> No
     assert "rm -f /tmp/docs-screenshots-artifact/artifact.zip" in artifact_section
     assert "path.is_symlink()" in artifact_section
     assert 'Path("screenshots/release/README.md")' in artifact_section
+    assert 'Path("screenshots/release/manifest.json")' in artifact_section
     assert 'Path("screenshots", "releases", release_key, "README.md")' in artifact_section
     assert 'is_current_image = relative.parts[:2] == ("screenshots", "current")' in artifact_section
     assert 'is_release_image = relative.parts[:2] == ("screenshots", "release")' in artifact_section


### PR DESCRIPTION
## What changed
- Allow `screenshots/release/manifest.json` in the docs screenshot publish artifact validator.
- Added a regression assertion so the publish workflow keeps accepting the release manifest emitted by the capture job.

## Why
The release docs screenshots workflow captured screenshots successfully for run 27389600084, but the reusable publish job failed while validating the artifact:

`Unexpected docs screenshot artifact file: screenshots/release/manifest.json`

The capture job includes a release manifest in `screenshots/release`, so the publish allowlist needs to permit that metadata file alongside the release README and images.

## Validation
- Inspected failed job `80944740697` from run `27389600084`.
- Downloaded the real `docs-screenshots-v0.6.84` artifact and ran the patched validation logic locally: `validated artifact for v0.6.84; files=14`.
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.yaml run --rm --no-deps app poetry run pytest -q tests/test_workflow_pr_head_qualification.py::test_screenshots_archive_workflow_publishes_directly_without_pr_flow`
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.yaml run --rm --no-deps app poetry run ruff check --output-format full tests/test_workflow_pr_head_qualification.py`
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.yaml run --rm --no-deps app poetry run ruff format --check tests/test_workflow_pr_head_qualification.py`
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.yaml run --rm --no-deps app sh -lc 'prettier --check .github/workflows/publish-docs-screenshots.yml'`

## Manual testing
- Not applicable beyond the artifact validation above; this is a GitHub Actions publish validator change.

## Known follow-up
- The failed `v0.6.84` release run used workflow code from the release tag, so rerunning that exact job will still use the tagged workflow unless the release/tag flow is re-triggered with a version containing this patch.