### PR TITLE
Require v2 envelopes for initial E2EE conversations

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -376,6 +376,19 @@
     });
   }
 
+  async function signingPrivateKeyForChatKey(chatKey) {
+    if (!chatKey) {
+      return null;
+    }
+    if (await restoreUnlockedChatKey(chatKey)) {
+      return unlockedChatSigningPrivateKey;
+    }
+    if (await restoreUnlockedChatKeyFromOtherTab(chatKey)) {
+      return unlockedChatSigningPrivateKey;
+    }
+    return null;
+  }
+
   async function unlockFromPassword(chatKey, password) {
     if (!chatKey) {
       clearChatKeyMaterial();
@@ -894,6 +907,10 @@
     return jsonFromScript("conversationParticipantPublicKeys", []);
   }
 
+  function conversationParticipantSigningPublicKeys() {
+    return jsonFromScript("conversationParticipantSigningPublicKeys", []);
+  }
+
   function participantPublicKeyById(participantId) {
     return conversationParticipantPublicKeys().find(
       (participantKey) =>
@@ -943,9 +960,15 @@
     if (!fingerprint) {
       return null;
     }
-    return conversationParticipantPublicKeys().find(
-      (participantKey) =>
-        participantKey.public_signing_key_fingerprint === fingerprint,
+    return (
+      conversationParticipantPublicKeys().find(
+        (participantKey) =>
+          participantKey.public_signing_key_fingerprint === fingerprint,
+      ) ||
+      conversationParticipantSigningPublicKeys().find(
+        (participantKey) =>
+          participantKey.public_signing_key_fingerprint === fingerprint,
+      )
     );
   }
 
@@ -1573,6 +1596,7 @@
     ensureChatKeyUnlockedAfterAuth,
     provisionChatKey,
     rewrapForPasswordChange,
+    signingPrivateKeyForChatKey,
     unlockFromPassword,
   };
 

--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -925,6 +925,30 @@
     }
   }
 
