### PR TITLE
Use checkout credentials for staging infra push

### DIFF
--- a/.github/workflows/bump-staging-after-release.yml
+++ b/.github/workflows/bump-staging-after-release.yml
@@ -193,8 +193,6 @@ jobs:
             echo "::error title=Missing infra push token::HUSHLINE_INFRA_STAGING_PAT and HUSHLINE_INFRA_TOKEN are both unset."
             exit 1
           fi
-
-          git remote set-url origin "https://x-access-token:${INFRA_PUSH_TOKEN}@github.com/${INFRA_REPOSITORY}.git"
           git push --force-with-lease=refs/heads/"$INFRA_BRANCH" origin "$INFRA_BRANCH"
 
       - name: Create or update staging PR


### PR DESCRIPTION
## Summary
- Remove the manual `git remote set-url` rewrite before pushing the staging infra release branch.
- Return the push path to the known-good behavior from the last successful releases: let `actions/checkout` persist the selected infra token credential and push to `origin` normally.

## Why
The latest failing release run for `v0.7.0` fails in `Push infra branch`:

```text
remote: You must verify your email address.
fatal: unable to access `https://github.com/scidsg/hushline-infra.git/`: The requested URL returned error: 403
```

A few days earlier, `v0.6.86` used the same staging PAT checkout path and pushed successfully without rewriting `origin`. The meaningful regression is the later explicit `https://x-access-token:${INFRA_PUSH_TOKEN}@github.com/...` remote URL. This PR removes that rewrite and keeps the checkout-managed credential path that was working.

## Validation
- Compared current workflow against `v0.6.86:.github/workflows/bump-staging-after-release.yml`.
- Confirmed PR diff is limited to removing the manual remote URL rewrite in `.github/workflows/bump-staging-after-release.yml`.
- Not manually runnable without publishing a release and writing to `scidsg/hushline-infra`.

## Manual testing
- Not run locally; this is a release-triggered cross-repository write workflow.

## Risks / follow-ups
- The workflow still depends on `HUSHLINE_INFRA_STAGING_PAT` or fallback `HUSHLINE_INFRA_TOKEN` having write access to `scidsg/hushline-infra`, as before.
