### PR TITLE
Require v2 envelopes for E2EE chat replies

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -1129,7 +1129,7 @@
     }
     if (root.dataset.canCompose !== "true") {
       setConversationStatus(
-        "Replies are unavailable until every participant has an active Hush Line chat key.",
+        "Replies are unavailable until every participant has an active signing-capable Hush Line chat key.",
       );
       return;
     }

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -378,6 +378,7 @@ def register_message_routes(app: Flask) -> None:
                 thread_participant.user
                 and thread_participant.user.active_chat_key
                 and thread_participant.user.chat_public_key
+                and thread_participant.user.chat_public_signing_key
             )
         ]
         rotated_participant_keys = [

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -204,7 +204,7 @@ def _chat_ciphertext_context_is_bound(
             return False
         context = _chat_ciphertext_context(encrypted_payload)
         if context is None:
-            continue
+            return False
         if context.get("purpose") != "hushline.chat.message":
             return False
         conversation_public_id = context.get("conversation_public_id")

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -1133,7 +1133,7 @@
     }
     if (root.dataset.canCompose !== "true") {
       setConversationStatus(
-        "Replies are unavailable until every participant has an active Hush Line chat key.",
+        "Replies are unavailable until every participant has an active signing-capable Hush Line chat key.",
       );
       return;
     }

--- a/hushline/templates/conversation.html
+++ b/hushline/templates/conversation.html
@@ -152,7 +152,8 @@
       ) }}
       {% if not can_compose %}
         <p id="conversation-compose-unavailable" class="meta">
-          Replies are unavailable until every participant has an active Hush Line chat key.
+          Replies are unavailable until every participant has an active signing-capable
+          Hush Line chat key.
         </p>
       {% endif %}
     </form>

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -26,12 +26,18 @@ def _authenticate_as(client: FlaskClient, user: User) -> None:
         session["is_authenticated"] = True
 
 
