### PR TITLE
Add browser E2EE regression test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ else
 CMD :=
 endif
 PRETTIER_STATIC_JS_TARGETS := ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js
-PRETTIER_TARGETS := ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js $(PRETTIER_STATIC_JS_TARGETS)
+PRETTIER_TARGETS := ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./package.json ./playwright.e2ee.config.js ./tests/playwright $(PRETTIER_STATIC_JS_TARGETS)
 PRETTIER_FLAGS := --ignore-path /dev/null
 RUNNER_APP_URL ?= http://localhost:8080
 RUNNER_APP_WAIT_ATTEMPTS ?= 30
@@ -312,6 +312,10 @@ playwright-visual: runner-wait-for-app ## Run Playwright visual regression check
 		-w /work \
 		$(PLAYWRIGHT_DOCKER_IMAGE) \
 		npx playwright test --config=playwright.visual.config.js
+
+.PHONY: playwright-e2ee
+playwright-e2ee: runner-wait-for-app ## Run browser E2EE submission checks against the local app
+	npx playwright test --config=playwright.e2ee.config.js
 
 .PHONY: playwright-visual-update
 playwright-visual-update: runner-wait-for-app ## Update Playwright visual regression baselines

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build:dev": "webpack --config webpack.config.js --watch",
     "build:prod": "webpack --config webpack.config.js",
+    "playwright:e2ee": "playwright test --config=playwright.e2ee.config.js",
     "playwright:visual": "playwright test --config=playwright.visual.config.js",
     "playwright:visual:update": "playwright test --config=playwright.visual.config.js --update-snapshots"
   },

--- a/playwright.e2ee.config.js
+++ b/playwright.e2ee.config.js
@@ -1,0 +1,17 @@
+const { defineConfig } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: "./tests/playwright/e2ee",
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  timeout: process.env.CI ? 60_000 : 30_000,
+  reporter: [["list"]],
+  outputDir: "test-results/playwright-e2ee",
+  use: {
+    baseURL: process.env.PLAYWRIGHT_BASE_URL || "http://localhost:8080",
+    browserName: "chromium",
+    locale: "en-US",
+    timezoneId: "UTC",
+  },
+});

