### PR TITLE
#2186 Suppress conversation notifications while the receiver is active in the thread

### DIFF
--- a/hushline/model/conversation.py
+++ b/hushline/model/conversation.py
@@ -73,6 +73,7 @@ class ConversationParticipant(Model):
         db.DateTime(timezone=True), server_default=text("NOW()"), nullable=False
     )
     last_read_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))
+    last_active_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))
     has_usable_public_key: Mapped[bool] = mapped_column(
         db.Boolean,
         nullable=False,

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -1,6 +1,6 @@
 import re
 import smtplib
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from flask import (
@@ -45,6 +45,8 @@ from hushline.routes.common import (
 )
 
 _CHAT_CIPHERTEXT_MAX_LENGTH = 200_000
+_CONVERSATION_ACTIVITY_TIMEOUT_SECONDS = 120
+_CONVERSATION_PRESENCE_HEARTBEAT_SECONDS = 60
 _CONVERSATION_NOTIFICATION_BODY = (
     "You have new Hush Line conversation activity. "
     "Log in and unlock your Hush Line chat key to read it."
@@ -64,6 +66,50 @@ def _conversation_latest_message(thread: Conversation) -> ConversationMessage | 
         thread.messages,
         key=lambda message: (message.created_at, message.id),
     )
+
+
+def _conversation_activity_timeout() -> timedelta:
+    configured_seconds = current_app.config.get(
+        "CONVERSATION_ACTIVITY_TIMEOUT_SECONDS", _CONVERSATION_ACTIVITY_TIMEOUT_SECONDS
+    )
+    try:
+        seconds = int(configured_seconds)
+    except (TypeError, ValueError):
+        seconds = _CONVERSATION_ACTIVITY_TIMEOUT_SECONDS
+    return timedelta(seconds=max(1, seconds))
+
+
+def _conversation_presence_heartbeat_ms() -> int:
+    configured_seconds = current_app.config.get(
+        "CONVERSATION_PRESENCE_HEARTBEAT_SECONDS", _CONVERSATION_PRESENCE_HEARTBEAT_SECONDS
+    )
+    try:
+        seconds = int(configured_seconds)
+    except (TypeError, ValueError):
+        seconds = _CONVERSATION_PRESENCE_HEARTBEAT_SECONDS
+    return max(1, seconds) * 1000
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+def _mark_conversation_participant_active(
+    participant: ConversationParticipant, now: datetime | None = None
+) -> None:
+    participant.last_active_at = now or datetime.now(UTC)
+
+
+def _conversation_participant_is_active(
+    participant: ConversationParticipant, now: datetime | None = None
+) -> bool:
+    if participant.last_active_at is None:
+        return False
+    active_at = _as_utc(participant.last_active_at)
+    current_time = now or datetime.now(UTC)
+    return current_time - active_at <= _conversation_activity_timeout()
 
 
 def _is_armored_pgp_message(value: str) -> bool:
@@ -131,6 +177,8 @@ def _notify_conversation_participants(
             continue
         if not recipient_user.enable_email_notifications:
             continue
+        if _conversation_participant_is_active(recipient_participant):
+            continue
 
         try:
             send_email_to_user_recipients(
@@ -189,12 +237,13 @@ def register_message_routes(app: Flask) -> None:
         if not participant:
             abort(404)
 
+        _mark_conversation_participant_active(participant)
         latest_message = _conversation_latest_message(thread)
         if latest_message and (
             participant.last_read_at is None or latest_message.created_at > participant.last_read_at
         ):
             participant.last_read_at = latest_message.created_at
-            db.session.commit()
+        db.session.commit()
 
         message_copies = []
         message_copy_payloads = []
@@ -236,8 +285,34 @@ def register_message_routes(app: Flask) -> None:
             message_copy_payloads=message_copy_payloads,
             participant_public_keys=participant_public_keys,
             can_compose=can_compose,
+            conversation_presence_interval_ms=_conversation_presence_heartbeat_ms(),
             conversation_message_form=conversation_message_form,
         )
+
+    @app.route("/conversation/<int:conversation_id>/presence", methods=["POST"])
+    @authentication_required
+    def conversation_presence(conversation_id: int) -> tuple[Response, int]:
+        user = db.session.get(User, session["user_id"])
+        if not user:
+            abort(404)
+
+        thread = db.session.scalars(
+            Conversation.for_user_id(user.id).where(Conversation.id == conversation_id)
+        ).one_or_none()
+        if not thread:
+            abort(404)
+
+        participant = thread.participant_for_user_id(user.id)
+        if not participant:
+            abort(404)
+
+        csrf_error = _validate_json_csrf()
+        if csrf_error:
+            return jsonify({"error": csrf_error}), 400
+
+        _mark_conversation_participant_active(participant)
+        db.session.commit()
+        return jsonify({"ok": True}), 200
 
     @app.route("/conversation/<int:conversation_id>/messages", methods=["POST"])
     @authentication_required
@@ -285,6 +360,7 @@ def register_message_routes(app: Flask) -> None:
         conversation_message = ConversationMessage()
         conversation_message.conversation = thread
         conversation_message.sender_participant = participant
+        _mark_conversation_participant_active(participant)
         for recipient_participant in thread.participants:
             encrypted_copy = ConversationMessageCopy()
             encrypted_copy.recipient_participant = recipient_participant

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -358,6 +358,55 @@
     }
   }
 
+  function conversationCsrfToken() {
+    return document
+      .getElementById("conversation-compose-form")
+      ?.querySelector("input[name='csrf_token']")
+      ?.value;
+  }
+
+  async function sendConversationPresence() {
+    const root = document.getElementById("conversation-chat");
+    if (!root?.dataset.presenceUrl) {
+      return;
+    }
+
+    try {
+      await fetch(root.dataset.presenceUrl, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+          "X-CSRFToken": conversationCsrfToken() || "",
+        },
+      });
+    } catch (error) {
+      return;
+    }
+  }
+
+  function bindConversationPresence(root) {
+    if (root.dataset.presenceBound === "true") {
+      return;
+    }
+    root.dataset.presenceBound = "true";
+
+    const configuredInterval = Number.parseInt(root.dataset.presenceIntervalMs, 10);
+    const intervalMs = Number.isFinite(configuredInterval)
+      ? Math.max(15000, configuredInterval)
+      : 60000;
+    const sendIfVisible = () => {
+      if (document.visibilityState === "visible") {
+        void sendConversationPresence();
+      }
+    };
+
+    sendIfVisible();
+    window.setInterval(sendIfVisible, intervalMs);
+    document.addEventListener("visibilitychange", sendIfVisible);
+    window.addEventListener("focus", sendIfVisible);
+  }
+
   async function unlockConversationFromPassword() {
     const passwordInput = document.getElementById("conversation-chat-password");
     if (!passwordInput?.value) {
@@ -440,6 +489,8 @@
     if (!root) {
       return;
     }
+
+    bindConversationPresence(root);
 
     document
       .getElementById("conversation-chat-unlock")

--- a/hushline/templates/conversation.html
+++ b/hushline/templates/conversation.html
@@ -23,9 +23,12 @@
   </div>
 
   {% set append_message_url = url_for('append_conversation_message', conversation_id=conversation.id) %}
+  {% set presence_url = url_for('conversation_presence', conversation_id=conversation.id) %}
   <section
     id="conversation-chat"
     data-message-url="{{ append_message_url }}"
+    data-presence-url="{{ presence_url }}"
+    data-presence-interval-ms="{{ conversation_presence_interval_ms }}"
     data-can-compose="{{ 'true' if can_compose else 'false' }}"
   >
     <div id="conversation-key-locked" class="message">

--- a/migrations/versions/7d1c2f3a4b5c_add_conversation_participant_activity.py
+++ b/migrations/versions/7d1c2f3a4b5c_add_conversation_participant_activity.py
@@ -1,0 +1,28 @@
+"""add conversation participant activity
+
+Revision ID: 7d1c2f3a4b5c
+Revises: f6c1e2d3a4b5
+Create Date: 2026-06-12 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "7d1c2f3a4b5c"
+down_revision = "f6c1e2d3a4b5"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "conversation_participants",
+        sa.Column("last_active_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("conversation_participants", "last_active_at")

--- a/tests/migrations/revision_7d1c2f3a4b5c.py
+++ b/tests/migrations/revision_7d1c2f3a4b5c.py
@@ -1,0 +1,100 @@
+from sqlalchemy import text
+
+from hushline.db import db
+
+
+def _insert_conversation_participant(include_activity: bool = False) -> None:
+    db.session.execute(
+        text(
+            """
+            INSERT INTO users (
+                id,
+                is_admin,
+                is_suspended,
+                password_hash,
+                session_id
+            )
+            VALUES (1, false, false, '$scrypt$', 'session-1')
+            """
+        )
+    )
+    db.session.execute(text("INSERT INTO conversations (id) VALUES (1)"))
+
+    if include_activity:
+        db.session.execute(
+            text(
+                """
+                INSERT INTO conversation_participants (
+                    id,
+                    conversation_id,
+                    user_id,
+                    last_active_at
+                )
+                VALUES (1, 1, 1, timestamp '2026-06-12 00:00:00')
+                """
+            )
+        )
+    else:
+        db.session.execute(
+            text(
+                """
+                INSERT INTO conversation_participants (
+                    id,
+                    conversation_id,
+                    user_id
+                )
+                VALUES (1, 1, 1)
+                """
+            )
+        )
+    db.session.commit()
+
+
+class UpgradeTester:
+    def load_data(self) -> None:
+        _insert_conversation_participant()
+
+    def check_upgrade(self) -> None:
+        assert db.session.execute(
+            text(
+                """
+                SELECT id, last_active_at
+                FROM conversation_participants
+                """
+            )
+        ).one() == (1, None)
+
+        column = db.session.execute(
+            text(
+                """
+                SELECT data_type, is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'conversation_participants'
+                  AND column_name = 'last_active_at'
+                """
+            )
+        ).one()
+        assert column == ("timestamp with time zone", "YES")
+
+
+class DowngradeTester:
+    def load_data(self) -> None:
+        _insert_conversation_participant(include_activity=True)
+
+    def check_downgrade(self) -> None:
+        assert db.session.scalar(text("SELECT count(*) FROM conversation_participants")) == 1
+        assert (
+            db.session.scalar(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM information_schema.columns
+                    WHERE table_schema = 'public'
+                      AND table_name = 'conversation_participants'
+                      AND column_name = 'last_active_at'
+                    """
+                )
+            )
+            == 0
+        )

