### PR TITLE
Fix release staging and docs screenshot workflows

### DIFF
--- a/.github/workflows/bump-staging-after-release.yml
+++ b/.github/workflows/bump-staging-after-release.yml
@@ -23,7 +23,6 @@ jobs:
       INFRA_BASE_REF: main
       INFRA_BRANCH: ${{ github.event.release.tag_name }}
       INFRA_FILE: hushline-env/hushline.tf
-      INFRA_PUSH_TOKEN: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT || secrets.HUSHLINE_INFRA_TOKEN }}
     steps:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f
@@ -58,7 +57,7 @@ jobs:
         with:
           repository: ${{ env.INFRA_REPOSITORY }}
           ref: ${{ env.INFRA_BASE_REF }}
-          token: ${{ env.INFRA_PUSH_TOKEN }}
+          token: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT }}
           path: hushline-infra
 
       - name: Reset release branch to trusted infra base
@@ -115,6 +114,7 @@ jobs:
 
       - name: Commit infra branch
         if: steps.update_infra.outputs.changed == 'true'
+        id: commit_infra
         working-directory: hushline-infra
         shell: bash
         run: |
@@ -128,6 +128,7 @@ jobs:
             exit 0
           fi
           git commit -m "Bump staging to $RELEASE_TAG"
+          echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Verify only the staging tag changed
         if: steps.update_infra.outputs.changed == 'true'
@@ -189,10 +190,6 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          if [ -z "${INFRA_PUSH_TOKEN:-}" ]; then
-            echo "::error title=Missing infra push token::HUSHLINE_INFRA_STAGING_PAT and HUSHLINE_INFRA_TOKEN are both unset."
-            exit 1
-          fi
           git push --force-with-lease=refs/heads/"$INFRA_BRANCH" origin "$INFRA_BRANCH"
 
       - name: Create or update staging PR
@@ -201,7 +198,7 @@ jobs:
         working-directory: hushline-infra
         shell: bash
         env:
-          GH_TOKEN: ${{ env.INFRA_PUSH_TOKEN }}
+          GH_TOKEN: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT }}
         run: |
           set -euo pipefail
 
@@ -244,7 +241,7 @@ jobs:
         working-directory: hushline-infra
         shell: bash
         env:
-          GH_TOKEN: ${{ env.INFRA_PUSH_TOKEN }}
+          GH_TOKEN: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT }}
           PR_URL: ${{ steps.create_or_update_pr.outputs.pr_url }}
         run: |
           set -euo pipefail
@@ -255,6 +252,7 @@ jobs:
             --repo "$INFRA_REPOSITORY" \
             --squash \
             --delete-branch \
+            --match-head-commit "${{ steps.commit_infra.outputs.head_sha }}" \
             "$PR_URL" >"$merge_output_file" 2>&1; then
             cat "$merge_output_file"
             exit 0

