### PR TITLE
Fix sandboxed embedded contact form submissions

### DIFF
--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -23,6 +23,21 @@ from hushline.secure_session import EncryptedSessionInterface
 from hushline.storage import public_store
 from hushline.version import __version__
 
+PERMISSIONS_POLICY = ", ".join(
+    (
+        "geolocation=()",
+        "midi=()",
+        "sync-xhr=()",
+        "microphone=()",
+        "camera=()",
+        "magnetometer=()",
+        "gyroscope=()",
+        "fullscreen=()",
+        "payment=()",
+        "interest-cohort=()",
+    )
+)
+
 
 def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
     app = Flask(__name__)
@@ -116,9 +131,7 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
         else:
             response.headers.pop("X-Frame-Options", None)
         response.headers["X-Content-Type-Options"] = "nosniff"
-        response.headers["Permissions-Policy"] = (
-            "geolocation=(), midi=(), notifications=(), push=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=(), vibrate=(), fullscreen=(), payment=(), interest-cohort=();"  # noqa: E501
-        )
+        response.headers["Permissions-Policy"] = PERMISSIONS_POLICY
         response.headers["Referrer-Policy"] = "no-referrer"
         response.headers["X-XSS-Protection"] = "1; mode=block"
 

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -201,6 +201,30 @@ def register_profile_routes(app: Flask) -> None:
 
         return True
 
+    def _embed_form_token_belongs_to_profile(uname: Username) -> bool:
+        embed_captcha_token = request.form.get("embed_captcha_token", "")
+        csrf_token = request.form.get("csrf_token", "")
+        if (
+            not embed_captcha_token
+            or not csrf_token
+            or not hmac.compare_digest(embed_captcha_token, csrf_token)
+        ):
+            return False
+
+        try:
+            payload: dict[str, Any] = _embed_captcha_serializer().loads(
+                embed_captcha_token,
+                max_age=EMBED_CAPTCHA_MAX_AGE_SECONDS,
+            )
+        except (BadData, SignatureExpired):
+            return False
+
+        return (
+            payload.get("v") == 1
+            and payload.get("username") == uname.username
+            and payload.get("user_id") == uname.user_id
+        )
+
     def _embed_post_origin_is_valid(uname: Username) -> bool:
         origin = request.headers.get("Origin", "").strip()
         if not origin:
@@ -209,7 +233,10 @@ def register_profile_routes(app: Flask) -> None:
                 parsed_referer = urlsplit(referer)
                 origin = f"{parsed_referer.scheme}://{parsed_referer.netloc}"
 
