### PR TITLE
Improve E2EE chat accessibility

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -865,10 +865,10 @@
   }
 
   function setConversationStatus(message) {
-    const status = document.getElementById("conversation-chat-status");
-    if (status) {
+    const statuses = document.querySelectorAll("[data-conversation-status]");
+    statuses.forEach((status) => {
       status.textContent = message;
-    }
+    });
   }
 
   function setConversationUnlockVisible(visible) {
@@ -1099,9 +1099,11 @@
 
     if (body) {
       body.disabled = !enabled;
+      body.setAttribute("aria-disabled", enabled ? "false" : "true");
     }
     if (submit) {
       submit.disabled = !enabled;
+      submit.setAttribute("aria-disabled", enabled ? "false" : "true");
     }
   }
 

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2472,7 +2472,8 @@ body.conversation-body {
 }
 
 .conversation-unlock-panel h2,
-.conversation-unlock-panel p {
+.conversation-unlock-panel p,
+.conversation-chat > .visually-hidden {
   margin: 0;
 }
 

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -869,10 +869,10 @@
   }
 
   function setConversationStatus(message) {
-    const status = document.getElementById("conversation-chat-status");
-    if (status) {
+    const statuses = document.querySelectorAll("[data-conversation-status]");
+    statuses.forEach((status) => {
       status.textContent = message;
-    }
+    });
   }
 
   function setConversationUnlockVisible(visible) {
@@ -1103,9 +1103,11 @@
 
     if (body) {
       body.disabled = !enabled;
+      body.setAttribute("aria-disabled", enabled ? "false" : "true");
     }
     if (submit) {
       submit.disabled = !enabled;
+      submit.setAttribute("aria-disabled", enabled ? "false" : "true");
     }
   }
 

--- a/hushline/templates/conversation.html
+++ b/hushline/templates/conversation.html
@@ -36,17 +36,34 @@
     data-conversation-public-id="{{ conversation.public_id }}"
     data-participant-id="{{ participant.id }}"
   >
-    <div id="conversation-key-locked" class="conversation-unlock-panel" role="status" hidden>
+    <div
+      id="conversation-key-locked"
+      class="conversation-unlock-panel"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      hidden
+    >
       <div>
         <h2>Secure chat unavailable</h2>
         <p>
           This conversation needs your browser chat key before messages can be read.
         </p>
       </div>
-      <p id="conversation-chat-status" class="meta" role="status">
+      <p id="conversation-key-lock-status" class="meta" data-conversation-status>
         Messages are encrypted until your browser chat key unlocks.
       </p>
     </div>
+    <p
+      id="conversation-chat-status"
+      class="visually-hidden"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      data-conversation-status
+    >
+      Messages are encrypted until your browser chat key unlocks.
+    </p>
 
     <script id="conversationParticipantPublicKeys" type="application/json">
       {{ participant_public_keys | tojson }}
@@ -55,13 +72,22 @@
       {{ message_copy_payloads | tojson }}
     </script>
 
-    <article class="conversation-thread" aria-live="polite" aria-label="Conversation messages">
+    <section
+      id="conversation-thread"
+      class="conversation-thread"
+      role="log"
+      aria-label="Conversation messages"
+      aria-live="polite"
+      aria-relevant="additions text"
+      aria-atomic="false"
+    >
       {% for conversation_message, encrypted_copy, is_own_message in message_copies %}
-        <div
+        <article
           class="conversation-message {{ 'is-own-message' if is_own_message else 'is-other-message' }}"
           data-conversation-message-id="{{ conversation_message.id }}"
+          aria-label="{{ 'Your message' if is_own_message else 'Message from ' ~ conversation_name }}"
         >
-          <time data-conversation-message-time class="meta" role="presentation"></time>
+          <time data-conversation-message-time class="meta"></time>
           {% if encrypted_copy %}
             <p class="conversation-message-body">Encrypted message. Waiting for browser chat key.</p>
           {% else %}
@@ -69,9 +95,9 @@
               No encrypted copy is available for your account.
             </p>
           {% endif %}
-        </div>
+        </article>
       {% endfor %}
-    </article>
+    </section>
 
     {% if rotated_participant_keys %}
       <div class="conversation-key-warning" role="status">
@@ -113,17 +139,19 @@
         name="message"
         rows="1"
         maxlength="50000"
+        aria-describedby="conversation-chat-status{% if not can_compose %} conversation-compose-unavailable{% endif %}"
         disabled="disabled"
         placeholder="Message"
         required
       ></textarea>
       {{ conversation_message_form.submit(
         id="conversation-compose-submit",
+        aria_describedby="conversation-chat-status",
         disabled="disabled",
         value="Send"
       ) }}
       {% if not can_compose %}
-        <p class="meta">
+        <p id="conversation-compose-unavailable" class="meta">
           Replies are unavailable until every participant has an active Hush Line chat key.
         </p>
       {% endif %}