--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -260,6 +260,8 @@ def test_chat_key_lifecycle_js_exposes_unlock_rewrap_and_cleanup() -> None:
     assert "unlockFromPassword" in lifecycle_js
     assert "rewrapForPasswordChange" in lifecycle_js
     assert "clearChatKeyMaterial" in lifecycle_js
+    assert "sendConversationPresence" in lifecycle_js
+    assert 'document.visibilityState === "visible"' in lifecycle_js
     assert "document.body?.dataset.authenticated" in lifecycle_js
     assert "Chat key unlock failed." in lifecycle_js
 

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -192,6 +192,75 @@ def test_conversation_view_shows_locked_chat_key_state(
     assert "Do not upload or paste any external private key." in response.text
     assert "Proton" not in response.text
     assert "PGP" not in response.text
+    assert url_for("conversation_presence", conversation_id=conversation.id) in response.text
+
+
+def test_conversation_view_marks_participant_active(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    participant = _participant_for(conversation, user)
+    _authenticate_as(client, user)
+
+    response = client.get(url_for("conversation", conversation_id=conversation.id))
+
+    assert response.status_code == 200
+    db.session.refresh(participant)
+    assert participant.last_active_at is not None
+
+
+def test_conversation_presence_requires_participant(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    admin_user: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    participant = _participant_for(conversation, user)
+    _authenticate_as(client, admin_user)
+
+    response = client.post(url_for("conversation_presence", conversation_id=conversation.id))
+
+    assert response.status_code == 404
+    db.session.refresh(participant)
+    assert participant.last_active_at is None
+
+
+def test_conversation_presence_heartbeat_marks_participant_active(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    participant = _participant_for(conversation, user)
+    _authenticate_as(client, user)
+
+    response = client.post(url_for("conversation_presence", conversation_id=conversation.id))
+
+    assert response.status_code == 200
+    db.session.refresh(participant)
+    assert participant.last_active_at is not None
+
+
+def test_conversation_presence_requires_csrf_when_enabled(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+    prior_setting = app.config.get("WTF_CSRF_ENABLED")
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        response = client.post(url_for("conversation_presence", conversation_id=conversation.id))
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = prior_setting
+
+    assert response.status_code == 400
+    assert "Invalid CSRF token." in response.text
 
 
 def test_participant_can_append_encrypted_conversation_message(
@@ -265,6 +334,94 @@ def test_append_conversation_message_sends_generic_notification_to_other_partici
     assert all(
         call.args[0].id != user.id for call in mock_send_email_to_user_recipients.call_args_list
     )
+
+
+@patch("hushline.routes.message.send_email_to_user_recipients")
+def test_append_conversation_message_suppresses_notification_for_active_recipient(
+    mock_send_email_to_user_recipients: MagicMock,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    _enable_conversation_notifications(
+        user2,
+        email="recipient@example.com",
+        include_content=False,
+        encrypt_entire_body=False,
+    )
+    conversation = _make_conversation(user, user2)
+    recipient_participant = _participant_for(conversation, user2)
+    recipient_participant.last_active_at = datetime.now(timezone.utc)
+    db.session.commit()
+    _authenticate_as(client, user)
+
+    response = client.post(
+        url_for("append_conversation_message", conversation_id=conversation.id),
+        json={"encrypted_copies": _copies_for(conversation, "active-recipient")},
+    )
+
+    assert response.status_code == 201
+    mock_send_email_to_user_recipients.assert_not_called()
+
+
+@patch("hushline.routes.message.send_email_to_user_recipients")
+def test_append_conversation_message_notifies_after_stale_recipient_activity(
+    mock_send_email_to_user_recipients: MagicMock,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    _enable_conversation_notifications(
+        user2,
+        email="recipient@example.com",
+        include_content=False,
+        encrypt_entire_body=False,
+    )
+    conversation = _make_conversation(user, user2)
+    recipient_participant = _participant_for(conversation, user2)
+    recipient_participant.last_active_at = datetime.now(timezone.utc) - timedelta(minutes=10)
+    db.session.commit()
+    _authenticate_as(client, user)
+
+    response = client.post(
+        url_for("append_conversation_message", conversation_id=conversation.id),
+        json={"encrypted_copies": _copies_for(conversation, "stale-recipient")},
+    )
+
+    assert response.status_code == 201
+    mock_send_email_to_user_recipients.assert_called_once()
+    assert mock_send_email_to_user_recipients.call_args.args[0].id == user2.id
+
+
+@patch("hushline.routes.message.send_email_to_user_recipients")
+def test_append_conversation_message_does_not_notify_sender(
+    mock_send_email_to_user_recipients: MagicMock,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    _enable_conversation_notifications(
+        user,
+        email="sender@example.com",
+        include_content=False,
+        encrypt_entire_body=False,
+    )
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    response = client.post(
+        url_for("append_conversation_message", conversation_id=conversation.id),
+        json={"encrypted_copies": _copies_for(conversation, "sender-notification")},
+    )
+
+    assert response.status_code == 201
+    mock_send_email_to_user_recipients.assert_not_called()
 
 
 @patch("hushline.routes.message.encrypt_message")

--- a/tests/test_conversation_model.py
+++ b/tests/test_conversation_model.py
@@ -86,15 +86,20 @@ def test_participant_read_state_and_key_defaults(app: Flask, user: User, user2: 
 
     assert participant.has_usable_public_key is True
     assert participant.last_read_at is None
+    assert participant.last_active_at is None
     assert participant2.has_usable_public_key is False
     assert participant2.last_read_at is None
+    assert participant2.last_active_at is None
 
     read_at = datetime.now(timezone.utc)
+    active_at = datetime.now(timezone.utc)
     participant2.last_read_at = read_at
+    participant2.last_active_at = active_at
     db.session.add(conversation)
     db.session.commit()
 
     assert participant2.last_read_at == read_at
+    assert participant2.last_active_at == active_at
 
 
 def test_initial_message_can_link_to_conversation(


### PR DESCRIPTION
This PR implements child issue #2186 (`Suppress conversation notifications while the receiver is active in the thread`) under epic #2177 (`Feasibility: two-way encrypted conversations between accounts`).
It is intended to merge into the epic branch first, not directly into `main`.

This PR addresses the issue "Suppress conversation notifications while the receiver is active in the thread" by updating data and model code in `hushline/model`, request-handling code in `hushline/routes`, and frontend assets in `hushline/static`.
The change includes both implementation work and automated tests, showing the intended behavior and how it is verified.
It touches 9 non-log file(s) (9 total including runner artifacts), primarily in hushline/model, hushline/routes, and hushline/static.

## Summary
- Automated code agent update for child issue #2186.
- Part of epic #2177: Feasibility: two-way encrypted conversations between accounts
- This PR targets the epic integration branch `codex/epic-2177`.
- The child issue is closed explicitly by workflow after this PR merges into the epic branch.

Linked issue: #2186

## Context
- Epic: https://github.com/scidsg/hushline/issues/2177
- Child issue: https://github.com/scidsg/hushline/issues/2186
- Branch: codex/daily-issue-2186
- Base branch: codex/epic-2177
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `hushline/model/conversation.py`
- `hushline/routes/message.py`
- `hushline/static/js/chat-key-lifecycle.js`
- `hushline/templates/conversation.html`
- `migrations/versions/7d1c2f3a4b5c_add_conversation_participant_activity.py`
- `tests/migrations/revision_7d1c2f3a4b5c.py`
- `tests/test_chat_keys.py`
- `tests/test_conversation.py`
- `tests/test_conversation_model.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
