### PR TITLE
Stop persisting chat private keys in localStorage

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -2,8 +2,7 @@
   const textEncoder = new TextEncoder();
   const textDecoder = new TextDecoder();
   const sessionStorageKey = "hushline:chat-private-jwk";
-  const browserStorageKey = "hushline:chat-private-jwk:browser-session";
-  const browserStorageMaxAgeMs = 12 * 60 * 60 * 1000;
+  const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";
   const crossTabChannelName = "hushline:chat-key-session";
   const crossTabRequestTimeoutMs = 750;
   const conversationPollMinIntervalMs = 3000;
@@ -158,19 +157,13 @@
       public_key: chatKey.public_key,
       public_signing_key: chatKey.public_signing_key || null,
       private_key_bundle: privateKeyBundle,
-      expires_at: Date.now() + browserStorageMaxAgeMs,
+      expires_at: Number.MAX_SAFE_INTEGER,
     });
 
     try {
       sessionStorage.setItem(sessionStorageKey, storedValue);
     } catch (error) {
-      // Continue with browser storage below when tab storage is unavailable.
-    }
-
-    try {
-      localStorage.setItem(browserStorageKey, storedValue);
-    } catch (error) {
-      return;
+      // Private key material must not be persisted beyond this tab.
     }
   }
 
@@ -181,7 +174,7 @@
       // Keep clearing other storage locations.
     }
     try {
-      localStorage.removeItem(browserStorageKey);
+      localStorage.removeItem(legacyBrowserStorageKey);
     } catch (error) {
       return;
     }
@@ -220,18 +213,6 @@
     try {
       const privateKeyBundle = privateKeyBundleFromStoredValue(
         sessionStorage.getItem(sessionStorageKey),
-        chatKey,
-      );
-      if (privateKeyBundle) {
-        return privateKeyBundle;
-      }
-    } catch (error) {
-      // Fall through to browser storage.
-    }
-
-    try {
-      const privateKeyBundle = privateKeyBundleFromStoredValue(
-        localStorage.getItem(browserStorageKey),
         chatKey,
       );
       if (privateKeyBundle) {

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -6,8 +6,7 @@
   const textEncoder = new TextEncoder();
   const textDecoder = new TextDecoder();
   const sessionStorageKey = "hushline:chat-private-jwk";
-  const browserStorageKey = "hushline:chat-private-jwk:browser-session";
-  const browserStorageMaxAgeMs = 12 * 60 * 60 * 1000;
+  const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";
   const crossTabChannelName = "hushline:chat-key-session";
   const crossTabRequestTimeoutMs = 750;
   const conversationPollMinIntervalMs = 3000;
@@ -162,19 +161,13 @@
       public_key: chatKey.public_key,
       public_signing_key: chatKey.public_signing_key || null,
       private_key_bundle: privateKeyBundle,
-      expires_at: Date.now() + browserStorageMaxAgeMs,
+      expires_at: Number.MAX_SAFE_INTEGER,
     });
 
     try {
       sessionStorage.setItem(sessionStorageKey, storedValue);
     } catch (error) {
-      // Continue with browser storage below when tab storage is unavailable.
-    }
-
-    try {
-      localStorage.setItem(browserStorageKey, storedValue);
-    } catch (error) {
-      return;
+      // Private key material must not be persisted beyond this tab.
     }
   }
 
@@ -185,7 +178,7 @@
       // Keep clearing other storage locations.
     }
     try {
-      localStorage.removeItem(browserStorageKey);
+      localStorage.removeItem(legacyBrowserStorageKey);
     } catch (error) {
       return;
     }
