### PR TITLE
Fix null-origin embed origin bypass

### DIFF
--- a/assets/js/client-side-encryption.js
+++ b/assets/js/client-side-encryption.js
@@ -173,6 +173,21 @@ function getMessageFields() {
   }));
 }
 
+async function submitEncryptedForm(form) {
+  const response = await fetch(form.action, {
+    method: form.method || "POST",
+    body: new FormData(form),
+    credentials: "same-origin",
+    headers: {
+      Accept: "text/html",
+    },
+  });
+  const html = await response.text();
+  document.open();
+  document.write(html);
+  document.close();
+}
+
 document.addEventListener("DOMContentLoaded", function () {
   const form = document.getElementById("messageForm");
   if (!form) {
@@ -306,7 +321,7 @@ document.addEventListener("DOMContentLoaded", function () {
 
       // Wait for all encryption operations to complete before submitting
       await Promise.all(encryptionPromises);
-      form.submit();
+      await submitEncryptedForm(form);
     } catch (error) {
       console.error("Encryption error:", error);
       alert(

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -201,30 +201,6 @@ def register_profile_routes(app: Flask) -> None:
 
         return True
 
-    def _embed_form_token_belongs_to_profile(uname: Username) -> bool:
-        embed_captcha_token = request.form.get("embed_captcha_token", "")
-        csrf_token = request.form.get("csrf_token", "")
-        if (
-            not embed_captcha_token
-            or not csrf_token
-            or not hmac.compare_digest(embed_captcha_token, csrf_token)
-        ):
-            return False
-
-        try:
-            payload: dict[str, Any] = _embed_captcha_serializer().loads(
-                embed_captcha_token,
-                max_age=EMBED_CAPTCHA_MAX_AGE_SECONDS,
-            )
-        except (BadData, SignatureExpired):
-            return False
-
-        return (
-            payload.get("v") == 1
-            and payload.get("username") == uname.username
-            and payload.get("user_id") == uname.user_id
-        )
-
     def _embed_post_origin_is_valid(uname: Username) -> bool:
         origin = request.headers.get("Origin", "").strip()
         if not origin:
@@ -233,10 +209,7 @@ def register_profile_routes(app: Flask) -> None:
                 parsed_referer = urlsplit(referer)
                 origin = f"{parsed_referer.scheme}://{parsed_referer.netloc}"
 
-        if origin == "null":
-            return _embed_form_token_belongs_to_profile(uname)
-
-        if not origin:
+        if not origin or origin == "null":
             return False
 
         parsed_origin = urlsplit(origin)

--- a/tests/test_embeddable_forms_settings.py
+++ b/tests/test_embeddable_forms_settings.py
@@ -768,7 +768,7 @@ def test_embed_profile_submission_rejects_invalid_csrf_token(
     assert _first_message_for(user.primary_username) is None
 
 
-def test_embed_profile_submission_accepts_sandboxed_null_origin_with_signed_form_token(
+def test_embed_profile_submission_rejects_harvested_null_origin_form_token_replay(
     client: FlaskClient, user: User
 ) -> None:
     _enable_embeds_globally()
@@ -778,26 +778,34 @@ def test_embed_profile_submission_accepts_sandboxed_null_origin_with_signed_form
     response = client.get(url_for("embed_profile", username=user.primary_username.username))
     assert response.status_code == 200
     submission_data = _embed_submission_data(response.text)
-    armored_contact = "-----BEGIN PGP MESSAGE-----\n\ncontact ciphertext\n-----END PGP MESSAGE-----"
-    armored_message = "-----BEGIN PGP MESSAGE-----\n\nmessage ciphertext\n-----END PGP MESSAGE-----"
 
-    post_response = client.post(
+    explicit_cross_site_response = client.post(
         url_for("embed_profile", username=user.primary_username.username),
         data={
-            "field_0": armored_contact,
-            "field_1": armored_message,
+            "field_0": "Harvested token contact",
+            "field_1": "Harvested token message",
             **submission_data,
         },
-        headers={"Origin": "null"},
+        headers={"Origin": "https://evil.example"},
     )
 
-    assert post_response.status_code == 200, post_response.text
-    message = _first_message_for(user.primary_username)
-    assert message is not None
-    assert [field_value.value for field_value in message.field_values] == [
-        armored_contact,
-        armored_message,
-    ]
+    assert explicit_cross_site_response.status_code == 400
+    assert "Invalid embed request origin" in explicit_cross_site_response.text
+
+    for _ in range(2):
+        null_origin_response = client.post(
+            url_for("embed_profile", username=user.primary_username.username),
+            data={
+                "field_0": "Harvested token contact",
+                "field_1": "Harvested token message",
+                **submission_data,
+            },
+            headers={"Origin": "null"},
+        )
+        assert null_origin_response.status_code == 400
+        assert "Invalid embed request origin" in null_origin_response.text
+
+    assert _message_count_for(user.primary_username) == 0
 
 
 def test_embed_profile_submission_rejects_null_origin_with_mismatched_form_token(

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -102,6 +102,12 @@ def test_client_side_encryption_has_platform_guards() -> None:
     assert "const encryptedEmailFieldsByRecipient = {};" in js
     assert "encrypted_email_fields_by_recipient" in js
     assert "assertClientCryptoSupport();" in js
+    assert "async function submitEncryptedForm(form)" in js
+    assert "body: new FormData(form)" in js
+    assert 'credentials: "same-origin"' in js
+    assert 'Accept: "text/html"' in js
+    assert "document.write(html);" in js
+    assert "form.submit();" not in js
 
 
 def test_profile_template_avoids_inline_submit_handlers() -> None:


### PR DESCRIPTION
## What changed

- Reject `Origin: null` embed POSTs again instead of treating the public embed CAPTCHA token as origin authorization.
- Keep legitimate embedded submissions working after client-side encryption by submitting the encrypted form with same-origin `fetch()` from inside the iframe, so the browser sends the iframe's Hush Line origin instead of `Origin: null`.
- Add regression coverage for harvested/replayed public embed form tokens with `Origin: null`, plus frontend compatibility assertions that the encrypted submit path no longer uses `form.submit()`.

## Why

The advisory is valid: the signed embed CAPTCHA token is rendered publicly in the embed HTML and is replayable, so it is not a safe substitute for exact origin validation. Accepting `Origin: null` let an attacker harvest form fields from `/embed/to/<username>` and replay them from a sandboxed null-origin document, bypassing `embed_allowed_origins` and creating inbox/notification abuse risk.

A naive server-only revert would have risked regressing the embedded form fix because the current browser submit path could produce `Origin: null` after client-side encryption. This patch restores strict server origin validation and changes the client submit mechanism so valid embedded forms continue to POST with the expected Hush Line iframe origin.

## Security impact

Affected data path: public embedded contact form submissions through `/embed/to/<username>` and legacy `/embed/<username>`.

Mitigation:

- `Origin: null` and missing-origin embed POSTs fail closed.
- Allowed-origin/canonical-origin checks remain exact-match based.
- Public, replayable embed tokens are no longer used as origin authorization.
- Client-side encryption still completes before submission, and encrypted form data is submitted by same-origin `fetch()`.

## Validation

- Dependabot pre-check: no open Dependabot PRs found.
- `docker compose run --rm app poetry run pytest tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_harvested_null_origin_form_token_replay tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_null_origin_with_mismatched_form_token tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_null_origin_with_malformed_form_token tests/test_embeddable_forms_settings.py::test_embed_profile_submission_rejects_null_origin_without_embed_form_token tests/test_embeddable_forms_settings.py::test_embed_profile_submission_accepts_client_encrypted_fields tests/test_frontend_compat.py::test_client_side_encryption_has_platform_guards -q` -> 6 passed.
- `docker compose run --rm app poetry run pytest tests/test_embeddable_forms_settings.py tests/test_embeds.py tests/test_security_headers.py tests/test_frontend_compat.py -q` -> 106 passed.
- `make lint` -> passed.
- `make test` initially hit the documented Docker/Postgres shared-memory recovery failure; after `docker compose down -v --remove-orphans`, rerun passed: 1,983 passed, 1 deselected, 1 xfailed, 100% coverage.
- `docker compose run --rm app poetry run pytest --cov hushline --cov-report term-missing -q --skip-local-only` -> 1,979 passed, 5 skipped, 1 xfailed, 100% coverage.
- `make audit-python` -> no known vulnerabilities found.
- `make audit-node-runtime` -> found 0 vulnerabilities.
- `git diff --check` -> passed.
- Commit signature verified with the project SSH allowed-signers file.

## Manual testing

- Tested the live `https://hushline.app/embed.html` flow in-browser and confirmed the current production bundle produces `Origin: null` after client-side encryption.
- Re-tested with the patched local `client-side-encryption.js` substituted into the live page, intercepting the POST to avoid sending a real message. The encrypted submit path produced `Origin: https://tips.hushline.app`, not `Origin: null`.

## Risks and follow-ups

- The client submit response is written back into the iframe document after `fetch()`, matching the existing form navigation outcome while preserving the correct request origin.
- No CSP broadening was needed; embed CSP/security header tests remain passing.