### PR TITLE
Add browser coverage for conversation presence CSRF

### DIFF
--- a/tests/playwright/e2ee/client-side-encryption.spec.js
+++ b/tests/playwright/e2ee/client-side-encryption.spec.js
@@ -100,6 +100,14 @@ async function openUnlockedConversation(page, url, plaintext) {
   await expectConversationMessage(page, plaintext);
 }
 
+function waitForPresenceHeartbeat(page, conversationPublicId) {
+  return page.waitForResponse(
+    (response) =>
+      response.request().method() === "POST" &&
+      response.url().endsWith(`/conversation/${conversationPublicId}/presence`),
+  );
+}
+
 async function postJsonFromPage(page, url, csrfToken, payload) {
   return page.evaluate(
     async ({ requestUrl, requestCsrfToken, requestPayload }) => {
@@ -318,10 +326,22 @@ test("logged-in account conversation stays encrypted through browser lifecycle",
     expect(conversationUrl).toContain(`/conversation/${conversationPublicId}`);
 
     await login(recipientPage, "newman");
+    const recipientPresenceResponsePromise = waitForPresenceHeartbeat(
+      recipientPage,
+      conversationPublicId,
+    );
     await openUnlockedConversation(
       recipientPage,
       conversationUrl,
       sentPlaintext,
+    );
+    const recipientPresenceResponse = await recipientPresenceResponsePromise;
+    const renderedPresenceCsrfToken = await recipientPage
+      .locator("#conversation-chat")
+      .evaluate((element) => element.dataset.csrfToken);
+    expect(recipientPresenceResponse.status()).toBe(200);
+    expect(recipientPresenceResponse.request().headers()["x-csrftoken"]).toBe(
+      renderedPresenceCsrfToken,
     );
 
     const replyRequestPromise = recipientPage.waitForRequest(
@@ -342,6 +362,7 @@ test("logged-in account conversation stays encrypted through browser lifecycle",
       .locator("#conversation-chat")
       .evaluate((element) => ({
         messageUrl: element.dataset.messageUrl,
+        presenceUrl: element.dataset.presenceUrl,
         participantId: element.dataset.participantId,
       }));
     const csrfToken = await recipientPage
@@ -400,6 +421,15 @@ test("logged-in account conversation stays encrypted through browser lifecycle",
     );
     expect(malformedResponse.status).toBe(400);
     expectNoPlaintext(malformedResponse.text, sensitiveValues);
+
+    const invalidPresenceResponse = await postJsonFromPage(
+      recipientPage,
+      rootData.presenceUrl,
+      "invalid-presence-csrf-token",
+      {},
+    );
+    expect(invalidPresenceResponse.status).toBe(400);
+    expect(invalidPresenceResponse.text).toContain("Invalid CSRF token.");
 
     const tamperedCopies = JSON.parse(
       JSON.stringify(replyPayload.encrypted_copies),


### PR DESCRIPTION
## What changed

- Added Playwright E2EE coverage that waits for the fresh conversation page presence heartbeat and verifies it returns `200`.
- Asserted the heartbeat request sends the rendered `#conversation-chat` CSRF token in `X-CSRFToken`.
- Added a browser-level negative check that an invalid presence CSRF token still returns `400` with the existing CSRF error.

## Why

Issue #2262 tracked repeated local `POST /conversation/<public_id>/presence` `400` responses observed during E2EE validation. Existing server and template coverage already indicated the fresh page path renders and accepts the correct CSRF token. This PR adds browser reproduction coverage to lock that behavior in.

## Security and privacy

Affected data path: authenticated conversation presence heartbeat at `/conversation/<public_id>/presence`.

Risk: presence heartbeats are low-content metadata, but weakening CSRF on this endpoint would broaden cross-site state mutation risk for conversation activity state. The test keeps the protection intact by proving fresh browser requests use the rendered CSRF token and malformed tokens remain rejected.

No production behavior changes are included. If the original 400s recur outside this fresh-page path, the remaining likely cause is stale tabs, session/token rotation, or cached assets sending an obsolete token. This PR does not suppress logging because the fresh CSRF path is healthy and the endpoint should continue to reject invalid tokens.

## Validation

- `env PLAYWRIGHT_BASE_URL=http://127.0.0.1:8080 npm run playwright:e2ee` - passed, 2 tests
- `env COMPOSE_FILE=docker-compose.yaml:/private/tmp/hushline-2260-no-db-ports.yaml COMPOSE_PROJECT_NAME=hushline-2262 make lint` - passed
- `env COMPOSE_FILE=docker-compose.yaml:/private/tmp/hushline-2260-no-db-ports.yaml COMPOSE_PROJECT_NAME=hushline-2262 make test` - passed, 2112 passed, 1 deselected, 1 xfailed
- `env COMPOSE_FILE=docker-compose.yaml:/private/tmp/hushline-2260-no-db-ports.yaml COMPOSE_PROJECT_NAME=hushline-2262 make audit-python` - passed, no known vulnerabilities
- `env COMPOSE_FILE=docker-compose.yaml:/private/tmp/hushline-2260-no-db-ports.yaml COMPOSE_PROJECT_NAME=hushline-2262 make audit-node-runtime` - passed, 0 vulnerabilities

## Manual testing

Automated browser reproduction was used for the fresh authenticated conversation page. No manual UI changes were made.

Closes #2262