### PR TITLE
Enforce chat key wrapping policy

### DIFF
--- a/hushline/chat_key_lifecycle.py
+++ b/hushline/chat_key_lifecycle.py
@@ -14,7 +14,10 @@ CHAT_KEY_RECOVERY_STATE_MAX_LENGTH = 64
 CHAT_KEY_KDF_ALGORITHM = "PBKDF2-SHA-256"
 CHAT_KEY_KDF_HASH = "SHA-256"
 CHAT_KEY_KDF_MIN_ITERATIONS = 310_000
+CHAT_KEY_KDF_SALT_BYTES = 16
 CHAT_KEY_WRAPPING_ALGORITHM = "AES-GCM"
+CHAT_KEY_WRAPPING_IV_BYTES = 12
+CHAT_KEY_WRAPPED_PRIVATE_KEY_FIELDS = {"algorithm", "iv", "ciphertext"}
 CHAT_KEY_FORBIDDEN_SECRET_FIELDS = {
     "decrypted_message_text",
     "decrypted_private_key",
@@ -98,13 +101,14 @@ def _valid_public_jwk(value: str, *, expected_use: str) -> bool:
     return True
 
 
-def _non_empty_base64(value: Any) -> bool:
+def _base64_bytes(value: Any) -> bytes | None:
     if not isinstance(value, str) or not value:
-        return False
+        return None
     try:
-        return bool(base64.b64decode(value, validate=True))
+        decoded = base64.b64decode(value, validate=True)
     except (binascii.Error, ValueError):
-        return False
+        return None
+    return decoded or None
 
 
 def _validate_wrapped_private_key(value: str) -> str:
@@ -115,11 +119,16 @@ def _validate_wrapped_private_key(value: str) -> str:
 
     if not isinstance(wrapped_private_key, dict):
         return "encrypted_private_key must be a JSON object."
+    if set(wrapped_private_key) != CHAT_KEY_WRAPPED_PRIVATE_KEY_FIELDS:
+        return "encrypted_private_key contains unsupported fields."
     if wrapped_private_key.get("algorithm") != CHAT_KEY_WRAPPING_ALGORITHM:
         return "encrypted_private_key algorithm must be AES-GCM."
-    if not _non_empty_base64(wrapped_private_key.get("iv")):
+    iv = _base64_bytes(wrapped_private_key.get("iv"))
+    if iv is None:
         return "encrypted_private_key iv must be non-empty base64."
-    if not _non_empty_base64(wrapped_private_key.get("ciphertext")):
+    if len(iv) != CHAT_KEY_WRAPPING_IV_BYTES:
+        return "encrypted_private_key iv must be 12 bytes."
+    if _base64_bytes(wrapped_private_key.get("ciphertext")) is None:
         return "encrypted_private_key ciphertext must be non-empty base64."
     return ""
 
@@ -172,18 +181,6 @@ def validate_chat_key_payload(payload: Any, *, current_user_id: int) -> tuple[di
         return {}, "kdf_salt is required."
     if not isinstance(kdf_params, dict) or not kdf_params:
         return {}, "kdf_params must be a non-empty object."
-    if kdf_params.get("hash") != CHAT_KEY_KDF_HASH:
-        return {}, "kdf_params.hash must be SHA-256."
-    iterations = kdf_params.get("iterations")
-    if not isinstance(iterations, int) or isinstance(iterations, bool):
-        return {}, "kdf_params.iterations must be an integer."
-    if iterations < CHAT_KEY_KDF_MIN_ITERATIONS:
-        return {}, "kdf_params.iterations is below the minimum."
-    if wrapping_algorithm != CHAT_KEY_WRAPPING_ALGORITHM:
-        return {}, "wrapping_algorithm must be AES-GCM."
-    wrapped_private_key_error = _validate_wrapped_private_key(encrypted_private_key)
-    if wrapped_private_key_error:
-        return {}, wrapped_private_key_error
 
     string_fields = {
         "public_key": public_key,
@@ -196,6 +193,24 @@ def validate_chat_key_payload(payload: Any, *, current_user_id: int) -> tuple[di
         string_fields["public_signing_key"] = public_signing_key
     if any(len(value) > CHAT_KEY_STRING_MAX_LENGTH for value in string_fields.values()):
         return {}, "Chat key payload is too large."
+
+    if kdf_params.get("hash") != CHAT_KEY_KDF_HASH:
+        return {}, "kdf_params.hash must be SHA-256."
+    iterations = kdf_params.get("iterations")
+    if not isinstance(iterations, int) or isinstance(iterations, bool):
+        return {}, "kdf_params.iterations must be an integer."
+    if iterations < CHAT_KEY_KDF_MIN_ITERATIONS:
+        return {}, "kdf_params.iterations is below the minimum."
+    salt = _base64_bytes(kdf_salt)
+    if salt is None:
+        return {}, "kdf_salt must be non-empty base64."
+    if len(salt) != CHAT_KEY_KDF_SALT_BYTES:
+        return {}, "kdf_salt must be 16 bytes."
+    if wrapping_algorithm != CHAT_KEY_WRAPPING_ALGORITHM:
+        return {}, "wrapping_algorithm must be AES-GCM."
+    wrapped_private_key_error = _validate_wrapped_private_key(encrypted_private_key)
+    if wrapped_private_key_error:
+        return {}, wrapped_private_key_error
 
     try:
         serialized_kdf_params = json.dumps(kdf_params, sort_keys=True)

--- a/hushline/chat_key_lifecycle.py
+++ b/hushline/chat_key_lifecycle.py
@@ -1,3 +1,5 @@
+import base64
+import binascii
 import json
 from datetime import UTC, datetime
 from hashlib import sha256
@@ -9,6 +11,10 @@ from hushline.model import ChatKey, User
 CHAT_KEY_STRING_MAX_LENGTH = 200_000
 CHAT_KEY_METADATA_MAX_LENGTH = 20_000
 CHAT_KEY_RECOVERY_STATE_MAX_LENGTH = 64
+CHAT_KEY_KDF_ALGORITHM = "PBKDF2-SHA-256"
+CHAT_KEY_KDF_HASH = "SHA-256"
+CHAT_KEY_KDF_MIN_ITERATIONS = 310_000
+CHAT_KEY_WRAPPING_ALGORITHM = "AES-GCM"
 CHAT_KEY_FORBIDDEN_SECRET_FIELDS = {
     "decrypted_message_text",
     "decrypted_private_key",
@@ -92,6 +98,32 @@ def _valid_public_jwk(value: str, *, expected_use: str) -> bool:
     return True
 
 
+def _non_empty_base64(value: Any) -> bool:
+    if not isinstance(value, str) or not value:
+        return False
+    try:
+        return bool(base64.b64decode(value, validate=True))
+    except (binascii.Error, ValueError):
+        return False
+
+
+def _validate_wrapped_private_key(value: str) -> str:
+    try:
+        wrapped_private_key = json.loads(value)
+    except (TypeError, ValueError):
+        return "encrypted_private_key must be a JSON object."
+
+    if not isinstance(wrapped_private_key, dict):
+        return "encrypted_private_key must be a JSON object."
+    if wrapped_private_key.get("algorithm") != CHAT_KEY_WRAPPING_ALGORITHM:
+        return "encrypted_private_key algorithm must be AES-GCM."
+    if not _non_empty_base64(wrapped_private_key.get("iv")):
+        return "encrypted_private_key iv must be non-empty base64."
+    if not _non_empty_base64(wrapped_private_key.get("ciphertext")):
+        return "encrypted_private_key ciphertext must be non-empty base64."
+    return ""
+
+
 def validate_chat_key_payload(payload: Any, *, current_user_id: int) -> tuple[dict[str, Any], str]:
     if not isinstance(payload, dict):
         return {}, "Expected a JSON object."
@@ -112,7 +144,7 @@ def validate_chat_key_payload(payload: Any, *, current_user_id: int) -> tuple[di
     )
     kdf_algorithm = payload_text(payload, "kdf_algorithm")
     kdf_salt = payload_text(payload, "kdf_salt", "salt")
-    wrapping_algorithm = payload_text(payload, "wrapping_algorithm") or "AES-GCM"
+    wrapping_algorithm = payload_text(payload, "wrapping_algorithm") or CHAT_KEY_WRAPPING_ALGORITHM
     kdf_params = payload.get("kdf_params")
 
     kdf = payload.get("kdf")
@@ -134,10 +166,24 @@ def validate_chat_key_payload(payload: Any, *, current_user_id: int) -> tuple[di
         return {}, "encrypted_private_key is required."
     if not kdf_algorithm:
         return {}, "kdf_algorithm is required."
+    if kdf_algorithm != CHAT_KEY_KDF_ALGORITHM:
+        return {}, "kdf_algorithm must be PBKDF2-SHA-256."
     if not kdf_salt:
         return {}, "kdf_salt is required."
     if not isinstance(kdf_params, dict) or not kdf_params:
         return {}, "kdf_params must be a non-empty object."
+    if kdf_params.get("hash") != CHAT_KEY_KDF_HASH:
+        return {}, "kdf_params.hash must be SHA-256."
+    iterations = kdf_params.get("iterations")
+    if not isinstance(iterations, int) or isinstance(iterations, bool):
+        return {}, "kdf_params.iterations must be an integer."
+    if iterations < CHAT_KEY_KDF_MIN_ITERATIONS:
+        return {}, "kdf_params.iterations is below the minimum."
+    if wrapping_algorithm != CHAT_KEY_WRAPPING_ALGORITHM:
+        return {}, "wrapping_algorithm must be AES-GCM."
+    wrapped_private_key_error = _validate_wrapped_private_key(encrypted_private_key)
+    if wrapped_private_key_error:
+        return {}, wrapped_private_key_error
 
     string_fields = {
         "public_key": public_key,

--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -20,11 +20,12 @@ def _chat_key_payload(**overrides: object) -> dict[str, object]:
             '{"kty":"EC","crv":"P-256","x":"signing-public-x","y":"signing-public-y"}'
         ),
         "encrypted_private_key": (
-            '{"algorithm":"AES-GCM","iv":"bm9uY2U=",' '"ciphertext":"d3JhcHBlZC1wcml2YXRlLWtleQ=="}'
+            '{"algorithm":"AES-GCM","iv":"bm9uY2UtMTIzNDU2",'
+            '"ciphertext":"d3JhcHBlZC1wcml2YXRlLWtleQ=="}'
         ),
         "kdf_algorithm": "PBKDF2-SHA-256",
         "kdf_params": {"iterations": 310000, "hash": "SHA-256"},
-        "kdf_salt": "salt",
+        "kdf_salt": "c2FsdC1zYWx0LXNhbHQtIQ==",
         "wrapping_algorithm": "AES-GCM",
     }
     payload.update(overrides)
@@ -136,7 +137,7 @@ def test_authenticated_user_can_provision_chat_key(client: FlaskClient, user: Us
     assert created_key.encrypted_private_key == _chat_key_payload()["encrypted_private_key"]
     assert created_key.kdf_algorithm == "PBKDF2-SHA-256"
     assert created_key.kdf_params == {"iterations": 310000, "hash": "SHA-256"}
-    assert created_key.kdf_salt == "salt"
+    assert created_key.kdf_salt == "c2FsdC1zYWx0LXNhbHQtIQ=="
     assert created_key.wrapping_algorithm == "AES-GCM"
     assert created_key.disabled_at is None
 
@@ -213,8 +214,20 @@ def test_chat_key_payload_rejects_plaintext_private_key_material(
             "kdf_params.hash must be SHA-256.",
         ),
         (
+            {"kdf_salt": "not base64"},
+            "kdf_salt must be non-empty base64.",
+        ),
+        (
+            {"kdf_salt": "QUE="},
+            "kdf_salt must be 16 bytes.",
+        ),
+        (
             {"wrapping_algorithm": "AES-CBC"},
             "wrapping_algorithm must be AES-GCM.",
+        ),
+        (
+            {"encrypted_private_key": "x" * 200_001},
+            "Chat key payload is too large.",
         ),
         (
             {"encrypted_private_key": "wrapped-private-key"},
@@ -223,7 +236,17 @@ def test_chat_key_payload_rejects_plaintext_private_key_material(
         (
             {
                 "encrypted_private_key": (
-                    '{"algorithm":"AES-CBC","iv":"bm9uY2U=",'
+                    '{"algorithm":"AES-GCM","iv":"bm9uY2UtMTIzNDU2",'
+                    '"ciphertext":"d3JhcHBlZC1wcml2YXRlLWtleQ==",'
+                    '"private_key":"plaintext-private-key"}'
+                )
+            },
+            "encrypted_private_key contains unsupported fields.",
+        ),
+        (
+            {
+                "encrypted_private_key": (
+                    '{"algorithm":"AES-CBC","iv":"bm9uY2UtMTIzNDU2",'
                     '"ciphertext":"d3JhcHBlZC1wcml2YXRlLWtleQ=="}'
                 )
             },
@@ -239,7 +262,20 @@ def test_chat_key_payload_rejects_plaintext_private_key_material(
             "encrypted_private_key iv must be non-empty base64.",
         ),
         (
-            {"encrypted_private_key": ('{"algorithm":"AES-GCM","iv":"bm9uY2U=","ciphertext":""}')},
+            {
+                "encrypted_private_key": (
+                    '{"algorithm":"AES-GCM","iv":"QUE=",'
+                    '"ciphertext":"d3JhcHBlZC1wcml2YXRlLWtleQ=="}'
+                )
+            },
+            "encrypted_private_key iv must be 12 bytes.",
+        ),
+        (
+            {
+                "encrypted_private_key": (
+                    '{"algorithm":"AES-GCM","iv":"bm9uY2UtMTIzNDU2","ciphertext":""}'
+                )
+            },
             "encrypted_private_key ciphertext must be non-empty base64.",
         ),
     ],

--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -20,7 +20,7 @@ def _chat_key_payload(**overrides: object) -> dict[str, object]:
             '{"kty":"EC","crv":"P-256","x":"signing-public-x","y":"signing-public-y"}'
         ),
         "encrypted_private_key": (
-            '{"algorithm":"AES-GCM","iv":"nonce","ciphertext":"wrapped-private-key"}'
+            '{"algorithm":"AES-GCM","iv":"bm9uY2U=",' '"ciphertext":"d3JhcHBlZC1wcml2YXRlLWtleQ=="}'
         ),
         "kdf_algorithm": "PBKDF2-SHA-256",
         "kdf_params": {"iterations": 310000, "hash": "SHA-256"},
@@ -193,6 +193,69 @@ def test_chat_key_payload_rejects_plaintext_private_key_material(
 
     assert response.status_code == 400
     assert "Plaintext chat key material is not accepted." in response.text
+    assert db.session.scalars(db.select(ChatKey)).all() == []
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+@pytest.mark.parametrize(
+    ("overrides", "expected_error"),
+    [
+        (
+            {"kdf_algorithm": "PBKDF2-SHA-1"},
+            "kdf_algorithm must be PBKDF2-SHA-256.",
+        ),
+        (
+            {"kdf_params": {"iterations": 309999, "hash": "SHA-256"}},
+            "kdf_params.iterations is below the minimum.",
+        ),
+        (
+            {"kdf_params": {"iterations": 310000, "hash": "SHA-1"}},
+            "kdf_params.hash must be SHA-256.",
+        ),
+        (
+            {"wrapping_algorithm": "AES-CBC"},
+            "wrapping_algorithm must be AES-GCM.",
+        ),
+        (
+            {"encrypted_private_key": "wrapped-private-key"},
+            "encrypted_private_key must be a JSON object.",
+        ),
+        (
+            {
+                "encrypted_private_key": (
+                    '{"algorithm":"AES-CBC","iv":"bm9uY2U=",'
+                    '"ciphertext":"d3JhcHBlZC1wcml2YXRlLWtleQ=="}'
+                )
+            },
+            "encrypted_private_key algorithm must be AES-GCM.",
+        ),
+        (
+            {
+                "encrypted_private_key": (
+                    '{"algorithm":"AES-GCM","iv":"not base64",'
+                    '"ciphertext":"d3JhcHBlZC1wcml2YXRlLWtleQ=="}'
+                )
+            },
+            "encrypted_private_key iv must be non-empty base64.",
+        ),
+        (
+            {"encrypted_private_key": ('{"algorithm":"AES-GCM","iv":"bm9uY2U=","ciphertext":""}')},
+            "encrypted_private_key ciphertext must be non-empty base64.",
+        ),
+    ],
+)
+def test_chat_key_payload_rejects_weak_or_malformed_wrapping_policy(
+    client: FlaskClient,
+    overrides: dict[str, object],
+    expected_error: str,
+) -> None:
+    response = client.post(
+        url_for("settings.chat_key"),
+        json=_chat_key_payload(**overrides),
+    )
+
+    assert response.status_code == 400
+    assert expected_error in response.text
     assert db.session.scalars(db.select(ChatKey)).all() == []
 
 

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -56,7 +56,8 @@ def _login_chat_key_payload(**overrides: object) -> dict[str, object]:
             '{"kty":"EC","crv":"P-256","x":"login-signing-public-x","y":"login-signing-public-y"}'
         ),
         "encrypted_private_key": (
-            '{"algorithm":"AES-GCM","iv":"login-nonce","ciphertext":"login-wrapped-private-key"}'
+            '{"algorithm":"AES-GCM","iv":"bG9naW4tbm9uY2U=",'
+            '"ciphertext":"bG9naW4td3JhcHBlZC1wcml2YXRlLWtleQ=="}'
         ),
         "kdf_algorithm": "PBKDF2-SHA-256",
         "kdf_params": {"iterations": 310000, "hash": "SHA-256"},

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -56,12 +56,12 @@ def _login_chat_key_payload(**overrides: object) -> dict[str, object]:
             '{"kty":"EC","crv":"P-256","x":"login-signing-public-x","y":"login-signing-public-y"}'
         ),
         "encrypted_private_key": (
-            '{"algorithm":"AES-GCM","iv":"bG9naW4tbm9uY2U=",'
+            '{"algorithm":"AES-GCM","iv":"bG9naW4tbm9uY2Uh",'
             '"ciphertext":"bG9naW4td3JhcHBlZC1wcml2YXRlLWtleQ=="}'
         ),
         "kdf_algorithm": "PBKDF2-SHA-256",
         "kdf_params": {"iterations": 310000, "hash": "SHA-256"},
-        "kdf_salt": "login-salt",
+        "kdf_salt": "bG9naW4tc2FsdC0xMjM0NQ==",
         "wrapping_algorithm": "AES-GCM",
     }
     payload.update(overrides)
@@ -389,7 +389,7 @@ def test_login_with_chat_key_payload_creates_missing_chat_key(
     assert created_key.public_key == _login_chat_key_payload()["public_key"]
     assert created_key.public_signing_key == _login_chat_key_payload()["public_signing_key"]
     assert created_key.encrypted_private_key == _login_chat_key_payload()["encrypted_private_key"]
-    assert created_key.kdf_salt == "login-salt"
+    assert created_key.kdf_salt == "bG9naW4tc2FsdC0xMjM0NQ=="
 
 
 def test_login_with_chat_key_payload_waits_for_successful_2fa(

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -538,11 +538,11 @@ def test_change_password_rewraps_active_chat_key(
         {
             "public_key": '{"kty":"EC","crv":"P-256","x":"public-chat","y":"key"}',
             "encrypted_private_key": (
-                '{"algorithm":"AES-GCM","iv":"bmV3","ciphertext":"cmV3cmFwcGVk"}'
+                '{"algorithm":"AES-GCM","iv":"bmV3LWl2LTEyMzQ1","ciphertext":"cmV3cmFwcGVk"}'
             ),
             "kdf_algorithm": "PBKDF2-SHA-256",
             "kdf_params": {"iterations": 310000, "hash": "SHA-256"},
-            "kdf_salt": "new-salt",
+            "kdf_salt": "bmV3LXNhbHQtMTIzNDU2Nw==",
             "wrapping_algorithm": "AES-GCM",
             "recovery_state": "available",
         }
@@ -567,9 +567,9 @@ def test_change_password_rewraps_active_chat_key(
     assert keys[1].disabled_at is None
     assert keys[1].public_key == '{"kty":"EC","crv":"P-256","x":"public-chat","y":"key"}'
     assert keys[1].encrypted_private_key == (
-        '{"algorithm":"AES-GCM","iv":"bmV3","ciphertext":"cmV3cmFwcGVk"}'
+        '{"algorithm":"AES-GCM","iv":"bmV3LWl2LTEyMzQ1","ciphertext":"cmV3cmFwcGVk"}'
     )
-    assert keys[1].kdf_salt == "new-salt"
+    assert keys[1].kdf_salt == "bmV3LXNhbHQtMTIzNDU2Nw=="
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -601,11 +601,11 @@ def test_change_password_rewrap_rejects_plaintext_chat_key_material(
         {
             "public_key": '{"kty":"EC","crv":"P-256","x":"public-chat","y":"key"}',
             "encrypted_private_key": (
-                '{"algorithm":"AES-GCM","iv":"bmV3","ciphertext":"cmV3cmFwcGVk"}'
+                '{"algorithm":"AES-GCM","iv":"bmV3LWl2LTEyMzQ1","ciphertext":"cmV3cmFwcGVk"}'
             ),
             "kdf_algorithm": "PBKDF2-SHA-256",
             "kdf_params": {"iterations": 310000, "hash": "SHA-256"},
-            "kdf_salt": "new-salt",
+            "kdf_salt": "bmV3LXNhbHQtMTIzNDU2Nw==",
             "private_key": "plaintext-private-key",
         }
     )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -538,7 +538,7 @@ def test_change_password_rewraps_active_chat_key(
         {
             "public_key": '{"kty":"EC","crv":"P-256","x":"public-chat","y":"key"}',
             "encrypted_private_key": (
-                '{"algorithm":"AES-GCM","iv":"new","ciphertext":"rewrapped"}'
+                '{"algorithm":"AES-GCM","iv":"bmV3","ciphertext":"cmV3cmFwcGVk"}'
             ),
             "kdf_algorithm": "PBKDF2-SHA-256",
             "kdf_params": {"iterations": 310000, "hash": "SHA-256"},
@@ -567,7 +567,7 @@ def test_change_password_rewraps_active_chat_key(
     assert keys[1].disabled_at is None
     assert keys[1].public_key == '{"kty":"EC","crv":"P-256","x":"public-chat","y":"key"}'
     assert keys[1].encrypted_private_key == (
-        '{"algorithm":"AES-GCM","iv":"new","ciphertext":"rewrapped"}'
+        '{"algorithm":"AES-GCM","iv":"bmV3","ciphertext":"cmV3cmFwcGVk"}'
     )
     assert keys[1].kdf_salt == "new-salt"
 
@@ -601,7 +601,7 @@ def test_change_password_rewrap_rejects_plaintext_chat_key_material(
         {
             "public_key": '{"kty":"EC","crv":"P-256","x":"public-chat","y":"key"}',
             "encrypted_private_key": (
-                '{"algorithm":"AES-GCM","iv":"new","ciphertext":"rewrapped"}'
+                '{"algorithm":"AES-GCM","iv":"bmV3","ciphertext":"cmV3cmFwcGVk"}'
             ),
             "kdf_algorithm": "PBKDF2-SHA-256",
             "kdf_params": {"iterations": 310000, "hash": "SHA-256"},


### PR DESCRIPTION
## What changed

- Enforces server-side chat-key ingress policy in `validate_chat_key_payload`.
- Requires submitted chat keys to use:
  - `kdf_algorithm == "PBKDF2-SHA-256"`
  - `kdf_params.hash == "SHA-256"`
  - `kdf_params.iterations >= 310000`
  - base64 `kdf_salt` exactly 16 bytes
  - `wrapping_algorithm == "AES-GCM"`
- Parses `encrypted_private_key` as JSON and requires an AES-GCM wrapped-key envelope with exactly `algorithm`, `iv`, and `ciphertext` fields.
- Requires the wrapped-key `iv` to be non-empty base64 and exactly 12 bytes, and `ciphertext` to be non-empty base64.
- Updates submitted chat-key fixtures for settings, login provisioning, and password rewrap to use valid base64 wrapped-key fields.
- Adds route-level rejection tests for unsupported KDF, low iterations, unsupported wrapping algorithm, malformed wrapped key JSON, wrong wrapped-key algorithm, invalid/short salt, extra wrapped-key fields, oversize payloads, invalid/short IV, and empty ciphertext.

Closes #2258.

## Why

The E2EE audit found that the server accepted arbitrary KDF/wrapping metadata for chat-key provisioning and rewrap payloads. That made the stored private-key bundle policy depend entirely on client behavior. This change keeps legacy stored rows readable but fails closed for new or rewrapped chat-key submissions that do not match the current browser-generated policy.

## Security and privacy impact

Threat/risk summary: malicious or compromised clients can no longer provision chat keys with weak KDF parameters, unsupported wrapping algorithms, malformed wrapped private-key envelopes, unsupported envelope fields, invalid salts, or non-policy AES-GCM nonce sizes.

Affected data paths:

- Chat key provisioning from settings.
- Login-time chat key payload provisioning.
- Password-change chat key rewrap payloads.

Mitigation:

- Rejects weak or malformed chat-key payloads before persistence.
- Applies size checks before JSON/base64 parsing to avoid avoidable large decode work.
- Does not log or inspect plaintext private key material.
- Does not change the database model or legacy read behavior for already-stored chat keys.

## Validation

Completed after review fixes on `cef17a5c`:

- `env COMPOSE_PROJECT_NAME=hushline-2258 make lint` - passed
- `env COMPOSE_PROJECT_NAME=hushline-2258 docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run pytest tests/test_chat_keys.py -q` - 27 passed
- `env COMPOSE_PROJECT_NAME=hushline-2258 docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run pytest tests/test_routes_auth.py::test_login_with_chat_key_payload_creates_missing_chat_key tests/test_routes_auth.py::test_login_with_chat_key_payload_waits_for_successful_2fa tests/test_settings.py::test_change_password_rewraps_active_chat_key tests/test_settings.py::test_change_password_rewrap_rejects_plaintext_chat_key_material -q` - 4 passed
- `env COMPOSE_PROJECT_NAME=hushline-2258 docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run ruff check hushline/chat_key_lifecycle.py tests/test_chat_keys.py tests/test_routes_auth.py tests/test_settings.py` - passed
- `env COMPOSE_PROJECT_NAME=hushline-2258 docker compose -f docker-compose.yaml -f /private/tmp/hushline-e2ee-audit-no-ports.yaml run --rm app poetry run ruff format --check hushline/chat_key_lifecycle.py tests/test_chat_keys.py tests/test_routes_auth.py tests/test_settings.py` - passed

Completed before review fixes:

- `env COMPOSE_PROJECT_NAME=hushline-2258 make lint` - passed
- `env COMPOSE_PROJECT_NAME=hushline-2258 make test` - 2106 passed, 1 deselected, 1 xfailed, 11 warnings
- `env COMPOSE_PROJECT_NAME=hushline-2258 make audit-python` - no known vulnerabilities found
- `env COMPOSE_PROJECT_NAME=hushline-2258 make audit-node-runtime` - found 0 vulnerabilities

## Manual testing

Not separately performed. The affected paths are covered by route-level tests for settings provisioning, login provisioning, and password rewrap.

## Known risks and follow-ups

- Existing database rows are not backfilled or rejected on read; this PR intentionally enforces policy only for new submitted payloads to avoid locking out users with historical chat-key rows.