### PR TITLE
Fix docs screenshot conversation captures

### DIFF
--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -20,6 +20,12 @@ Each release stores images by session under `releases/<version>/<session>/`.
 
 ![Directory featured carousel](./releases/latest/guest/guest-directory-featured-carousel-desktop-light-fold.png)
 
+## Conversations
+
+![Conversation inbox](./releases/latest/artvandelay/auth-artvandelay-inbox-conversations-desktop-light-fold.png)
+![Conversation thread](./releases/latest/artvandelay/auth-artvandelay-conversation-thread-desktop-light-fold.png)
+![Conversation thread mobile](./releases/latest/artvandelay/auth-artvandelay-conversation-thread-mobile-light-fold.png)
+
 ## Required accounts
 
 - admin (admin and org settings scenes)

--- a/docs/screenshots/scenes.json
+++ b/docs/screenshots/scenes.json
@@ -451,6 +451,20 @@
       "waitForSelector": ".inbox-content"
     },
     {
+      "slug": "auth-artvandelay-inbox-conversations",
+      "title": "Inbox - artvandelay conversations",
+      "path": "/inbox?type=conversations",
+      "session": "artvandelay",
+      "waitForSelector": ".conversation-summary"
+    },
+    {
+      "slug": "auth-artvandelay-conversation-thread",
+      "title": "Conversation thread - artvandelay",
+      "path": "/conversation/33333333-3333-4333-8333-333333333333",
+      "session": "artvandelay",
+      "waitForSelector": ".conversation-message-body:has-text('The procurement file has three dates')"
+    },
+    {
       "slug": "auth-artvandelay-tools-email-validation",
       "title": "Tools - Email Validation (artvandelay)",
       "path": "/email-headers",
@@ -575,6 +589,13 @@
       "path": "/inbox",
       "session": "newman",
       "waitForSelector": ".inbox-content"
+    },
+    {
+      "slug": "auth-newman-conversation-thread",
+      "title": "Conversation thread - newman",
+      "path": "/conversation/33333333-3333-4333-8333-333333333333",
+      "session": "newman",
+      "waitForSelector": ".conversation-message-body:has-text('I can confirm the Feb 9 shipment')"
     },
     {
       "slug": "auth-newman-onboarding-profile",

--- a/scripts/capture-doc-screenshots.mjs
+++ b/scripts/capture-doc-screenshots.mjs
@@ -99,10 +99,9 @@ async function login(baseUrl, context, username, password) {
   await page.goto(`${baseUrl}/login`, { waitUntil: "networkidle" });
   await page.fill("#username", username);
   await page.fill("#password", password);
-  await Promise.all([
-    page.waitForLoadState("networkidle"),
-    page.click("button[type='submit']"),
-  ]);
+  await page.click("button[type='submit']");
+  await page.waitForFunction(() => window.location.pathname !== "/login");
+  await page.waitForLoadState("networkidle").catch(() => {});
 
   if (page.url().includes("/login")) {
     throw new Error(`Login failed for user ${username}.`);

--- a/scripts/dev_data.py
+++ b/scripts/dev_data.py
@@ -1,14 +1,28 @@
 #!/usr/bin/env python
+import base64
 import json
+import os
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import List, Optional, Tuple, cast
+from typing import Any, List, Optional, Tuple, cast
 
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import ec
+from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from flask import current_app
 from sqlalchemy import func, select
 
 from hushline import create_app
+from hushline.chat_key_lifecycle import chat_key_fingerprint
 from hushline.db import db
 from hushline.model import (
+    ChatKey,
+    Conversation,
+    ConversationMessage,
+    ConversationMessageCopy,
+    ConversationParticipant,
     FieldValue,
     Message,
     MessageStatus,
@@ -32,6 +46,7 @@ def main() -> None:
         create_users()
         create_org_settings()
         create_sample_messages()
+        create_sample_conversations()
         create_localstack_buckets()
 
 
@@ -707,6 +722,325 @@ def create_sample_messages() -> None:
         msg.status = MessageStatus[cast(str, item["status"]).upper()]
 
         db.session.commit()
+
+
+DOCS_CONVERSATION_PUBLIC_ID = "33333333-3333-4333-8333-333333333333"
+DOCS_FOLLOWUP_CONVERSATION_PUBLIC_ID = "33333333-3333-4333-8333-333333333334"
+DOCS_SCREENSHOT_PASSWORD = "Test-testtesttesttest-1"  # noqa: S105
+
+
+def _b64(value: bytes) -> str:
+    return base64.b64encode(value).decode("ascii")
+
+
+def _b64url_uint(value: int) -> str:
+    return base64.urlsafe_b64encode(value.to_bytes(32, "big")).decode("ascii").rstrip("=")
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _jwk_public(private_key: ec.EllipticCurvePrivateKey, *, key_ops: list[str]) -> dict[str, Any]:
+    numbers = private_key.public_key().public_numbers()
+    return {
+        "crv": "P-256",
+        "ext": True,
+        "key_ops": key_ops,
+        "kty": "EC",
+        "x": _b64url_uint(numbers.x),
+        "y": _b64url_uint(numbers.y),
+    }
+
+
+def _jwk_private(private_key: ec.EllipticCurvePrivateKey, *, key_ops: list[str]) -> dict[str, Any]:
+    private_numbers = private_key.private_numbers()
+    jwk = _jwk_public(private_key, key_ops=key_ops)
+    jwk["d"] = _b64url_uint(private_numbers.private_value)
+    return jwk
+
+
+def _wrap_private_key_bundle(private_key_bundle: dict[str, Any], password: str) -> dict[str, Any]:
+    salt = os.urandom(16)
+    iv = os.urandom(12)
+    kdf_iterations = 310000
+    kdf_params: dict[str, int | str] = {"iterations": kdf_iterations, "hash": "SHA-256"}
+    wrapping_key = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=kdf_iterations,
+    ).derive(password.encode("utf-8"))
+    encrypted_private_key = AESGCM(wrapping_key).encrypt(
+        iv,
+        json.dumps(private_key_bundle, separators=(",", ":")).encode("utf-8"),
+        None,
+    )
+    return {
+        "encrypted_private_key": json.dumps(
+            {
+                "algorithm": "AES-GCM",
+                "iv": _b64(iv),
+                "ciphertext": _b64(encrypted_private_key),
+            },
+            separators=(",", ":"),
+        ),
+        "kdf_algorithm": "PBKDF2-SHA-256",
+        "kdf_params": kdf_params,
+        "kdf_salt": _b64(salt),
+        "wrapping_algorithm": "AES-GCM",
+    }
+
+
+def _demo_chat_identity(password: str) -> dict[str, Any]:
+    ecdh_private_key = ec.generate_private_key(ec.SECP256R1())
+    signing_private_key = ec.generate_private_key(ec.SECP256R1())
+    private_key_bundle = {
+        "ecdh_private_jwk": _jwk_private(ecdh_private_key, key_ops=["deriveKey"]),
+        "signing_private_jwk": _jwk_private(signing_private_key, key_ops=["sign"]),
+    }
+    public_key = json.dumps(_jwk_public(ecdh_private_key, key_ops=[]), separators=(",", ":"))
+    public_signing_key = json.dumps(
+        _jwk_public(signing_private_key, key_ops=["verify"]), separators=(",", ":")
+    )
+    return {
+        "ecdh_private_key": ecdh_private_key,
+        "signing_private_key": signing_private_key,
+        "payload": {
+            "public_key": public_key,
+            "public_signing_key": public_signing_key,
+            **_wrap_private_key_bundle(private_key_bundle, password),
+            "recovery_state": None,
+        },
+    }
+
+
+def _reset_demo_chat_key(user: User, identity: dict[str, Any]) -> ChatKey:
+    for chat_key in list(user.chat_keys):
+        db.session.delete(chat_key)
+    db.session.flush()
+    payload = cast(dict[str, Any], identity["payload"])
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key=cast(str, payload["public_key"]),
+        public_signing_key=cast(str, payload["public_signing_key"]),
+        encrypted_private_key=cast(str, payload["encrypted_private_key"]),
+        kdf_algorithm=cast(str, payload["kdf_algorithm"]),
+        kdf_params=cast(dict[str, Any], payload["kdf_params"]),
+        kdf_salt=cast(str, payload["kdf_salt"]),
+        wrapping_algorithm=cast(str, payload["wrapping_algorithm"]),
+        recovery_state=None,
+    )
+    db.session.add(chat_key)
+    db.session.flush()
+    return chat_key
+
+
+def _encrypt_conversation_copy(  # noqa: PLR0913
+    *,
+    plaintext: str,
+    conversation: Conversation,
+    sender_participant: ConversationParticipant,
+    sender_identity: dict[str, Any],
+    recipient_participant: ConversationParticipant,
+    recipient_identity: dict[str, Any],
+) -> str:
+    recipient_payload = cast(dict[str, Any], recipient_identity["payload"])
+    recipient_public_key = cast(
+        ec.EllipticCurvePrivateKey, recipient_identity["ecdh_private_key"]
+    ).public_key()
+    ephemeral_private_key = ec.generate_private_key(ec.SECP256R1())
+    shared_secret = ephemeral_private_key.exchange(ec.ECDH(), recipient_public_key)
+    iv = os.urandom(12)
+    context = {
+        "purpose": "hushline.chat.message",
+        "conversation_public_id": conversation.public_id,
+        "sender_participant_id": str(sender_participant.id),
+        "recipient_participant_id": str(recipient_participant.id),
+        "recipient_key_version": 1,
+        "recipient_public_key_fingerprint": chat_key_fingerprint(
+            cast(str, recipient_payload["public_key"])
+        ),
+    }
+    ciphertext = AESGCM(shared_secret).encrypt(
+        iv,
+        plaintext.encode("utf-8"),
+        _canonical_json(context).encode("utf-8"),
+    )
+    ephemeral_public_key = json.dumps(
+        _jwk_public(ephemeral_private_key, key_ops=[]), separators=(",", ":")
+    )
+    envelope: dict[str, Any] = {
+        "v": 2,
+        "algorithm": "ECDH-P256-AES-GCM",
+        "ephemeral_public_key": ephemeral_public_key,
+        "iv": _b64(iv),
+        "ciphertext": _b64(ciphertext),
+        "context": context,
+    }
+    signed_payload = {
+        "v": envelope["v"],
+        "algorithm": envelope["algorithm"],
+        "ephemeral_public_key": envelope["ephemeral_public_key"],
+        "iv": envelope["iv"],
+        "ciphertext": envelope["ciphertext"],
+        "context": envelope["context"],
+    }
+    signature = cast(ec.EllipticCurvePrivateKey, sender_identity["signing_private_key"]).sign(
+        _canonical_json(signed_payload).encode("utf-8"), ec.ECDSA(hashes.SHA256())
+    )
+    r, s = decode_dss_signature(signature)
+    envelope["signature"] = _b64(r.to_bytes(32, "big") + s.to_bytes(32, "big"))
+    return json.dumps(envelope, separators=(",", ":"))
+
+
+def _conversation_plaintext(content: str, created_at: datetime) -> str:
+    return json.dumps(
+        {
+            "content": content,
+            "created_at": created_at.isoformat().replace("+00:00", "Z"),
+        },
+        separators=(",", ":"),
+    )
+
+
+def _seed_demo_conversation(
+    *,
+    public_id: str,
+    artvandelay: User,
+    newman: User,
+    identities: dict[str, dict[str, Any]],
+    messages: list[tuple[str, str, datetime]],
+) -> None:
+    existing = db.session.scalars(
+        select(Conversation).where(Conversation.public_id == public_id)
+    ).one_or_none()
+    if existing is not None:
+        db.session.delete(existing)
+        db.session.flush()
+
+    conversation = Conversation()
+    conversation.public_id = public_id
+    artvandelay_participant = ConversationParticipant()
+    artvandelay_participant.conversation = conversation
+    artvandelay_participant.user = artvandelay
+    artvandelay_participant.has_usable_public_key = True
+    newman_participant = ConversationParticipant()
+    newman_participant.conversation = conversation
+    newman_participant.user = newman
+    newman_participant.has_usable_public_key = True
+    db.session.add(conversation)
+    db.session.flush()
+
+    participants = {
+        "artvandelay": artvandelay_participant,
+        "newman": newman_participant,
+    }
+    for sender_username, content, created_at in messages:
+        sender_participant = participants[sender_username]
+        conversation_message = ConversationMessage()
+        conversation_message.conversation = conversation
+        conversation_message.sender_participant = sender_participant
+        conversation_message.created_at = created_at
+        db.session.add(conversation_message)
+        db.session.flush()
+
+        plaintext = _conversation_plaintext(content, created_at)
+        for recipient_username, recipient_participant in participants.items():
+            encrypted_copy = ConversationMessageCopy()
+            encrypted_copy.recipient_participant = recipient_participant
+            encrypted_copy.encrypted_payload = _encrypt_conversation_copy(
+                plaintext=plaintext,
+                conversation=conversation,
+                sender_participant=sender_participant,
+                sender_identity=identities[sender_username],
+                recipient_participant=recipient_participant,
+                recipient_identity=identities[recipient_username],
+            )
+            conversation_message.encrypted_copies.append(encrypted_copy)
+
+    latest_message = conversation.messages[-1]
+    artvandelay_participant.last_read_at = latest_message.created_at
+    artvandelay_participant.last_read_message = latest_message
+
+
+def create_sample_conversations() -> None:
+    artvandelay_username = db.session.scalars(
+        select(Username).where(
+            func.lower(Username._username) == "artvandelay",
+            Username.is_primary.is_(True),
+        )
+    ).one_or_none()
+    newman_username = db.session.scalars(
+        select(Username).where(
+            func.lower(Username._username) == "newman",
+            Username.is_primary.is_(True),
+        )
+    ).one_or_none()
+    if artvandelay_username is None or newman_username is None:
+        return
+
+    identities = {
+        "artvandelay": _demo_chat_identity(DOCS_SCREENSHOT_PASSWORD),
+        "newman": _demo_chat_identity(DOCS_SCREENSHOT_PASSWORD),
+    }
+    _reset_demo_chat_key(artvandelay_username.user, identities["artvandelay"])
+    _reset_demo_chat_key(newman_username.user, identities["newman"])
+
+    base_time = datetime(2026, 2, 16, 17, 30, tzinfo=timezone.utc)
+    _seed_demo_conversation(
+        public_id=DOCS_CONVERSATION_PUBLIC_ID,
+        artvandelay=artvandelay_username.user,
+        newman=newman_username.user,
+        identities=identities,
+        messages=[
+            (
+                "newman",
+                "The procurement file has three dates that do not match the public agenda.",
+                base_time,
+            ),
+            (
+                "artvandelay",
+                "I am in the thread now. Share only what you can safely document.",
+                base_time + timedelta(minutes=8),
+            ),
+            (
+                "newman",
+                "I can confirm the Feb 9 shipment was approved before the safety review closed.",
+                base_time + timedelta(minutes=19),
+            ),
+            (
+                "artvandelay",
+                "Received. I will cross-check the contract number and keep this conversation here.",
+                base_time + timedelta(minutes=24),
+            ),
+            (
+                "newman",
+                "There is also an internal memo saying the vendor was preselected.",
+                base_time + timedelta(minutes=37),
+            ),
+        ],
+    )
+    _seed_demo_conversation(
+        public_id=DOCS_FOLLOWUP_CONVERSATION_PUBLIC_ID,
+        artvandelay=artvandelay_username.user,
+        newman=newman_username.user,
+        identities=identities,
+        messages=[
+            (
+                "newman",
+                "I found the records-retention note. It says the backup exports run weekly.",
+                base_time - timedelta(days=1),
+            ),
+            (
+                "artvandelay",
+                "Good. Please do not send files from a work device or managed network.",
+                base_time - timedelta(days=1, minutes=-11),
+            ),
+        ],
+    )
+    db.session.commit()
 
 
 def create_tiers() -> None:

--- a/tests/test_docs_screenshots_manifest.py
+++ b/tests/test_docs_screenshots_manifest.py
@@ -142,6 +142,37 @@ def test_docs_screenshots_manifest_includes_featured_directory_carousel() -> Non
     )
 
 
+def test_docs_screenshots_manifest_includes_decrypted_conversation_scenes() -> None:
+    scenes = _scene_map()
+    screenshots_readme = (REPO_ROOT / "docs" / "screenshots" / "README.md").read_text(
+        encoding="utf-8"
+    )
+    dev_data = (REPO_ROOT / "scripts" / "dev_data.py").read_text(encoding="utf-8")
+
+    inbox_scene = scenes["auth-artvandelay-inbox-conversations"]
+    artvandelay_thread = scenes["auth-artvandelay-conversation-thread"]
+    newman_thread = scenes["auth-newman-conversation-thread"]
+
+    assert inbox_scene["path"] == "/inbox?type=conversations"
+    assert inbox_scene["session"] == "artvandelay"
+    assert inbox_scene["waitForSelector"] == ".conversation-summary"
+    assert artvandelay_thread["path"] == "/conversation/33333333-3333-4333-8333-333333333333"
+    assert artvandelay_thread["waitForSelector"] == (
+        ".conversation-message-body:has-text('The procurement file has three dates')"
+    )
+    assert newman_thread["path"] == artvandelay_thread["path"]
+    assert newman_thread["waitForSelector"] == (
+        ".conversation-message-body:has-text('I can confirm the Feb 9 shipment')"
+    )
+    assert "create_sample_conversations()" in dev_data
+    assert "ECDH-P256-AES-GCM" in dev_data
+    assert "PBKDF2-SHA-256" in dev_data
+    assert (
+        "./releases/latest/artvandelay/auth-artvandelay-conversation-thread-mobile-light-fold.png"
+        in screenshots_readme
+    )
+
+
 def test_docs_screenshot_capture_suppresses_first_load_splash() -> None:
     script = CAPTURE_SCRIPT_PATH.read_text(encoding="utf-8")
 
@@ -164,6 +195,17 @@ def test_docs_screenshot_capture_filters_to_manifest_capture_files() -> None:
     assert "shouldVisitCaptureTarget(" in script
     assert "shouldCaptureFile(captureFiles, relativeFile)" in script
     assert "Required screenshot captures were not produced" in script
+
+
+def test_docs_screenshot_capture_login_waits_for_fetch_driven_redirect() -> None:
+    script = CAPTURE_SCRIPT_PATH.read_text(encoding="utf-8")
+    login_body = script[
+        script.index("async function login(") : script.index("async function runAction")
+    ]
+
+    assert "await page.click(\"button[type='submit']\");" in login_body
+    assert 'window.location.pathname !== "/login"' in login_body
+    assert "Promise.all" not in login_body
 
 
 def test_docs_screenshot_capture_supports_scene_masks() -> None:


### PR DESCRIPTION
## What changed

- Fixed docs screenshot auth so the capture script waits for the login URL to change after the chat-key login handler submits via `fetch` and replaces the document.
- Added docs screenshot scenes for the conversations inbox and conversation thread views.
- Added README screenshot references so the release allowlist captures the new conversation images.
- Added rich dev seed data for two Art Vandelay/Newman conversations, including browser-decryptable E2EE chat keys and signed ECDH/AES-GCM conversation message envelopes.
- Added manifest tests that lock the fetch-driven login wait and require conversation scenes to wait for decrypted bubble text.

## Why

The last docs screenshots workflow failed during authenticated capture with:

`Error: Login failed for user artvandelay.`

The login page now intercepts submit in `chat-key-lifecycle.js`, posts with `fetch`, unlocks/provisions the browser chat key, and swaps the document with `replaceDocument()`. The screenshot script was still waiting for a traditional navigation load state, so it could race the fetch-driven redirect and conclude it was still on `/login`.

The new conversation screenshots need decrypted bubbles, not placeholder ciphertext. The seed data now creates demo-only chat keys and encrypted message copies using the same protocol shape as the browser:

- P-256 ECDH for message key agreement.
- AES-GCM for encrypted message envelopes.
- P-256 ECDSA signatures over canonical envelope fields.
- PBKDF2-SHA-256 wrapped private key bundles, matching the login unlock flow.

This keeps the screenshots representative of real E2EE behavior while limiting plaintext fixture content to local seeded demo conversations.

## Validation

- `make lint` attempted, but Docker could not bind `127.0.0.1:5432` because another local Postgres stack already owns that port.
- Passed equivalent no-deps lint commands after rebase:
  - `docker compose run --rm --no-deps app poetry run ruff format --check`
  - `docker compose run --rm --no-deps app poetry run ruff check --output-format full`
  - `docker compose run --rm --no-deps app poetry run mypy --no-incremental .`
  - `docker compose run --rm --no-deps app sh -lc '...prettier --check...'`
- Passed focused tests after rebase:
  - `docker compose run --rm --no-deps app poetry run pytest tests/test_docs_screenshots_manifest.py -q`

## Manual testing

- Not run locally. The full docs screenshot workflow requires an isolated app/Postgres/LocalStack stack; the local host Postgres port was already allocated.
- The PR relies on the docs screenshot workflow to perform the end-to-end browser capture against the seeded conversation data.

## Risks / follow-ups

- The seeded demo conversation keys are regenerated by `scripts/dev_data.py` for the demo accounts so seeded encrypted messages and browser unlock state stay in sync.
- Full `make test` was not run locally due the same Docker port conflict; CI should run the full suite.