+  function conversationMessageSenderSigningFingerprintFromPayload(
+    encryptedPayload,
+  ) {
+    if (!encryptedPayload || typeof encryptedPayload !== "string") {
+      return null;
+    }
+    try {
+      const envelope = JSON.parse(encryptedPayload);
+      return envelope?.context?.sender_public_signing_key_fingerprint || null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function participantPublicKeyBySigningFingerprint(fingerprint) {
+    if (!fingerprint) {
+      return null;
+    }
+    return conversationParticipantPublicKeys().find(
+      (participantKey) =>
+        participantKey.public_signing_key_fingerprint === fingerprint,
+    );
+  }
+
   function conversationMessagePayloadFromPlaintext(plaintext) {
     try {
       const parsed = JSON.parse(plaintext);
@@ -1065,7 +1089,13 @@
         const senderParticipantId = conversationMessageSenderIdFromPayload(
           copy.encrypted_payload,
         );
-        const senderKey = participantPublicKeyById(senderParticipantId);
+        const senderKey =
+          participantPublicKeyById(senderParticipantId) ||
+          participantPublicKeyBySigningFingerprint(
+            conversationMessageSenderSigningFingerprintFromPayload(
+              copy.encrypted_payload,
+            ),
+          );
         const plaintext = await decryptChatCiphertext(
           copy.encrypted_payload,
           senderKey?.public_signing_key || null,

--- a/assets/js/client-side-encryption.js
+++ b/assets/js/client-side-encryption.js
@@ -1,6 +1,7 @@
 import * as openpgp from "openpgp";
 
 const textEncoder = new TextEncoder();
+const sessionStorageKey = "hushline:chat-private-jwk";
 
 function assertClientCryptoSupport() {
   // OpenPGP.js v6 requires secure context + SubtleCrypto + Web Streams + BigInt.
@@ -100,6 +101,19 @@ function bytesToBase64(bytes) {
   return btoa(binary);
 }
 
+function canonicalStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map((item) => canonicalStringify(item)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${canonicalStringify(value[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value);
+}
+
 function jsonFromScript(id, fallback) {
   const script = document.getElementById(id);
   if (!script?.textContent) {
@@ -130,8 +144,15 @@ async function importChatPublicKey(publicKeyValue) {
   );
 }
 
-async function encryptForChatPublicKey(plaintext, publicKeyValue) {
-  const recipientPublicKey = await importChatPublicKey(publicKeyValue);
+async function encryptForChatPublicKey(
+  plaintext,
+  recipientChatKey,
+  context,
+  signingKey,
+) {
+  const recipientPublicKey = await importChatPublicKey(
+    recipientChatKey.public_key || recipientChatKey,
+  );
   const ephemeralKeyPair = await window.crypto.subtle.generateKey(
     {
       name: "ECDH",
@@ -154,12 +175,27 @@ async function encryptForChatPublicKey(plaintext, publicKeyValue) {
     ["encrypt"],
   );
   const iv = window.crypto.getRandomValues(new Uint8Array(12));
+  const envelopeContext =
+    context && signingKey
+      ? {
+          ...context,
+          recipient_key_version: recipientChatKey.key_version || null,
+          recipient_public_key_fingerprint:
+            recipientChatKey.public_key_fingerprint || null,
+        }
+      : null;
+  const encryptParams = {
+    name: "AES-GCM",
+    iv,
+  };
+  if (envelopeContext) {
+    encryptParams.additionalData = textEncoder.encode(
+      canonicalStringify(envelopeContext),
+    );
+  }
   const ciphertext = new Uint8Array(
     await window.crypto.subtle.encrypt(
-      {
-        name: "AES-GCM",
-        iv,
-      },
+      encryptParams,
       messageKey,
       textEncoder.encode(plaintext),
     ),
@@ -169,12 +205,18 @@ async function encryptForChatPublicKey(plaintext, publicKeyValue) {
     ephemeralKeyPair.publicKey,
   );
 
-  return JSON.stringify({
+  const envelope = {
     algorithm: "ECDH-P256-AES-GCM",
     ephemeral_public_key: JSON.stringify(ephemeralPublicJwk),
     iv: bytesToBase64(iv),
     ciphertext: bytesToBase64(ciphertext),
-  });
+  };
+  if (envelopeContext) {
+    envelope.v = 2;
+    envelope.context = envelopeContext;
+    envelope.signature = await signChatEnvelope(envelope, signingKey);
+  }
+  return JSON.stringify(envelope);
 }
 
 function getFieldValue(field) {
@@ -256,6 +298,104 @@ function getChatPublicKey(id) {
   return typeof publicKey === "string" && publicKey.trim() ? publicKey : null;
 }
 
+function getChatKeyDescriptor(id) {
+  const descriptor = jsonFromScript(id, null);
+  if (
+    !descriptor ||
+    typeof descriptor !== "object" ||
+    typeof descriptor.public_key !== "string" ||
+    !descriptor.public_key.trim()
+  ) {
+    return null;
+  }
+  return descriptor;
+}
+
+function normalizePrivateKeyBundle(value) {
+  if (value?.ecdh_private_jwk) {
+    return value;
+  }
+  return {
+    ecdh_private_jwk: value,
+    signing_private_jwk: null,
+  };
+}
+
+function rememberedPrivateKeyBundleForChatKey(chatKey) {
+  if (!chatKey) {
+    return null;
+  }
+  try {
+    const stored = JSON.parse(sessionStorage.getItem(sessionStorageKey) || "null");
+    if (
+      stored?.key_version !== chatKey.key_version ||
+      stored.public_key !== chatKey.public_key ||
+      (stored.public_signing_key || null) !==
+        (chatKey.public_signing_key || null) ||
+      !(stored.private_key_bundle || stored.private_jwk) ||
+      !stored.expires_at ||
+      Date.now() > Number(stored.expires_at)
+    ) {
+      return null;
+    }
+    return normalizePrivateKeyBundle(
+      stored.private_key_bundle || stored.private_jwk,
+    );
+  } catch (error) {
+    return null;
+  }
+}
+
+async function importSigningPrivateKey(privateJwk) {
+  if (!privateJwk) {
+    return null;
+  }
+  const importJwk = {
+    ...privateJwk,
+    key_ops: ["sign"],
+  };
+  return window.crypto.subtle.importKey(
+    "jwk",
+    importJwk,
+    {
+      name: "ECDSA",
+      namedCurve: importJwk.crv || "P-256",
+    },
+    false,
+    ["sign"],
+  );
+}
+
+async function initialConversationSigningKey(senderChatKey) {
+  const privateKeyBundle = rememberedPrivateKeyBundleForChatKey(senderChatKey);
+  if (!privateKeyBundle?.signing_private_jwk) {
+    return null;
+  }
+  return importSigningPrivateKey(privateKeyBundle.signing_private_jwk);
+}
+
+async function signChatEnvelope(envelope, signingKey) {
+  const signedPayload = {
+    v: envelope.v,
+    algorithm: envelope.algorithm,
+    ephemeral_public_key: envelope.ephemeral_public_key,
+    iv: envelope.iv,
+    ciphertext: envelope.ciphertext,
+    context: envelope.context,
+  };
+  const signature = new Uint8Array(
+    await window.crypto.subtle.sign(
+      {
+        name: "ECDSA",
+        hash: "SHA-256",
+      },
+      signingKey,
+      textEncoder.encode(canonicalStringify(signedPayload)),
+    ),
+  );
+  return bytesToBase64(signature);
+}
+
 function getMessageFields() {
   return Array.from(document.querySelectorAll(".form-field")).map((field) => ({
     name: field.name || field.querySelector("input")?.name,
@@ -297,26 +437,51 @@ function replaceSubmittedFieldsWithConversationPlaceholder() {
 }
 
 async function buildEncryptedConversationCopies(messageFields) {
-  const recipientChatPublicKey = getChatPublicKey("recipientChatPublicKey");
-  if (!recipientChatPublicKey) {
+  const recipientChatKey =
+    getChatKeyDescriptor("recipientChatKey") ||
+    (getChatPublicKey("recipientChatPublicKey")
+      ? { public_key: getChatPublicKey("recipientChatPublicKey") }
+      : null);
+  const senderChatKey = getChatKeyDescriptor("senderChatKey");
+  const signingKey = await initialConversationSigningKey(senderChatKey);
+  const initialConversationNonce = document.querySelector(
+    "input[name='owner_guard_nonce']",
+  )?.value;
+  if (
+    !recipientChatKey?.public_key ||
+    !senderChatKey?.public_key ||
+    !senderChatKey?.public_signing_key ||
+    !signingKey ||
+    !initialConversationNonce
+  ) {
     return {};
   }
 
   try {
     const conversationBody = conversationBodyFromFields(messageFields);
+    const context = {
+      purpose: "hushline.chat.initial_message",
+      initial_conversation_nonce: initialConversationNonce,
+      sender_key_version: senderChatKey.key_version || null,
+      sender_public_key_fingerprint:
+        senderChatKey.public_key_fingerprint || null,
+      sender_public_signing_key_fingerprint:
+        senderChatKey.public_signing_key_fingerprint || null,
+    };
     const encryptedCopies = {
       recipient: await encryptForChatPublicKey(
         conversationBody,
-        recipientChatPublicKey,
+        recipientChatKey,
+        context,
+        signingKey,
       ),
     };
-    const senderChatPublicKey = getChatPublicKey("senderChatPublicKey");
-    if (senderChatPublicKey) {
-      encryptedCopies.sender = await encryptForChatPublicKey(
-        conversationBody,
-        senderChatPublicKey,
-      );
-    }
+    encryptedCopies.sender = await encryptForChatPublicKey(
+      conversationBody,
+      senderChatKey,
+      context,
+      signingKey,
+    );
     return encryptedCopies;
   } catch (error) {
     console.error("Chat transcript encryption failed.");

--- a/assets/js/client-side-encryption.js
+++ b/assets/js/client-side-encryption.js
@@ -367,6 +367,13 @@ async function importSigningPrivateKey(privateJwk) {
 }
 
 async function initialConversationSigningKey(senderChatKey) {
+  const restoredSigningKey =
+    await window.HushLineChatKeys?.signingPrivateKeyForChatKey?.(
+      senderChatKey,
+    );
+  if (restoredSigningKey) {
+    return restoredSigningKey;
+  }
   const privateKeyBundle = rememberedPrivateKeyBundleForChatKey(senderChatKey);
   if (!privateKeyBundle?.signing_private_jwk) {
     return null;

--- a/hushline/model/__init__.py
+++ b/hushline/model/__init__.py
@@ -25,6 +25,7 @@ from hushline.model.globaleaks_directory_listing import (
     get_globaleaks_directory_listing,
     get_globaleaks_directory_listings,
 )
+from hushline.model.initial_conversation_nonce import InitialConversationNonce
 from hushline.model.invite_code import InviteCode
 from hushline.model.message import Message
 from hushline.model.message_status_text import MessageStatusText

--- a/hushline/model/initial_conversation_nonce.py
+++ b/hushline/model/initial_conversation_nonce.py
@@ -1,0 +1,44 @@
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import Index, UniqueConstraint
+from sqlalchemy.orm import Mapped, mapped_column
+
+from hushline.db import db
+
+if TYPE_CHECKING:
+    from flask_sqlalchemy.model import Model
+else:
+    Model = db.Model
+
+
+class InitialConversationNonce(Model):
+    __tablename__ = "initial_conversation_nonces"
+    __table_args__ = (
+        UniqueConstraint("nonce_hash"),
+        Index(
+            "ix_initial_conversation_nonces_sender_recipient_created",
+            "sender_user_id",
+            "recipient_user_id",
+            "created_at",
+        ),
+        Index("ix_initial_conversation_nonces_consumed_at", "consumed_at"),
+    )
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    nonce_hash: Mapped[str] = mapped_column(db.String(64), nullable=False)
+    sender_user_id: Mapped[int] = mapped_column(
+        db.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    recipient_user_id: Mapped[int] = mapped_column(
+        db.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        db.DateTime(timezone=True),
+        default=lambda: datetime.now(UTC),
+        nullable=False,
+    )
+    consumed_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)

--- a/hushline/model/initial_conversation_nonce.py
+++ b/hushline/model/initial_conversation_nonce.py
@@ -1,7 +1,7 @@
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
-from sqlalchemy import Index, UniqueConstraint
+from sqlalchemy import Index, UniqueConstraint, text
 from sqlalchemy.orm import Mapped, mapped_column
 
 from hushline.db import db
@@ -36,6 +36,7 @@ class InitialConversationNonce(Model):
     created_at: Mapped[datetime] = mapped_column(
         db.DateTime(timezone=True),
         default=lambda: datetime.now(UTC),
+        server_default=text("NOW()"),
         nullable=False,
     )
     consumed_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -381,6 +381,18 @@ def register_message_routes(app: Flask) -> None:
                 and thread_participant.user.chat_public_signing_key
             )
         ]
+        participant_signing_public_keys = [
+            {
+                "participant_id": thread_participant.id,
+                "key_version": chat_key.key_version,
+                "public_signing_key": chat_key.public_signing_key,
+                "public_signing_key_fingerprint": chat_key_fingerprint(chat_key.public_signing_key),
+            }
+            for thread_participant in thread.participants
+            if thread_participant.user
+            for chat_key in thread_participant.user.chat_keys
+            if chat_key.public_signing_key
+        ]
         rotated_participant_keys = [
             thread_participant.user.active_chat_key
             for thread_participant in thread.participants
@@ -400,6 +412,7 @@ def register_message_routes(app: Flask) -> None:
             message_copies=message_copies,
             message_copy_payloads=message_copy_payloads,
             participant_public_keys=participant_public_keys,
+            participant_signing_public_keys=participant_signing_public_keys,
             rotated_participant_keys=rotated_participant_keys,
             chat_key_fingerprint=chat_key_fingerprint,
             can_compose=can_compose,

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -24,6 +24,7 @@ from sqlalchemy.exc import MultipleResultsFound
 from werkzeug.wrappers.response import Response
 
 from hushline.auth import get_session_user
+from hushline.chat_key_lifecycle import chat_key_fingerprint
 from hushline.crypto import encrypt_message
 from hushline.db import db
 from hushline.embeds import (
@@ -59,10 +60,12 @@ from hushline.routes.common import (
     validate_captcha,
 )
 from hushline.routes.forms import DynamicMessageForm
-from hushline.routes.message import _is_chat_ciphertext_envelope
+from hushline.routes.message import _chat_ciphertext_context, _is_chat_ciphertext_envelope
 from hushline.safe_template import safe_render_template
 
 EMBED_CAPTCHA_MAX_AGE_SECONDS = 60 * 60
+INITIAL_CONVERSATION_NONCE_SESSION_KEY = "initial_conversation_nonces"
+INITIAL_CONVERSATION_NONCE_SESSION_LIMIT = 10
 
 
 def register_profile_routes(app: Flask) -> None:
@@ -252,20 +255,154 @@ def register_profile_routes(app: Flask) -> None:
             return None
         return get_session_user()
 
+    def _chat_key_descriptor(user: User | None) -> dict[str, Any] | None:
+        active_key = user.active_chat_key if user is not None else None
+        if active_key is None or not active_key.public_key:
+            return None
+
+        return {
+            "key_version": active_key.key_version,
+            "public_key": active_key.public_key,
+            "public_key_fingerprint": chat_key_fingerprint(active_key.public_key),
+            "public_signing_key": active_key.public_signing_key,
+            "public_signing_key_fingerprint": chat_key_fingerprint(active_key.public_signing_key),
+        }
+
+    def _chat_key_can_sign(user: User | None) -> bool:
+        active_key = user.active_chat_key if user is not None else None
+        return bool(active_key and active_key.public_key and active_key.public_signing_key)
+
     def _chat_submission_base_available(uname: Username, sender: User | None) -> bool:
-        return bool(sender and sender.id != uname.user_id and uname.user.chat_public_key)
+        return bool(
+            sender
+            and sender.id != uname.user_id
+            and _chat_key_can_sign(sender)
+            and uname.user.active_chat_key
+            and uname.user.chat_public_key
+        )
+
+    def _remember_initial_conversation_nonce(nonce: str) -> None:
+        remembered_nonces = session.get(INITIAL_CONVERSATION_NONCE_SESSION_KEY, [])
+        if not isinstance(remembered_nonces, list):
+            remembered_nonces = []
+        remembered_nonces = [
+            remembered_nonce
+            for remembered_nonce in remembered_nonces
+            if isinstance(remembered_nonce, str)
+        ]
+        if nonce not in remembered_nonces:
+            remembered_nonces.append(nonce)
+        session[INITIAL_CONVERSATION_NONCE_SESSION_KEY] = remembered_nonces[
+            -INITIAL_CONVERSATION_NONCE_SESSION_LIMIT:
+        ]
+
+    def _initial_conversation_nonce_is_known(nonce: str) -> bool:
+        remembered_nonces = session.get(INITIAL_CONVERSATION_NONCE_SESSION_KEY, [])
+        return isinstance(remembered_nonces, list) and nonce in remembered_nonces
+
+    def _consume_initial_conversation_nonce(nonce: str) -> bool:
+        remembered_nonces = session.get(INITIAL_CONVERSATION_NONCE_SESSION_KEY, [])
+        if not isinstance(remembered_nonces, list) or nonce not in remembered_nonces:
+            return False
+        remembered_nonces.remove(nonce)
+        session[INITIAL_CONVERSATION_NONCE_SESSION_KEY] = remembered_nonces
+        return True
+
+    def _copy_recipient_for_role(role: str, sender: User, recipient: User) -> User | None:
+        if role == "sender":
+            return sender
+        if role == "recipient":
+            return recipient
+        return None
+
+    def _initial_conversation_copy_context_is_bound(
+        *,
+        role: str,
+        encrypted_payload: str,
+        sender: User,
+        recipient: User,
+        initial_conversation_nonce: str,
+    ) -> bool:
+        context = _chat_ciphertext_context(encrypted_payload)
+        if context is None:
+            return False
+        if context.get("purpose") != "hushline.chat.initial_message":
+            return False
+        if context.get("initial_conversation_nonce") != initial_conversation_nonce:
+            return False
+
+        sender_key = sender.active_chat_key
+        if sender_key is None or not sender_key.public_signing_key:
+            return False
+        if str(context.get("sender_key_version")) != str(sender_key.key_version):
+            return False
+        if context.get("sender_public_key_fingerprint") != chat_key_fingerprint(
+            sender_key.public_key
+        ):
+            return False
+        if context.get("sender_public_signing_key_fingerprint") != chat_key_fingerprint(
+            sender_key.public_signing_key
+        ):
+            return False
+
+        copy_recipient = _copy_recipient_for_role(role, sender, recipient)
+        recipient_key = copy_recipient.active_chat_key if copy_recipient else None
+        if recipient_key is None:
+            return False
+        if str(context.get("recipient_key_version")) != str(recipient_key.key_version):
+            return False
+        return context.get("recipient_public_key_fingerprint") == chat_key_fingerprint(
+            recipient_key.public_key
+        )
+
+    def _initial_conversation_copies_are_bound(
+        *,
+        sender: User,
+        recipient: User,
+        encrypted_conversation_copies: dict[str, str],
+        initial_conversation_nonce: str,
+        consume_nonce: bool = False,
+    ) -> bool:
+        if not initial_conversation_nonce or not _initial_conversation_nonce_is_known(
+            initial_conversation_nonce
+        ):
+            return False
+        if not _chat_key_can_sign(sender):
+            return False
+        if not recipient.active_chat_key or not recipient.chat_public_key:
+            return False
+
+        if set(encrypted_conversation_copies.keys()) != {"recipient", "sender"}:
+            return False
+        if not all(
+            _initial_conversation_copy_context_is_bound(
+                role=role,
+                encrypted_payload=encrypted_payload,
+                sender=sender,
+                recipient=recipient,
+                initial_conversation_nonce=initial_conversation_nonce,
+            )
+            for role, encrypted_payload in encrypted_conversation_copies.items()
+        ):
+            return False
+
+        return not consume_nonce or _consume_initial_conversation_nonce(initial_conversation_nonce)
 
     def _conversation_payload_can_start(
         *,
         sender: User | None,
         recipient: User,
         encrypted_conversation_copies: dict[str, str],
+        initial_conversation_nonce: str,
     ) -> bool:
         if sender is None or sender.id == recipient.id or not recipient.chat_public_key:
             return False
-        if not encrypted_conversation_copies.get("recipient"):
-            return False
-        return not (sender.chat_public_key and not encrypted_conversation_copies.get("sender"))
+        return _initial_conversation_copies_are_bound(
+            sender=sender,
+            recipient=recipient,
+            encrypted_conversation_copies=encrypted_conversation_copies,
+            initial_conversation_nonce=initial_conversation_nonce,
+        )
 
     def _message_submission_block_reason(
         uname: Username, *, allow_chat_submission: bool = False
@@ -282,20 +419,24 @@ def register_profile_routes(app: Flask) -> None:
         sender: User,
         recipient: User,
         encrypted_conversation_copies: dict[str, str],
+        initial_conversation_nonce: str,
     ) -> Conversation | None:
         if sender.id == recipient.id:
             return None
 
         if not recipient.chat_public_key:
             return None
-
-        recipient_payload = encrypted_conversation_copies.get("recipient")
-        if not recipient_payload:
+        if not _initial_conversation_copies_are_bound(
+            sender=sender,
+            recipient=recipient,
+            encrypted_conversation_copies=encrypted_conversation_copies,
+            initial_conversation_nonce=initial_conversation_nonce,
+            consume_nonce=True,
+        ):
             return None
 
-        sender_payload = encrypted_conversation_copies.get("sender")
-        if sender.chat_public_key and not sender_payload:
-            return None
+        recipient_payload = encrypted_conversation_copies["recipient"]
+        sender_payload = encrypted_conversation_copies["sender"]
 
         conversation = Conversation()
         sender_participant = ConversationParticipant()
@@ -379,6 +520,17 @@ def register_profile_routes(app: Flask) -> None:
                 uname.user_id,
                 owner_guard_nonce,
             )
+            sender_chat_key = (
+                _chat_key_descriptor(sender)
+                if sender is not None and sender.id != uname.user_id
+                else None
+            )
+            if (
+                not is_embedded
+                and sender is not None
+                and _chat_submission_base_available(uname, sender)
+            ):
+                _remember_initial_conversation_nonce(owner_guard_nonce)
             rendered = render_template(
                 "embed_profile.html" if is_embedded else "profile.html",
                 profile_header=profile_header,
@@ -396,11 +548,13 @@ def register_profile_routes(app: Flask) -> None:
                 current_user_id=session.get("user_id"),
                 recipient_public_keys=uname.user.message_recipient_keys,
                 recipient_chat_public_key=uname.user.chat_public_key,
+                recipient_chat_key=_chat_key_descriptor(uname.user),
                 sender_chat_public_key=(
                     sender.chat_public_key
                     if sender is not None and sender.id != uname.user_id
                     else None
                 ),
+                sender_chat_key=sender_chat_key,
                 recipient_public_key_entries=(
                     notification_recipient_public_key_entries(uname.user)
                     if (
@@ -501,6 +655,7 @@ def register_profile_routes(app: Flask) -> None:
                     sender=sender,
                     recipient=uname.user,
                     encrypted_conversation_copies=encrypted_conversation_copies,
+                    initial_conversation_nonce=owner_guard_nonce,
                 )
             )
             block_reason = _message_submission_block_reason(
@@ -600,6 +755,7 @@ def register_profile_routes(app: Flask) -> None:
                         sender=sender,
                         recipient=uname.user,
                         encrypted_conversation_copies=encrypted_conversation_copies,
+                        initial_conversation_nonce=owner_guard_nonce,
                     )
 
                 db.session.commit()

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -19,8 +19,8 @@ from flask import (
     url_for,
 )
 from itsdangerous import BadData, SignatureExpired, URLSafeTimedSerializer
-from sqlalchemy import func
-from sqlalchemy.exc import MultipleResultsFound
+from sqlalchemy import func, update
+from sqlalchemy.exc import IntegrityError, MultipleResultsFound
 from werkzeug.wrappers.response import Response
 
 from hushline.auth import get_session_user
@@ -43,6 +43,7 @@ from hushline.model import (
     ConversationParticipant,
     FieldDefinition,
     FieldValue,
+    InitialConversationNonce,
     Message,
     NotificationRecipient,
     OrganizationSetting,
@@ -64,8 +65,6 @@ from hushline.routes.message import _chat_ciphertext_context, _is_chat_ciphertex
 from hushline.safe_template import safe_render_template
 
 EMBED_CAPTCHA_MAX_AGE_SECONDS = 60 * 60
-INITIAL_CONVERSATION_NONCE_SESSION_KEY = "initial_conversation_nonces"
-INITIAL_CONVERSATION_NONCE_SESSION_LIMIT = 10
 
 
 def register_profile_routes(app: Flask) -> None:
@@ -281,32 +280,47 @@ def register_profile_routes(app: Flask) -> None:
             and uname.user.chat_public_key
         )
 
-    def _remember_initial_conversation_nonce(nonce: str) -> None:
-        remembered_nonces = session.get(INITIAL_CONVERSATION_NONCE_SESSION_KEY, [])
-        if not isinstance(remembered_nonces, list):
-            remembered_nonces = []
-        remembered_nonces = [
-            remembered_nonce
-            for remembered_nonce in remembered_nonces
-            if isinstance(remembered_nonce, str)
-        ]
-        if nonce not in remembered_nonces:
-            remembered_nonces.append(nonce)
-        session[INITIAL_CONVERSATION_NONCE_SESSION_KEY] = remembered_nonces[
-            -INITIAL_CONVERSATION_NONCE_SESSION_LIMIT:
-        ]
+    def _initial_conversation_nonce_hash(nonce: str) -> str:
+        return sha256(f"hushline:initial-conversation:{nonce}".encode()).hexdigest()
 
-    def _initial_conversation_nonce_is_known(nonce: str) -> bool:
-        remembered_nonces = session.get(INITIAL_CONVERSATION_NONCE_SESSION_KEY, [])
-        return isinstance(remembered_nonces, list) and nonce in remembered_nonces
+    def _remember_initial_conversation_nonce(nonce: str, sender: User, recipient: User) -> None:
+        db.session.add(
+            InitialConversationNonce(
+                nonce_hash=_initial_conversation_nonce_hash(nonce),
+                sender_user_id=sender.id,
+                recipient_user_id=recipient.id,
+            )
+        )
+        try:
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
 
-    def _consume_initial_conversation_nonce(nonce: str) -> bool:
-        remembered_nonces = session.get(INITIAL_CONVERSATION_NONCE_SESSION_KEY, [])
-        if not isinstance(remembered_nonces, list) or nonce not in remembered_nonces:
-            return False
-        remembered_nonces.remove(nonce)
-        session[INITIAL_CONVERSATION_NONCE_SESSION_KEY] = remembered_nonces
-        return True
+    def _initial_conversation_nonce_is_known(nonce: str, sender: User, recipient: User) -> bool:
+        nonce_id = db.session.scalar(
+            db.select(InitialConversationNonce.id)
+            .where(
+                InitialConversationNonce.nonce_hash == _initial_conversation_nonce_hash(nonce),
+                InitialConversationNonce.sender_user_id == sender.id,
+                InitialConversationNonce.recipient_user_id == recipient.id,
+                InitialConversationNonce.consumed_at.is_(None),
+            )
+            .limit(1)
+        )
+        return nonce_id is not None
+
+    def _consume_initial_conversation_nonce(nonce: str, sender: User, recipient: User) -> bool:
+        result = db.session.execute(
+            update(InitialConversationNonce)
+            .where(
+                InitialConversationNonce.nonce_hash == _initial_conversation_nonce_hash(nonce),
+                InitialConversationNonce.sender_user_id == sender.id,
+                InitialConversationNonce.recipient_user_id == recipient.id,
+                InitialConversationNonce.consumed_at.is_(None),
+            )
+            .values(consumed_at=func.now())
+        )
+        return result.rowcount == 1
 
     def _copy_recipient_for_role(role: str, sender: User, recipient: User) -> User | None:
         if role == "sender":
@@ -361,10 +375,11 @@ def register_profile_routes(app: Flask) -> None:
         recipient: User,
         encrypted_conversation_copies: dict[str, str],
         initial_conversation_nonce: str,
-        consume_nonce: bool = False,
     ) -> bool:
         if not initial_conversation_nonce or not _initial_conversation_nonce_is_known(
-            initial_conversation_nonce
+            initial_conversation_nonce,
+            sender,
+            recipient,
         ):
             return False
         if not _chat_key_can_sign(sender):
@@ -386,7 +401,7 @@ def register_profile_routes(app: Flask) -> None:
         ):
             return False
 
-        return not consume_nonce or _consume_initial_conversation_nonce(initial_conversation_nonce)
+        return True
 
     def _conversation_payload_can_start(
         *,
@@ -431,8 +446,9 @@ def register_profile_routes(app: Flask) -> None:
             recipient=recipient,
             encrypted_conversation_copies=encrypted_conversation_copies,
             initial_conversation_nonce=initial_conversation_nonce,
-            consume_nonce=True,
         ):
+            return None
+        if not _consume_initial_conversation_nonce(initial_conversation_nonce, sender, recipient):
             return None
 
         recipient_payload = encrypted_conversation_copies["recipient"]
@@ -530,7 +546,7 @@ def register_profile_routes(app: Flask) -> None:
                 and sender is not None
                 and _chat_submission_base_available(uname, sender)
             ):
-                _remember_initial_conversation_nonce(owner_guard_nonce)
+                _remember_initial_conversation_nonce(owner_guard_nonce, sender, uname.user)
             rendered = render_template(
                 "embed_profile.html" if is_embedded else "profile.html",
                 profile_header=profile_header,
@@ -757,6 +773,16 @@ def register_profile_routes(app: Flask) -> None:
                         encrypted_conversation_copies=encrypted_conversation_copies,
                         initial_conversation_nonce=owner_guard_nonce,
                     )
+                if chat_only_submission and conversation is None:
+                    db.session.rollback()
+                    flash(
+                        (
+                            "⛔️ You cannot submit messages to users who do not have any "
+                            "usable recipient PGP keys."
+                        ),
+                        "error",
+                    )
+                    return _render_profile(400)
 
                 db.session.commit()
 

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -929,6 +929,30 @@
     }
   }
 
+  function conversationMessageSenderSigningFingerprintFromPayload(
+    encryptedPayload,
+  ) {
+    if (!encryptedPayload || typeof encryptedPayload !== "string") {
+      return null;
+    }
+    try {
+      const envelope = JSON.parse(encryptedPayload);
+      return envelope?.context?.sender_public_signing_key_fingerprint || null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function participantPublicKeyBySigningFingerprint(fingerprint) {
+    if (!fingerprint) {
+      return null;
+    }
+    return conversationParticipantPublicKeys().find(
+      (participantKey) =>
+        participantKey.public_signing_key_fingerprint === fingerprint,
+    );
+  }
+
   function conversationMessagePayloadFromPlaintext(plaintext) {
     try {
       const parsed = JSON.parse(plaintext);
@@ -1069,7 +1093,13 @@
         const senderParticipantId = conversationMessageSenderIdFromPayload(
           copy.encrypted_payload,
         );
-        const senderKey = participantPublicKeyById(senderParticipantId);
+        const senderKey =
+          participantPublicKeyById(senderParticipantId) ||
+          participantPublicKeyBySigningFingerprint(
+            conversationMessageSenderSigningFingerprintFromPayload(
+              copy.encrypted_payload,
+            ),
+          );
         const plaintext = await decryptChatCiphertext(
           copy.encrypted_payload,
           senderKey?.public_signing_key || null,

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -380,6 +380,19 @@
     });
   }
 
+  async function signingPrivateKeyForChatKey(chatKey) {
+    if (!chatKey) {
+      return null;
+    }
+    if (await restoreUnlockedChatKey(chatKey)) {
+      return unlockedChatSigningPrivateKey;
+    }
+    if (await restoreUnlockedChatKeyFromOtherTab(chatKey)) {
+      return unlockedChatSigningPrivateKey;
+    }
+    return null;
+  }
+
   async function unlockFromPassword(chatKey, password) {
     if (!chatKey) {
       clearChatKeyMaterial();
@@ -898,6 +911,10 @@
     return jsonFromScript("conversationParticipantPublicKeys", []);
   }
 
+  function conversationParticipantSigningPublicKeys() {
+    return jsonFromScript("conversationParticipantSigningPublicKeys", []);
+  }
+
   function participantPublicKeyById(participantId) {
     return conversationParticipantPublicKeys().find(
       (participantKey) =>
@@ -947,9 +964,15 @@
     if (!fingerprint) {
       return null;
     }
-    return conversationParticipantPublicKeys().find(
-      (participantKey) =>
-        participantKey.public_signing_key_fingerprint === fingerprint,
+    return (
+      conversationParticipantPublicKeys().find(
+        (participantKey) =>
+          participantKey.public_signing_key_fingerprint === fingerprint,
+      ) ||
+      conversationParticipantSigningPublicKeys().find(
+        (participantKey) =>
+          participantKey.public_signing_key_fingerprint === fingerprint,
+      )
     );
   }
 
@@ -1577,6 +1600,7 @@
     ensureChatKeyUnlockedAfterAuth,
     provisionChatKey,
     rewrapForPasswordChange,
+    signingPrivateKeyForChatKey,
     unlockFromPassword,
   };
 

--- a/hushline/templates/conversation.html
+++ b/hushline/templates/conversation.html
@@ -68,6 +68,9 @@
     <script id="conversationParticipantPublicKeys" type="application/json">
       {{ participant_public_keys | tojson }}
     </script>
+    <script id="conversationParticipantSigningPublicKeys" type="application/json">
+      {{ participant_signing_public_keys | tojson }}
+    </script>
     <script id="conversationMessageCopies" type="application/json">
       {{ message_copy_payloads | tojson }}
     </script>

--- a/hushline/templates/embed_profile.html
+++ b/hushline/templates/embed_profile.html
@@ -213,6 +213,8 @@
         <script id="recipientPublicKeyEntries" type="application/json">{{ recipient_public_key_entries | tojson }}</script>
         <script id="recipientChatPublicKey" type="application/json">{{ recipient_chat_public_key | tojson }}</script>
         <script id="senderChatPublicKey" type="application/json">{{ sender_chat_public_key | tojson }}</script>
+        <script id="recipientChatKey" type="application/json">{{ recipient_chat_key | tojson }}</script>
+        <script id="senderChatKey" type="application/json">{{ sender_chat_key | tojson }}</script>
 
         {% if not message_submission_block_reason %}
           <div class="captcha">

--- a/hushline/templates/profile.html
+++ b/hushline/templates/profile.html
@@ -158,6 +158,8 @@
     <script id="recipientPublicKeyEntries" type="application/json">{{ recipient_public_key_entries | tojson }}</script>
     <script id="recipientChatPublicKey" type="application/json">{{ recipient_chat_public_key | tojson }}</script>
     <script id="senderChatPublicKey" type="application/json">{{ sender_chat_public_key | tojson }}</script>
+    <script id="recipientChatKey" type="application/json">{{ recipient_chat_key | tojson }}</script>
+    <script id="senderChatKey" type="application/json">{{ sender_chat_key | tojson }}</script>
 
     {% if not message_submission_block_reason %}
       <div class="captcha">

--- a/migrations/versions/0f6d4c8e9a21_add_initial_conversation_nonces.py
+++ b/migrations/versions/0f6d4c8e9a21_add_initial_conversation_nonces.py
@@ -24,7 +24,12 @@ def upgrade() -> None:
         sa.Column("nonce_hash", sa.String(length=64), nullable=False),
         sa.Column("sender_user_id", sa.Integer(), nullable=False),
         sa.Column("recipient_user_id", sa.Integer(), nullable=False),
-        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
         sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
         sa.ForeignKeyConstraint(["recipient_user_id"], ["users.id"], ondelete="CASCADE"),
         sa.ForeignKeyConstraint(["sender_user_id"], ["users.id"], ondelete="CASCADE"),

--- a/migrations/versions/0f6d4c8e9a21_add_initial_conversation_nonces.py
+++ b/migrations/versions/0f6d4c8e9a21_add_initial_conversation_nonces.py
@@ -1,0 +1,77 @@
+"""add initial conversation nonces
+
+Revision ID: 0f6d4c8e9a21
+Revises: 8a4e2c9f1b7d
+Create Date: 2026-06-17 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "0f6d4c8e9a21"
+down_revision = "8a4e2c9f1b7d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "initial_conversation_nonces",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("nonce_hash", sa.String(length=64), nullable=False),
+        sa.Column("sender_user_id", sa.Integer(), nullable=False),
+        sa.Column("recipient_user_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("consumed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["recipient_user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(["sender_user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("nonce_hash"),
+    )
+    op.create_index(
+        "ix_initial_conversation_nonces_consumed_at",
+        "initial_conversation_nonces",
+        ["consumed_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_initial_conversation_nonces_recipient_user_id",
+        "initial_conversation_nonces",
+        ["recipient_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_initial_conversation_nonces_sender_recipient_created",
+        "initial_conversation_nonces",
+        ["sender_user_id", "recipient_user_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_initial_conversation_nonces_sender_user_id",
+        "initial_conversation_nonces",
+        ["sender_user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_initial_conversation_nonces_sender_user_id",
+        table_name="initial_conversation_nonces",
+    )
+    op.drop_index(
+        "ix_initial_conversation_nonces_sender_recipient_created",
+        table_name="initial_conversation_nonces",
+    )
+    op.drop_index(
+        "ix_initial_conversation_nonces_recipient_user_id",
+        table_name="initial_conversation_nonces",
+    )
+    op.drop_index(
+        "ix_initial_conversation_nonces_consumed_at",
+        table_name="initial_conversation_nonces",
+    )
+    op.drop_table("initial_conversation_nonces")

--- a/tests/migrations/revision_0f6d4c8e9a21.py
+++ b/tests/migrations/revision_0f6d4c8e9a21.py
@@ -1,0 +1,174 @@
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from hushline.db import db
+
+SENDER_USER_ID = 9901
+RECIPIENT_USER_ID = 9902
+NONCE_HASH = "a" * 64
+
+
+def _insert_users() -> None:
+    db.session.execute(
+        text(
+            """
+            INSERT INTO users (
+                id,
+                is_admin,
+                is_suspended,
+                password_hash,
+                session_id
+            )
+            VALUES
+                (:sender_user_id, false, false, '$scrypt$', 'session-sender-9901'),
+                (:recipient_user_id, false, false, '$scrypt$', 'session-recipient-9902')
+            """
+        ),
+        {
+            "sender_user_id": SENDER_USER_ID,
+            "recipient_user_id": RECIPIENT_USER_ID,
+        },
+    )
+    db.session.commit()
+
+
+def _table_exists() -> int:
+    return db.session.scalar(
+        text(
+            """
+            SELECT count(*)
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_name = 'initial_conversation_nonces'
+            """
+        )
+    )
+
+
+class UpgradeTester:
+    def load_data(self) -> None:
+        _insert_users()
+
+    def check_upgrade(self) -> None:
+        assert _table_exists() == 1
+        columns = db.session.execute(
+            text(
+                """
+                SELECT column_name, is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'initial_conversation_nonces'
+                ORDER BY ordinal_position
+                """
+            )
+        ).all()
+        assert columns == [
+            ("id", "NO"),
+            ("nonce_hash", "NO"),
+            ("sender_user_id", "NO"),
+            ("recipient_user_id", "NO"),
+            ("created_at", "NO"),
+            ("consumed_at", "YES"),
+        ]
+
+        db.session.execute(
+            text(
+                """
+                INSERT INTO initial_conversation_nonces (
+                    nonce_hash,
+                    sender_user_id,
+                    recipient_user_id
+                )
+                VALUES (:nonce_hash, :sender_user_id, :recipient_user_id)
+                """
+            ),
+            {
+                "nonce_hash": NONCE_HASH,
+                "sender_user_id": SENDER_USER_ID,
+                "recipient_user_id": RECIPIENT_USER_ID,
+            },
+        )
+        db.session.commit()
+
+        assert (
+            db.session.scalar(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM initial_conversation_nonces
+                    WHERE nonce_hash = :nonce_hash
+                      AND created_at IS NOT NULL
+                      AND consumed_at IS NULL
+                    """
+                ),
+                {"nonce_hash": NONCE_HASH},
+            )
+            == 1
+        )
+
+        try:
+            db.session.execute(
+                text(
+                    """
+                    INSERT INTO initial_conversation_nonces (
+                        nonce_hash,
+                        sender_user_id,
+                        recipient_user_id
+                    )
+                    VALUES (:nonce_hash, :sender_user_id, :recipient_user_id)
+                    """
+                ),
+                {
+                    "nonce_hash": NONCE_HASH,
+                    "sender_user_id": SENDER_USER_ID,
+                    "recipient_user_id": RECIPIENT_USER_ID,
+                },
+            )
+            db.session.commit()
+        except IntegrityError:
+            db.session.rollback()
+        else:
+            raise AssertionError("duplicate initial conversation nonce hash was accepted")
+
+
+class DowngradeTester:
+    def load_data(self) -> None:
+        _insert_users()
+        db.session.execute(
+            text(
+                """
+                INSERT INTO initial_conversation_nonces (
+                    nonce_hash,
+                    sender_user_id,
+                    recipient_user_id,
+                    consumed_at
+                )
+                VALUES (:nonce_hash, :sender_user_id, :recipient_user_id, NOW())
+                """
+            ),
+            {
+                "nonce_hash": NONCE_HASH,
+                "sender_user_id": SENDER_USER_ID,
+                "recipient_user_id": RECIPIENT_USER_ID,
+            },
+        )
+        db.session.commit()
+
+    def check_downgrade(self) -> None:
+        assert _table_exists() == 0
+        assert (
+            db.session.scalar(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM users
+                    WHERE id IN (:sender_user_id, :recipient_user_id)
+                    """
+                ),
+                {
+                    "sender_user_id": SENDER_USER_ID,
+                    "recipient_user_id": RECIPIENT_USER_ID,
+                },
+            )
+            == 2
+        )

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -329,6 +329,63 @@ def test_conversation_view_disables_composer_when_participant_key_cannot_sign(
     ]
 
 
+def test_conversation_view_exposes_historical_signing_keys_for_initial_message_verification(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    old_signing_key = '{"kty":"EC","crv":"P-256","x":"old-signing","y":"key"}'
+    new_signing_key = '{"kty":"EC","crv":"P-256","x":"new-signing","y":"key"}'
+    db.session.add_all(
+        [
+            ChatKey(
+                user=user,
+                key_version=1,
+                public_key='{"kty":"EC","crv":"P-256","x":"old-sender","y":"key"}',
+                public_signing_key=old_signing_key,
+                encrypted_private_key="wrapped-old-private-chat-key",
+                kdf_algorithm="PBKDF2-SHA-256",
+                kdf_params={"iterations": 310000},
+                kdf_salt="salt",
+                wrapping_algorithm="AES-GCM",
+                disabled_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+            ChatKey(
+                user=user,
+                key_version=2,
+                public_key='{"kty":"EC","crv":"P-256","x":"new-sender","y":"key"}',
+                public_signing_key=new_signing_key,
+                encrypted_private_key="wrapped-new-private-chat-key",
+                kdf_algorithm="PBKDF2-SHA-256",
+                kdf_params={"iterations": 310000},
+                kdf_salt="salt",
+                wrapping_algorithm="AES-GCM",
+            ),
+        ]
+    )
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user2)
+
+    response = client.get(url_for("conversation", public_id=conversation.public_id))
+
+    assert response.status_code == 200
+    signing_keys_match = re.search(
+        r'<script id="conversationParticipantSigningPublicKeys" type="application/json">\s*'
+        r"([\s\S]*?)</script>",
+        response.text,
+    )
+    assert signing_keys_match is not None
+    signing_keys = json.loads(signing_keys_match.group(1))
+    sender_participant_id = _participant_for(conversation, user).id
+    assert {
+        signing_key["public_signing_key"]
+        for signing_key in signing_keys
+        if signing_key["participant_id"] == sender_participant_id
+    } == {old_signing_key, new_signing_key}
+
+
 def test_conversation_view_hides_message_metadata_from_page_payload(
     client: FlaskClient,
     user: User,

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -125,6 +125,7 @@ def test_client_side_encryption_prepares_chat_conversation_copies() -> None:
     assert "recipient_public_key_fingerprint" in js
     assert "canonicalStringify(envelopeContext)" in js
     assert "await signChatEnvelope(envelope, signingKey)" in js
+    assert "signingPrivateKeyForChatKey" in js
     assert 'const sessionStorageKey = "hushline:chat-private-jwk";' in js
     assert 'getChatPublicKey("recipientChatPublicKey")' in js
     assert 'getChatKeyDescriptor("recipientChatKey")' in js
@@ -154,6 +155,8 @@ def test_chat_key_lifecycle_imports_private_key_for_message_decryption() -> None
     assert "conversationMessageSenderSigningFingerprintFromPayload" in static_js
     assert "participantPublicKeyBySigningFingerprint" in js
     assert "participantPublicKeyBySigningFingerprint" in static_js
+    assert "conversationParticipantSigningPublicKeys" in js
+    assert "conversationParticipantSigningPublicKeys" in static_js
     assert "privateKeyBundle.ecdh_private_jwk" in js
     assert "unlockedChatSigningPrivateKey = await importSigningPrivateKey(" in js
     assert "privateKeyBundle.signing_private_jwk" in js
@@ -194,6 +197,7 @@ def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session(
     assert "localStorage.removeItem(legacyBrowserStorageKey)" in js
     assert "restoreConversationFromSession" in js
     assert "restoreUnlockedChatKeyFromOtherTab" in js
+    assert "async function signingPrivateKeyForChatKey(chatKey)" in js
     assert "function setConversationSecureBadgeVisible(visible)" in js
     assert "setConversationSecureBadgeVisible(true);" in js
     assert "setConversationSecureBadgeVisible(false);" in js
@@ -214,6 +218,7 @@ def test_conversation_does_not_prompt_for_password_after_login() -> None:
     js = (ROOT / "assets/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
     template = (ROOT / "hushline/templates/conversation.html").read_text(encoding="utf-8")
 
+    assert 'id="conversationParticipantSigningPublicKeys"' in template
     assert "conversation-chat-password" not in js
     assert "unlockConversationFromPassword" not in js
     assert "conversation-chat-password" not in template

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -117,10 +117,18 @@ def test_client_side_encryption_prepares_chat_conversation_copies() -> None:
     profile_template = (ROOT / "hushline/templates/profile.html").read_text(encoding="utf-8")
     embed_template = (ROOT / "hushline/templates/embed_profile.html").read_text(encoding="utf-8")
 
-    assert "function encryptForChatPublicKey(plaintext, publicKeyValue)" in js
+    assert "async function encryptForChatPublicKey(" in js
     assert 'algorithm: "ECDH-P256-AES-GCM"' in js
+    assert 'purpose: "hushline.chat.initial_message"' in js
+    assert "initial_conversation_nonce: initialConversationNonce" in js
+    assert "sender_public_signing_key_fingerprint" in js
+    assert "recipient_public_key_fingerprint" in js
+    assert "canonicalStringify(envelopeContext)" in js
+    assert "await signChatEnvelope(envelope, signingKey)" in js
+    assert 'const sessionStorageKey = "hushline:chat-private-jwk";' in js
     assert 'getChatPublicKey("recipientChatPublicKey")' in js
-    assert 'getChatPublicKey("senderChatPublicKey")' in js
+    assert 'getChatKeyDescriptor("recipientChatKey")' in js
+    assert 'getChatKeyDescriptor("senderChatKey")' in js
     assert "recipient: await encryptForChatPublicKey(" in js
     assert "encryptedCopies.sender = await encryptForChatPublicKey(" in js
     assert "function replaceSubmittedFieldsWithConversationPlaceholder()" in js
@@ -128,16 +136,24 @@ def test_client_side_encryption_prepares_chat_conversation_copies() -> None:
     assert "if (recipientPublicKeys.length === 0)" in js
     assert "replaceSubmittedFieldsWithConversationPlaceholder();" in js
     assert "encrypted_conversation_copies" in js
-    assert "private_key" not in js
+    assert "plaintext_private_key" not in js
+    assert "decrypted_private_key" not in js
     assert "derived wrapping key" not in js.lower()
     assert 'id="senderChatPublicKey"' in profile_template
     assert 'id="senderChatPublicKey"' in embed_template
+    assert 'id="recipientChatKey"' in profile_template
+    assert 'id="senderChatKey"' in profile_template
 
 
 def test_chat_key_lifecycle_imports_private_key_for_message_decryption() -> None:
     js = (ROOT / "assets/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
+    static_js = (ROOT / "hushline/static/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
 
     assert "unlockedChatPrivateKey = await importPrivateKey(" in js
+    assert "conversationMessageSenderSigningFingerprintFromPayload" in js
+    assert "conversationMessageSenderSigningFingerprintFromPayload" in static_js
+    assert "participantPublicKeyBySigningFingerprint" in js
+    assert "participantPublicKeyBySigningFingerprint" in static_js
     assert "privateKeyBundle.ecdh_private_jwk" in js
     assert "unlockedChatSigningPrivateKey = await importSigningPrivateKey(" in js
     assert "privateKeyBundle.signing_private_jwk" in js

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -8,11 +8,13 @@ from flask.testing import FlaskClient
 from helpers import get_profile_submission_data
 
 from hushline import auth
+from hushline.chat_key_lifecycle import chat_key_fingerprint
 from hushline.db import db
 from hushline.model import ChatKey, FieldValue, Message, MessageStatus, User, Username
 
 MSG_CONTACT_METHOD = "I prefer Signal."
 MSG_CONTENT = "This is a test message."
+CHAT_MESSAGE_ALGORITHM = "ECDH-P256-AES-GCM"
 
 
 def _authenticate_as(client: FlaskClient, user: User) -> None:
@@ -27,12 +29,19 @@ def _set_pgp_key(user: User) -> None:
     user.pgp_key = Path("tests/test_pgp_key.txt").read_text()
 
 
-def _add_chat_key(user: User, public_key: str) -> None:
+def _add_chat_key(
+    user: User,
+    public_key: str,
+    *,
+    public_signing_key: str | None = None,
+) -> None:
     db.session.add(
         ChatKey(
             user=user,
             key_version=1,
             public_key=public_key,
+            public_signing_key=public_signing_key
+            or '{"kty":"EC","crv":"P-256","x":"signing","y":"key"}',
             encrypted_private_key="wrapped-private-chat-key",
             kdf_algorithm="PBKDF2-SHA-256",
             kdf_params={"iterations": 310000, "hash": "SHA-256"},
@@ -42,15 +51,59 @@ def _add_chat_key(user: User, public_key: str) -> None:
     )
 
 
-def _chat_ciphertext(label: str) -> str:
-    return json.dumps(
-        {
-            "algorithm": "ECDH-P256-AES-GCM",
-            "ephemeral_public_key": '{"kty":"EC","crv":"P-256","x":"ephemeral","y":"key"}',
-            "iv": f"iv-{label}",
-            "ciphertext": f"ciphertext-{label}",
-        }
-    )
+def _initial_chat_ciphertext(
+    *,
+    label: str,
+    sender: User,
+    recipient: User,
+    nonce: str,
+) -> str:
+    sender_key = sender.active_chat_key
+    recipient_key = recipient.active_chat_key
+    assert sender_key is not None
+    assert recipient_key is not None
+    envelope = {
+        "v": 2,
+        "algorithm": CHAT_MESSAGE_ALGORITHM,
+        "ephemeral_public_key": '{"kty":"EC","crv":"P-256","x":"ephemeral","y":"key"}',
+        "iv": f"iv-{label}",
+        "ciphertext": f"ciphertext-{label}",
+        "context": {
+            "purpose": "hushline.chat.initial_message",
+            "initial_conversation_nonce": nonce,
+            "sender_key_version": sender_key.key_version,
+            "sender_public_key_fingerprint": chat_key_fingerprint(sender_key.public_key),
+            "sender_public_signing_key_fingerprint": chat_key_fingerprint(
+                sender_key.public_signing_key
+            ),
+            "recipient_key_version": recipient_key.key_version,
+            "recipient_public_key_fingerprint": chat_key_fingerprint(recipient_key.public_key),
+        },
+        "signature": f"signature-{label}",
+    }
+    return json.dumps(envelope)
+
+
+def _initial_conversation_copies_for(
+    *,
+    sender: User,
+    recipient: User,
+    nonce: str,
+) -> dict[str, str]:
+    return {
+        "sender": _initial_chat_ciphertext(
+            label="sender-initial",
+            sender=sender,
+            recipient=sender,
+            nonce=nonce,
+        ),
+        "recipient": _initial_chat_ciphertext(
+            label="recipient-initial",
+            sender=sender,
+            recipient=recipient,
+            nonce=nonce,
+        ),
+    }
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -179,18 +232,20 @@ def test_inbox_lists_conversation_for_sender_and_recipient_after_submission(
     _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
     db.session.commit()
 
+    submission_data = get_profile_submission_data(client, user2.primary_username.username)
     response = client.post(
         url_for("profile", username=user2.primary_username.username),
         data={
             "field_0": MSG_CONTACT_METHOD,
             "field_1": MSG_CONTENT,
             "encrypted_conversation_copies": json.dumps(
-                {
-                    "sender": _chat_ciphertext("sender-initial"),
-                    "recipient": _chat_ciphertext("recipient-initial"),
-                }
+                _initial_conversation_copies_for(
+                    sender=user,
+                    recipient=user2,
+                    nonce=submission_data["owner_guard_nonce"],
+                )
             ),
-            **get_profile_submission_data(client, user2.primary_username.username),
+            **submission_data,
         },
         follow_redirects=False,
     )

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -19,6 +19,7 @@ from hushline.model import (
     ChatKey,
     Conversation,
     ConversationMessageCopy,
+    InitialConversationNonce,
     Message,
     NotificationRecipient,
     OrganizationSetting,
@@ -580,6 +581,58 @@ def test_logged_in_profile_submit_initial_chat_nonce_is_single_use(
     assert "do not have any usable recipient PGP keys" in second_response.text
     assert db.session.scalar(db.select(db.func.count()).select_from(Message)) == 1
     assert db.session.scalar(db.select(db.func.count()).select_from(Conversation)) == 1
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_logged_in_profile_submit_initial_chat_nonce_rejects_stale_session_cookie_replay(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    user.pgp_key = None
+    user2.pgp_key = None
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+    submission_data = get_profile_submission_data(client, user2.primary_username.username)
+    post_data = {
+        "field_0": msg_contact_method,
+        "field_1": msg_content,
+        "encrypted_conversation_copies": json.dumps(
+            _initial_conversation_copies_for(
+                sender=user,
+                recipient=user2,
+                nonce=submission_data["owner_guard_nonce"],
+            )
+        ),
+        **submission_data,
+    }
+    replay_client = app.test_client()
+    _authenticate_as(replay_client, user)
+    with replay_client.session_transaction() as stale_session:
+        stale_session["initial_conversation_nonces"] = [submission_data["owner_guard_nonce"]]
+
+    first_response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data=post_data,
+        follow_redirects=False,
+    )
+    replay_response = replay_client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data=post_data,
+        follow_redirects=True,
+    )
+
+    assert first_response.status_code == 302
+    assert replay_response.status_code == 400
+    assert "do not have any usable recipient PGP keys" in replay_response.text
+    assert db.session.scalar(db.select(db.func.count()).select_from(Message)) == 1
+    assert db.session.scalar(db.select(db.func.count()).select_from(Conversation)) == 1
+    consumed_nonce_rows = db.session.scalars(
+        db.select(InitialConversationNonce).where(InitialConversationNonce.consumed_at.is_not(None))
+    ).all()
+    assert len(consumed_nonce_rows) == 1
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -12,6 +12,7 @@ from itsdangerous import BadData, SignatureExpired, URLSafeTimedSerializer
 from sqlalchemy.exc import MultipleResultsFound
 from werkzeug.exceptions import NotFound
 
+from hushline.chat_key_lifecycle import chat_key_fingerprint
 from hushline.db import db
 from hushline.model import (
     AccountCategory,
@@ -38,12 +39,19 @@ def _set_pgp_key(user: User) -> None:
     user.pgp_key = Path("tests/test_pgp_key.txt").read_text()
 
 
-def _add_chat_key(user: User, public_key: str) -> None:
+def _add_chat_key(
+    user: User,
+    public_key: str,
+    *,
+    public_signing_key: str | None = None,
+) -> None:
     db.session.add(
         ChatKey(
             user=user,
             key_version=1,
             public_key=public_key,
+            public_signing_key=public_signing_key
+            or '{"kty":"EC","crv":"P-256","x":"signing","y":"key"}',
             encrypted_private_key="wrapped-private-chat-key",
             kdf_algorithm="PBKDF2-SHA-256",
             kdf_params={"iterations": 310000, "hash": "SHA-256"},
@@ -62,6 +70,68 @@ def _chat_ciphertext(label: str) -> str:
             "ciphertext": f"ciphertext-{label}",
         }
     )
+
+
+def _initial_chat_ciphertext(
+    *,
+    label: str,
+    sender: User,
+    recipient: User,
+    nonce: str,
+    context_overrides: dict[str, object] | None = None,
+) -> str:
+    sender_key = sender.active_chat_key
+    recipient_key = recipient.active_chat_key
+    assert sender_key is not None
+    assert recipient_key is not None
+    context: dict[str, object] = {
+        "purpose": "hushline.chat.initial_message",
+        "initial_conversation_nonce": nonce,
+        "sender_key_version": sender_key.key_version,
+        "sender_public_key_fingerprint": chat_key_fingerprint(sender_key.public_key),
+        "sender_public_signing_key_fingerprint": chat_key_fingerprint(
+            sender_key.public_signing_key
+        ),
+        "recipient_key_version": recipient_key.key_version,
+        "recipient_public_key_fingerprint": chat_key_fingerprint(recipient_key.public_key),
+    }
+    if context_overrides:
+        context.update(context_overrides)
+    envelope = {
+        "v": 2,
+        "algorithm": chat_message_algorithm,
+        "ephemeral_public_key": '{"kty":"EC","crv":"P-256","x":"ephemeral","y":"key"}',
+        "iv": f"iv-{label}",
+        "ciphertext": f"ciphertext-{label}",
+        "context": context,
+    }
+    envelope["signature"] = f"signature-{label}"
+    return json.dumps(envelope)
+
+
+def _initial_conversation_copies_for(
+    *,
+    sender: User,
+    recipient: User,
+    nonce: str,
+    context_overrides: dict[str, object] | None = None,
+) -> dict[str, str]:
+    return {
+        "sender": _initial_chat_ciphertext(
+            label="sender-initial",
+            sender=sender,
+            recipient=sender,
+            nonce=nonce,
+            context_overrides=context_overrides,
+        ),
+        "recipient": _initial_chat_ciphertext(
+            label="recipient-initial",
+            sender=sender,
+            recipient=recipient,
+            nonce=nonce,
+            context_overrides=context_overrides,
+        ),
+    }
 
 
 def _authenticate_as(client: FlaskClient, user: User) -> None:
@@ -312,6 +382,7 @@ def test_logged_in_profile_submit_message_creates_conversation_for_distinct_reci
     _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
     _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
     db.session.commit()
+    submission_data = get_profile_submission_data(client, user2.primary_username.username)
 
     response = client.post(
         url_for("profile", username=user2.primary_username.username),
@@ -319,12 +390,13 @@ def test_logged_in_profile_submit_message_creates_conversation_for_distinct_reci
             "field_0": msg_contact_method,
             "field_1": msg_content,
             "encrypted_conversation_copies": json.dumps(
-                {
-                    "sender": _chat_ciphertext("sender-initial"),
-                    "recipient": _chat_ciphertext("recipient-initial"),
-                }
+                _initial_conversation_copies_for(
+                    sender=user,
+                    recipient=user2,
+                    nonce=submission_data["owner_guard_nonce"],
+                )
             ),
-            **get_profile_submission_data(client, user2.primary_username.username),
+            **submission_data,
         },
         follow_redirects=False,
     )
@@ -396,6 +468,7 @@ def test_logged_in_profile_submit_without_recipient_pgp_uses_chat_only_conversat
     assert submit_button.get("disabled") is None
     assert 'disabled="disabled"' not in profile_response.text
     assert "Sending messages is disabled" not in profile_response.text
+    submission_data = get_profile_submission_data(client, user2.primary_username.username)
 
     response = client.post(
         url_for("profile", username=user2.primary_username.username),
@@ -403,12 +476,13 @@ def test_logged_in_profile_submit_without_recipient_pgp_uses_chat_only_conversat
             "field_0": msg_contact_method,
             "field_1": msg_content,
             "encrypted_conversation_copies": json.dumps(
-                {
-                    "sender": _chat_ciphertext("sender-chat-only"),
-                    "recipient": _chat_ciphertext("recipient-chat-only"),
-                }
+                _initial_conversation_copies_for(
+                    sender=user,
+                    recipient=user2,
+                    nonce=submission_data["owner_guard_nonce"],
+                )
             ),
-            **get_profile_submission_data(client, user2.primary_username.username),
+            **submission_data,
         },
         follow_redirects=False,
     )
@@ -432,7 +506,84 @@ def test_logged_in_profile_submit_without_recipient_pgp_uses_chat_only_conversat
 
 
 @pytest.mark.usefixtures("_authenticated_user")
-def test_logged_in_profile_submit_message_creates_conversation_without_sender_key(
+def test_logged_in_profile_submit_without_pgp_rejects_misbound_initial_chat_payload(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    user.pgp_key = None
+    user2.pgp_key = None
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+    submission_data = get_profile_submission_data(client, user2.primary_username.username)
+
+    response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            "encrypted_conversation_copies": json.dumps(
+                _initial_conversation_copies_for(
+                    sender=user,
+                    recipient=user2,
+                    nonce=submission_data["owner_guard_nonce"],
+                    context_overrides={"recipient_public_key_fingerprint": "WRONG"},
+                )
+            ),
+            **submission_data,
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 400
+    assert "do not have any usable recipient PGP keys" in response.text
+    assert db.session.scalars(db.select(Message)).all() == []
+    assert db.session.scalars(db.select(Conversation)).all() == []
+    assert db.session.scalars(db.select(ConversationMessageCopy)).all() == []
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_logged_in_profile_submit_initial_chat_nonce_is_single_use(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    user.pgp_key = None
+    user2.pgp_key = None
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+    submission_data = get_profile_submission_data(client, user2.primary_username.username)
+    post_data = {
+        "field_0": msg_contact_method,
+        "field_1": msg_content,
+        "encrypted_conversation_copies": json.dumps(
+            _initial_conversation_copies_for(
+                sender=user,
+                recipient=user2,
+                nonce=submission_data["owner_guard_nonce"],
+            )
+        ),
+        **submission_data,
+    }
+
+    first_response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data=post_data,
+        follow_redirects=False,
+    )
+    second_response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data=post_data,
+        follow_redirects=True,
+    )
+
+    assert first_response.status_code == 302
+    assert second_response.status_code == 400
+    assert "do not have any usable recipient PGP keys" in second_response.text
+    assert db.session.scalar(db.select(db.func.count()).select_from(Message)) == 1
+    assert db.session.scalar(db.select(db.func.count()).select_from(Conversation)) == 1
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_logged_in_profile_submit_message_skips_conversation_without_sender_key(
     client: FlaskClient, user: User, user2: User
 ) -> None:
     _set_pgp_key(user2)
@@ -452,35 +603,14 @@ def test_logged_in_profile_submit_message_creates_conversation_without_sender_ke
         follow_redirects=True,
     )
     assert response.status_code == 200, response.text
-    assert "No encrypted copy is available for your account." in response.text
+    assert "Message submitted successfully." in response.text
 
     message = db.session.scalars(
         db.select(Message).filter_by(username_id=user2.primary_username.id)
     ).one()
-    conversation = message.conversation
-    assert conversation is not None
-    assert {participant.user_id for participant in conversation.participants} == {
-        user.id,
-        user2.id,
-    }
-    participants_by_user_id = {
-        participant.user_id: participant for participant in conversation.participants
-    }
-    assert participants_by_user_id[user.id].has_usable_public_key is False
-    assert participants_by_user_id[user2.id].has_usable_public_key is True
-    copies = db.session.scalars(db.select(ConversationMessageCopy)).all()
-    assert len(copies) == 1
-    assert copies[0].recipient_participant.user_id == user2.id
-    assert chat_message_algorithm in copies[0].encrypted_payload
-    assert msg_contact_method not in copies[0].encrypted_payload
-    assert msg_content not in copies[0].encrypted_payload
-
-    _authenticate_as(client, user2)
-    recipient_response = client.get(url_for("conversation", public_id=conversation.public_id))
-    assert recipient_response.status_code == 200
-    assert "Secure chat unavailable" in recipient_response.text
-    assert "conversation-chat-password" not in recipient_response.text
-    assert "Encrypted message. Waiting for browser chat key." in recipient_response.text
+    assert message.conversation is None
+    assert db.session.scalars(db.select(Conversation)).all() == []
+    assert db.session.scalars(db.select(ConversationMessageCopy)).all() == []
 
 
 @pytest.mark.usefixtures("_authenticated_user")


### PR DESCRIPTION
## What changed

- Initial authenticated profile-to-profile chat submissions now require v2 chat envelopes with context and signatures.
- The server issues a one-time initial conversation nonce on profile render and stores a hashed server-side nonce row for the sender/recipient pair.
- Initial conversation creation consumes the nonce with a conditional DB update against unconsumed server-side state, preventing stale-cookie replay and duplicate POST reuse.
- Initial chat envelope context is bound to:
  - `purpose: hushline.chat.initial_message`
  - the one-time initial conversation nonce
  - sender chat key version and public/signing key fingerprints
  - recipient chat key version and public key fingerprint
- The client-side profile encryptor restores the sender signing key through the existing chat-key lifecycle path, including cross-tab unlock sharing, before falling back to tab-local session storage.
- Conversation decryption can verify initial-message v2 envelopes by sender signing-key fingerprint before participant IDs are available, including after the sender rotates away from the original signing key.
- Tests cover valid initial conversation creation, misbound context rejection, nonce replay rejection, stale-cookie replay rejection, historical signing-key exposure, migration upgrade/downgrade behavior, and frontend/static contract coverage.
- Inbox conversation-list coverage now submits signed v2 initial envelopes instead of legacy v1 fixture payloads.

Fixes #2256.

## Why

The E2EE audit found that initial account conversations still used unsigned/contextless v1 chat envelopes. Replies were context-bound, but the first message in a conversation had weaker replay/misbinding resistance. This change brings the initial write path up to the v2 envelope contract without adding server-side plaintext fallback or storing private key material.

The review pass also caught three launch-blocking edge cases: historical initial messages could become undecryptable after sender key rotation, chat-only profile submits could fail when the signing key was unlocked in another tab, and cookie-backed nonce removal was not an atomic server-side consume.

## Security and privacy impact

Threat/risk summary: initial E2EE conversation writes now fail closed unless the browser submits signed, nonce-bound v2 envelopes for both sender and recipient copies, and nonce reuse is blocked by server-side state instead of client-side session mutation.

Affected data paths:

- Authenticated profile submission path that creates an initial conversation.
- Browser-side profile encryption flow in `client-side-encryption.js`.
- Conversation message decryption signature-key lookup for initial messages.
- Database schema: new `initial_conversation_nonces` table storing nonce hashes and consume timestamps.

Mitigation:

- Legacy v1 initial chat payloads no longer start chat-only conversations.
- Initial nonces are stored hashed server-side and consumed once with an atomic conditional update.
- The server validates context/key fingerprints before storing encrypted copies.
- Conversation pages expose historical signing public keys as verification-only metadata so rotated keys do not break initial-message signature checks.
- Profile encryption can recover the unlocked signing key from another authenticated tab before failing a chat-only submission.

## Validation

Completed after CI failure fix on commit `411c2d82`:

- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run pytest tests/test_inbox.py::test_inbox_lists_conversation_for_sender_and_recipient_after_submission -q` - 1 passed
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run pytest --alembic tests/test_inbox.py::test_inbox_lists_conversation_for_sender_and_recipient_after_submission -q` - 1 passed
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run pytest tests/test_inbox.py -q` - 7 passed
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run ruff check tests/test_inbox.py` - passed
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run ruff format --check tests/test_inbox.py` - passed

Completed after rebase onto `main` at `ee044a38`:

- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run pytest tests/test_profile.py tests/test_conversation.py tests/test_frontend_compat.py -q` - 124 passed, 8 warnings
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run pytest tests/test_migrations.py -k '0f6d4c8e9a21 or linear_revision_history' -q` - 4 passed, 84 deselected
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run ruff format --check hushline/routes/profile.py hushline/routes/message.py hushline/model/initial_conversation_nonce.py tests/test_profile.py tests/test_conversation.py tests/test_frontend_compat.py tests/migrations/revision_0f6d4c8e9a21.py migrations/versions/0f6d4c8e9a21_add_initial_conversation_nonces.py` - passed
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run ruff check hushline/routes/profile.py hushline/routes/message.py hushline/model/initial_conversation_nonce.py tests/test_profile.py tests/test_conversation.py tests/test_frontend_compat.py tests/migrations/revision_0f6d4c8e9a21.py migrations/versions/0f6d4c8e9a21_add_initial_conversation_nonces.py` - passed

Also completed before rebase:

- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run pytest tests/test_migrations.py -k '0f6d4c8e9a21 or linear_revision_history' -q` - 4 passed, 84 deselected

Known validation note:

- One attempted concurrent run of the focused app tests and migration tests failed because the migration test mutated the shared Postgres template database while ordinary tests were creating per-test databases. The same focused app tests passed when rerun serially after the migration test.
- One attempted concurrent rerun of standard and Alembic variants of the inbox target hit the same shared template database collision. After resetting the isolated `/private/tmp` test stack and rerunning serially, both target modes passed.

Not completed before PR open / latest update:

- Full `make lint` was started but interrupted by request to open the PR immediately.
- Full `make test` has not been run on this branch yet.
- Dependency audits have not been rerun on this branch yet.

## Manual testing

Not separately performed. Focused tests cover the server/client contract, migration behavior, and addressed review regressions.

## Known risks and follow-ups

- This changes chat-only profile submission behavior for senders without a signing-capable active chat key: they no longer create an initial conversation. If the recipient has PGP notification keys, the submission remains a normal encrypted message.
- The committed `hushline/static/js/chat-key-lifecycle.js` was updated alongside `assets/js/chat-key-lifecycle.js`; the bundled `client-side-encryption.js` artifact is not committed in this repo layout.
- Full suite and audit checks should run before merge.