--- a/scripts/capture-doc-screenshots.mjs
+++ b/scripts/capture-doc-screenshots.mjs
@@ -31,6 +31,7 @@ async function sleep(ms) {
 
 const GUIDANCE_STORAGE_KEY = "hasFinishedGuidance";
 const FIRST_LOAD_SPLASH_SEEN_KEY = "hushline:first-load-splash-seen";
+const CHAT_PRIVATE_JWK_STORAGE_KEY = "hushline:chat-private-jwk";
 const SCREENSHOT_SPLASH_SUPPRESSION_CSS = `
 /* Capture-only: docs screenshots need the target screen, not the first-load splash. */
 #first-load-splash,
@@ -105,6 +106,23 @@ async function login(baseUrl, context, username, password) {
 
   if (page.url().includes("/login")) {
     throw new Error(`Login failed for user ${username}.`);
+  }
+
+  const unlockedChatKey = await page
+    .evaluate((storageKey) => sessionStorage.getItem(storageKey), CHAT_PRIVATE_JWK_STORAGE_KEY)
+    .catch(() => null);
+  if (unlockedChatKey) {
+    await context.addInitScript(
+      ({ storageKey, storageValue }) => {
+        try {
+          sessionStorage.setItem(storageKey, storageValue);
+        } catch {}
+      },
+      {
+        storageKey: CHAT_PRIVATE_JWK_STORAGE_KEY,
+        storageValue: unlockedChatKey,
+      },
+    );
   }
 
   await page.close();

--- a/tests/test_docs_screenshots_manifest.py
+++ b/tests/test_docs_screenshots_manifest.py
@@ -203,8 +203,12 @@ def test_docs_screenshot_capture_login_waits_for_fetch_driven_redirect() -> None
         script.index("async function login(") : script.index("async function runAction")
     ]
 
+    assert 'const CHAT_PRIVATE_JWK_STORAGE_KEY = "hushline:chat-private-jwk";' in script
     assert "await page.click(\"button[type='submit']\");" in login_body
     assert 'window.location.pathname !== "/login"' in login_body
+    assert "sessionStorage.getItem(storageKey)" in login_body
+    assert "sessionStorage.setItem(storageKey, storageValue)" in login_body
+    assert "await context.addInitScript(" in login_body
     assert "Promise.all" not in login_body
 
 

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -399,10 +399,22 @@ def test_staging_release_branch_resets_to_trusted_base_before_auto_merge() -> No
         "      - name: Create or update staging PR",
         1,
     )[0]
+    pr_section = workflow_text.split("      - name: Create or update staging PR", 1)[1].split(
+        "      - name: Merge staging PR if immediately allowed",
+        1,
+    )[0]
+    merge_section = workflow_text.split(
+        "      - name: Merge staging PR if immediately allowed",
+        1,
+    )[1]
 
+    assert "HUSHLINE_INFRA_STAGING_PAT || HUSHLINE_INFRA_TOKEN" not in workflow_text
+    assert "HUSHLINE_INFRA_TOKEN" not in workflow_text
+    assert "token: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT }}" in workflow_text
     assert 'git fetch origin "$INFRA_BRANCH":"refs/remotes/origin/$INFRA_BRANCH"' in reset_section
     assert 'git checkout -B "$INFRA_BRANCH" "origin/$INFRA_BASE_REF"' in reset_section
     assert 'git checkout -B "$INFRA_BRANCH" "origin/$INFRA_BRANCH"' not in reset_section
+    assert 'echo "head_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"' in commit_section
     assert (
         'git push --force-with-lease=refs/heads/"$INFRA_BRANCH" origin "$INFRA_BRANCH"'
         not in commit_section
@@ -414,3 +426,7 @@ def test_staging_release_branch_resets_to_trusted_base_before_auto_merge() -> No
         'git push --force-with-lease=refs/heads/"$INFRA_BRANCH" origin "$INFRA_BRANCH"'
         in push_section
     )
+    assert "Missing infra push token" not in push_section
+    assert "GH_TOKEN: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT }}" in pr_section
+    assert "GH_TOKEN: ${{ secrets.HUSHLINE_INFRA_STAGING_PAT }}" in merge_section
+    assert '--match-head-commit "${{ steps.commit_infra.outputs.head_sha }}"' in merge_section


### PR DESCRIPTION
## What changed

- Restored staging release bump auth to the dedicated staging PAT path instead of falling back to `HUSHLINE_INFRA_TOKEN`.
- Kept staging branch pushes on the checkout-managed authenticated remote, matching the successful personal-server workflow pattern.
- Added `--match-head-commit` to the staging PR merge step so auto-merge cannot race a changed branch head.
- Preserved the unlocked chat-key `sessionStorage` value from screenshot login and injects it into subsequent Playwright pages in the same browser context.
- Added tests locking the staging token path and docs screenshot auth/session behavior.

## Why

### Staging bump

The `v0.7.1` release run failed on `Push infra branch` with:

`remote: You must verify your email address.`

The personal-server bump succeeded because it uses its dedicated `PERSONAL_SERVER_VERSION_BUMP` secret directly. Staging had a fallback expression:

`secrets.HUSHLINE_INFRA_STAGING_PAT || secrets.HUSHLINE_INFRA_TOKEN`

The recent `v0.7.0` staging run looked green but skipped commit/push/PR because infra already pointed at `v0.7.0`. The older `v0.6.86` write path succeeded before this fallback token path was used. Removing the fallback prevents the workflow from silently using the shared token that GitHub now rejects.

### Docs screenshots

The current docs screenshot run got past login but timed out waiting for decrypted conversation text:

`Scene auth-artvandelay-conversation-thread ... failed waiting for selector .conversation-message-body:has-text(...)`

Login unlocks the chat key in the login page, but unlocked key material now lives in `sessionStorage`, which is per tab. The screenshot helper closed the login page and opened later screenshot pages in new tabs, so those pages had auth cookies but not the unlocked chat key. The helper now copies the capture-only unlocked chat-key session value into future pages for that Playwright context.

## Validation

- `make lint` attempted and blocked before linting because local Docker could not bind `127.0.0.1:5432`; another local Postgres stack owns the port.
- Passed equivalent no-deps lint sequence:
  - `docker compose run --rm --no-deps app poetry run ruff format --check`
  - `docker compose run --rm --no-deps app poetry run ruff check --output-format full`
  - `docker compose run --rm --no-deps app poetry run mypy --no-incremental .`
  - `docker compose run --rm --no-deps app sh -lc '...prettier --check...'`
- Passed focused tests:
  - `docker compose run --rm --no-deps app poetry run pytest tests/test_docs_screenshots_manifest.py tests/test_workflow_pr_head_qualification.py -q`

## Manual testing

- Not run locally; both fixes target GitHub Actions release workflows and need repository secrets plus release-triggered workflow context.
- CI should validate workflow syntax and the next release/docs screenshot run should validate the end-to-end behavior.

## Risks / follow-ups

- `HUSHLINE_INFRA_STAGING_PAT` must be present and must have write access to `scidsg/hushline-infra`. The workflow intentionally no longer falls back to `HUSHLINE_INFRA_TOKEN`.
- The docs screenshot key copy is capture-only and scoped to the Playwright browser context used by `scripts/capture-doc-screenshots.mjs`.
