### PR TITLE
Fix docs screenshot publish flow for manual dispatch

### DIFF
--- a/.github/workflows/docs-screenshots.yml
+++ b/.github/workflows/docs-screenshots.yml
@@ -296,7 +296,7 @@ jobs:
           path: ${{ steps.artifact.outputs.artifact_root }}
 
   publish-release:
-    if: ${{ github.event_name == 'release' }}
+    if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}
     needs: capture
     uses: ./.github/workflows/publish-docs-screenshots.yml
     with:

--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -54,8 +54,8 @@ jobs:
 
           if str(run.get("id")) != os.environ["RUN_ID"]:
               errors.append("source run ID mismatch")
-          if run.get("event") != "release":
-              errors.append(f"source run event must be release, got {run.get('event')!r}")
+          if run.get("event") not in {"release", "workflow_dispatch"}:
+              errors.append(f"source run event must be release or workflow_dispatch, got {run.get('event')!r}")
           if run.get("path") != ".github/workflows/docs-screenshots.yml":
               errors.append(f"source run workflow path is unexpected: {run.get('path')!r}")
           head_repository = run.get("head_repository") or {}

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -117,7 +117,7 @@ def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> No
         "      - name: Publish screenshots to hushline-screenshots", 1
     )[1].split("      - name: Publish current screenshots to hushline-website", 1)[0]
 
-    assert 'run.get("event") != "release"' in source_section
+    assert 'run.get("event") not in {"release", "workflow_dispatch"}' in source_section
     assert 'run.get("path") != ".github/workflows/docs-screenshots.yml"' in source_section
     assert 'head_repository.get("full_name") != os.environ["GITHUB_REPOSITORY"]' in source_section
     assert (
@@ -185,7 +185,10 @@ def test_screenshots_workflow_publishes_current_folder_to_website_directly() -> 
         "      - name: Publish current screenshots to hushline-website", 1
     )[1]
 
-    assert "if: ${{ github.event_name == 'release' }}" in publish_job_section
+    assert (
+        "if: ${{ github.event_name == 'release' || github.event_name == 'workflow_dispatch' }}"
+        in publish_job_section
+    )
     assert "if: ${{ github.event_name != 'workflow_call' }}" not in capture_workflow_text
     assert "fetch-depth: 1" in checkout_section
     assert "fetch-depth: 0" not in checkout_section


### PR DESCRIPTION
## Summary
- Allow `docs-screenshots.yml` publish job to run for both `release` and `workflow_dispatch` events.
- Update `publish-docs-screenshots.yml` source-run validation to accept `workflow_dispatch` as a trusted source event for the same workflow.
- Update workflow contract tests in `tests/test_workflow_pr_head_qualification.py` to match the new dispatch behavior.

## Validation
- `poetry run pytest tests/test_workflow_pr_head_qualification.py -q`
- Result: `19 passed`