### PR TITLE
Harden chat key browser exposure and CSP

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -1034,7 +1034,7 @@
     setConversationUnlockVisible(true);
     setConversationSecureBadgeVisible(false);
     setConversationStatus(
-      "Chat key expired. Log out and log back in to unlock chat.",
+      "Chat key expired for this browser session. Secure replies are paused.",
     );
   }
 

--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -5,6 +5,8 @@
   const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";
   const crossTabChannelName = "hushline:chat-key-session";
   const crossTabRequestTimeoutMs = 750;
+  const unlockedKeyMaxAgeMs = 15 * 60 * 1000;
+  const unlockedKeyIdleTimeoutMs = 5 * 60 * 1000;
   const conversationPollMinIntervalMs = 3000;
   const tabId = window.crypto?.randomUUID
     ? window.crypto.randomUUID()
@@ -13,6 +15,7 @@
   let crossTabSharingBound = false;
   let unlockedChatPrivateKey = null;
   let unlockedChatSigningPrivateKey = null;
+  let unlockedChatKeyExpiryTimer = null;
   let pendingLoginPassword = null;
   const state = {
     status: "empty",
@@ -66,6 +69,32 @@
     if (!window.crypto?.subtle) {
       throw new Error("Web Crypto is unavailable.");
     }
+  }
+
+  function chatKeySessionSecret(sourceDocument = document) {
+    return sourceDocument.body?.dataset.chatKeySessionSecret || "";
+  }
+
+  function clearUnlockedKeyExpiryTimer() {
+    if (unlockedChatKeyExpiryTimer) {
+      window.clearTimeout(unlockedChatKeyExpiryTimer);
+      unlockedChatKeyExpiryTimer = null;
+    }
+  }
+
+  function scheduleUnlockedKeyExpiry(expiresAt, lastUsedAt) {
+    clearUnlockedKeyExpiryTimer();
+    const now = Date.now();
+    const idleExpiresAt = Number(lastUsedAt) + unlockedKeyIdleTimeoutMs;
+    const nextExpiry = Math.min(Number(expiresAt), idleExpiresAt);
+    if (!Number.isFinite(nextExpiry) || nextExpiry <= now) {
+      clearChatKeyMaterial();
+      return;
+    }
+    unlockedChatKeyExpiryTimer = window.setTimeout(
+      clearChatKeyMaterial,
+      nextExpiry - now,
+    );
   }
 
   async function deriveWrappingKey(password, salt, kdfParams, usages) {
@@ -151,15 +180,25 @@
     );
   }
 
