### PR TITLE
Defer initial conversation nonce storage until submit

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -283,7 +283,7 @@ def register_profile_routes(app: Flask) -> None:
     def _initial_conversation_nonce_hash(nonce: str) -> str:
         return sha256(f"hushline:initial-conversation:{nonce}".encode()).hexdigest()
 
-    def _remember_initial_conversation_nonce(nonce: str, sender: User, recipient: User) -> None:
+    def _remember_initial_conversation_nonce(nonce: str, sender: User, recipient: User) -> bool:
         db.session.add(
             InitialConversationNonce(
                 nonce_hash=_initial_conversation_nonce_hash(nonce),
@@ -292,9 +292,11 @@ def register_profile_routes(app: Flask) -> None:
             )
         )
         try:
-            db.session.commit()
+            db.session.flush()
         except IntegrityError:
             db.session.rollback()
+            return False
+        return True
 
     def _initial_conversation_nonce_is_known(nonce: str, sender: User, recipient: User) -> bool:
         nonce_id = db.session.scalar(
@@ -375,8 +377,11 @@ def register_profile_routes(app: Flask) -> None:
         recipient: User,
         encrypted_conversation_copies: dict[str, str],
         initial_conversation_nonce: str,
+        require_known_nonce: bool = True,
     ) -> bool:
-        if not initial_conversation_nonce or not _initial_conversation_nonce_is_known(
+        if not initial_conversation_nonce:
+            return False
+        if require_known_nonce and not _initial_conversation_nonce_is_known(
             initial_conversation_nonce,
             sender,
             recipient,
@@ -409,6 +414,7 @@ def register_profile_routes(app: Flask) -> None:
         recipient: User,
         encrypted_conversation_copies: dict[str, str],
         initial_conversation_nonce: str,
+        require_known_nonce: bool = True,
     ) -> bool:
         if sender is None or sender.id == recipient.id or not recipient.chat_public_key:
             return False
@@ -417,6 +423,7 @@ def register_profile_routes(app: Flask) -> None:
             recipient=recipient,
             encrypted_conversation_copies=encrypted_conversation_copies,
             initial_conversation_nonce=initial_conversation_nonce,
+            require_known_nonce=require_known_nonce,
         )
 
     def _message_submission_block_reason(
@@ -541,12 +548,6 @@ def register_profile_routes(app: Flask) -> None:
                 if sender is not None and sender.id != uname.user_id
                 else None
             )
-            if (
-                not is_embedded
-                and sender is not None
-                and _chat_submission_base_available(uname, sender)
-            ):
-                _remember_initial_conversation_nonce(owner_guard_nonce, sender, uname.user)
             rendered = render_template(
                 "embed_profile.html" if is_embedded else "profile.html",
                 profile_header=profile_header,
@@ -672,7 +673,15 @@ def register_profile_routes(app: Flask) -> None:
                     recipient=uname.user,
                     encrypted_conversation_copies=encrypted_conversation_copies,
                     initial_conversation_nonce=owner_guard_nonce,
+                    require_known_nonce=False,
                 )
+            )
+            initial_conversation_submission = not is_embedded and _conversation_payload_can_start(
+                sender=sender,
+                recipient=uname.user,
+                encrypted_conversation_copies=encrypted_conversation_copies,
+                initial_conversation_nonce=owner_guard_nonce,
+                require_known_nonce=False,
             )
             block_reason = _message_submission_block_reason(
                 uname, allow_chat_submission=chat_only_submission
@@ -725,6 +734,18 @@ def register_profile_routes(app: Flask) -> None:
                             reason="captcha",
                         )
                     flash("⛔️ Invalid CAPTCHA answer.", "error")