-def _add_chat_key(user: User, public_key: str) -> None:
+def _add_chat_key(
+    user: User,
+    public_key: str,
+    *,
+    public_signing_key: str | None = None,
+) -> None:
     db.session.add(
         ChatKey(
             user=user,
             key_version=1,
             public_key=public_key,
+            public_signing_key=public_signing_key,
             encrypted_private_key="wrapped-private-chat-key",
             kdf_algorithm="PBKDF2-SHA-256",
             kdf_params={"iterations": 310000},
@@ -282,7 +288,7 @@ def test_conversation_view_shows_locked_chat_key_state(
     assert "server-side chat fallback for conversations" in response.text
     assert "Encrypted message. Waiting for browser chat key." in response.text
     assert (
-        "Replies are unavailable until every participant has an active Hush Line chat key."
+        "Replies are unavailable until every participant has an active signing-capable"
         in response.text
     )
     assert "conversation-chat-password" not in response.text
@@ -290,6 +296,37 @@ def test_conversation_view_shows_locked_chat_key_state(
     assert "Proton" not in response.text
     assert "PGP" not in response.text
     assert url_for("conversation_presence", public_id=conversation.public_id) in response.text
+
+
+def test_conversation_view_disables_composer_when_participant_key_cannot_sign(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(
+        user2,
+        '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}',
+        public_signing_key='{"kty":"EC","crv":"P-256","x":"recipient-sign","y":"key"}',
+    )
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    response = client.get(url_for("conversation", public_id=conversation.public_id))
+
+    assert response.status_code == 200
+    assert 'data-can-compose="false"' in response.text
+    assert "active signing-capable" in response.text
+    participant_keys_match = re.search(
+        r'<script id="conversationParticipantPublicKeys" type="application/json">\s*'
+        r"([\s\S]*?)</script>",
+        response.text,
+    )
+    assert participant_keys_match is not None
+    participant_keys = json.loads(participant_keys_match.group(1))
+    assert [participant_key["participant_id"] for participant_key in participant_keys] == [
+        _participant_for(conversation, user2).id
+    ]
 
 
 def test_conversation_view_hides_message_metadata_from_page_payload(

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -163,6 +163,10 @@ def _bound_copies_for(
     }
 
 
+def _reply_copies_for(conversation: Conversation, sender: User, label: str) -> dict[str, str]:
+    return _bound_copies_for(conversation, _participant_for(conversation, sender), label)
+
+
 def _participant_for(conversation: Conversation, user: User) -> ConversationParticipant:
     participant = conversation.participant_for_user_id(user.id)
     assert participant is not None
@@ -442,7 +446,7 @@ def test_participant_can_append_encrypted_conversation_message(
 
     response = client.post(
         url_for("append_conversation_message", public_id=conversation.public_id),
-        json={"encrypted_copies": _copies_for(conversation, "follow-up")},
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "follow-up")},
     )
 
     assert response.status_code == 201
@@ -457,6 +461,27 @@ def test_participant_can_append_encrypted_conversation_message(
     for encrypted_copy in messages[-1].encrypted_copies:
         assert "ECDH-P256-AES-GCM" in encrypted_copy.encrypted_payload
         assert plaintext not in encrypted_copy.encrypted_payload
+
+
+def test_append_conversation_message_rejects_unsigned_legacy_envelopes(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _copies_for(conversation, "legacy-follow-up")},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Invalid encrypted message payload."}
+    message_count = db.session.scalar(db.select(db.func.count()).select_from(ConversationMessage))
+    assert message_count == 1
 
 
 def test_append_conversation_message_rejects_mismatched_bound_context(
@@ -585,7 +610,7 @@ def test_append_conversation_message_sends_generic_notification_to_other_partici
 
     response = client.post(
         url_for("append_conversation_message", public_id=conversation.public_id),
-        json={"encrypted_copies": _copies_for(conversation, "generic-notification")},
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "generic-notification")},
     )
 
     assert response.status_code == 201
@@ -625,7 +650,7 @@ def test_append_conversation_message_suppresses_notification_for_active_recipien
 
     response = client.post(
         url_for("append_conversation_message", public_id=conversation.public_id),
-        json={"encrypted_copies": _copies_for(conversation, "active-recipient")},
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "active-recipient")},
     )
 
     assert response.status_code == 201
@@ -656,7 +681,7 @@ def test_append_conversation_message_suppresses_notification_for_active_recipien
 
     response = client.post(
         url_for("append_conversation_message", public_id=target_conversation.public_id),
-        json={"encrypted_copies": _copies_for(target_conversation, "active-recipient")},
+        json={"encrypted_copies": _reply_copies_for(target_conversation, user, "active-recipient")},
     )
 
     assert response.status_code == 201
@@ -686,7 +711,7 @@ def test_append_conversation_message_notifies_after_stale_recipient_activity(
 
     response = client.post(
         url_for("append_conversation_message", public_id=conversation.public_id),
-        json={"encrypted_copies": _copies_for(conversation, "stale-recipient")},
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "stale-recipient")},
     )
 
     assert response.status_code == 201
@@ -714,7 +739,7 @@ def test_append_conversation_message_does_not_notify_sender(
 
     response = client.post(
         url_for("append_conversation_message", public_id=conversation.public_id),
-        json={"encrypted_copies": _copies_for(conversation, "sender-notification")},
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "sender-notification")},
     )
 
     assert response.status_code == 201
@@ -740,7 +765,7 @@ def test_append_conversation_message_include_content_mode_still_sends_safe_gener
     )
     conversation = _make_conversation(user, user2)
     _authenticate_as(client, user)
-    encrypted_copies = _copies_for(conversation, "include-content")
+    encrypted_copies = _reply_copies_for(conversation, user, "include-content")
 
     response = client.post(
         url_for("append_conversation_message", public_id=conversation.public_id),
@@ -786,7 +811,7 @@ def test_append_conversation_message_encrypts_generic_body_for_full_body_mode(
 
     response = client.post(
         url_for("append_conversation_message", public_id=conversation.public_id),
-        json={"encrypted_copies": _copies_for(conversation, "full-body")},
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "full-body")},
     )
 
     assert response.status_code == 201
@@ -822,7 +847,7 @@ def test_append_conversation_message_notification_failure_does_not_rollback_mess
 
     response = client.post(
         url_for("append_conversation_message", public_id=conversation.public_id),
-        json={"encrypted_copies": _copies_for(conversation, "failed-notification")},
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "failed-notification")},
     )
 
     assert response.status_code == 201
@@ -871,7 +896,7 @@ def test_append_conversation_message_requires_encrypted_copy_for_every_participa
     _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
     conversation = _make_conversation(user, user2)
     participant = _participant_for(conversation, user)
-    encrypted_copies = _copies_for(conversation, "missing-recipient")
+    encrypted_copies = _reply_copies_for(conversation, user, "missing-recipient")
     encrypted_copies = {str(participant.id): encrypted_copies[str(participant.id)]}
     _authenticate_as(client, user)
 
