### PR TITLE
Fix chat key unlock and conversation QA blockers

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -1,6 +1,7 @@
 (function () {
   const textEncoder = new TextEncoder();
   const textDecoder = new TextDecoder();
+  const sessionStorageKey = "hushline:chat-private-jwk";
   let unlockedChatPrivateKey = null;
   const state = {
     status: "empty",
@@ -76,16 +77,76 @@
   }
 
   async function importPrivateKey(privateJwk) {
+    const importJwk = {
+      ...privateJwk,
+      key_ops: ["deriveKey"],
+    };
     return window.crypto.subtle.importKey(
       "jwk",
-      privateJwk,
+      importJwk,
       {
         name: "ECDH",
-        namedCurve: privateJwk.crv || "P-256",
+        namedCurve: importJwk.crv || "P-256",
       },
       false,
-      ["deriveBits"],
+      ["deriveKey"],
     );
+  }
+
+  function rememberUnlockedPrivateJwk(privateJwk, chatKey) {
+    if (!window.sessionStorage) {
+      return;
+    }
+
+    try {
+      sessionStorage.setItem(
+        sessionStorageKey,
+        JSON.stringify({
+          key_version: chatKey.key_version,
+          private_jwk: privateJwk,
+        }),
+      );
+    } catch (error) {
+      return;
+    }
+  }
+
+  function forgetUnlockedPrivateJwk() {
+    try {
+      sessionStorage.removeItem(sessionStorageKey);
+    } catch (error) {
+      return;
+    }
+  }
+
+  async function restoreUnlockedChatKey(chatKey) {
+    if (!chatKey || !window.sessionStorage) {
+      return false;
+    }
+
+    try {
+      const storedValue = sessionStorage.getItem(sessionStorageKey);
+      if (!storedValue) {
+        return false;
+      }
+      const stored = JSON.parse(storedValue);
+      if (
+        stored?.key_version !== chatKey.key_version
+        || !stored.private_jwk
+      ) {
+        forgetUnlockedPrivateJwk();
+        return false;
+      }
+
+      unlockedChatPrivateKey = await importPrivateKey(stored.private_jwk);
+      state.status = "unlocked";
+      state.keyVersion = chatKey.key_version;
+      state.lastError = null;
+      return true;
+    } catch (error) {
+      clearChatKeyMaterial();
+      return false;
+    }
   }
 
   async function unlockFromPassword(chatKey, password) {
@@ -100,6 +161,7 @@
     try {
       privateJwk = await decryptPrivateJwk(chatKey, password);
       unlockedChatPrivateKey = await importPrivateKey(privateJwk);
+      rememberUnlockedPrivateJwk(privateJwk, chatKey);
       state.status = "unlocked";
       state.keyVersion = chatKey.key_version;
       state.lastError = null;
@@ -278,6 +340,7 @@
   }
 
   function clearChatKeyMaterial() {
+    forgetUnlockedPrivateJwk();
     unlockedChatPrivateKey = null;
     state.status = "empty";
     state.keyVersion = null;
@@ -320,6 +383,18 @@
     }
   }
 
+  function setConversationUnlockVisible(visible) {
+    const panel = document.getElementById("conversation-key-locked");
+    if (panel) {
+      panel.hidden = !visible;
+    }
+  }
+
+  function currentConversationParticipantId() {
+    const root = document.getElementById("conversation-chat");
+    return root?.dataset.participantId || "";
+  }
+
   async function decryptConversationMessages() {
     const copies = jsonFromScript("conversationMessageCopies", []);
     for (const copy of copies) {
@@ -330,12 +405,21 @@
       const messageElement = document.querySelector(
         `[data-conversation-message-id="${copy.message_id}"] .conversation-message-body`,
       );
+      const messageContainer = document.querySelector(
+        `[data-conversation-message-id="${copy.message_id}"]`,
+      );
       if (!messageElement) {
         continue;
       }
 
       try {
         messageElement.textContent = await decryptChatCiphertext(copy.encrypted_payload);
+        if (messageContainer) {
+          const isOwnMessage = String(copy.sender_participant_id)
+            === currentConversationParticipantId();
+          messageContainer.classList.toggle("is-own-message", isOwnMessage);
+          messageContainer.classList.toggle("is-other-message", !isOwnMessage);
+        }
       } catch (error) {
         messageElement.textContent = "This message cannot be decrypted in this browser.";
       }
@@ -380,6 +464,7 @@
       await decryptConversationMessages();
       const root = document.getElementById("conversation-chat");
       setConversationComposeEnabled(root?.dataset.canCompose === "true");
+      setConversationUnlockVisible(false);
       setConversationStatus("Chat key unlocked in this browser.");
       passwordInput.value = "";
     } catch (error) {
@@ -435,11 +520,88 @@
     }
   }
 
+  function conversationCsrfToken() {
+    return document
+      .getElementById("conversation-compose-form")
+      ?.querySelector("input[name='csrf_token']")
+      ?.value;
+  }
+
+  async function sendConversationPresence() {
+    const root = document.getElementById("conversation-chat");
+    if (!root?.dataset.presenceUrl) {
+      return;
+    }
+
+    try {
+      await fetch(root.dataset.presenceUrl, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+          "X-CSRFToken": conversationCsrfToken() || "",
+        },
+      });
+    } catch (error) {
+      return;
+    }
+  }
+
+  function bindConversationPresence(root) {
+    if (root.dataset.presenceBound === "true") {
+      return;
+    }
+    root.dataset.presenceBound = "true";
+
+    const configuredInterval = Number.parseInt(root.dataset.presenceIntervalMs, 10);
+    const intervalMs = Number.isFinite(configuredInterval)
+      ? Math.max(15000, configuredInterval)
+      : 60000;
+    const sendIfVisible = () => {
+      if (document.visibilityState === "visible") {
+        void sendConversationPresence();
+      }
+    };
+
+    sendIfVisible();
+    window.setInterval(sendIfVisible, intervalMs);
+    document.addEventListener("visibilitychange", sendIfVisible);
+    window.addEventListener("focus", sendIfVisible);
+  }
+
+  async function restoreConversationFromSession() {
+    const root = document.getElementById("conversation-chat");
+    if (!root) {
+      return;
+    }
+
+    try {
+      const chatKey = await fetchChatKey(chatKeyUrlFromCurrentOrigin());
+      if (!chatKey) {
+        setConversationUnlockVisible(true);
+        setConversationStatus("Create a Hush Line chat key before reading this conversation.");
+        return;
+      }
+      if (await restoreUnlockedChatKey(chatKey)) {
+        await decryptConversationMessages();
+        setConversationComposeEnabled(root.dataset.canCompose === "true");
+        setConversationUnlockVisible(false);
+        setConversationStatus("Chat key unlocked for this session.");
+        return;
+      }
+      setConversationUnlockVisible(true);
+    } catch (error) {
+      setConversationUnlockVisible(true);
+    }
+  }
+
   function bindConversation() {
     const root = document.getElementById("conversation-chat");
     if (!root) {
       return;
     }
+
+    bindConversationPresence(root);
 
     document
       .getElementById("conversation-chat-unlock")
@@ -454,8 +616,12 @@
     if (state.status === "unlocked") {
       decryptConversationMessages();
       setConversationComposeEnabled(root.dataset.canCompose === "true");
+      setConversationUnlockVisible(false);
       setConversationStatus("Chat key unlocked in this browser.");
+      return;
     }
+
+    void restoreConversationFromSession();
   }
 
   async function handleLoginSubmit(event) {
@@ -477,8 +643,12 @@
       const responseText = await response.text();
       if (response.redirected && responseUrl.pathname !== "/login") {
         if (responseUrl.pathname !== "/verify-2fa-login") {
-          const chatKey = await fetchChatKey(chatKeyUrlFromCurrentOrigin());
-          await unlockFromPassword(chatKey, password);
+          try {
+            const chatKey = await fetchChatKey(chatKeyUrlFromCurrentOrigin());
+            await unlockFromPassword(chatKey, password);
+          } catch (error) {
+            clearChatKeyMaterial();
+          }
         }
         replaceDocument(responseText, response.url);
         return;

--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -253,7 +253,7 @@ async function provisionChatKey(form) {
         namedCurve: "P-256",
       },
       true,
-      ["deriveBits"],
+      ["deriveKey"],
     );
     const publicJwk = await window.crypto.subtle.exportKey(
       "jwk",

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2250,6 +2250,174 @@ a.logoutLink {
   box-shadow: 0 0 0 0.1875rem var(--color-highlight);
 }
 
+.conversation-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  max-width: 56rem;
+  margin: 0 auto 2rem;
+}
+
+.conversation-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+  border-bottom: 1px solid var(--color-border);
+  padding-bottom: 0.75rem;
+}
+
+.conversation-header h1 {
+  margin: 0;
+}
+
+.conversation-eyebrow,
+.conversation-context {
+  margin: 0;
+  color: var(--color-text-light);
+  font-size: var(--font-size-smaller);
+}
+
+.conversation-eyebrow {
+  font-family: var(--font-sans-bold);
+  text-transform: uppercase;
+}
+
+.conversation-profile-link {
+  flex: 0 0 auto;
+  font-size: var(--font-size-smaller);
+}
+
+.conversation-unlock-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 18rem) auto;
+  gap: 0.75rem;
+  align-items: end;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: var(--color-highlight);
+}
+
+.conversation-unlock-panel[hidden] {
+  display: none;
+}
+
+.conversation-unlock-panel h2,
+.conversation-unlock-panel p {
+  margin: 0;
+}
+
+.conversation-unlock-panel > div,
+.conversation-unlock-panel > p,
+.conversation-unlock-panel .meta {
+  grid-column: 1 / -1;
+}
+
+.conversation-unlock-panel h2 {
+  font-size: var(--font-size-4);
+}
+
+.conversation-unlock-panel label {
+  grid-column: 1;
+  font-size: var(--font-size-smaller);
+}
+
+.conversation-unlock-panel input {
+  grid-column: 1;
+  width: 100%;
+}
+
+.conversation-unlock-panel button {
+  grid-column: 2;
+  grid-row: 4;
+}
+
+.conversation-thread {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  min-height: 18rem;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  padding: 1rem;
+  background: var(--color-brand-bg);
+}
+
+.conversation-message {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  max-width: min(80%, 36rem);
+  align-self: flex-start;
+}
+
+.conversation-message.is-own-message {
+  align-self: flex-end;
+}
+
+.conversation-message time {
+  color: var(--color-text-light);
+  font-size: var(--font-size-smaller);
+}
+
+.conversation-message.is-own-message time {
+  text-align: right;
+}
+
+.conversation-message-body {
+  margin: 0;
+  border: 1px solid var(--color-border);
+  border-radius: 0.5rem;
+  padding: 0.75rem 0.875rem;
+  background: var(--color-highlight);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.conversation-message.is-own-message .conversation-message-body {
+  background: var(--color-brand);
+  color: white;
+  border-color: var(--color-brand);
+}
+
+.conversation-message-body.unavailable {
+  font-family: var(--font-mono);
+  font-size: var(--font-size-smaller);
+}
+
+.conversation-composer {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.conversation-composer label,
+.conversation-composer textarea,
+.conversation-composer .meta {
+  grid-column: 1 / -1;
+}
+
+.conversation-composer textarea {
+  min-height: 7rem;
+  resize: vertical;
+}
+
+@media (max-width: 720px) {
+  .conversation-header,
+  .conversation-unlock-panel,
+  .conversation-composer {
+    display: flex;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .conversation-message {
+    max-width: 92%;
+  }
+}
+
 footer {
   font-size: var(--font-size-smaller);
   padding-right: 1rem;

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -117,7 +117,7 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
             response.headers.pop("X-Frame-Options", None)
         response.headers["X-Content-Type-Options"] = "nosniff"
         response.headers["Permissions-Policy"] = (
-            "geolocation=(), midi=(), notifications=(), push=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=(), vibrate=(), fullscreen=(), payment=(), interest-cohort=();"  # noqa: E501
+            "geolocation=(), midi=(), notifications=(), push=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=(), vibrate=(), fullscreen=(), payment=(), interest-cohort=()"  # noqa: E501
         )
         response.headers["Referrer-Policy"] = "no-referrer"
         response.headers["X-XSS-Protection"] = "1; mode=block"

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -1,6 +1,11 @@
+/******/ (() => { // webpackBootstrap
+/*!*****************************************!*\
+  !*** ./assets/js/chat-key-lifecycle.js ***!
+  \*****************************************/
 (function () {
   const textEncoder = new TextEncoder();
   const textDecoder = new TextDecoder();
+  const sessionStorageKey = "hushline:chat-private-jwk";
   let unlockedChatPrivateKey = null;
   const state = {
     status: "empty",
@@ -76,16 +81,76 @@
   }
 
   async function importPrivateKey(privateJwk) {
+    const importJwk = {
+      ...privateJwk,
+      key_ops: ["deriveKey"],
+    };
     return window.crypto.subtle.importKey(
       "jwk",
-      privateJwk,
+      importJwk,
       {
         name: "ECDH",
-        namedCurve: privateJwk.crv || "P-256",
+        namedCurve: importJwk.crv || "P-256",
       },
       false,
-      ["deriveBits"],
+      ["deriveKey"],
     );
+  }
+
+  function rememberUnlockedPrivateJwk(privateJwk, chatKey) {
+    if (!window.sessionStorage) {
+      return;
+    }
+
+    try {
+      sessionStorage.setItem(
+        sessionStorageKey,
+        JSON.stringify({
+          key_version: chatKey.key_version,
+          private_jwk: privateJwk,
+        }),
+      );
+    } catch (error) {
+      return;
+    }
+  }
+
+  function forgetUnlockedPrivateJwk() {
+    try {
+      sessionStorage.removeItem(sessionStorageKey);
+    } catch (error) {
+      return;
+    }
+  }
+
+  async function restoreUnlockedChatKey(chatKey) {
+    if (!chatKey || !window.sessionStorage) {
+      return false;
+    }
+
+    try {
+      const storedValue = sessionStorage.getItem(sessionStorageKey);
+      if (!storedValue) {
+        return false;
+      }
+      const stored = JSON.parse(storedValue);
+      if (
+        stored?.key_version !== chatKey.key_version
+        || !stored.private_jwk
+      ) {
+        forgetUnlockedPrivateJwk();
+        return false;
+      }
+
+      unlockedChatPrivateKey = await importPrivateKey(stored.private_jwk);
+      state.status = "unlocked";
+      state.keyVersion = chatKey.key_version;
+      state.lastError = null;
+      return true;
+    } catch (error) {
+      clearChatKeyMaterial();
+      return false;
+    }
   }
 
   async function unlockFromPassword(chatKey, password) {
@@ -100,6 +165,7 @@
     try {
       privateJwk = await decryptPrivateJwk(chatKey, password);
       unlockedChatPrivateKey = await importPrivateKey(privateJwk);
+      rememberUnlockedPrivateJwk(privateJwk, chatKey);
       state.status = "unlocked";
       state.keyVersion = chatKey.key_version;
       state.lastError = null;
@@ -278,6 +344,7 @@
   }
 
   function clearChatKeyMaterial() {
+    forgetUnlockedPrivateJwk();
     unlockedChatPrivateKey = null;
     state.status = "empty";
     state.keyVersion = null;
@@ -320,6 +387,18 @@
     }
   }
 
+  function setConversationUnlockVisible(visible) {
+    const panel = document.getElementById("conversation-key-locked");
+    if (panel) {
+      panel.hidden = !visible;
+    }
+  }
+
+  function currentConversationParticipantId() {
+    const root = document.getElementById("conversation-chat");
+    return root?.dataset.participantId || "";
+  }
+
   async function decryptConversationMessages() {
     const copies = jsonFromScript("conversationMessageCopies", []);
     for (const copy of copies) {
@@ -330,12 +409,21 @@
       const messageElement = document.querySelector(
         `[data-conversation-message-id="${copy.message_id}"] .conversation-message-body`,
       );
+      const messageContainer = document.querySelector(
+        `[data-conversation-message-id="${copy.message_id}"]`,
+      );
       if (!messageElement) {
         continue;
       }
 
       try {
         messageElement.textContent = await decryptChatCiphertext(copy.encrypted_payload);
+        if (messageContainer) {
+          const isOwnMessage = String(copy.sender_participant_id)
+            === currentConversationParticipantId();
+          messageContainer.classList.toggle("is-own-message", isOwnMessage);
+          messageContainer.classList.toggle("is-other-message", !isOwnMessage);
+        }
       } catch (error) {
         messageElement.textContent = "This message cannot be decrypted in this browser.";
       }
@@ -356,55 +444,6 @@
     if (submit) {
       submit.disabled = !enabled;
     }
-  }
-
-  function conversationCsrfToken() {
-    return document
-      .getElementById("conversation-compose-form")
-      ?.querySelector("input[name='csrf_token']")
-      ?.value;
-  }
-
-  async function sendConversationPresence() {
-    const root = document.getElementById("conversation-chat");
-    if (!root?.dataset.presenceUrl) {
-      return;
-    }
-
-    try {
-      await fetch(root.dataset.presenceUrl, {
-        method: "POST",
-        credentials: "same-origin",
-        headers: {
-          Accept: "application/json",
-          "X-CSRFToken": conversationCsrfToken() || "",
-        },
-      });
-    } catch (error) {
-      return;
-    }
-  }
-
-  function bindConversationPresence(root) {
-    if (root.dataset.presenceBound === "true") {
-      return;
-    }
-    root.dataset.presenceBound = "true";
-
-    const configuredInterval = Number.parseInt(root.dataset.presenceIntervalMs, 10);
-    const intervalMs = Number.isFinite(configuredInterval)
-      ? Math.max(15000, configuredInterval)
-      : 60000;
-    const sendIfVisible = () => {
-      if (document.visibilityState === "visible") {
-        void sendConversationPresence();
-      }
-    };
-
-    sendIfVisible();
-    window.setInterval(sendIfVisible, intervalMs);
-    document.addEventListener("visibilitychange", sendIfVisible);
-    window.addEventListener("focus", sendIfVisible);
   }
 
   async function unlockConversationFromPassword() {
@@ -429,6 +468,7 @@
       await decryptConversationMessages();
       const root = document.getElementById("conversation-chat");
       setConversationComposeEnabled(root?.dataset.canCompose === "true");
+      setConversationUnlockVisible(false);
       setConversationStatus("Chat key unlocked in this browser.");
       passwordInput.value = "";
     } catch (error) {
@@ -484,6 +524,81 @@
     }
   }
 
+  function conversationCsrfToken() {
+    return document
+      .getElementById("conversation-compose-form")
+      ?.querySelector("input[name='csrf_token']")
+      ?.value;
+  }
+
+  async function sendConversationPresence() {
+    const root = document.getElementById("conversation-chat");
+    if (!root?.dataset.presenceUrl) {
+      return;
+    }
+
+    try {
+      await fetch(root.dataset.presenceUrl, {
+        method: "POST",
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+          "X-CSRFToken": conversationCsrfToken() || "",
+        },
+      });
+    } catch (error) {
+      return;
+    }
+  }
+
+  function bindConversationPresence(root) {
+    if (root.dataset.presenceBound === "true") {
+      return;
+    }
+    root.dataset.presenceBound = "true";
+
+    const configuredInterval = Number.parseInt(root.dataset.presenceIntervalMs, 10);
+    const intervalMs = Number.isFinite(configuredInterval)
+      ? Math.max(15000, configuredInterval)
+      : 60000;
+    const sendIfVisible = () => {
+      if (document.visibilityState === "visible") {
+        void sendConversationPresence();
+      }
+    };
+
+    sendIfVisible();
+    window.setInterval(sendIfVisible, intervalMs);
+    document.addEventListener("visibilitychange", sendIfVisible);
+    window.addEventListener("focus", sendIfVisible);
+  }
+
+  async function restoreConversationFromSession() {
+    const root = document.getElementById("conversation-chat");
+    if (!root) {
+      return;
+    }
+
+    try {
+      const chatKey = await fetchChatKey(chatKeyUrlFromCurrentOrigin());
+      if (!chatKey) {
+        setConversationUnlockVisible(true);
+        setConversationStatus("Create a Hush Line chat key before reading this conversation.");
+        return;
+      }
+      if (await restoreUnlockedChatKey(chatKey)) {
+        await decryptConversationMessages();
+        setConversationComposeEnabled(root.dataset.canCompose === "true");
+        setConversationUnlockVisible(false);
+        setConversationStatus("Chat key unlocked for this session.");
+        return;
+      }
+      setConversationUnlockVisible(true);
+    } catch (error) {
+      setConversationUnlockVisible(true);
+    }
+  }
+
   function bindConversation() {
     const root = document.getElementById("conversation-chat");
     if (!root) {
@@ -505,8 +620,12 @@
     if (state.status === "unlocked") {
       decryptConversationMessages();
       setConversationComposeEnabled(root.dataset.canCompose === "true");
+      setConversationUnlockVisible(false);
       setConversationStatus("Chat key unlocked in this browser.");
+      return;
     }
+
+    void restoreConversationFromSession();
   }
 
   async function handleLoginSubmit(event) {
@@ -528,8 +647,12 @@
       const responseText = await response.text();
       if (response.redirected && responseUrl.pathname !== "/login") {
         if (responseUrl.pathname !== "/verify-2fa-login") {
-          const chatKey = await fetchChatKey(chatKeyUrlFromCurrentOrigin());
-          await unlockFromPassword(chatKey, password);
+          try {
+            const chatKey = await fetchChatKey(chatKeyUrlFromCurrentOrigin());
+            await unlockFromPassword(chatKey, password);
+          } catch (error) {
+            clearChatKeyMaterial();
+          }
         }
         replaceDocument(responseText, response.url);
         return;
@@ -627,3 +750,7 @@
     bindPage();
   });
 })();
+
+/******/ })()
+;
+//# sourceMappingURL=chat-key-lifecycle.js.map

--- a/hushline/templates/conversation.html
+++ b/hushline/templates/conversation.html
@@ -3,24 +3,37 @@
 {% block title %}Conversation{% endblock %}
 
 {% block content %}
-<div class="message-header">
-  <h1>Conversation</h1>
-</div>
+{% if conversation.initial_message %}
+  {% set conversation_name = conversation.initial_message.username.display_name
+    or conversation.initial_message.username.username %}
+{% else %}
+  {% set conversation_name = "Conversation" %}
+{% endif %}
 
-<div class="message-container">
-  <div class="message-meta">
+<div class="conversation-page">
+  <header class="conversation-header">
+    <div>
+      <p class="conversation-eyebrow">Secure Chat</p>
+      <h1>{{ conversation_name }}</h1>
+    </div>
     {% if conversation.initial_message %}
-      <p>
-        To:
-        <a href="{{ url_for('profile', username=conversation.initial_message.username.username) }}">
-          {{
-            conversation.initial_message.username.display_name
-            or conversation.initial_message.username.username
-          }}
-        </a>
-      </p>
+      <a
+        class="conversation-profile-link"
+        href="{{ url_for('profile', username=conversation.initial_message.username.username) }}"
+      >
+        @{{ conversation.initial_message.username.username }}
+      </a>
     {% endif %}
-  </div>
+  </header>
+
+  {% if conversation.initial_message %}
+    <p class="conversation-context">
+      Started from a disclosure to
+        <a href="{{ url_for('profile', username=conversation.initial_message.username.username) }}">
+          {{ conversation_name }}
+        </a>
+    </p>
+  {% endif %}
 
   {% set append_message_url = url_for('append_conversation_message', conversation_id=conversation.id) %}
   {% set presence_url = url_for('conversation_presence', conversation_id=conversation.id) %}
@@ -30,11 +43,17 @@
     data-presence-url="{{ presence_url }}"
     data-presence-interval-ms="{{ conversation_presence_interval_ms }}"
     data-can-compose="{{ 'true' if can_compose else 'false' }}"
+    data-participant-id="{{ participant.id }}"
   >
-    <div id="conversation-key-locked" class="message">
-      <h2>Chat Key Locked</h2>
+    <div id="conversation-key-locked" class="conversation-unlock-panel">
+      <div>
+        <h2>Chat locked on this device</h2>
+        <p>
+          Unlock your Hush Line chat key in this browser session if it was not
+          unlocked during login.
+        </p>
+      </div>
       <p>
-        Unlock your Hush Line chat key with your account password to read and reply.
         Do not upload or paste any external private key.
       </p>
       <label for="conversation-chat-password">Account Password</label>
@@ -46,7 +65,7 @@
       />
       <button id="conversation-chat-unlock" type="button">Unlock Chat</button>
       <p id="conversation-chat-status" class="meta" role="status">
-        Transcript content is hidden until your chat key is unlocked in this browser.
+        Transcript content is hidden until your chat key is unlocked for this session.
       </p>
     </div>
 
@@ -57,25 +76,27 @@
       {{ message_copy_payloads | tojson }}
     </script>
 
-    <article class="message" aria-live="polite">
+    <article class="conversation-thread" aria-live="polite" aria-label="Conversation messages">
       {% for conversation_message, encrypted_copy in message_copies %}
         <div
-          class="field-value encrypted"
+          class="conversation-message"
           data-conversation-message-id="{{ conversation_message.id }}"
         >
-          <div class="label">
-            {{ conversation_message.created_at.date() }}
-          </div>
+          <time datetime="{{ conversation_message.created_at.isoformat() }}">
+            {{ conversation_message.created_at.strftime("%b %-d, %Y") }}
+          </time>
           {% if encrypted_copy %}
-            <p class="conversation-message-body">Locked until your chat key is unlocked.</p>
+            <p class="conversation-message-body">Locked message. Unlock chat to read.</p>
           {% else %}
-            <p>No encrypted copy is available for your account.</p>
+            <p class="conversation-message-body unavailable">
+              No encrypted copy is available for your account.
+            </p>
           {% endif %}
         </div>
       {% endfor %}
     </article>
 
-    <form id="conversation-compose-form">
+    <form id="conversation-compose-form" class="conversation-composer">
       {{ conversation_message_form.hidden_tag() }}
       <label for="conversation-compose-body">Reply</label>
       <textarea
@@ -86,7 +107,11 @@
         disabled="disabled"
         required
       ></textarea>
-      {{ conversation_message_form.submit(id="conversation-compose-submit", disabled="disabled") }}
+      {{ conversation_message_form.submit(
+        id="conversation-compose-submit",
+        disabled="disabled",
+        value="Send"
+      ) }}
       {% if not can_compose %}
         <p class="meta">
           Replies are unavailable until every participant has an active Hush Line chat key.

--- a/hushline/templates/settings/auth.html
+++ b/hushline/templates/settings/auth.html
@@ -11,8 +11,6 @@
   <form
     method="POST"
     class="formBody"
-    id="change-password-form"
-    data-chat-key-url="{{ url_for('settings.chat_key') if chat_key else '' }}"
   >
     {% set username_field = change_username_form.new_username %}
     {{ change_username_form.hidden_tag() }}
@@ -47,6 +45,8 @@
   <form
     method="POST"
     class="formBody"
+    id="change-password-form"
+    data-chat-key-url="{{ url_for('settings.chat_key') if chat_key else '' }}"
   >
     {% set old_password_field = change_password_form.old_password %}
     {% set new_password_field = change_password_form.new_password %}

--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -255,14 +255,17 @@ def test_chat_key_schema_has_no_plaintext_private_key_columns(app: Flask) -> Non
 
 def test_chat_key_lifecycle_js_exposes_unlock_rewrap_and_cleanup() -> None:
     lifecycle_js = (ROOT / "hushline/static/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
+    lifecycle_source = (ROOT / "assets/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
 
     assert "window.HushLineChatKeys" in lifecycle_js
-    assert "unlockFromPassword" in lifecycle_js
-    assert "rewrapForPasswordChange" in lifecycle_js
-    assert "clearChatKeyMaterial" in lifecycle_js
-    assert "sendConversationPresence" in lifecycle_js
-    assert 'document.visibilityState === "visible"' in lifecycle_js
-    assert "document.body?.dataset.authenticated" in lifecycle_js
+    assert "unlockFromPassword" in lifecycle_source
+    assert "rewrapForPasswordChange" in lifecycle_source
+    assert "clearChatKeyMaterial" in lifecycle_source
+    assert "restoreConversationFromSession" in lifecycle_source
+    assert "hushline:chat-private-jwk" in lifecycle_js
+    assert "sendConversationPresence" in lifecycle_source
+    assert 'document.visibilityState === "visible"' in lifecycle_source
+    assert "document.body?.dataset.authenticated" in lifecycle_source
     assert "Chat key unlock failed." in lifecycle_js
 
 

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -184,7 +184,13 @@ def test_conversation_view_shows_locked_chat_key_state(
     response = client.get(url_for("conversation", conversation_id=conversation.id))
 
     assert response.status_code == 200
-    assert "Transcript content is hidden until your chat key is unlocked" in response.text
+    assert 'class="conversation-thread"' in response.text
+    assert 'class="conversation-composer"' in response.text
+    assert 'data-participant-id="' in response.text
+    assert "Transcript content is hidden until your chat key is unlocked for this session" in (
+        response.text
+    )
+    assert "Locked message. Unlock chat to read." in response.text
     assert (
         "Replies are unavailable until every participant has an active Hush Line chat key."
         in response.text

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -122,6 +122,36 @@ def test_client_side_encryption_prepares_chat_conversation_copies() -> None:
     assert 'id="senderChatPublicKey"' in embed_template
 
 
+def test_chat_key_lifecycle_imports_private_key_for_message_decryption() -> None:
+    js = (ROOT / "assets/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
+
+    assert "unlockedChatPrivateKey = await importPrivateKey(privateJwk);" in js
+    assert 'key_ops: ["deriveKey"]' in js
+    assert '["deriveKey"]' in js
+    assert "deriveChatMessageKey(" in js
+    assert "decryptChatCiphertext" in js
+
+
+def test_settings_chat_key_provisioning_generates_decryptable_ecdh_key() -> None:
+    js = (ROOT / "assets/js/settings.js").read_text(encoding="utf-8")
+
+    assert 'name: "ECDH"' in js
+    assert '["deriveKey"]' in js
+    assert '["deriveBits"]' not in js
+
+
+def test_chat_key_lifecycle_restores_unlocked_key_for_session_only() -> None:
+    js = (ROOT / "assets/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
+
+    assert 'const sessionStorageKey = "hushline:chat-private-jwk";' in js
+    assert "sessionStorage.setItem(" in js
+    assert "sessionStorage.getItem(sessionStorageKey)" in js
+    assert "sessionStorage.removeItem(sessionStorageKey)" in js
+    assert "restoreConversationFromSession" in js
+    assert 'passwordInput.value = "";' in js
+    assert "localStorage.setItem" not in js
+
+
 def test_profile_template_avoids_inline_submit_handlers() -> None:
     template = (ROOT / "hushline/templates/profile.html").read_text(encoding="utf-8")
     scss = (ROOT / "assets/scss/style.scss").read_text(encoding="utf-8")

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -361,13 +361,13 @@ def test_logged_in_profile_submit_message_creates_conversation_for_distinct_reci
     )
     assert sender_response.status_code == 200
     assert "Unlock your Hush Line chat key" in sender_response.text
-    assert "Locked until your chat key is unlocked." in sender_response.text
+    assert "Locked message. Unlock chat to read." in sender_response.text
 
     _authenticate_as(client, user2)
     recipient_response = client.get(url_for("conversation", conversation_id=conversation.id))
     assert recipient_response.status_code == 200
     assert "Unlock your Hush Line chat key" in recipient_response.text
-    assert "Locked until your chat key is unlocked." in recipient_response.text
+    assert "Locked message. Unlock chat to read." in recipient_response.text
     message_response = client.get(url_for("message", public_id=message.public_id))
     assert url_for("conversation", conversation_id=conversation.id) in message_response.text
 
@@ -424,7 +424,7 @@ def test_logged_in_profile_submit_message_creates_conversation_without_sender_ke
     recipient_response = client.get(url_for("conversation", conversation_id=conversation.id))
     assert recipient_response.status_code == 200
     assert "Unlock your Hush Line chat key" in recipient_response.text
-    assert "Locked until your chat key is unlocked." in recipient_response.text
+    assert "Locked message. Unlock chat to read." in recipient_response.text
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -276,7 +276,7 @@ def test_permissions_policy(client: FlaskClient) -> None:
     response = client.get(url_for("directory"), follow_redirects=True)
     assert response.status_code == 200
     assert response.headers["Permissions-Policy"] == (
-        "geolocation=(), midi=(), notifications=(), push=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=(), vibrate=(), fullscreen=(), payment=(), interest-cohort=();"  # noqa: E501
+        "geolocation=(), midi=(), notifications=(), push=(), sync-xhr=(), microphone=(), camera=(), magnetometer=(), gyroscope=(), speaker=(), vibrate=(), fullscreen=(), payment=(), interest-cohort=()"  # noqa: E501
     )
 
 

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -212,6 +212,37 @@ def test_change_username_rejects_case_insensitive_duplicate(
 
 
 @pytest.mark.usefixtures("_authenticated_user")
+def test_auth_page_binds_chat_key_rewrap_to_password_form(
+    client: FlaskClient,
+    user: User,
+) -> None:
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="public-chat-key",
+        encrypted_private_key="wrapped-private-chat-key",
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000},
+        kdf_salt="salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    db.session.add(chat_key)
+    db.session.commit()
+
+    response = client.get(url_for("settings.auth"))
+
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+    rewrap_form = soup.find("form", id="change-password-form")
+    assert rewrap_form is not None
+    assert rewrap_form.get("data-chat-key-url") == url_for("settings.chat_key")
+    assert rewrap_form.find(id="old_password") is not None
+    assert rewrap_form.find(id="new_password") is not None
+    assert rewrap_form.find(id="rewrapped_chat_key") is not None
+    assert rewrap_form.find(id="new_username") is None
+
+
+@pytest.mark.usefixtures("_authenticated_user")
 def test_settings_auth_requires_csrf_token(app: Flask, client: FlaskClient, user: User) -> None:
     prior_setting = app.config.get("WTF_CSRF_ENABLED")
     app.config["WTF_CSRF_ENABLED"] = True


### PR DESCRIPTION
## What changed

- Fixed chat private-key import so existing and new ECDH JWKs are imported for `deriveKey`, matching how conversation encryption derives shared keys.
- Added a session-scoped chat-key unlock cache after login so authenticated users land in conversations with messages decrypted without re-entering their password in the thread.
- Redesigned the conversation page as a chat interface with sender/recipient bubble alignment, a compact header, a composer, and a fallback unlock panel only when the browser session is not unlocked.
- Moved chat-key password rewrap binding to the actual Change Password form.
- Removed the invalid trailing semicolon from the `Permissions-Policy` header after Playwright exposed Chromium console parsing errors.
- Added regression tests covering WebCrypto compatibility, session unlock behavior, password-change binding, locked conversation markup, and CSP/header expectations.

## Why

Manual QA showed the epic branch did not feel like a chat UI, and logged-in users were still being asked for their password inside a conversation. The root E2EE blocker was a WebCrypto key-usage mismatch: stored ECDH private JWKs were imported with `deriveBits`, while message encryption/decryption uses `deriveKey`. That prevented reliable front-end decryption and also broke expected password-change rewrap behavior.

## Security and privacy impact

Affected paths: login chat-key unlock, `/conversation/<id>`, `/settings/auth`, `/settings/encryption`, and the global `Permissions-Policy` header.

The private chat JWK remains decrypted only in the browser. The server still never receives plaintext disclosures or private key material. The session unlock cache uses `sessionStorage`, is scoped to the current browser session, and is cleared on logout/password reset. A 2FA login flow that cannot reuse the password still falls back to the explicit unlock panel.

## Validation

- `make lint`
- `make test` - 2026 passed, 1 deselected, 1 xfailed, 7 warnings, 99% coverage
- `docker compose run --rm app poetry run pytest --cov hushline --cov-report term-missing -q --skip-local-only` - 2022 passed, 5 skipped, 1 xfailed, 7 warnings, 99% coverage
- `make audit-python` - no known vulnerabilities found
- `make audit-node-runtime` - found 0 vulnerabilities
- `node /tmp/hushline-epic-2177-visual-qa/epic-2177-visual-qa.mjs`

Playwright screenshots are in `/tmp/hushline-epic-2177-visual-qa/screenshots`, including:

- `sender-conversation-after-submit-auto-unlocked.png`
- `sender-conversation-after-auto-unlock-initial.png`
- `recipient-conversation-after-auto-unlock.png`
- `recipient-conversation-after-reply-auto-unlocked.png`
- `sender-conversation-after-recipient-reply-auto-unlocked.png`
- `anonymous-submission-success-legacy-reply-link.png`
- `tobiasfunke-auth-after-password-change-success.png`
- `tobiasfunke-encryption-after-password-change-login.png`

## Manual testing

1. Create chat keys for two seeded users from Settings -> Encryption.
2. Log in as the sender, submit a message to the recipient profile, and confirm the redirected conversation renders as an unlocked chat without asking for the password again.
3. Log in as the recipient, open the inbox conversation, and confirm the received message decrypts without an in-thread password prompt.
4. Reply as the recipient, return as the sender, and confirm both bubbles decrypt and align by sender/recipient.
5. Submit an anonymous legacy message and confirm the non-chat reply link flow still renders.
6. Change a password for a chat-key-enabled account, log in with the new password, and confirm Settings -> Encryption still shows the active chat key.

## Known risks and follow-ups

- The session unlock cache intentionally favors usability after login, but any same-origin JavaScript running in the active browser session can access `sessionStorage`. This PR does not broaden CSP and keeps the cache non-persistent.
- 2FA flows may still require the fallback conversation unlock panel because the password is not retained across the second-factor challenge.