### PR TITLE
Allow docs screenshots workflow dispatch runs to publish artifacts

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -296,7 +296,7 @@ jobs:
           path: ${{ steps.artifact.outputs.artifact_root }}
 
   publish-release:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
     needs: capture
     uses: ./.github/workflows/publish-docs-screenshots.yml
     with:

--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -54,8 +54,10 @@ jobs:
 
           if str(run.get("id")) != os.environ["RUN_ID"]:
               errors.append("source run ID mismatch")
-          if run.get("event") != "release":
-              errors.append(f"source run event must be release, got {run.get('event')!r}")
+          if run.get("event") not in {"release", "workflow_dispatch"}:
+              errors.append(
+                  f"source run event must be release or workflow_dispatch, got {run.get('event')!r}"
+              )
           if run.get("path") != ".github/workflows/docs-screenshots.yml":
               errors.append(f"source run workflow path is unexpected: {run.get('path')!r}")
           head_repository = run.get("head_repository") or {}

--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -55,9 +55,7 @@ jobs:
           if str(run.get("id")) != os.environ["RUN_ID"]:
               errors.append("source run ID mismatch")
           if run.get("event") not in {"release", "workflow_dispatch"}:
-              errors.append(
-                  f"source run event must be release or workflow_dispatch, got {run.get('event')!r}"
-              )
+              errors.append(f"source run event must be release or workflow_dispatch, got {run.get('event')!r}")
           if run.get("path") != ".github/workflows/docs-screenshots.yml":
               errors.append(f"source run workflow path is unexpected: {run.get('path')!r}")
           head_repository = run.get("head_repository") or {}

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -117,7 +117,7 @@ def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> No
         "      - name: Publish screenshots to hushline-screenshots", 1
     )[1].split("      - name: Publish current screenshots to hushline-website", 1)[0]
 
-    assert 'run.get("event") != "release"' in source_section
+    assert 'run.get("event") not in {"release", "workflow_dispatch"}' in source_section
     assert 'run.get("path") != ".github/workflows/docs-screenshots.yml"' in source_section
     assert 'head_repository.get("full_name") != os.environ["GITHUB_REPOSITORY"]' in source_section
     assert (
@@ -185,7 +185,10 @@ def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> 
         "      - name: Publish current screenshots to hushline-website", 1
     )[1]
 
-    assert "if: ${{ github.event_name == 'release' }}" in publish_job_section
+    assert (
+        "if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}"
+        in publish_job_section
+    )
     assert "if: ${{ github.event_name != 'workflow_call' }}" not in capture_workflow_text
     assert "fetch-depth: 1" in checkout_section
     assert "fetch-depth: 0" not in checkout_section


### PR DESCRIPTION
## Summary
- Root cause: publish job in `.github/workflows/docs-screenshots.yml` was gated to `github.event_name == 'release'`, so manually dispatched runs uploaded screenshot artifacts but skipped the `publish-release` reusable workflow.
- Fix: updated publish job condition to also run on `workflow_dispatch`, so manual captures can proceed to publish.

## Files changed
- `.github/workflows/docs-screenshots.yml`:
  - Changed `publish-release` job condition from `if: github.event_name == 'release'` to `if: github.event_name == 'release' || github.event_name == 'workflow_dispatch'`.

## Validation
- Verified via run inspection (`run_id=27598600162`) that capture succeeded and publish job was marked `skipped`, which is consistent with the `release`-only guard.
- No code-path changes besides workflow condition; no automated tests were run (workflow change only).