+                    return _render_profile(400)
+
+                if (
+                    initial_conversation_submission
+                    and sender is not None
+                    and not _remember_initial_conversation_nonce(
+                        owner_guard_nonce,
+                        sender,
+                        uname.user,
+                    )
+                ):
+                    flash("⛔️ This tip line changed while you were composing. Please reload.")
                     return _render_profile(400)
 
                 # Create a message

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -507,6 +507,68 @@ def test_logged_in_profile_submit_without_recipient_pgp_uses_chat_only_conversat
 
 
 @pytest.mark.usefixtures("_authenticated_user")
+def test_profile_get_does_not_persist_initial_chat_nonce(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    user.pgp_key = None
+    user2.pgp_key = None
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+
+    rendered_nonces = set()
+    for _ in range(3):
+        response = client.get(url_for("profile", username=user2.primary_username.username))
+        assert response.status_code == 200
+        soup = BeautifulSoup(response.text, "html.parser")
+        nonce_input = soup.find("input", attrs={"name": "owner_guard_nonce"})
+        assert nonce_input is not None
+        rendered_nonces.add(nonce_input.get("value"))
+
+    assert len(rendered_nonces) == 3
+    assert db.session.scalar(db.select(db.func.count()).select_from(InitialConversationNonce)) == 0
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_invalid_captcha_chat_submission_does_not_persist_initial_chat_nonce(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    user.pgp_key = None
+    user2.pgp_key = None
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+    submission_data = get_profile_submission_data(client, user2.primary_username.username)
+
+    assert db.session.scalar(db.select(db.func.count()).select_from(InitialConversationNonce)) == 0
+
+    response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            "captcha_answer": "incorrect",
+            "encrypted_conversation_copies": json.dumps(
+                _initial_conversation_copies_for(
+                    sender=user,
+                    recipient=user2,
+                    nonce=submission_data["owner_guard_nonce"],
+                )
+            ),
+            "owner_guard_nonce": submission_data["owner_guard_nonce"],
+            "owner_guard_signature": submission_data["owner_guard_signature"],
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 400
+    assert "Invalid CAPTCHA answer." in response.text
+    assert db.session.scalar(db.select(db.func.count()).select_from(InitialConversationNonce)) == 0
+    assert db.session.scalars(db.select(Message)).all() == []
+    assert db.session.scalars(db.select(Conversation)).all() == []
+
+
+@pytest.mark.usefixtures("_authenticated_user")
 def test_logged_in_profile_submit_without_pgp_rejects_misbound_initial_chat_payload(
     client: FlaskClient, user: User, user2: User
 ) -> None:
@@ -578,7 +640,7 @@ def test_logged_in_profile_submit_initial_chat_nonce_is_single_use(
 
     assert first_response.status_code == 302
     assert second_response.status_code == 400
-    assert "do not have any usable recipient PGP keys" in second_response.text
+    assert "This tip line changed while you were composing. Please reload." in second_response.text
     assert db.session.scalar(db.select(db.func.count()).select_from(Message)) == 1
     assert db.session.scalar(db.select(db.func.count()).select_from(Conversation)) == 1
 
@@ -610,8 +672,13 @@ def test_logged_in_profile_submit_initial_chat_nonce_rejects_stale_session_cooki
     }
     replay_client = app.test_client()
     _authenticate_as(replay_client, user)
-    with replay_client.session_transaction() as stale_session:
-        stale_session["initial_conversation_nonces"] = [submission_data["owner_guard_nonce"]]
+    replay_submission_data = get_profile_submission_data(
+        replay_client, user2.primary_username.username
+    )
+    replay_post_data = {
+        **post_data,
+        "captcha_answer": replay_submission_data["captcha_answer"],
+    }
 
     first_response = client.post(
         url_for("profile", username=user2.primary_username.username),
@@ -620,13 +687,13 @@ def test_logged_in_profile_submit_initial_chat_nonce_rejects_stale_session_cooki
     )
     replay_response = replay_client.post(
         url_for("profile", username=user2.primary_username.username),
-        data=post_data,
+        data=replay_post_data,
         follow_redirects=True,
     )
 
     assert first_response.status_code == 302
     assert replay_response.status_code == 400
-    assert "do not have any usable recipient PGP keys" in replay_response.text
+    assert "This tip line changed while you were composing. Please reload." in replay_response.text
     assert db.session.scalar(db.select(db.func.count()).select_from(Message)) == 1
     assert db.session.scalar(db.select(db.func.count()).select_from(Conversation)) == 1
     consumed_nonce_rows = db.session.scalars(


### PR DESCRIPTION
## What changed
- Removed durable `InitialConversationNonce` writes from authenticated profile GET rendering.
- Moved initial conversation nonce reservation to validated non-embedded profile POST handling after form validation and CAPTCHA success, immediately before message creation.
- Kept single-use replay protection by requiring the reserved nonce during conversation creation and consuming it in the existing path.
- Added tests proving eligible profile GETs and invalid-CAPTCHA chat submissions do not persist nonce rows, while duplicate/stale initial conversation submissions are rejected.

## Why
Fixes the security finding where ordinary authenticated `GET /to/<username>` renders could create unbounded `initial_conversation_nonces` rows and indexes before any message submission or CAPTCHA check.

## Security and privacy
Threat/risk: a low-privileged authenticated sender with a chat-capable key could repeatedly render an eligible recipient profile and grow shared database storage one durable nonce row per GET, creating availability and backup/index bloat risk.

Affected data paths:
- `GET /to/<username>` profile render path
- `POST /to/<username>` initial E2EE conversation submission path
- `InitialConversationNonce` storage and consumption

Mitigation:
- Safe/idempotent profile GETs no longer mutate nonce storage.
- Nonce persistence is gated behind POST form validation and CAPTCHA success.
- Replay resistance remains enforced by reserving the submitted owner-guard nonce in the same transaction before creating the message/conversation and by consuming it during conversation creation.
- Invalid CAPTCHA submissions do not create nonce rows.

No plaintext disclosures, private keys, secrets, or tokens are logged or newly stored by this change.

## Validation
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-2260-no-db-ports.yaml -p hushline-nonce-fix run --rm app poetry run pytest tests/test_profile.py -k "initial_chat_nonce or chat_only_conversation or does_not_persist_initial_chat_nonce" -vv` -> 5 passed, 52 deselected
- `docker compose -f docker-compose.yaml -f /private/tmp/hushline-2260-no-db-ports.yaml -p hushline-nonce-fix run --rm app poetry run pytest tests/test_profile.py tests/test_inbox.py -k "initial_conversation or conversation_for_sender or profile_submit_without_recipient_pgp or initial_chat_nonce or does_not_persist_initial_chat_nonce" -vv` -> 6 passed, 58 deselected
- `env COMPOSE_FILE=docker-compose.yaml:/private/tmp/hushline-2260-no-db-ports.yaml COMPOSE_PROJECT_NAME=hushline-nonce-fix make lint` -> passed
- `env COMPOSE_FILE=docker-compose.yaml:/private/tmp/hushline-2260-no-db-ports.yaml COMPOSE_PROJECT_NAME=hushline-nonce-fix make test` -> 2114 passed, 1 deselected, 1 xfailed
- `env COMPOSE_FILE=docker-compose.yaml:/private/tmp/hushline-2260-no-db-ports.yaml COMPOSE_PROJECT_NAME=hushline-nonce-fix make audit-python` -> No known vulnerabilities found
- `env COMPOSE_FILE=docker-compose.yaml:/private/tmp/hushline-2260-no-db-ports.yaml COMPOSE_PROJECT_NAME=hushline-nonce-fix make audit-node-runtime` -> found 0 vulnerabilities

## Manual testing
Automated route tests cover the changed GET/POST behavior. No separate browser/manual UI pass was performed because the change does not alter the visible profile form flow except the duplicate/stale replay failure copy.

## Known risks or follow-ups
- Existing consumed nonce rows are still retained by design; this PR specifically removes the cheap GET-based unbounded creation path.
- A future retention/cleanup policy for consumed nonce rows may still be useful operational hardening, but it is not required to close this finding.