-        if not origin or origin == "null":
+        if origin == "null":
+            return _embed_form_token_belongs_to_profile(uname)
+
+        if not origin:
             return False
 
         parsed_origin = urlsplit(origin)

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -768,7 +768,7 @@ def test_embed_profile_submission_rejects_invalid_csrf_token(
     assert _first_message_for(user.primary_username) is None
 
 
-def test_embed_profile_submission_rejects_sandboxed_null_origin(
+def test_embed_profile_submission_accepts_sandboxed_null_origin_with_signed_form_token(
     client: FlaskClient, user: User
 ) -> None:
     _enable_embeds_globally()
@@ -778,6 +778,67 @@ def test_embed_profile_submission_rejects_sandboxed_null_origin(
     response = client.get(url_for("embed_profile", username=user.primary_username.username))
     assert response.status_code == 200
     submission_data = _embed_submission_data(response.text)
+    armored_contact = "-----BEGIN PGP MESSAGE-----\n\ncontact ciphertext\n-----END PGP MESSAGE-----"
+    armored_message = "-----BEGIN PGP MESSAGE-----\n\nmessage ciphertext\n-----END PGP MESSAGE-----"
+
+    post_response = client.post(
+        url_for("embed_profile", username=user.primary_username.username),
+        data={
+            "field_0": armored_contact,
+            "field_1": armored_message,
+            **submission_data,
+        },
+        headers={"Origin": "null"},
+    )
+
+    assert post_response.status_code == 200, post_response.text
+    message = _first_message_for(user.primary_username)
+    assert message is not None
+    assert [field_value.value for field_value in message.field_values] == [
+        armored_contact,
+        armored_message,
+    ]
+
+
+def test_embed_profile_submission_rejects_null_origin_with_mismatched_form_token(
+    client: FlaskClient, user: User
+) -> None:
+    _enable_embeds_globally()
+    _make_message_capable(user)
+    _configure_embed(user.primary_username)
+
+    response = client.get(url_for("embed_profile", username=user.primary_username.username))
+    assert response.status_code == 200
+    submission_data = _embed_submission_data(response.text)
+    submission_data["csrf_token"] = "tampered-token"
+
+    post_response = client.post(
+        url_for("embed_profile", username=user.primary_username.username),
+        data={
+            "field_0": "Embedded Signal contact",
+            "field_1": "Embedded message",
+            **submission_data,
+        },
+        headers={"Origin": "null"},
+    )
+
+    assert post_response.status_code == 400
+    assert "Invalid embed request origin" in post_response.text
+    assert _first_message_for(user.primary_username) is None
+
+
+def test_embed_profile_submission_rejects_null_origin_with_malformed_form_token(
+    client: FlaskClient, user: User
+) -> None:
+    _enable_embeds_globally()
+    _make_message_capable(user)
+    _configure_embed(user.primary_username)
+
+    response = client.get(url_for("embed_profile", username=user.primary_username.username))
+    assert response.status_code == 200
+    submission_data = _embed_submission_data(response.text)
+    submission_data["embed_captcha_token"] = "malformed-token"
+    submission_data["csrf_token"] = "malformed-token"
 
     post_response = client.post(
         url_for("embed_profile", username=user.primary_username.username),

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -5,6 +5,7 @@ from flask import Flask, url_for
 from flask.testing import FlaskClient
 from werkzeug.datastructures import Headers
 
+from hushline import PERMISSIONS_POLICY
 from hushline.db import db
 from hushline.model import OrganizationSetting, StripeSubscriptionStatusEnum, User
 
@@ -244,9 +245,11 @@ def test_x_content_type_options(client: FlaskClient) -> None:
 def test_permissions_policy(client: FlaskClient) -> None:
     response = client.get(url_for("directory"), follow_redirects=True)
     assert response.status_code == 200
-    assert response.headers["Permissions-Policy"] == (
-        "geolocation=(), midi=(), notifications=(), push=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=(), vibrate=(), fullscreen=(), payment=(), interest-cohort=();"  # noqa: E501
-    )
+    assert response.headers["Permissions-Policy"] == PERMISSIONS_POLICY
+    assert not response.headers["Permissions-Policy"].endswith(";")
+    assert ";," not in response.headers["Permissions-Policy"]
+    for unsupported_feature in ("notifications", "push", "speaker", "vibrate"):
+        assert f"{unsupported_feature}=()" not in response.headers["Permissions-Policy"]
 
 
 def test_referrer_policy(client: FlaskClient) -> None:


### PR DESCRIPTION
## What changed
- Allow embedded contact form POSTs with browser-sandboxed `Origin: null` only when the signed embed form token belongs to the target profile and matches the CSRF token.
- Keep explicit origin/referer validation for non-sandboxed embed submissions.
- Clean up the `Permissions-Policy` header so browsers no longer report a structured-header parse error on the live embed page.
- Add regression coverage for sandboxed embed submission success, malformed/mismatched token rejection, replay/cross-site rejection, and the cleaned permissions policy.

## Why
The production embed at `https://hushline.app/embed.html` renders the recipient form inside a sandboxed iframe. Browser form submissions from that iframe send `Origin: null`, and the server was rejecting those requests before the encrypted payload could be accepted. That broke embedded contact forms even though the iframe was allowed by `frame-ancestors`.

## Security / privacy impact
- Threat/risk: accepting all `Origin: null` posts would weaken embed CSRF/origin protections for the whistleblower disclosure path.
- Affected data paths: unauthenticated embedded disclosure submission to `/embed/to/<username>`, client-encrypted field submission, captcha/form-token validation, and message storage.
- Mitigation: `Origin: null` is accepted only with a fresh signed embed token for the same username/user id and only when it exactly matches the submitted CSRF token. Missing origin, malformed token, mismatched token, and explicit cross-site origins remain rejected.
- E2EE: verified local browser submission stored armored PGP ciphertext for contact and message fields; plaintext probe strings were not persisted.

## Validation
- Dependabot pre-check: no open Dependabot PRs found before starting.
- Live reproduction: loaded `https://hushline.app/embed.html`; the iframe rendered, browser console showed the invalid `Permissions-Policy` parse error, and intercepted sandboxed form POST headers showed `origin: "null"`.
- Local browser verification: rendered a sandboxed iframe against local `/embed/to/admin`, submitted the form successfully, received the success page, and confirmed stored field values were armored PGP ciphertext with no plaintext probe values persisted.
- `make lint` passed.
- `make test` passed: `1983 passed, 1 deselected, 1 xfailed`, total coverage 100%.
- `docker compose run --rm app poetry run pytest --cov hushline --cov-report term-missing -q --skip-local-only` passed: `1979 passed, 5 skipped, 1 xfailed`, total coverage 100%.
- `make audit-python` passed: no known vulnerabilities found.
- `make audit-node-runtime` passed: found 0 vulnerabilities.
- Commit signature verified locally with `git -c gpg.ssh.allowedSignersFile=/tmp/hushline_allowed_signers verify-commit HEAD`.

## Manual testing steps
1. Open `https://hushline.app/embed.html` to observe the production sandbox behavior and confirm the failing POST uses `Origin: null`.
2. Locally enable embeds for seeded `admin` with `http://localhost:8080` as the allowed origin.
3. Serve a local parent page with a sandboxed iframe pointed at `/embed/to/admin`.
4. Submit contact/message/captcha through the iframe.
5. Confirm the success page renders and the saved message field values are PGP-armored ciphertext, not the submitted plaintext.

## Known risks / follow-ups
- This is intentionally scoped to restoring browser sandbox form submissions without broadening cross-site origin acceptance. Production should still receive a normal deploy and smoke test on `https://hushline.app/embed.html` after merge.