--- a/tests/playwright/e2ee/client-side-encryption.spec.js
+++ b/tests/playwright/e2ee/client-side-encryption.spec.js
@@ -1,0 +1,99 @@
+const { expect, test } = require("@playwright/test");
+
+const PGP_ARMOR_HEADER = "-----BEGIN PGP MESSAGE-----";
+const contactPlaintext = "P0 frontend e2ee contact sentinel";
+const messagePlaintext = "P0 frontend e2ee message sentinel";
+
+function captchaAnswer(labelText) {
+  const match = labelText.match(/(\d+)\s*\+\s*(\d+)/);
+  expect(
+    match,
+    `CAPTCHA label should be parseable: ${labelText}`,
+  ).not.toBeNull();
+  return String(Number(match[1]) + Number(match[2]));
+}
+
+test("JS-enabled profile submissions encrypt fields before the POST leaves the browser", async ({
+  page,
+}) => {
+  const consoleErrors = [];
+  const pageErrors = [];
+  let capturedPostBody = null;
+
+  page.on("console", (message) => {
+    if (message.type() === "error") {
+      consoleErrors.push(message.text());
+    }
+  });
+  page.on("pageerror", (error) => {
+    pageErrors.push(error.message);
+  });
+  page.on("request", (request) => {
+    if (request.method() === "POST" && request.url().endsWith("/to/admin")) {
+      capturedPostBody = request.postData() || "";
+    }
+  });
+
+  await page.goto("/to/admin", { waitUntil: "networkidle" });
+  await page.evaluate(() => {
+    localStorage.setItem("hasFinishedGuidance", "true");
+    document.getElementById("guidance-modal")?.classList.remove("show");
+  });
+
+  await expect(page.locator("#messageForm")).toBeVisible();
+  await expect
+    .poll(() =>
+      page.evaluate(
+        () => document.getElementById("recipientPublicKeys")?.textContent || "",
+      ),
+    )
+    .toContain("BEGIN PGP PUBLIC KEY BLOCK");
+  await expect(
+    page.locator('script[src$="/static/js/client-side-encryption.js"]'),
+  ).toHaveCount(1);
+
+  await expect
+    .poll(() => page.evaluate(() => window.isSecureContext))
+    .toBe(true);
+
+  await page.fill("#field_0", contactPlaintext);
+  await page.fill("#field_1", messagePlaintext);
+  await page.fill(
+    "#captcha_answer",
+    captchaAnswer(
+      await page.locator('label[for="captcha_answer"]').innerText(),
+    ),
+  );
+
+  await Promise.all([
+    page.waitForRequest(
+      (request) =>
+        request.method() === "POST" && request.url().endsWith("/to/admin"),
+    ),
+    page.locator("#submitBtn").click(),
+  ]);
+
+  expect(pageErrors).toEqual([]);
+  expect(
+    consoleErrors.filter(
+      (message) =>
+        !message.includes("Permissions-Policy header") &&
+        !message.includes("Failed to load resource"),
+    ),
+  ).toEqual([]);
+  expect(capturedPostBody).toBeTruthy();
+
+  const params = new URLSearchParams(capturedPostBody);
+  const encryptedContact = params.get("field_0") || "";
+  const encryptedMessage = params.get("field_1") || "";
+  const encryptedEmailBody = params.get("encrypted_email_body") || "";
+
+  expect(encryptedContact).toContain(PGP_ARMOR_HEADER);
+  expect(encryptedMessage).toContain(PGP_ARMOR_HEADER);
+  expect(encryptedEmailBody).toContain(PGP_ARMOR_HEADER);
+
+  expect(encryptedContact).not.toContain(contactPlaintext);
+  expect(encryptedMessage).not.toContain(messagePlaintext);
+  expect(encryptedEmailBody).not.toContain(contactPlaintext);
+  expect(encryptedEmailBody).not.toContain(messagePlaintext);
+});


### PR DESCRIPTION
## What changed

Adds a dedicated Playwright E2EE browser regression test for the JS-enabled profile submission flow.

The new test opens `/to/admin` in Chromium, fills encrypted message fields with sentinel plaintext, submits the real form, captures the outgoing browser POST body, and verifies:

- encrypted field values are PGP armored before leaving the browser
- the encrypted email body is PGP armored before leaving the browser
- sentinel plaintext does not appear in the submitted encrypted fields or encrypted email body
- the page is running in a secure browser context
- the client-side encryption script and recipient public key are present

Also adds:

- `playwright.e2ee.config.js`
- `npm run playwright:e2ee`
- `make playwright-e2ee`
- Prettier coverage for the new Playwright E2EE files in `make lint`

## Why it changed

A missing visual flash of ciphertext raised concern about a possible frontend E2EE regression. Manual investigation showed encryption was still occurring, but the visible flash is not a reliable security signal. This PR locks the actual browser POST payload instead, which is the critical behavior.

## User and developer impact

This gives maintainers a direct browser-level regression check for the highest-priority E2EE guarantee: plaintext typed into encrypted fields must not leave the browser in the JS-enabled submission path.

## Validation

- `make playwright-e2ee`
- focused E2EE Python tests: `5 passed`
- `make lint`
- `make test`: `1981 passed, 1 deselected, 1 xfailed`, 100% coverage
- `make audit-node-runtime`: found 0 vulnerabilities
- `make audit-python`: no known vulnerabilities found
- Signed commit verified locally with the SSH signing key SHA256:H7hI2rcyXGPnnAGFb7AnPUg13nrmP1NovWXve2wcXuk

## Manual testing

- Confirmed the local stack was running.
- Submitted a real message through Chromium and captured the browser POST body.
- Confirmed the submitted encrypted fields and encrypted email body contained PGP armor and did not contain sentinel plaintext.

## Known risks and follow-ups

- The new browser E2EE target expects a running local app at `http://localhost:8080` unless `PLAYWRIGHT_BASE_URL` is set.
- This PR adds the test target but does not yet wire it into GitHub Actions required checks.