@@ -905,7 +930,7 @@ def test_append_conversation_message_ignores_extra_plaintext_fields(
             "body": plaintext,
             "message": plaintext,
             "plaintext": plaintext,
-            "encrypted_copies": _copies_for(conversation, "plaintext-extra-field"),
+            "encrypted_copies": _reply_copies_for(conversation, user, "plaintext-extra-field"),
         },
     )
 
@@ -942,7 +967,7 @@ def test_append_conversation_message_requires_csrf_when_enabled(
     try:
         response = client.post(
             url_for("append_conversation_message", public_id=conversation.public_id),
-            json={"encrypted_copies": _copies_for(conversation, "csrf")},
+            json={"encrypted_copies": _reply_copies_for(conversation, user, "csrf")},
         )
     finally:
         app.config["WTF_CSRF_ENABLED"] = prior_setting
@@ -966,7 +991,7 @@ def test_append_conversation_message_rejects_non_participant(
 
     response = client.post(
         url_for("append_conversation_message", public_id=conversation.public_id),
-        json={"encrypted_copies": _copies_for(conversation, "unrelated")},
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "unrelated")},
     )
 
     assert response.status_code == 404
@@ -985,7 +1010,7 @@ def test_append_conversation_message_redirects_unauthenticated_user(
 
     response = client.post(
         url_for("append_conversation_message", public_id=conversation.public_id),
-        json={"encrypted_copies": _copies_for(conversation, "unauthenticated")},
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "unauthenticated")},
     )
 
     assert response.status_code == 302


### PR DESCRIPTION
## What changed

- Reject new E2EE conversation reply writes when any submitted chat ciphertext copy lacks a v2 context envelope.
- Disable the reply composer when any participant has only a legacy encryption-only chat key and cannot produce signed v2 reply envelopes.
- Keep successful reply tests on context-bound envelopes and add regression tests proving unsigned legacy reply envelopes are rejected without appending a message and legacy signing-less chat keys do not expose a broken composer.

Fixes #2257.

## Why

During the E2EE chat audit, reply writes still accepted legacy v1 ciphertext envelopes. Those envelopes are encrypted, but they do not carry signed/context-bound metadata tying a copy to the conversation, sender participant, and recipient participant. For new replies, accepting them leaves more room for replay/substitution mistakes than the v2 envelope contract.

The review pass also caught that encryption-only legacy chat keys could still see an enabled composer even though the browser would generate v1 envelopes that this PR now rejects. This PR now fails closed before compose for those accounts until they rotate to signing-capable chat keys.

## Security and privacy impact

Threat/risk summary: new chat replies now fail closed unless every encrypted copy is bound to the expected conversation and participant context, and the reply UI is not exposed for participants whose active chat keys cannot produce signed v2 envelopes.

Affected data paths: authenticated conversation reply POSTs through `append_conversation_message` and authenticated conversation page rendering through `conversation`; stored legacy reads and initial profile-submission conversation creation are not changed by this PR.

Mitigation: server-side validation now rejects missing v2 context on reply append, while preserving the existing participant/context checks for v2 payloads. Conversation rendering only marks compose available when every participant has an active chat key with both encryption and signing public keys.

## Validation

Before rebase onto `main`:

- `make lint CMD="docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app"` - passed
- `make test CMD="docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app"` - 2090 passed, 1 deselected, 1 xfailed, 11 warnings, total coverage 99%

After rebase/comment fix:

- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run pytest tests/test_conversation.py -q` - 33 passed, 8 warnings
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run ruff format --check hushline/routes/message.py tests/test_conversation.py` - passed
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run ruff check hushline/routes/message.py tests/test_conversation.py` - passed
- `make audit-python CMD="docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app"` - no known vulnerabilities found
- `make audit-node-runtime CMD="docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app"` - found 0 vulnerabilities

## Manual testing

Not separately performed. This is server-side validation and render gating covered by focused regression tests and the full test suite before the final review-comment fix.

## Known risks and follow-ups

- Initial conversation creation can still accept legacy v1 envelopes to preserve the current unauthenticated/profile submission path. Follow-up: #2256.
- Presence heartbeat `400` logs observed during local manual use are for `POST /conversation/<id>/presence`, not this reply append route. Existing tests verify both CSRF-required `400` behavior and successful heartbeat with the rendered token; if reproducible from a fresh page load, that should be tracked separately from this reply-envelope fix.
- Other audit follow-ups are tracked in #2258, #2259, and #2260.