### PR TITLE
Preserve conversation URL after encrypted submission

### DIFF
--- a/assets/js/client-side-encryption.js
+++ b/assets/js/client-side-encryption.js
@@ -334,6 +334,9 @@ async function submitEncryptedForm(form) {
     },
   });
   const html = await response.text();
+  if (response.url && response.url.startsWith(window.location.origin)) {
+    window.history.replaceState({}, "", response.url);
+  }
   document.open();
   document.write(html);
   document.close();

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -81,6 +81,9 @@ def test_embed_resize_bundle_is_declared_and_height_only() -> None:
 
 def test_client_side_encryption_has_platform_guards() -> None:
     js = (ROOT / "assets/js/client-side-encryption.js").read_text(encoding="utf-8")
+    static_js = (ROOT / "hushline/static/js/client-side-encryption.js").read_text(
+        encoding="utf-8"
+    )
 
     assert "function assertClientCryptoSupport()" in js
     assert "function getRecipientPublicKeys()" in js
@@ -106,6 +109,10 @@ def test_client_side_encryption_has_platform_guards() -> None:
     assert "body: new FormData(form)" in js
     assert 'credentials: "same-origin"' in js
     assert 'Accept: "text/html"' in js
+    assert "response.url.startsWith(window.location.origin)" in js
+    assert "window.history.replaceState({}, \"\", response.url);" in js
+    assert "startsWith(window.location.origin)" in static_js
+    assert "history.replaceState" in static_js
     assert "document.write(html);" in js
     assert "form.submit();" not in js
 

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -81,9 +81,6 @@ def test_embed_resize_bundle_is_declared_and_height_only() -> None:
 
 def test_client_side_encryption_has_platform_guards() -> None:
     js = (ROOT / "assets/js/client-side-encryption.js").read_text(encoding="utf-8")
-    static_js = (ROOT / "hushline/static/js/client-side-encryption.js").read_text(
-        encoding="utf-8"
-    )
 
     assert "function assertClientCryptoSupport()" in js
     assert "function getRecipientPublicKeys()" in js
@@ -110,9 +107,7 @@ def test_client_side_encryption_has_platform_guards() -> None:
     assert 'credentials: "same-origin"' in js
     assert 'Accept: "text/html"' in js
     assert "response.url.startsWith(window.location.origin)" in js
-    assert "window.history.replaceState({}, \"\", response.url);" in js
-    assert "startsWith(window.location.origin)" in static_js
-    assert "history.replaceState" in static_js
+    assert 'window.history.replaceState({}, "", response.url);' in js
     assert "document.write(html);" in js
     assert "form.submit();" not in js
 


### PR DESCRIPTION
## What changed

- Updates the client-side encrypted message submission helper to replace browser history with the final same-origin response URL before writing the returned HTML.
- Adds a frontend compatibility regression asserting the URL replacement remains in place.
- Keeps the regression assertion on tracked source JS only so CI does not depend on generated static bundle artifacts.

## Why

When a logged-in sender submits to another logged-in user and the submission starts an E2EE conversation, the server correctly redirects to `/conversation/<id>`. The client-side encrypted submit flow follows that redirect with `fetch()` and writes the returned HTML into the current document, but it previously left the browser URL on the original `/to/<username>` tip-line route. Refreshing the page therefore reloaded the recipient profile instead of the new conversation.

This keeps refresh/bookmark behavior aligned with the conversation page the user is actually seeing.

## Validation

- `docker compose run --rm app poetry run pytest tests/test_frontend_compat.py::test_client_side_encryption_has_platform_guards -q` (passed before PR update)
- `make lint` (passed)
- `make test` (passed: 2088 passed, 1 deselected, 1 xfailed; coverage 99%)

Note: the first local `make test` attempt failed with the repo-documented Postgres shared-memory condition: `could not resize shared memory segment ... No space left on device`. Per `AGENTS.md`, I reset Docker volumes with `docker compose down -v` and reran the full suite successfully.

## Manual testing

Not run manually. The change is covered by the frontend compatibility regression and full test suite.

## Security / privacy notes

- No cryptography changes.
- No server-side authorization changes.
- URL replacement is restricted to same-origin response URLs.
- No CSP broadening.
- No dependency changes.

## Risks / follow-up

Before production launch, a browser smoke test should confirm the end-to-end sender flow: logged-in sender submits to logged-in recipient, lands on the conversation URL, refresh stays on the conversation, and later replies appear via conversation polling.