@@ -224,18 +217,6 @@
     try {
       const privateKeyBundle = privateKeyBundleFromStoredValue(
         sessionStorage.getItem(sessionStorageKey),
-        chatKey,
-      );
-      if (privateKeyBundle) {
-        return privateKeyBundle;
-      }
-    } catch (error) {
-      // Fall through to browser storage.
-    }
-
-    try {
-      const privateKeyBundle = privateKeyBundleFromStoredValue(
-        localStorage.getItem(browserStorageKey),
         chatKey,
       );
       if (privateKeyBundle) {

--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -335,6 +335,8 @@ def test_chat_key_lifecycle_js_exposes_unlock_rewrap_and_cleanup() -> None:
     assert "BroadcastChannel" in lifecycle_source
     assert "hushline:chat-private-jwk" in lifecycle_js
     assert "hushline:chat-private-jwk:browser-session" in lifecycle_js
+    assert "localStorage.setItem" not in lifecycle_js
+    assert "localStorage.getItem" not in lifecycle_js
     assert "sendConversationPresence" in lifecycle_source
     assert 'document.visibilityState === "visible"' in lifecycle_source
     assert "document.body?.dataset.authenticated" in lifecycle_source

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -159,21 +159,21 @@ def test_settings_chat_key_provisioning_generates_decryptable_ecdh_key() -> None
     assert "Old conversations encrypted to earlier keys are no longer readable." in js
 
 
-def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_browser_session() -> None:
+def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session() -> None:
     js = (ROOT / "assets/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
     login_template = (ROOT / "hushline/templates/login.html").read_text(encoding="utf-8")
 
     assert 'const sessionStorageKey = "hushline:chat-private-jwk";' in js
-    assert 'const browserStorageKey = "hushline:chat-private-jwk:browser-session";' in js
-    assert "const browserStorageMaxAgeMs = 12 * 60 * 60 * 1000;" in js
+    assert 'const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";' in js
+    assert "browserStorageMaxAgeMs" not in js
     assert 'const crossTabChannelName = "hushline:chat-key-session";' in js
     assert "new BroadcastChannel(crossTabChannelName)" in js
     assert "sessionStorage.setItem(" in js
     assert "sessionStorage.getItem(sessionStorageKey)" in js
     assert "sessionStorage.removeItem(sessionStorageKey)" in js
-    assert "localStorage.setItem(browserStorageKey" in js
-    assert "localStorage.getItem(browserStorageKey)" in js
-    assert "localStorage.removeItem(browserStorageKey)" in js
+    assert "localStorage.setItem" not in js
+    assert "localStorage.getItem" not in js
+    assert "localStorage.removeItem(legacyBrowserStorageKey)" in js
     assert "restoreConversationFromSession" in js
     assert "restoreUnlockedChatKeyFromOtherTab" in js
     assert "function setConversationSecureBadgeVisible(visible)" in js


### PR DESCRIPTION
### Motivation
- Prevent storage of decrypted E2EE chat private JWK material in persistent browser storage because `localStorage` is readable by any same-origin script and survives tab/Browser close. 
- Close a vulnerability where persisted private key bundles could be used to unlock conversation ciphertexts without the account password after an XSS, shared-machine access, or profile compromise.

### Description
- Replace the persistent `localStorage` write/restore path in `assets/js/chat-key-lifecycle.js` with tab-scoped `sessionStorage` only and rename the previous browser key to `legacyBrowserStorageKey` so it can be cleared but is no longer used for unlocks. 
- Remove `localStorage.setItem`/`localStorage.getItem` usage and the 12-hour `browserStorageMaxAgeMs` retention behavior, keeping the session-scoped stored payload and cross-tab `BroadcastChannel` handoff. 
- Update the shipped bundle `hushline/static/js/chat-key-lifecycle.js` to match the session-only behavior and adjust `expires_at` handling to avoid relying on persistent browser cache for unlocks. 
- Update frontend compatibility tests in `tests/test_frontend_compat.py` and `tests/test_chat_keys.py` to assert the lifecycle no longer reads/writes `localStorage` while still removing the legacy key.

### Testing
- Ran the focused unit/source assertions with `pytest -q tests/test_frontend_compat.py::test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session tests/test_chat_keys.py::test_chat_key_lifecycle_js_exposes_unlock_rewrap_and_cleanup`, and both tests passed. 
- Rebuilt the static assets with `npx webpack --config webpack.config.js --env WEBPACK_WATCH=true` and verified the built bundle contains the session-only behavior. 
- Ran style and static checks `ruff format --check` and `ruff check` against the modified tests and they succeeded. 
- `make lint`, `make test`, `make audit-python`, and `make audit-node-runtime` could not be executed in this environment because `docker` is not installed, so CI-style full linting, test suite, and dependency audits must be run in CI before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3075d8b4a08330aa8c9fb8b0d2a856)