### PR TITLE
Fix staging infra bump auth and token fallback

### DIFF
--- a/.github/workflows/bump-staging-after-release.yml
+++ b/.github/workflows/bump-staging-after-release.yml
@@ -23,6 +23,7 @@ jobs:
       INFRA_BASE_REF: main
       INFRA_BRANCH: ${{ github.event.release.tag_name }}
       INFRA_FILE: hushline-env/hushline.tf
+      INFRA_PUSH_TOKEN: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT || secrets.HUSHLINE_INFRA_TOKEN }}
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
@@ -57,7 +58,7 @@ jobs:
         with:
           repository: ${{ env.INFRA_REPOSITORY }}
           ref: ${{ env.INFRA_BASE_REF }}
-          token: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT }}
+          token: ${{ env.INFRA_PUSH_TOKEN }}
           path: hushline-infra
 
       - name: Reset release branch to trusted infra base
@@ -188,7 +189,12 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          if [ -z "${INFRA_PUSH_TOKEN:-}" ]; then
+            echo "::error title=Missing infra push token::HUSHLINE_INFRA_STAGING_PAT and HUSHLINE_INFRA_TOKEN are both unset."
+            exit 1
+          fi
 
+          git remote set-url origin "https://x-access-token:${INFRA_PUSH_TOKEN}@github.com/${INFRA_REPOSITORY}.git"
           git push --force-with-lease=refs/heads/"$INFRA_BRANCH" origin "$INFRA_BRANCH"
 
       - name: Create or update staging PR
@@ -197,7 +203,7 @@ jobs:
         working-directory: hushline-infra
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT }}
+          GH_TOKEN: ${{ env.INFRA_PUSH_TOKEN }}
         run: |
           set -euo pipefail
 
@@ -240,7 +246,7 @@ jobs:
         working-directory: hushline-infra
         shell: bash
         env:
-          GH_TOKEN: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT }}
+          GH_TOKEN: ${{ env.INFRA_PUSH_TOKEN }}
           PR_URL: ${{ steps.create_or_update_pr.outputs.pr_url }}
         run: |
           set -euo pipefail

--- a/Makefile
+++ b/Makefile
@@ -78,7 +78,7 @@ dev-data: migrate-dev ## Run dev env migrations, and add dev data
 lint: ## Lint the code
 	$(CMD) poetry run ruff format --check && \
 	$(CMD) poetry run ruff check --output-format full && \
-	$(CMD) poetry run mypy . && \
+	$(CMD) poetry run mypy --no-incremental . && \
 	$(CMD) sh -lc 'if [ -x node_modules/.bin/prettier ] && node_modules/.bin/prettier --version >/dev/null 2>&1; then node_modules/.bin/prettier $(PRETTIER_FLAGS) --check $(PRETTIER_TARGETS); elif command -v prettier >/dev/null 2>&1 && prettier --version >/dev/null 2>&1; then prettier $(PRETTIER_FLAGS) --check $(PRETTIER_TARGETS); else echo "Error: prettier/node is unavailable in this environment." >&2; exit 1; fi'
 
 .PHONY: fix


### PR DESCRIPTION
## Summary
- Resolve email-verified/PAT restriction failures in the staging infra bump job by using a dedicated push token path with explicit token-based remote push URL.
- Add fallback from `HUSHLINE_INFRA_STAGING_PAT` to `HUSHLINE_INFRA_TOKEN` for checkout, commit signing, PR creation, and merge steps.
- Fail fast if no infra push token is configured.

## Why
The release bump job was failing with `remote: You must verify your email address` during `git push` to `hushline-infra`. This PR hardens the workflow so it can authenticate with the intended infra-maintenance token and avoids depending on ambiguous actor auth state.

## Validation
- Confirmed push to branch succeeded after patch.
- No functional app code changes in this PR.