-  function rememberUnlockedPrivateKeyBundle(privateKeyBundle, chatKey) {
+  function rememberUnlockedPrivateKeyBundle(
+    privateKeyBundle,
+    chatKey,
+    sourceDocument = document,
+  ) {
+    const now = Date.now();
+    const expiresAt = now + unlockedKeyMaxAgeMs;
+    const sessionSecret = chatKeySessionSecret(sourceDocument);
     const storedValue = JSON.stringify({
       key_version: chatKey.key_version,
       public_key: chatKey.public_key,
       public_signing_key: chatKey.public_signing_key || null,
       private_key_bundle: privateKeyBundle,
-      expires_at: Number.MAX_SAFE_INTEGER,
+      expires_at: expiresAt,
+      last_used_at: now,
+      session_secret: sessionSecret,
     });
 
+    scheduleUnlockedKeyExpiry(expiresAt, now);
     try {
       sessionStorage.setItem(sessionStorageKey, storedValue);
     } catch (error) {
@@ -187,20 +226,29 @@
 
     try {
       const stored = JSON.parse(storedValue);
+      const now = Date.now();
+      const expiresAt = Number(stored.expires_at);
+      const lastUsedAt = Number(stored.last_used_at);
       if (
         stored?.key_version !== chatKey.key_version ||
         stored.public_key !== chatKey.public_key ||
         (stored.public_signing_key || null) !==
           (chatKey.public_signing_key || null) ||
         !(stored.private_key_bundle || stored.private_jwk) ||
-        !stored.expires_at
+        !Number.isFinite(expiresAt) ||
+        expiresAt > now + unlockedKeyMaxAgeMs ||
+        !Number.isFinite(lastUsedAt) ||
+        stored.session_secret !== chatKeySessionSecret()
       ) {
         return null;
       }
-      if (Date.now() > Number(stored.expires_at)) {
+      if (now > expiresAt || now - lastUsedAt > unlockedKeyIdleTimeoutMs) {
         forgetUnlockedPrivateJwk();
         return null;
       }
+      stored.last_used_at = now;
+      sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
+      scheduleUnlockedKeyExpiry(expiresAt, now);
       return normalizePrivateKeyBundle(
         stored.private_key_bundle || stored.private_jwk,
       );
@@ -224,14 +272,18 @@
     return null;
   }
 
-  async function restoreUnlockedChatKeyFromBundle(chatKey, privateKeyBundle) {
+  async function restoreUnlockedChatKeyFromBundle(
+    chatKey,
+    privateKeyBundle,
+    sourceDocument = document,
+  ) {
     unlockedChatPrivateKey = await importPrivateKey(
       privateKeyBundle.ecdh_private_jwk,
     );
     unlockedChatSigningPrivateKey = await importSigningPrivateKey(
       privateKeyBundle.signing_private_jwk,
     );
-    rememberUnlockedPrivateKeyBundle(privateKeyBundle, chatKey);
+    rememberUnlockedPrivateKeyBundle(privateKeyBundle, chatKey, sourceDocument);
     state.status = "unlocked";
     state.keyVersion = chatKey.key_version;
     state.lastError = null;
@@ -269,12 +321,14 @@
 
   function postChatKeyBroadcast(message) {
     const channel = chatKeyBroadcastChannel();
+    const sessionSecret = chatKeySessionSecret();
     if (!channel) {
       return false;
     }
     channel.postMessage({
       v: 1,
       source_tab_id: tabId,
+      session_secret: sessionSecret,
       ...message,
     });
     return true;
@@ -283,7 +337,8 @@
   function bindCrossTabChatKeySharing() {
     if (
       crossTabSharingBound ||
-      document.body?.dataset.authenticated !== "true"
+      document.body?.dataset.authenticated !== "true" ||
+      !chatKeySessionSecret()
     ) {
       return;
     }
@@ -298,6 +353,7 @@
       if (
         message.v !== 1 ||
         message.source_tab_id === tabId ||
+        message.session_secret !== chatKeySessionSecret() ||
         message.type !== "request-unlocked-chat-key" ||
         !message.request_id
       ) {
@@ -322,7 +378,8 @@
 
   async function restoreUnlockedChatKeyFromOtherTab(chatKey) {
     const channel = chatKeyBroadcastChannel();
-    if (!channel || !chatKey) {
+    const sessionSecret = chatKeySessionSecret();
+    if (!channel || !chatKey || !sessionSecret) {
       return false;
     }
 
@@ -341,10 +398,13 @@
         if (
           message.v !== 1 ||
           message.source_tab_id === tabId ||
+          message.session_secret !== sessionSecret ||
           message.type !== "unlocked-chat-key" ||
           message.request_id !== requestId ||
           message.chat_key?.key_version !== chatKey.key_version ||
           message.chat_key?.public_key !== chatKey.public_key ||
+          (message.chat_key?.public_signing_key || null) !==
+            (chatKey.public_signing_key || null) ||
           !message.private_key_bundle
         ) {
           return;
@@ -368,9 +428,11 @@
       postChatKeyBroadcast({
         type: "request-unlocked-chat-key",
         request_id: requestId,
+        session_secret: sessionSecret,
         chat_key: {
           key_version: chatKey.key_version,
           public_key: chatKey.public_key,
+          public_signing_key: chatKey.public_signing_key || null,
         },
       });
     });
@@ -389,7 +451,11 @@
     return null;
   }
 
-  async function unlockFromPassword(chatKey, password) {
+  async function unlockFromPassword(
+    chatKey,
+    password,
+    sourceDocument = document,
+  ) {
     if (!chatKey) {
       clearChatKeyMaterial();
       state.status = "no-key";
@@ -400,17 +466,11 @@
     let privateKeyBundle = null;
     try {
       privateKeyBundle = await decryptPrivateKeyBundle(chatKey, password);
-      unlockedChatPrivateKey = await importPrivateKey(
-        privateKeyBundle.ecdh_private_jwk,
+      return restoreUnlockedChatKeyFromBundle(
+        chatKey,
+        privateKeyBundle,
+        sourceDocument,
       );
-      unlockedChatSigningPrivateKey = await importSigningPrivateKey(
-        privateKeyBundle.signing_private_jwk,
-      );
-      rememberUnlockedPrivateKeyBundle(privateKeyBundle, chatKey);
-      state.status = "unlocked";
-      state.keyVersion = chatKey.key_version;
-      state.lastError = null;
-      return true;
     } catch (error) {
       clearChatKeyMaterial();
       state.status = "locked";
@@ -805,7 +865,11 @@
     if (!chatKey) {
       throw new Error("Created chat key was unavailable.");
     }
-    await restoreUnlockedChatKeyFromBundle(chatKey, created.privateKeyBundle);
+    await restoreUnlockedChatKeyFromBundle(
+      chatKey,
+      created.privateKeyBundle,
+      sourceDocument,
+    );
     return chatKey;
   }
 
@@ -816,7 +880,7 @@
     const chatKeyUrl = chatKeyUrlFromCurrentOrigin();
     const chatKey = await fetchChatKey(chatKeyUrl);
     if (chatKey) {
-      return unlockFromPassword(chatKey, password);
+      return unlockFromPassword(chatKey, password, sourceDocument);
     }
     await provisionChatKey(chatKeyUrl, password, sourceDocument);
     return true;
@@ -838,6 +902,7 @@
 
   function clearChatKeyMaterial() {
     forgetUnlockedPrivateJwk();
+    clearUnlockedKeyExpiryTimer();
     unlockedChatPrivateKey = null;
     unlockedChatSigningPrivateKey = null;
     state.status = "empty";
@@ -1556,9 +1621,24 @@
     }
   }
 
-  function bindLogoutCleanup() {
-    document.querySelectorAll("a[href$='/logout']").forEach((link) => {
-      link.addEventListener("click", clearChatKeyMaterial);
+  function bindChatKeyCleanupTriggers() {
+    if (document.documentElement.dataset.chatKeyCleanupBound === "true") {
+      return;
+    }
+    document.documentElement.dataset.chatKeyCleanupBound = "true";
+    document.addEventListener("click", (event) => {
+      const trigger = event.target?.closest?.(
+        "[data-clear-chat-key-material='true']",
+      );
+      if (trigger) {
+        clearChatKeyMaterial();
+      }
+    });
+    document.addEventListener("submit", (event) => {
+      const form = event.target;
+      if (form?.matches?.("[data-clear-chat-key-material='true']")) {
+        clearChatKeyMaterial();
+      }
     });
   }
 
@@ -1581,7 +1661,7 @@
     document
       .querySelector("form[action*='password-reset']")
       ?.addEventListener("submit", clearChatKeyMaterial);
-    bindLogoutCleanup();
+    bindChatKeyCleanupTriggers();
     bindConversation();
   }
 

--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -16,6 +16,8 @@
   let unlockedChatPrivateKey = null;
   let unlockedChatSigningPrivateKey = null;
   let unlockedChatKeyExpiryTimer = null;
+  let unlockedChatKeyExpiresAt = null;
+  let unlockedChatKeyLastUsedAt = null;
   let pendingLoginPassword = null;
   const state = {
     status: "empty",
@@ -71,8 +73,8 @@
     }
   }
 
-  function chatKeySessionSecret(sourceDocument = document) {
-    return sourceDocument.body?.dataset.chatKeySessionSecret || "";
+  function chatKeySessionId(sourceDocument = document) {
+    return sourceDocument.body?.dataset.chatKeySessionId || "";
   }
 
   function clearUnlockedKeyExpiryTimer() {
@@ -85,8 +87,12 @@
   function scheduleUnlockedKeyExpiry(expiresAt, lastUsedAt) {
     clearUnlockedKeyExpiryTimer();
     const now = Date.now();
-    const idleExpiresAt = Number(lastUsedAt) + unlockedKeyIdleTimeoutMs;
-    const nextExpiry = Math.min(Number(expiresAt), idleExpiresAt);
+    const normalizedExpiresAt = Number(expiresAt);
+    const normalizedLastUsedAt = Number(lastUsedAt);
+    unlockedChatKeyExpiresAt = normalizedExpiresAt;
+    unlockedChatKeyLastUsedAt = normalizedLastUsedAt;
+    const idleExpiresAt = normalizedLastUsedAt + unlockedKeyIdleTimeoutMs;
+    const nextExpiry = Math.min(normalizedExpiresAt, idleExpiresAt);
     if (!Number.isFinite(nextExpiry) || nextExpiry <= now) {
       clearChatKeyMaterial();
       return;
@@ -187,7 +193,7 @@
   ) {
     const now = Date.now();
     const expiresAt = now + unlockedKeyMaxAgeMs;
-    const sessionSecret = chatKeySessionSecret(sourceDocument);
+    const sessionId = chatKeySessionId(sourceDocument);
     const storedValue = JSON.stringify({
       key_version: chatKey.key_version,
       public_key: chatKey.public_key,
@@ -195,7 +201,7 @@
       private_key_bundle: privateKeyBundle,
       expires_at: expiresAt,
       last_used_at: now,
-      session_secret: sessionSecret,
+      session_id: sessionId,
     });
 
     scheduleUnlockedKeyExpiry(expiresAt, now);
@@ -238,7 +244,7 @@
         !Number.isFinite(expiresAt) ||
         expiresAt > now + unlockedKeyMaxAgeMs ||
         !Number.isFinite(lastUsedAt) ||
-        stored.session_secret !== chatKeySessionSecret()
+        stored.session_id !== chatKeySessionId()
       ) {
         return null;
       }
@@ -270,6 +276,45 @@
       return null;
     }
     return null;
+  }
+
+  function touchUnlockedChatKeyUse() {
+    if (!unlockedChatPrivateKey && !unlockedChatSigningPrivateKey) {
+      return false;
+    }
+
+    const now = Date.now();
+    if (
+      !Number.isFinite(unlockedChatKeyExpiresAt) ||
+      !Number.isFinite(unlockedChatKeyLastUsedAt) ||
+      now > unlockedChatKeyExpiresAt ||
+      now - unlockedChatKeyLastUsedAt > unlockedKeyIdleTimeoutMs
+    ) {
+      clearChatKeyMaterial();
+      return false;
+    }
+
+    try {
+      const stored = JSON.parse(
+        sessionStorage.getItem(sessionStorageKey) || "null",
+      );
+      if (stored) {
+        if (
+          Number(stored.expires_at) !== unlockedChatKeyExpiresAt ||
+          stored.session_id !== chatKeySessionId()
+        ) {
+          clearChatKeyMaterial();
+          return false;
+        }
+        stored.last_used_at = now;
+        sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
+      }
+    } catch (error) {
+      // The in-memory key remains bounded by its absolute expiry.
+    }
+
+    scheduleUnlockedKeyExpiry(unlockedChatKeyExpiresAt, now);
+    return true;
   }
 
   async function restoreUnlockedChatKeyFromBundle(
@@ -321,14 +366,14 @@
 
   function postChatKeyBroadcast(message) {
     const channel = chatKeyBroadcastChannel();
-    const sessionSecret = chatKeySessionSecret();
+    const sessionId = chatKeySessionId();
     if (!channel) {
       return false;
     }
     channel.postMessage({
       v: 1,
       source_tab_id: tabId,
-      session_secret: sessionSecret,
+      session_id: sessionId,
       ...message,
     });
     return true;
@@ -338,7 +383,7 @@
     if (
       crossTabSharingBound ||
       document.body?.dataset.authenticated !== "true" ||
-      !chatKeySessionSecret()
+      !chatKeySessionId()
     ) {
       return;
     }
@@ -353,7 +398,7 @@
       if (
         message.v !== 1 ||
         message.source_tab_id === tabId ||
-        message.session_secret !== chatKeySessionSecret() ||
+        message.session_id !== chatKeySessionId() ||
         message.type !== "request-unlocked-chat-key" ||
         !message.request_id
       ) {
@@ -378,8 +423,8 @@
 
   async function restoreUnlockedChatKeyFromOtherTab(chatKey) {
     const channel = chatKeyBroadcastChannel();
-    const sessionSecret = chatKeySessionSecret();
-    if (!channel || !chatKey || !sessionSecret) {
+    const sessionId = chatKeySessionId();
+    if (!channel || !chatKey || !sessionId) {
       return false;
     }
 
@@ -398,7 +443,7 @@
         if (
           message.v !== 1 ||
           message.source_tab_id === tabId ||
-          message.session_secret !== sessionSecret ||
+          message.session_id !== sessionId ||
           message.type !== "unlocked-chat-key" ||
           message.request_id !== requestId ||
           message.chat_key?.key_version !== chatKey.key_version ||
@@ -428,7 +473,7 @@
       postChatKeyBroadcast({
         type: "request-unlocked-chat-key",
         request_id: requestId,
-        session_secret: sessionSecret,
+        session_id: sessionId,
         chat_key: {
           key_version: chatKey.key_version,
           public_key: chatKey.public_key,
@@ -646,6 +691,9 @@
     if (!unlockedChatSigningPrivateKey) {
       return null;
     }
+    if (!touchUnlockedChatKeyUse()) {
+      return null;
+    }
     const signedPayload = {
       v: envelope.v,
       algorithm: envelope.algorithm,
@@ -771,6 +819,9 @@
     senderPublicSigningKey = null,
   ) {
     if (!unlockedChatPrivateKey) {
+      throw new Error("Chat key is locked.");
+    }
+    if (!touchUnlockedChatKeyUse()) {
       throw new Error("Chat key is locked.");
     }
     assertCryptoSupport();
@@ -901,13 +952,23 @@
   }
 
   function clearChatKeyMaterial() {
+    const hadUnlockedKey = Boolean(
+      unlockedChatPrivateKey ||
+        unlockedChatSigningPrivateKey ||
+        state.status === "unlocked",
+    );
     forgetUnlockedPrivateJwk();
     clearUnlockedKeyExpiryTimer();
     unlockedChatPrivateKey = null;
     unlockedChatSigningPrivateKey = null;
+    unlockedChatKeyExpiresAt = null;
+    unlockedChatKeyLastUsedAt = null;
     state.status = "empty";
     state.keyVersion = null;
     state.lastError = null;
+    if (hadUnlockedKey) {
+      updateConversationLockedAfterKeyClear();
+    }
   }
 
   function replaceDocument(responseText, responseUrl) {
@@ -961,6 +1022,20 @@
     if (badge) {
       badge.hidden = !visible;
     }
+  }
+
+  function updateConversationLockedAfterKeyClear() {
+    const root = document.getElementById("conversation-chat");
+    if (!root) {
+      return;
+    }
+
+    setConversationComposeEnabled(false);
+    setConversationUnlockVisible(true);
+    setConversationSecureBadgeVisible(false);
+    setConversationStatus(
+      "Chat key expired. Log out and log back in to unlock chat.",
+    );
   }
 
   function currentConversationParticipantId() {

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -11,7 +11,7 @@ from werkzeug.exceptions import HTTPException, InternalServerError
 from werkzeug.wrappers.response import Response
 
 from hushline import admin, premium, routes, settings, storage
-from hushline.auth import CHAT_KEY_SESSION_SECRET_SESSION_KEY, rotate_chat_key_session_secret
+from hushline.auth import CHAT_KEY_SESSION_ID_SESSION_KEY, rotate_chat_key_session_id
 from hushline.cli_encrypted_field import register_encrypted_field_commands
 from hushline.cli_password_hash import register_password_hash_commands
 from hushline.cli_reg import register_reg_commands
@@ -294,7 +294,7 @@ def configure_jinja(app: Flask) -> None:
             splash_screen_duration_ms=app.config.get(SPLASH_SCREEN_DURATION_MS, 2000),
             setup_incomplete=False,
             user=None,
-            chat_key_session_secret="",
+            chat_key_session_id="",
         )
         brand_primary_color = data.get(OrganizationSetting.BRAND_PRIMARY_COLOR, "#7d25c1")
         data["brand_primary_color_dark"] = _brand_dark_color(brand_primary_color)
@@ -304,11 +304,9 @@ def configure_jinja(app: Flask) -> None:
             data["user"] = user
             if user:
                 if session.get("is_authenticated", False):
-                    if not isinstance(session.get(CHAT_KEY_SESSION_SECRET_SESSION_KEY), str):
-                        rotate_chat_key_session_secret()
-                    data["chat_key_session_secret"] = session.get(
-                        CHAT_KEY_SESSION_SECRET_SESSION_KEY, ""
-                    )
+                    if not isinstance(session.get(CHAT_KEY_SESSION_ID_SESSION_KEY), str):
+                        rotate_chat_key_session_id()
+                    data["chat_key_session_id"] = session.get(CHAT_KEY_SESSION_ID_SESSION_KEY, "")
                 username = user.primary_username
                 data["setup_incomplete"] = bool(
                     not username

--- a/hushline/__init__.py
+++ b/hushline/__init__.py
@@ -11,6 +11,7 @@ from werkzeug.exceptions import HTTPException, InternalServerError
 from werkzeug.wrappers.response import Response
 
 from hushline import admin, premium, routes, settings, storage
+from hushline.auth import CHAT_KEY_SESSION_SECRET_SESSION_KEY, rotate_chat_key_session_secret
 from hushline.cli_encrypted_field import register_encrypted_field_commands
 from hushline.cli_password_hash import register_password_hash_commands
 from hushline.cli_reg import register_reg_commands
@@ -38,6 +39,10 @@ PERMISSIONS_POLICY = ", ".join(
         "interest-cohort=()",
     )
 )
+
+OPENPGP_WASM_SCRIPT_ENDPOINTS = frozenset(("embed_profile", "embed_profile_legacy", "profile"))
+JSDELIVR_SCRIPT_ENDPOINTS = frozenset(("vision",))
+STRIPE_SCRIPT_ENDPOINTS = frozenset(("premium.waiting",))
 
 
 def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
@@ -85,17 +90,24 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
             )
         style_sources = ["'self'", "'unsafe-inline'"]
         font_sources = ["'self'"]
-        script_sources = [
-            "'self'",
-            "https://js.stripe.com",
-            "https://cdn.jsdelivr.net",
-            "'wasm-unsafe-eval'",
-        ]
-        script_element_sources = [
-            "'self'",
-            "https://js.stripe.com",
-            "https://cdn.jsdelivr.net",
-        ]
+        endpoint = request.endpoint or ""
+        script_sources = ["'self'"]
+        script_element_sources = ["'self'"]
+        connect_sources = ["'self'", "data:"]
+        child_sources = ["'none'"]
+        frame_sources = ["'none'"]
+        if endpoint in JSDELIVR_SCRIPT_ENDPOINTS:
+            script_sources.append("https://cdn.jsdelivr.net")
+            script_element_sources.append("https://cdn.jsdelivr.net")
+            connect_sources.append("https://cdn.jsdelivr.net")
+        if endpoint in OPENPGP_WASM_SCRIPT_ENDPOINTS or endpoint in JSDELIVR_SCRIPT_ENDPOINTS:
+            script_sources.append("'wasm-unsafe-eval'")
+        if endpoint in STRIPE_SCRIPT_ENDPOINTS:
+            script_sources.append("https://js.stripe.com")
+            script_element_sources.append("https://js.stripe.com")
+            connect_sources.append("https://api.stripe.com")
+            child_sources = ["https://js.stripe.com"]
+            frame_sources = ["https://js.stripe.com"]
         form_action_sources = ["'self'"]
         if app.config.get("STRIPE_SECRET_KEY"):
             form_action_sources.extend(
@@ -122,9 +134,9 @@ def create_app(config: Optional[Mapping[str, Any]] = None) -> Flask:
                 "worker-src": "'self' blob:",
                 "frame-ancestors": frame_ancestors,
                 "form-action": " ".join(form_action_sources),
-                "connect-src": "'self' https://api.stripe.com https://cdn.jsdelivr.net data:",
-                "child-src": "https://js.stripe.com",
-                "frame-src": "https://js.stripe.com",
+                "connect-src": " ".join(connect_sources),
+                "child-src": " ".join(child_sources),
+                "frame-src": " ".join(frame_sources),
             }.items()
         )
         if frame_ancestors == "'none'":
@@ -282,6 +294,7 @@ def configure_jinja(app: Flask) -> None:
             splash_screen_duration_ms=app.config.get(SPLASH_SCREEN_DURATION_MS, 2000),
             setup_incomplete=False,
             user=None,
+            chat_key_session_secret="",
         )
         brand_primary_color = data.get(OrganizationSetting.BRAND_PRIMARY_COLOR, "#7d25c1")
         data["brand_primary_color_dark"] = _brand_dark_color(brand_primary_color)
@@ -290,6 +303,12 @@ def configure_jinja(app: Flask) -> None:
             user = db.session.get(User, session["user_id"])
             data["user"] = user
             if user:
+                if session.get("is_authenticated", False):
+                    if not isinstance(session.get(CHAT_KEY_SESSION_SECRET_SESSION_KEY), str):
+                        rotate_chat_key_session_secret()
+                    data["chat_key_session_secret"] = session.get(
+                        CHAT_KEY_SESSION_SECRET_SESSION_KEY, ""
+                    )
                 username = user.primary_username
                 data["setup_incomplete"] = bool(
                     not username

--- a/hushline/auth.py
+++ b/hushline/auth.py
@@ -1,3 +1,4 @@
+import secrets
 from functools import wraps
 from hmac import compare_digest
 from typing import Any, Callable
@@ -10,11 +11,13 @@ from hushline.model import User
 PENDING_PASSWORD_REHASH_SESSION_KEY = "pending_password_rehash"  # noqa: S105
 PENDING_PASSWORD_REHASH_SOURCE_DIGEST_SESSION_KEY = "pending_password_rehash_source_digest"  # noqa: S105
 POST_AUTH_REDIRECT_SESSION_KEY = "post_auth_redirect"
+CHAT_KEY_SESSION_SECRET_SESSION_KEY = "chat_key_session_secret"  # noqa: S105
 AUTH_SESSION_KEYS = (
     "user_id",
     "session_id",
     "username",
     "is_authenticated",
+    CHAT_KEY_SESSION_SECRET_SESSION_KEY,
     POST_AUTH_REDIRECT_SESSION_KEY,
     PENDING_PASSWORD_REHASH_SESSION_KEY,
     PENDING_PASSWORD_REHASH_SOURCE_DIGEST_SESSION_KEY,
@@ -31,12 +34,21 @@ def rotate_user_session_id(user: User) -> None:
     db.session.add(user)
 
 
+def rotate_chat_key_session_secret() -> str:
+    session[CHAT_KEY_SESSION_SECRET_SESSION_KEY] = secrets.token_urlsafe(32)
+    return str(session[CHAT_KEY_SESSION_SECRET_SESSION_KEY])
+
+
 def set_session_user(*, user: User, username: str, is_authenticated: bool) -> None:
     session.permanent = True
     session["user_id"] = user.id
     session["session_id"] = user.session_id
     session["username"] = username
     session["is_authenticated"] = is_authenticated
+    if is_authenticated:
+        rotate_chat_key_session_secret()
+    else:
+        session.pop(CHAT_KEY_SESSION_SECRET_SESSION_KEY, None)
 
 
 def stash_post_auth_redirect() -> None:

--- a/hushline/auth.py
+++ b/hushline/auth.py
@@ -11,13 +11,13 @@ from hushline.model import User
 PENDING_PASSWORD_REHASH_SESSION_KEY = "pending_password_rehash"  # noqa: S105
 PENDING_PASSWORD_REHASH_SOURCE_DIGEST_SESSION_KEY = "pending_password_rehash_source_digest"  # noqa: S105
 POST_AUTH_REDIRECT_SESSION_KEY = "post_auth_redirect"
-CHAT_KEY_SESSION_SECRET_SESSION_KEY = "chat_key_session_secret"  # noqa: S105
+CHAT_KEY_SESSION_ID_SESSION_KEY = "chat_key_session_id"
 AUTH_SESSION_KEYS = (
     "user_id",
     "session_id",
     "username",
     "is_authenticated",
-    CHAT_KEY_SESSION_SECRET_SESSION_KEY,
+    CHAT_KEY_SESSION_ID_SESSION_KEY,
     POST_AUTH_REDIRECT_SESSION_KEY,
     PENDING_PASSWORD_REHASH_SESSION_KEY,
     PENDING_PASSWORD_REHASH_SOURCE_DIGEST_SESSION_KEY,
@@ -34,9 +34,9 @@ def rotate_user_session_id(user: User) -> None:
     db.session.add(user)
 
 
-def rotate_chat_key_session_secret() -> str:
-    session[CHAT_KEY_SESSION_SECRET_SESSION_KEY] = secrets.token_urlsafe(32)
-    return str(session[CHAT_KEY_SESSION_SECRET_SESSION_KEY])
+def rotate_chat_key_session_id() -> str:
+    session[CHAT_KEY_SESSION_ID_SESSION_KEY] = secrets.token_urlsafe(32)
+    return str(session[CHAT_KEY_SESSION_ID_SESSION_KEY])
 
 
 def set_session_user(*, user: User, username: str, is_authenticated: bool) -> None:
@@ -46,9 +46,9 @@ def set_session_user(*, user: User, username: str, is_authenticated: bool) -> No
     session["username"] = username
     session["is_authenticated"] = is_authenticated
     if is_authenticated:
-        rotate_chat_key_session_secret()
+        rotate_chat_key_session_id()
     else:
-        session.pop(CHAT_KEY_SESSION_SECRET_SESSION_KEY, None)
+        session.pop(CHAT_KEY_SESSION_ID_SESSION_KEY, None)
 
 
 def stash_post_auth_redirect() -> None:

--- a/hushline/routes/auth.py
+++ b/hushline/routes/auth.py
@@ -28,6 +28,7 @@ from hushline.auth import (
     clear_auth_session,
     get_session_user,
     pop_post_auth_redirect,
+    rotate_chat_key_session_secret,
     rotate_user_session_id,
     set_session_user,
 )
@@ -648,6 +649,7 @@ def register_auth_routes(app: Flask) -> None:
                 rotate_user_session_id(user)
                 session["session_id"] = user.session_id
                 session["is_authenticated"] = True
+                rotate_chat_key_session_secret()
                 password_rehash_source_hash = user.password_hash
                 has_pending_password_rehash = PENDING_PASSWORD_REHASH_SESSION_KEY in session
                 try:

--- a/hushline/routes/auth.py
+++ b/hushline/routes/auth.py
@@ -28,7 +28,7 @@ from hushline.auth import (
     clear_auth_session,
     get_session_user,
     pop_post_auth_redirect,
-    rotate_chat_key_session_secret,
+    rotate_chat_key_session_id,
     rotate_user_session_id,
     set_session_user,
 )
@@ -649,7 +649,7 @@ def register_auth_routes(app: Flask) -> None:
                 rotate_user_session_id(user)
                 session["session_id"] = user.session_id
                 session["is_authenticated"] = True
-                rotate_chat_key_session_secret()
+                rotate_chat_key_session_id()
                 password_rehash_source_hash = user.password_hash
                 has_pending_password_rehash = PENDING_PASSWORD_REHASH_SESSION_KEY in session
                 try:

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -9,6 +9,8 @@
   const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";
   const crossTabChannelName = "hushline:chat-key-session";
   const crossTabRequestTimeoutMs = 750;
+  const unlockedKeyMaxAgeMs = 15 * 60 * 1000;
+  const unlockedKeyIdleTimeoutMs = 5 * 60 * 1000;
   const conversationPollMinIntervalMs = 3000;
   const tabId = window.crypto?.randomUUID
     ? window.crypto.randomUUID()
@@ -17,6 +19,7 @@
   let crossTabSharingBound = false;
   let unlockedChatPrivateKey = null;
   let unlockedChatSigningPrivateKey = null;
+  let unlockedChatKeyExpiryTimer = null;
   let pendingLoginPassword = null;
   const state = {
     status: "empty",
@@ -70,6 +73,32 @@
     if (!window.crypto?.subtle) {
       throw new Error("Web Crypto is unavailable.");
     }
+  }
+
+  function chatKeySessionSecret(sourceDocument = document) {
+    return sourceDocument.body?.dataset.chatKeySessionSecret || "";
+  }
+
+  function clearUnlockedKeyExpiryTimer() {
+    if (unlockedChatKeyExpiryTimer) {
+      window.clearTimeout(unlockedChatKeyExpiryTimer);
+      unlockedChatKeyExpiryTimer = null;
+    }
+  }
+
+  function scheduleUnlockedKeyExpiry(expiresAt, lastUsedAt) {
+    clearUnlockedKeyExpiryTimer();
+    const now = Date.now();
+    const idleExpiresAt = Number(lastUsedAt) + unlockedKeyIdleTimeoutMs;
+    const nextExpiry = Math.min(Number(expiresAt), idleExpiresAt);
+    if (!Number.isFinite(nextExpiry) || nextExpiry <= now) {
+      clearChatKeyMaterial();
+      return;
+    }
+    unlockedChatKeyExpiryTimer = window.setTimeout(
+      clearChatKeyMaterial,
+      nextExpiry - now,
+    );
   }
 
   async function deriveWrappingKey(password, salt, kdfParams, usages) {
@@ -155,15 +184,25 @@
     );
   }
 
-  function rememberUnlockedPrivateKeyBundle(privateKeyBundle, chatKey) {
+  function rememberUnlockedPrivateKeyBundle(
+    privateKeyBundle,
+    chatKey,
+    sourceDocument = document,
+  ) {
+    const now = Date.now();
+    const expiresAt = now + unlockedKeyMaxAgeMs;
+    const sessionSecret = chatKeySessionSecret(sourceDocument);
     const storedValue = JSON.stringify({
       key_version: chatKey.key_version,
       public_key: chatKey.public_key,
       public_signing_key: chatKey.public_signing_key || null,
       private_key_bundle: privateKeyBundle,
-      expires_at: Number.MAX_SAFE_INTEGER,
+      expires_at: expiresAt,
+      last_used_at: now,
+      session_secret: sessionSecret,
     });
 
+    scheduleUnlockedKeyExpiry(expiresAt, now);
     try {
       sessionStorage.setItem(sessionStorageKey, storedValue);
     } catch (error) {
@@ -191,20 +230,29 @@
 
     try {
       const stored = JSON.parse(storedValue);
+      const now = Date.now();
+      const expiresAt = Number(stored.expires_at);
+      const lastUsedAt = Number(stored.last_used_at);
       if (
         stored?.key_version !== chatKey.key_version ||
         stored.public_key !== chatKey.public_key ||
         (stored.public_signing_key || null) !==
           (chatKey.public_signing_key || null) ||
         !(stored.private_key_bundle || stored.private_jwk) ||
-        !stored.expires_at
+        !Number.isFinite(expiresAt) ||
+        expiresAt > now + unlockedKeyMaxAgeMs ||
+        !Number.isFinite(lastUsedAt) ||
+        stored.session_secret !== chatKeySessionSecret()
       ) {
         return null;
       }
-      if (Date.now() > Number(stored.expires_at)) {
+      if (now > expiresAt || now - lastUsedAt > unlockedKeyIdleTimeoutMs) {
         forgetUnlockedPrivateJwk();
         return null;
       }
+      stored.last_used_at = now;
+      sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
+      scheduleUnlockedKeyExpiry(expiresAt, now);
       return normalizePrivateKeyBundle(
         stored.private_key_bundle || stored.private_jwk,
       );
@@ -228,14 +276,18 @@
     return null;
   }
 
-  async function restoreUnlockedChatKeyFromBundle(chatKey, privateKeyBundle) {
+  async function restoreUnlockedChatKeyFromBundle(
+    chatKey,
+    privateKeyBundle,
+    sourceDocument = document,
+  ) {
     unlockedChatPrivateKey = await importPrivateKey(
       privateKeyBundle.ecdh_private_jwk,
     );
     unlockedChatSigningPrivateKey = await importSigningPrivateKey(
       privateKeyBundle.signing_private_jwk,
     );
-    rememberUnlockedPrivateKeyBundle(privateKeyBundle, chatKey);
+    rememberUnlockedPrivateKeyBundle(privateKeyBundle, chatKey, sourceDocument);
     state.status = "unlocked";
     state.keyVersion = chatKey.key_version;
     state.lastError = null;
@@ -273,12 +325,14 @@
 
   function postChatKeyBroadcast(message) {
     const channel = chatKeyBroadcastChannel();
+    const sessionSecret = chatKeySessionSecret();
     if (!channel) {
       return false;
     }
     channel.postMessage({
       v: 1,
       source_tab_id: tabId,
+      session_secret: sessionSecret,
       ...message,
     });
     return true;
@@ -287,7 +341,8 @@
   function bindCrossTabChatKeySharing() {
     if (
       crossTabSharingBound ||
-      document.body?.dataset.authenticated !== "true"
+      document.body?.dataset.authenticated !== "true" ||
+      !chatKeySessionSecret()
     ) {
       return;
     }
@@ -302,6 +357,7 @@
       if (
         message.v !== 1 ||
         message.source_tab_id === tabId ||
+        message.session_secret !== chatKeySessionSecret() ||
         message.type !== "request-unlocked-chat-key" ||
         !message.request_id
       ) {
@@ -326,7 +382,8 @@
 
   async function restoreUnlockedChatKeyFromOtherTab(chatKey) {
     const channel = chatKeyBroadcastChannel();
-    if (!channel || !chatKey) {
+    const sessionSecret = chatKeySessionSecret();
+    if (!channel || !chatKey || !sessionSecret) {
       return false;
     }
 
@@ -345,10 +402,13 @@
         if (
           message.v !== 1 ||
           message.source_tab_id === tabId ||
+          message.session_secret !== sessionSecret ||
           message.type !== "unlocked-chat-key" ||
           message.request_id !== requestId ||
           message.chat_key?.key_version !== chatKey.key_version ||
           message.chat_key?.public_key !== chatKey.public_key ||
+          (message.chat_key?.public_signing_key || null) !==
+            (chatKey.public_signing_key || null) ||
           !message.private_key_bundle
         ) {
           return;
@@ -372,9 +432,11 @@
       postChatKeyBroadcast({
         type: "request-unlocked-chat-key",
         request_id: requestId,
+        session_secret: sessionSecret,
         chat_key: {
           key_version: chatKey.key_version,
           public_key: chatKey.public_key,
+          public_signing_key: chatKey.public_signing_key || null,
         },
       });
     });
@@ -393,7 +455,11 @@
     return null;
   }
 
-  async function unlockFromPassword(chatKey, password) {
+  async function unlockFromPassword(
+    chatKey,
+    password,
+    sourceDocument = document,
+  ) {
     if (!chatKey) {
       clearChatKeyMaterial();
       state.status = "no-key";
@@ -404,17 +470,11 @@
     let privateKeyBundle = null;
     try {
       privateKeyBundle = await decryptPrivateKeyBundle(chatKey, password);
-      unlockedChatPrivateKey = await importPrivateKey(
-        privateKeyBundle.ecdh_private_jwk,
+      return restoreUnlockedChatKeyFromBundle(
+        chatKey,
+        privateKeyBundle,
+        sourceDocument,
       );
-      unlockedChatSigningPrivateKey = await importSigningPrivateKey(
-        privateKeyBundle.signing_private_jwk,
-      );
-      rememberUnlockedPrivateKeyBundle(privateKeyBundle, chatKey);
-      state.status = "unlocked";
-      state.keyVersion = chatKey.key_version;
-      state.lastError = null;
-      return true;
     } catch (error) {
       clearChatKeyMaterial();
       state.status = "locked";
@@ -809,7 +869,11 @@
     if (!chatKey) {
       throw new Error("Created chat key was unavailable.");
     }
-    await restoreUnlockedChatKeyFromBundle(chatKey, created.privateKeyBundle);
+    await restoreUnlockedChatKeyFromBundle(
+      chatKey,
+      created.privateKeyBundle,
+      sourceDocument,
+    );
     return chatKey;
   }
 
@@ -820,7 +884,7 @@
     const chatKeyUrl = chatKeyUrlFromCurrentOrigin();
     const chatKey = await fetchChatKey(chatKeyUrl);
     if (chatKey) {
-      return unlockFromPassword(chatKey, password);
+      return unlockFromPassword(chatKey, password, sourceDocument);
     }
     await provisionChatKey(chatKeyUrl, password, sourceDocument);
     return true;
@@ -842,6 +906,7 @@
 
   function clearChatKeyMaterial() {
     forgetUnlockedPrivateJwk();
+    clearUnlockedKeyExpiryTimer();
     unlockedChatPrivateKey = null;
     unlockedChatSigningPrivateKey = null;
     state.status = "empty";
@@ -1560,9 +1625,24 @@
     }
   }
 
-  function bindLogoutCleanup() {
-    document.querySelectorAll("a[href$='/logout']").forEach((link) => {
-      link.addEventListener("click", clearChatKeyMaterial);
+  function bindChatKeyCleanupTriggers() {
+    if (document.documentElement.dataset.chatKeyCleanupBound === "true") {
+      return;
+    }
+    document.documentElement.dataset.chatKeyCleanupBound = "true";
+    document.addEventListener("click", (event) => {
+      const trigger = event.target?.closest?.(
+        "[data-clear-chat-key-material='true']",
+      );
+      if (trigger) {
+        clearChatKeyMaterial();
+      }
+    });
+    document.addEventListener("submit", (event) => {
+      const form = event.target;
+      if (form?.matches?.("[data-clear-chat-key-material='true']")) {
+        clearChatKeyMaterial();
+      }
     });
   }
 
@@ -1585,7 +1665,7 @@
     document
       .querySelector("form[action*='password-reset']")
       ?.addEventListener("submit", clearChatKeyMaterial);
-    bindLogoutCleanup();
+    bindChatKeyCleanupTriggers();
     bindConversation();
   }
 

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -20,6 +20,8 @@
   let unlockedChatPrivateKey = null;
   let unlockedChatSigningPrivateKey = null;
   let unlockedChatKeyExpiryTimer = null;
+  let unlockedChatKeyExpiresAt = null;
+  let unlockedChatKeyLastUsedAt = null;
   let pendingLoginPassword = null;
   const state = {
     status: "empty",
@@ -75,8 +77,8 @@
     }
   }
 
-  function chatKeySessionSecret(sourceDocument = document) {
-    return sourceDocument.body?.dataset.chatKeySessionSecret || "";
+  function chatKeySessionId(sourceDocument = document) {
+    return sourceDocument.body?.dataset.chatKeySessionId || "";
   }
 
   function clearUnlockedKeyExpiryTimer() {
@@ -89,8 +91,12 @@
   function scheduleUnlockedKeyExpiry(expiresAt, lastUsedAt) {
     clearUnlockedKeyExpiryTimer();
     const now = Date.now();
-    const idleExpiresAt = Number(lastUsedAt) + unlockedKeyIdleTimeoutMs;
-    const nextExpiry = Math.min(Number(expiresAt), idleExpiresAt);
+    const normalizedExpiresAt = Number(expiresAt);
+    const normalizedLastUsedAt = Number(lastUsedAt);
+    unlockedChatKeyExpiresAt = normalizedExpiresAt;
+    unlockedChatKeyLastUsedAt = normalizedLastUsedAt;
+    const idleExpiresAt = normalizedLastUsedAt + unlockedKeyIdleTimeoutMs;
+    const nextExpiry = Math.min(normalizedExpiresAt, idleExpiresAt);
     if (!Number.isFinite(nextExpiry) || nextExpiry <= now) {
       clearChatKeyMaterial();
       return;
@@ -191,7 +197,7 @@
   ) {
     const now = Date.now();
     const expiresAt = now + unlockedKeyMaxAgeMs;
-    const sessionSecret = chatKeySessionSecret(sourceDocument);
+    const sessionId = chatKeySessionId(sourceDocument);
     const storedValue = JSON.stringify({
       key_version: chatKey.key_version,
       public_key: chatKey.public_key,
@@ -199,7 +205,7 @@
       private_key_bundle: privateKeyBundle,
       expires_at: expiresAt,
       last_used_at: now,
-      session_secret: sessionSecret,
+      session_id: sessionId,
     });
 
     scheduleUnlockedKeyExpiry(expiresAt, now);
@@ -242,7 +248,7 @@
         !Number.isFinite(expiresAt) ||
         expiresAt > now + unlockedKeyMaxAgeMs ||
         !Number.isFinite(lastUsedAt) ||
-        stored.session_secret !== chatKeySessionSecret()
+        stored.session_id !== chatKeySessionId()
       ) {
         return null;
       }
@@ -274,6 +280,45 @@
       return null;
     }
     return null;
+  }
+
+  function touchUnlockedChatKeyUse() {
+    if (!unlockedChatPrivateKey && !unlockedChatSigningPrivateKey) {
+      return false;
+    }
+
+    const now = Date.now();
+    if (
+      !Number.isFinite(unlockedChatKeyExpiresAt) ||
+      !Number.isFinite(unlockedChatKeyLastUsedAt) ||
+      now > unlockedChatKeyExpiresAt ||
+      now - unlockedChatKeyLastUsedAt > unlockedKeyIdleTimeoutMs
+    ) {
+      clearChatKeyMaterial();
+      return false;
+    }
+
+    try {
+      const stored = JSON.parse(
+        sessionStorage.getItem(sessionStorageKey) || "null",
+      );
+      if (stored) {
+        if (
+          Number(stored.expires_at) !== unlockedChatKeyExpiresAt ||
+          stored.session_id !== chatKeySessionId()
+        ) {
+          clearChatKeyMaterial();
+          return false;
+        }
+        stored.last_used_at = now;
+        sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
+      }
+    } catch (error) {
+      // The in-memory key remains bounded by its absolute expiry.
+    }
+
+    scheduleUnlockedKeyExpiry(unlockedChatKeyExpiresAt, now);
+    return true;
   }
 
   async function restoreUnlockedChatKeyFromBundle(
@@ -325,14 +370,14 @@
 
   function postChatKeyBroadcast(message) {
     const channel = chatKeyBroadcastChannel();
-    const sessionSecret = chatKeySessionSecret();
+    const sessionId = chatKeySessionId();
     if (!channel) {
       return false;
     }
     channel.postMessage({
       v: 1,
       source_tab_id: tabId,
-      session_secret: sessionSecret,
+      session_id: sessionId,
       ...message,
     });
     return true;
@@ -342,7 +387,7 @@
     if (
       crossTabSharingBound ||
       document.body?.dataset.authenticated !== "true" ||
-      !chatKeySessionSecret()
+      !chatKeySessionId()
     ) {
       return;
     }
@@ -357,7 +402,7 @@
       if (
         message.v !== 1 ||
         message.source_tab_id === tabId ||
-        message.session_secret !== chatKeySessionSecret() ||
+        message.session_id !== chatKeySessionId() ||
         message.type !== "request-unlocked-chat-key" ||
         !message.request_id
       ) {
@@ -382,8 +427,8 @@
 
   async function restoreUnlockedChatKeyFromOtherTab(chatKey) {
     const channel = chatKeyBroadcastChannel();
-    const sessionSecret = chatKeySessionSecret();
-    if (!channel || !chatKey || !sessionSecret) {
+    const sessionId = chatKeySessionId();
+    if (!channel || !chatKey || !sessionId) {
       return false;
     }
 
@@ -402,7 +447,7 @@
         if (
           message.v !== 1 ||
           message.source_tab_id === tabId ||
-          message.session_secret !== sessionSecret ||
+          message.session_id !== sessionId ||
           message.type !== "unlocked-chat-key" ||
           message.request_id !== requestId ||
           message.chat_key?.key_version !== chatKey.key_version ||
@@ -432,7 +477,7 @@
       postChatKeyBroadcast({
         type: "request-unlocked-chat-key",
         request_id: requestId,
-        session_secret: sessionSecret,
+        session_id: sessionId,
         chat_key: {
           key_version: chatKey.key_version,
           public_key: chatKey.public_key,
@@ -650,6 +695,9 @@
     if (!unlockedChatSigningPrivateKey) {
       return null;
     }
+    if (!touchUnlockedChatKeyUse()) {
+      return null;
+    }
     const signedPayload = {
       v: envelope.v,
       algorithm: envelope.algorithm,
@@ -775,6 +823,9 @@
     senderPublicSigningKey = null,
   ) {
     if (!unlockedChatPrivateKey) {
+      throw new Error("Chat key is locked.");
+    }
+    if (!touchUnlockedChatKeyUse()) {
       throw new Error("Chat key is locked.");
     }
     assertCryptoSupport();
@@ -905,13 +956,23 @@
   }
 
   function clearChatKeyMaterial() {
+    const hadUnlockedKey = Boolean(
+      unlockedChatPrivateKey ||
+        unlockedChatSigningPrivateKey ||
+        state.status === "unlocked",
+    );
     forgetUnlockedPrivateJwk();
     clearUnlockedKeyExpiryTimer();
     unlockedChatPrivateKey = null;
     unlockedChatSigningPrivateKey = null;
+    unlockedChatKeyExpiresAt = null;
+    unlockedChatKeyLastUsedAt = null;
     state.status = "empty";
     state.keyVersion = null;
     state.lastError = null;
+    if (hadUnlockedKey) {
+      updateConversationLockedAfterKeyClear();
+    }
   }
 
   function replaceDocument(responseText, responseUrl) {
@@ -965,6 +1026,20 @@
     if (badge) {
       badge.hidden = !visible;
     }
+  }
+
+  function updateConversationLockedAfterKeyClear() {
+    const root = document.getElementById("conversation-chat");
+    if (!root) {
+      return;
+    }
+
+    setConversationComposeEnabled(false);
+    setConversationUnlockVisible(true);
+    setConversationSecureBadgeVisible(false);
+    setConversationStatus(
+      "Chat key expired. Log out and log back in to unlock chat.",
+    );
   }
 
   function currentConversationParticipantId() {

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -1038,7 +1038,7 @@
     setConversationUnlockVisible(true);
     setConversationSecureBadgeVisible(false);
     setConversationStatus(
-      "Chat key expired. Log out and log back in to unlock chat.",
+      "Chat key expired for this browser session. Secure replies are paused.",
     );
   }
 

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -176,7 +176,7 @@
   <body
     class="{% block body_class %}{% endblock %}"
     data-authenticated="{{ 'true' if 'user_id' in session and session.get('is_authenticated', False) else 'false' }}"
-    data-chat-key-session-secret="{{ chat_key_session_secret }}"
+    data-chat-key-session-id="{{ chat_key_session_id }}"
   >
     {% if splash_screen_enabled %}
       <div

--- a/hushline/templates/base.html
+++ b/hushline/templates/base.html
@@ -176,6 +176,7 @@
   <body
     class="{% block body_class %}{% endblock %}"
     data-authenticated="{{ 'true' if 'user_id' in session and session.get('is_authenticated', False) else 'false' }}"
+    data-chat-key-session-secret="{{ chat_key_session_secret }}"
   >
     {% if splash_screen_enabled %}
       <div
@@ -306,7 +307,13 @@
                     <li>
                       <a href="{{ url_for('settings.profile') }}">Settings</a>
                     </li>
-                    <li><a href="{{ url_for('logout') }}">Logout</a></li>
+                    <li>
+                      <a
+                        href="{{ url_for('logout') }}"
+                        data-clear-chat-key-material="true"
+                        >Logout</a
+                      >
+                    </li>
                   </ul>
                 </div>
               </li>

--- a/hushline/templates/password_reset.html
+++ b/hushline/templates/password_reset.html
@@ -3,7 +3,11 @@
 
 {% block content %}
   <h2>Set New Password</h2>
-  <form method="POST" data-submit-spinner="true">
+  <form
+    method="POST"
+    data-submit-spinner="true"
+    data-clear-chat-key-material="true"
+  >
     {{ form.hidden_tag() }}
     <div>
       {{ form.password.label(for="password") }}

--- a/hushline/templates/password_reset_request.html
+++ b/hushline/templates/password_reset_request.html
@@ -7,7 +7,12 @@
     Password reset email delivery is unavailable until Hush Line supports verified recovery
     addresses. Hush Line does not require an email address to use an account.
   </p>
-  <form method="POST" action="{{ url_for('request_password_reset') }}" data-submit-spinner="true">
+  <form
+    method="POST"
+    action="{{ url_for('request_password_reset') }}"
+    data-submit-spinner="true"
+    data-clear-chat-key-material="true"
+  >
     {{ form.hidden_tag() }}
     <div>
       {{ form.username.label(for="username") }}

--- a/hushline/templates/settings/advanced.html
+++ b/hushline/templates/settings/advanced.html
@@ -39,6 +39,7 @@
     method="POST"
     action="{{ url_for('settings.delete_account') }}"
     class="formBody"
+    data-clear-chat-key-material="true"
   >
     <button type="submit" class="btn-danger" id="deleteAccountButton">
       Delete Account

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -182,13 +182,35 @@ def test_settings_chat_key_provisioning_generates_decryptable_ecdh_key() -> None
 
 def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session() -> None:
     js = (ROOT / "assets/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
+    base_template = (ROOT / "hushline/templates/base.html").read_text(encoding="utf-8")
     login_template = (ROOT / "hushline/templates/login.html").read_text(encoding="utf-8")
+    password_reset_template = (ROOT / "hushline/templates/password_reset.html").read_text(
+        encoding="utf-8"
+    )
+    password_reset_request_template = (
+        ROOT / "hushline/templates/password_reset_request.html"
+    ).read_text(encoding="utf-8")
+    advanced_template = (ROOT / "hushline/templates/settings/advanced.html").read_text(
+        encoding="utf-8"
+    )
 
     assert 'const sessionStorageKey = "hushline:chat-private-jwk";' in js
     assert 'const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";' in js
     assert "browserStorageMaxAgeMs" not in js
+    assert "const unlockedKeyMaxAgeMs = 15 * 60 * 1000;" in js
+    assert "const unlockedKeyIdleTimeoutMs = 5 * 60 * 1000;" in js
+    assert "expires_at: expiresAt" in js
+    assert "last_used_at: now" in js
+    assert "scheduleUnlockedKeyExpiry(expiresAt, now);" in js
+    assert "now - lastUsedAt > unlockedKeyIdleTimeoutMs" in js
+    assert "expiresAt > now + unlockedKeyMaxAgeMs" in js
     assert 'const crossTabChannelName = "hushline:chat-key-session";' in js
     assert "new BroadcastChannel(crossTabChannelName)" in js
+    assert "function chatKeySessionSecret(sourceDocument = document)" in js
+    assert "message.session_secret !== chatKeySessionSecret()" in js
+    assert "message.session_secret !== sessionSecret" in js
+    assert "session_secret: sessionSecret" in js
+    assert "stored.session_secret !== chatKeySessionSecret()" in js
     assert "sessionStorage.setItem(" in js
     assert "sessionStorage.getItem(sessionStorageKey)" in js
     assert "sessionStorage.removeItem(sessionStorageKey)" in js
@@ -212,6 +234,12 @@ def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session(
     assert "request-unlocked-chat-key" in js
     assert "unlocked-chat-key" in js
     assert "pendingLoginPassword = null;" in js
+    assert 'data-chat-key-session-secret="{{ chat_key_session_secret }}"' in base_template
+    assert 'data-clear-chat-key-material="true"' in base_template
+    assert 'data-clear-chat-key-material="true"' in password_reset_template
+    assert 'data-clear-chat-key-material="true"' in password_reset_request_template
+    assert 'data-clear-chat-key-material="true"' in advanced_template
+    assert "function bindChatKeyCleanupTriggers()" in js
 
 
 def test_conversation_does_not_prompt_for_password_after_login() -> None:

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -206,11 +206,11 @@ def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session(
     assert "expiresAt > now + unlockedKeyMaxAgeMs" in js
     assert 'const crossTabChannelName = "hushline:chat-key-session";' in js
     assert "new BroadcastChannel(crossTabChannelName)" in js
-    assert "function chatKeySessionSecret(sourceDocument = document)" in js
-    assert "message.session_secret !== chatKeySessionSecret()" in js
-    assert "message.session_secret !== sessionSecret" in js
-    assert "session_secret: sessionSecret" in js
-    assert "stored.session_secret !== chatKeySessionSecret()" in js
+    assert "function chatKeySessionId(sourceDocument = document)" in js
+    assert "message.session_id !== chatKeySessionId()" in js
+    assert "message.session_id !== sessionId" in js
+    assert "session_id: sessionId" in js
+    assert "stored.session_id !== chatKeySessionId()" in js
     assert "sessionStorage.setItem(" in js
     assert "sessionStorage.getItem(sessionStorageKey)" in js
     assert "sessionStorage.removeItem(sessionStorageKey)" in js
@@ -220,6 +220,10 @@ def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session(
     assert "restoreConversationFromSession" in js
     assert "restoreUnlockedChatKeyFromOtherTab" in js
     assert "async function signingPrivateKeyForChatKey(chatKey)" in js
+    assert "function touchUnlockedChatKeyUse()" in js
+    assert "if (!touchUnlockedChatKeyUse())" in js
+    assert "function updateConversationLockedAfterKeyClear()" in js
+    assert "setConversationComposeEnabled(false);" in js
     assert "function setConversationSecureBadgeVisible(visible)" in js
     assert "setConversationSecureBadgeVisible(true);" in js
     assert "setConversationSecureBadgeVisible(false);" in js
@@ -234,7 +238,7 @@ def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session(
     assert "request-unlocked-chat-key" in js
     assert "unlocked-chat-key" in js
     assert "pendingLoginPassword = null;" in js
-    assert 'data-chat-key-session-secret="{{ chat_key_session_secret }}"' in base_template
+    assert 'data-chat-key-session-id="{{ chat_key_session_id }}"' in base_template
     assert 'data-clear-chat-key-material="true"' in base_template
     assert 'data-clear-chat-key-material="true"' in password_reset_template
     assert 'data-clear-chat-key-material="true"' in password_reset_request_template

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -13,7 +13,7 @@ from werkzeug.security import generate_password_hash
 
 from hushline.auth import (
     AUTH_SESSION_KEYS,
-    CHAT_KEY_SESSION_SECRET_SESSION_KEY,
+    CHAT_KEY_SESSION_ID_SESSION_KEY,
     PENDING_PASSWORD_REHASH_SESSION_KEY,
     PENDING_PASSWORD_REHASH_SOURCE_DIGEST_SESSION_KEY,
     POST_AUTH_REDIRECT_SESSION_KEY,
@@ -334,8 +334,8 @@ def test_login_redirects_to_original_protected_page(
 
     with client.session_transaction() as sess:
         assert POST_AUTH_REDIRECT_SESSION_KEY not in sess
-        assert isinstance(sess[CHAT_KEY_SESSION_SECRET_SESSION_KEY], str)
-        assert sess[CHAT_KEY_SESSION_SECRET_SESSION_KEY]
+        assert isinstance(sess[CHAT_KEY_SESSION_ID_SESSION_KEY], str)
+        assert sess[CHAT_KEY_SESSION_ID_SESSION_KEY]
 
 
 def test_login_password_step_for_2fa_does_not_revoke_existing_sessions(
@@ -415,7 +415,7 @@ def test_login_with_chat_key_payload_waits_for_successful_2fa(
     assert response.headers["Location"].endswith(url_for("verify_2fa_login"))
     assert db.session.scalars(db.select(ChatKey).filter_by(user_id=user.id)).all() == []
     with client.session_transaction() as sess:
-        assert CHAT_KEY_SESSION_SECRET_SESSION_KEY not in sess
+        assert CHAT_KEY_SESSION_ID_SESSION_KEY not in sess
 
     response = client.post(
         url_for("verify_2fa_login"),
@@ -425,8 +425,8 @@ def test_login_with_chat_key_payload_waits_for_successful_2fa(
 
     assert response.status_code == 302
     with client.session_transaction() as sess:
-        assert isinstance(sess[CHAT_KEY_SESSION_SECRET_SESSION_KEY], str)
-        assert sess[CHAT_KEY_SESSION_SECRET_SESSION_KEY]
+        assert isinstance(sess[CHAT_KEY_SESSION_ID_SESSION_KEY], str)
+        assert sess[CHAT_KEY_SESSION_ID_SESSION_KEY]
     created_key = db.session.scalars(db.select(ChatKey).filter_by(user_id=user.id)).one()
     assert created_key.key_version == 1
     assert created_key.disabled_at is None

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -13,6 +13,7 @@ from werkzeug.security import generate_password_hash
 
 from hushline.auth import (
     AUTH_SESSION_KEYS,
+    CHAT_KEY_SESSION_SECRET_SESSION_KEY,
     PENDING_PASSWORD_REHASH_SESSION_KEY,
     PENDING_PASSWORD_REHASH_SOURCE_DIGEST_SESSION_KEY,
     POST_AUTH_REDIRECT_SESSION_KEY,
@@ -333,6 +334,8 @@ def test_login_redirects_to_original_protected_page(
 
     with client.session_transaction() as sess:
         assert POST_AUTH_REDIRECT_SESSION_KEY not in sess
+        assert isinstance(sess[CHAT_KEY_SESSION_SECRET_SESSION_KEY], str)
+        assert sess[CHAT_KEY_SESSION_SECRET_SESSION_KEY]
 
 
 def test_login_password_step_for_2fa_does_not_revoke_existing_sessions(
@@ -411,6 +414,8 @@ def test_login_with_chat_key_payload_waits_for_successful_2fa(
     assert response.status_code == 302
     assert response.headers["Location"].endswith(url_for("verify_2fa_login"))
     assert db.session.scalars(db.select(ChatKey).filter_by(user_id=user.id)).all() == []
+    with client.session_transaction() as sess:
+        assert CHAT_KEY_SESSION_SECRET_SESSION_KEY not in sess
 
     response = client.post(
         url_for("verify_2fa_login"),
@@ -419,6 +424,9 @@ def test_login_with_chat_key_payload_waits_for_successful_2fa(
     )
 
     assert response.status_code == 302
+    with client.session_transaction() as sess:
+        assert isinstance(sess[CHAT_KEY_SESSION_SECRET_SESSION_KEY], str)
+        assert sess[CHAT_KEY_SESSION_SECRET_SESSION_KEY]
     created_key = db.session.scalars(db.select(ChatKey).filter_by(user_id=user.id)).one()
     assert created_key.key_version == 1
     assert created_key.disabled_at is None

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -66,9 +66,12 @@ def test_csp_form_action_omits_stripe_redirect_hosts_when_premium_disabled(
 def test_csp_script_src_elem_disallows_inline_scripts(client: FlaskClient) -> None:
     response = client.get(url_for("directory"), follow_redirects=True)
     assert response.status_code == 200
-    csp = response.headers["Content-Security-Policy"]
-    assert "script-src-elem 'self' https://js.stripe.com https://cdn.jsdelivr.net" in csp
-    assert "script-src-elem 'self' 'unsafe-inline'" not in csp
+    directives = _csp_directives(response.headers)
+    assert directives["script-src"] == "'self'"
+    assert directives["script-src-elem"] == "'self'"
+    assert (
+        "script-src-elem 'self' 'unsafe-inline'" not in response.headers["Content-Security-Policy"]
+    )
 
 
 def test_custom_splash_logo_keeps_csp_enforced(client: FlaskClient) -> None:
@@ -102,10 +105,15 @@ def test_profile_page_keeps_csp_enforced(client: FlaskClient, user: User) -> Non
     response = client.get(url_for("profile", username=user.primary_username.username))
     assert response.status_code == 200
 
-    csp = (response.headers.get("Content-Security-Policy") or "").strip()
-    assert csp
-    assert "'unsafe-eval'" not in csp
-    assert "script-src-elem 'self' 'unsafe-inline'" not in csp
+    directives = _csp_directives(response.headers)
+    assert directives["script-src"] == "'self' 'wasm-unsafe-eval'"
+    assert directives["script-src-elem"] == "'self'"
+    assert "https://js.stripe.com" not in response.headers["Content-Security-Policy"]
+    assert "https://cdn.jsdelivr.net" not in response.headers["Content-Security-Policy"]
+    assert "'unsafe-eval'" not in response.headers["Content-Security-Policy"]
+    assert (
+        "script-src-elem 'self' 'unsafe-inline'" not in response.headers["Content-Security-Policy"]
+    )
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -114,8 +122,25 @@ def test_settings_profile_keeps_frame_restrictions(client: FlaskClient) -> None:
     assert response.status_code == 200
 
     csp = (response.headers.get("Content-Security-Policy") or "").strip()
+    directives = _csp_directives(response.headers)
     assert "frame-ancestors 'none'" in csp
+    assert directives["script-src"] == "'self'"
+    assert directives["script-src-elem"] == "'self'"
+    assert "https://js.stripe.com" not in csp
+    assert "https://cdn.jsdelivr.net" not in csp
+    assert "'wasm-unsafe-eval'" not in csp
     assert response.headers["X-Frame-Options"] == "DENY"
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_vision_page_allows_jsdelivr_only_for_tooling(client: FlaskClient) -> None:
+    response = client.get(url_for("vision"))
+    assert response.status_code == 200
+
+    directives = _csp_directives(response.headers)
+    assert directives["script-src"] == ("'self' https://cdn.jsdelivr.net 'wasm-unsafe-eval'")
+    assert directives["script-src-elem"] == "'self' https://cdn.jsdelivr.net"
+    assert "https://js.stripe.com" not in response.headers["Content-Security-Policy"]
 
 
 def test_embed_profile_uses_allowed_origins_for_frames_and_sandboxed_assets(
@@ -143,13 +168,8 @@ def test_embed_profile_uses_allowed_origins_for_frames_and_sandboxed_assets(
     )
     assert directives["style-src"] == "'self' 'unsafe-inline' https://tips.hushline.app"
     assert directives["font-src"] == "'self' https://tips.hushline.app"
-    assert directives["script-src"] == (
-        "'self' https://js.stripe.com https://cdn.jsdelivr.net "
-        "'wasm-unsafe-eval' https://tips.hushline.app"
-    )
-    assert directives["script-src-elem"] == (
-        "'self' https://js.stripe.com https://cdn.jsdelivr.net https://tips.hushline.app"
-    )
+    assert directives["script-src"] == ("'self' 'wasm-unsafe-eval' https://tips.hushline.app")
+    assert directives["script-src-elem"] == "'self' https://tips.hushline.app"
     assert "X-Frame-Options" not in response.headers
 
 
@@ -162,9 +182,8 @@ def test_non_embed_csp_does_not_add_canonical_asset_origin(client: FlaskClient, 
     directives = _csp_directives(response.headers)
     assert directives["style-src"] == "'self' 'unsafe-inline'"
     assert directives["font-src"] == "'self'"
-    assert directives["script-src-elem"] == (
-        "'self' https://js.stripe.com https://cdn.jsdelivr.net"
-    )
+    assert directives["script-src"] == "'self'"
+    assert directives["script-src-elem"] == "'self'"
 
 
 def test_denied_embed_csp_does_not_add_canonical_asset_origin(
@@ -179,9 +198,8 @@ def test_denied_embed_csp_does_not_add_canonical_asset_origin(
     assert directives["frame-ancestors"] == "'none'"
     assert directives["style-src"] == "'self' 'unsafe-inline'"
     assert directives["font-src"] == "'self'"
-    assert directives["script-src-elem"] == (
-        "'self' https://js.stripe.com https://cdn.jsdelivr.net"
-    )
+    assert directives["script-src"] == "'self' 'wasm-unsafe-eval'"
+    assert directives["script-src-elem"] == "'self'"
     assert response.headers["X-Frame-Options"] == "DENY"
 
 
@@ -244,10 +262,11 @@ def test_conversation_page_keeps_csp_enforced(client: FlaskClient, user: User, u
 
     assert response.status_code == 200
     directives = _csp_directives(response.headers)
+    assert directives["script-src"] == "'self'"
+    assert directives["script-src-elem"] == "'self'"
     assert "'unsafe-eval'" not in response.headers["Content-Security-Policy"]
-    assert directives["script-src-elem"] == (
-        "'self' https://js.stripe.com https://cdn.jsdelivr.net"
-    )
+    assert "https://js.stripe.com" not in response.headers["Content-Security-Policy"]
+    assert "https://cdn.jsdelivr.net" not in response.headers["Content-Security-Policy"]
     assert (
         "script-src-elem 'self' 'unsafe-inline'" not in response.headers["Content-Security-Policy"]
     )


### PR DESCRIPTION
## Summary

Closes #2259.

This hardens browser-side chat key handling and narrows CSP exposure for the E2EE chat launch path.

## What Changed

- Added per-authenticated-session chat key session secrets and exposed only the current authenticated session secret to the frontend.
- Bound remembered unlocked chat private key bundles to that session secret, added a 15 minute absolute expiry and 5 minute idle expiry, and cleared in-memory keys on timer expiry.
- Required BroadcastChannel chat key sharing requests/responses to carry the matching session secret and full chat key identity, including signing key identity.
- Added explicit browser key cleanup markers for logout, password reset request/reset, and account deletion flows.
- Narrowed CSP so default, settings, and conversation routes no longer receive Stripe/jsdelivr script sources or `wasm-unsafe-eval`; profile/embed keep the local OpenPGP wasm allowance; Vision keeps jsdelivr only for the OCR tool; Stripe script/frame/connect sources are limited to the Stripe waiting route.

## Threat / Risk Summary

Unlocked chat private key bundles previously remained in `sessionStorage` for the tab lifetime and could be shared to any same-origin authenticated tab via BroadcastChannel. Global CSP also allowed third-party script origins and `wasm-unsafe-eval` across routes that did not need them. This PR reduces the browser exposure window, binds cross-tab sharing to the authenticated session, clears key material on account lifecycle exits, and reduces script execution sources on chat/settings routes.

## Affected Data Paths

- Browser chat key lifecycle and cross-tab unlock flow: `assets/js/chat-key-lifecycle.js`, `hushline/static/js/chat-key-lifecycle.js`
- Authenticated session metadata: `hushline/auth.py`, `hushline/routes/auth.py`, `hushline/templates/base.html`
- Account lifecycle cleanup paths: logout, password reset, account deletion templates
- CSP generation and route-level security headers: `hushline/__init__.py`

## Validation

- `npx webpack --config webpack.config.js --env WEBPACK_WATCH=1` (rebuilt static chat lifecycle bundle; Sass legacy API deprecation warning only)
- `make lint CMD="docker compose -p hushline2259 -f docker-compose.yaml -f docker-compose.codex-noports.yml run --rm app"`
- `make test CMD="docker compose -p hushline2259 -f docker-compose.yaml -f docker-compose.codex-noports.yml run --rm app"` (2112 passed, 1 deselected, 1 xfailed)
- `make audit-python CMD="docker compose -p hushline2259 -f docker-compose.yaml -f docker-compose.codex-noports.yml run --rm app"` (no known vulnerabilities found)
- `make audit-node-runtime CMD="docker compose -p hushline2259 -f docker-compose.yaml -f docker-compose.codex-noports.yml run --rm app"` (0 vulnerabilities)

The `docker-compose.codex-noports.yml` override was a temporary local-only test helper to avoid host port conflicts with other local Hush Line stacks and is not included in this PR.

## Manual Testing

Not applicable beyond automated route/render/security coverage; this change is lifecycle/CSP hardening without a new user-visible workflow.

## Known Risks / Follow-ups

- Short key retention windows may require users to re-authenticate chat keys more often after idle tabs. This is intentional for the security boundary in #2259.
- No CSP broadening is introduced for conversation/settings routes; route-specific allowances are covered by tests.