--- a/tests/test_accessibility.py
+++ b/tests/test_accessibility.py
@@ -308,6 +308,69 @@ def test_inbox_conversation_rows_have_accessible_status_and_unread_state(
     assert unavailable_link.get_text(" ", strip=True) == "Go to conversation"
 
 
+@pytest.mark.usefixtures("_authenticated_user")
+def test_conversation_view_exposes_accessible_chat_state(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_inbox_conversation(
+        user,
+        user2,
+        user_has_copy=True,
+        sender_is_other_user=True,
+    )
+
+    response = client.get(
+        url_for("conversation", public_id=conversation.public_id),
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+
+    soup = BeautifulSoup(response.text, "html.parser")
+    chat = soup.find(id="conversation-chat")
+    unlock_panel = soup.find(id="conversation-key-locked")
+    status = soup.find(id="conversation-chat-status")
+    visible_status = soup.find(id="conversation-key-lock-status")
+    thread = soup.find(id="conversation-thread")
+    message = soup.select_one("[data-conversation-message-id]")
+    timestamp = message.find("time") if message else None
+    textarea = soup.find(id="conversation-compose-body")
+    submit = soup.find(id="conversation-compose-submit")
+
+    assert chat is not None
+    assert unlock_panel is not None
+    assert unlock_panel.get("role") == "status"
+    assert unlock_panel.get("aria-live") == "polite"
+    assert unlock_panel.get("aria-atomic") == "true"
+    assert visible_status is not None
+    assert visible_status.get("data-conversation-status") == ""
+    assert status is not None
+    assert "visually-hidden" in status.get("class", [])
+    assert status.get("role") == "status"
+    assert status.get("aria-live") == "polite"
+    assert status.get("aria-atomic") == "true"
+    assert status.get("data-conversation-status") == ""
+    assert thread is not None
+    assert thread.name == "section"
+    assert thread.get("role") == "log"
+    assert thread.get("aria-label") == "Conversation messages"
+    assert thread.get("aria-live") == "polite"
+    assert thread.get("aria-relevant") == "additions text"
+    assert thread.get("aria-atomic") == "false"
+    assert message is not None
+    assert message.name == "article"
+    assert message.get("aria-label") == f"Message from {user2.primary_username.username}"
+    assert timestamp is not None
+    assert timestamp.get("role") is None
+    assert textarea is not None
+    assert "conversation-chat-status" in textarea.get("aria-describedby", "")
+    assert textarea.get("aria-disabled") is None
+    assert submit is not None
+    assert submit.get("aria-describedby") == "conversation-chat-status"
+    assert submit.get("aria-disabled") is None
+
+
 def test_guidance_modal_has_accessible_attributes(client: FlaskClient) -> None:
     OrganizationSetting.upsert(OrganizationSetting.GUIDANCE_ENABLED, True)
     OrganizationSetting.upsert(

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -267,7 +267,11 @@ def test_conversation_view_shows_locked_chat_key_state(
     assert response.text.count("is-other-message") == 1
     assert 'rows="1"' in response.text
     assert 'placeholder="Message"' in response.text
-    assert '<button disabled="disabled" id="conversation-compose-submit"' in response.text
+    assert re.search(
+        r'<button(?=[^>]*\bid="conversation-compose-submit")'
+        r'(?=[^>]*\bdisabled="disabled")[^>]*>',
+        response.text,
+    )
     assert 'data-participant-id="' in response.text
     assert "Messages are encrypted until your browser chat key unlocks." in response.text
     assert "JavaScript is required for end-to-end encrypted chat." in response.text


### PR DESCRIPTION
## What changed

- Added persistent screen-reader chat status for the E2EE conversation view.
- Marked the conversation transcript as a polite live `role="log"` region.
- Rendered individual chat messages as labeled `article` elements and kept timestamps available to assistive tech.
- Connected the disabled composer controls to the chat status text and unavailable-replies explanation.
- Updated chat-key lifecycle JS to keep all status regions synchronized and mirror disabled state with `aria-disabled`.
- Added regression coverage for the accessible E2EE chat state and relaxed a brittle disabled-button assertion.

## Why

This is part of the E2EE chat launch accessibility audit. Locked, unlocking, and unlocked chat states are dynamic, so screen-reader users need stable status announcements and transcript semantics without changing the encryption flow.

## Validation

- `npm run build:prod` (passed; existing Sass legacy JS API deprecation warning from the toolchain)
- `docker compose run --rm app poetry run pytest tests/test_conversation.py::test_conversation_view_shows_locked_chat_key_state tests/test_accessibility.py -q` (passed)
- `make lint` (passed)
- `make test` (passed: 2089 passed, 1 deselected, 1 xfailed)

## Manual testing

Not run manually. The change is covered with template/static regression tests for the rendered conversation accessibility contract.

## Security / privacy notes

- No crypto behavior changed.
- No CSP broadening.
- No dependency changes.
- No plaintext disclosure or key-handling paths changed.

## Risks / follow-up

A later Playwright/axe pass against an actual unlocked chat session would be useful before final launch, but this PR locks in the server-rendered and JS status semantics that were missing.