### PR TITLE
Document two-way chat E2EE launch materials

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Hush Line
 
-[Hush Line](https://hushline.app) is an open source whistleblower platform for secure, anonymous, one-way disclosures to journalists, lawyers, and other trusted recipients.
+[Hush Line](https://hushline.app) is an open source whistleblower platform for secure, anonymous disclosures to journalists, lawyers, and other trusted recipients, with optional end-to-end encrypted account conversations for follow-up.
 
 Hosted service: <https://tips.hushline.app>  
 Start here: <https://hushline.app/library/docs/getting-started/start-here/>
@@ -31,16 +31,16 @@ Hush Line is built for safety-critical reporting workflows where trust, anonymit
 
 ## Core Capabilities
 
-| Area                   | What Hush Line Provides                                                                |
-| ---------------------- | -------------------------------------------------------------------------------------- |
-| Anonymous submissions  | No submitter account required for sending disclosures                                  |
-| Encryption             | End-to-end encryption workflow with recipient PGP keys, plus server-side fallback path |
-| Receiver trust         | Verified account workflow and trusted directory UX                                     |
-| Account security       | Password authentication with optional TOTP 2FA                                         |
-| Privacy access         | Tor onion support and privacy-preserving defaults                                      |
-| Communication workflow | Message status management, one-way replies, and optional email forwarding modes        |
-| Org customization      | Branding controls, onboarding guidance, and configurable profile fields                |
-| Operational controls   | Strong CI checks, migration compatibility testing, and workflow security validation    |
+| Area                   | What Hush Line Provides                                                                                        |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Anonymous submissions  | No submitter account required for sending disclosures                                                          |
+| Encryption             | End-to-end encrypted submissions with recipient PGP keys, plus server-side fallback path                       |
+| Receiver trust         | Verified account workflow and trusted directory UX                                                             |
+| Account security       | Password authentication with optional TOTP 2FA                                                                 |
+| Privacy access         | Tor onion support and privacy-preserving defaults                                                              |
+| Communication workflow | Message status management, reply links, signed E2EE account conversations, and optional email forwarding modes |
+| Org customization      | Branding controls, onboarding guidance, and configurable profile fields                                        |
+| Operational controls   | Strong CI checks, migration compatibility testing, and workflow security validation                            |
 
 ## Quickstart (Local)
 
@@ -73,6 +73,7 @@ If you want a slower, guided setup for a brand-new machine, use the AI-ready pro
 ## Security and Privacy
 
 - Threat model: [`docs/THREAT-MODEL.md`](./docs/THREAT-MODEL.md)
+- Two-way chat E2EE: [`docs/TWO-WAY-CHAT-E2EE.md`](./docs/TWO-WAY-CHAT-E2EE.md)
 - Security policy and vulnerability reporting: [`SECURITY.md`](./SECURITY.md)
 - Privacy policy: [`docs/PRIVACY.md`](./docs/PRIVACY.md)
 
@@ -130,6 +131,8 @@ If local audit commands are blocked by network/tooling availability, document th
 - Local contributor onboarding prompt: [`docs/LOCAL-CONTRIBUTOR-ONBOARDING-PROMPT.md`](./docs/LOCAL-CONTRIBUTOR-ONBOARDING-PROMPT.md)
 - Developer notes: [`docs/DEV.md`](./docs/DEV.md)
 - Architecture: [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md)
+- Two-way chat E2EE: [`docs/TWO-WAY-CHAT-E2EE.md`](./docs/TWO-WAY-CHAT-E2EE.md)
+- Two-way chat E2EE whitepaper: [`docs/HUSH-LINE-TWO-WAY-CHAT-E2EE-WHITEPAPER.md`](./docs/HUSH-LINE-TWO-WAY-CHAT-E2EE-WHITEPAPER.md)
 - Runner automation: [Agent automation and policy](https://github.com/scidsg/hushline-agents)
 - Terms: [`docs/TERMS.md`](./docs/TERMS.md)
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -42,3 +42,26 @@ Automated follow-on release actions:
 - `.github/workflows/bump-personal-server-after-release.yml` opens or updates a PR in `scidsg/hushline-personal-server` so the package version and bundled app image track the released image tag.
 - `.github/workflows/docs-screenshots.yml` is the release and manual entrypoint for screenshots. On published releases it waits for the released GHCR image, scans Hush Line docs plus `scidsg/hushline-website` for referenced screenshot paths, captures only that generated allowlist, and then calls `.github/workflows/publish-docs-screenshots.yml` to publish the standalone archive to `scidsg/hushline-screenshots` and the current website screenshots to `scidsg/hushline-website`. Both publishes push directly to the target repository default branch without opening PRs. The website sync only updates `src/assets/img/screenshots/current/`, while the screenshots repo keeps the used-only standalone release archive and badge.
 - `.github/workflows/public-directory-weekly-report.yml` can run weekly or on demand, fetches `https://tips.hushline.app/directory/users.json`, filters to opted-in public Hush Line users, compares against both the last sync and the most recent snapshot from at least 7 days earlier, then syncs `scidsg/hushline-stats` via a dedicated automation branch and PR. The workflow attempts to merge that PR immediately after generating the `README.md`, latest aliases, and timestamped historical JSON/Markdown reports.
+
+## Application Data and Encryption Boundaries
+
+Hush Line separates one-way disclosure intake from account conversation
+follow-up.
+
+- Public tip submissions use recipient PGP keys for encrypted intake and keep
+  the no-account sender path available.
+- Anonymous submissions use the message inbox and reply/status link flow; they
+  do not create account conversations.
+- Logged-in senders and recipients can use two-way account conversations when
+  both sides have active, signing-capable Hush Line chat keys.
+- Conversation plaintext is encrypted and decrypted in the browser. The server
+  stores per-participant encrypted message copies, participant records,
+  timestamps, unread/activity state, and generic notification state.
+- New conversation replies require all participants to have chat public
+  encryption keys and chat public signing keys before the server accepts the
+  append request.
+- Conversation notifications are generic activity alerts; plaintext and
+  ciphertext are not copied into notification email.
+
+See [Two-way chat end-to-end encryption](./TWO-WAY-CHAT-E2EE.md) for the
+feature-specific security model.

--- a/docs/HUSH-LINE-TWO-WAY-CHAT-E2EE-WHITEPAPER.md
+++ b/docs/HUSH-LINE-TWO-WAY-CHAT-E2EE-WHITEPAPER.md
@@ -1,0 +1,387 @@
+# Hush Line Two-Way Chat: End-to-End Encryption for Safer Disclosures
+
+Last updated: 2026-06-18
+
+## Abstract
+
+Hush Line is an open source whistleblower platform built for secure,
+privacy-preserving disclosures to journalists, lawyers, educators, organizers,
+employers, boards, and other trusted recipients. Its original sender path is a
+low-friction public tip form: a whistleblower can send a disclosure without
+creating an account, and the recipient can triage it in a protected inbox.
+
+Two-way chat adds an account-based follow-up channel for situations where a
+logged-in sender and recipient both want to continue inside Hush Line. The
+feature stores conversation messages as per-participant encrypted payloads,
+requires signing-capable Hush Line chat keys for new replies, and keeps
+conversation plaintext out of server-side storage. It does not replace anonymous
+submissions. Instead, it gives users a second communication mode for cases where
+ongoing account-based follow-up is appropriate.
+
+This whitepaper explains the product motivation, security model, cryptographic
+architecture, key lifecycle, operational boundaries, and known limitations of
+Hush Line two-way chat.
+
+## Executive Summary
+
+Whistleblowing systems need more than secure intake. They also need usable
+follow-up. Recipients often need clarifying details, sources need status and
+next-step signals, and both sides need a workflow that does not force sensitive
+communication into ordinary email, ad hoc messaging, or untrusted case notes.
+
+Hush Line now supports two complementary paths:
+
+- **Anonymous disclosure intake:** no sender account required, recipient PGP
+  keys protect one-way submissions, and senders can return through a one-time
+  reply/status link.
+- **Two-way account conversations:** logged-in participants can continue
+  follow-up in Hush Line with browser-based end-to-end encrypted conversation
+  messages.
+
+The two-way chat design has five core security goals:
+
+- Store conversation content only as per-participant encrypted payloads.
+- Restrict conversation routes to authenticated participants.
+- Require signing-capable Hush Line chat keys for new replies.
+- Bind encrypted envelopes to their intended conversation, sender, and
+  recipient.
+- Keep notifications generic so plaintext and ciphertext are not copied into
+  email.
+
+The feature improves follow-up usability without weakening the anonymous intake
+flow. It also makes clear tradeoffs: account conversations expose operational
+metadata to the Hush Line server, depend on trustworthy client code, and cannot
+recover old chat history if a user loses the relevant chat key material.
+
+## The Problem
+
+Secure disclosure systems often focus on the first message. That first contact
+matters, but many real cases do not end there. A recipient may need to ask for
+dates, records, context, or corroborating details. A sender may need to learn
+whether the recipient is reviewing the report, declining it, or waiting for more
+information.
+
+Without an integrated follow-up path, users tend to fall back to tools that are
+easier but less appropriate for sensitive disclosures:
+
+- ordinary email threads,
+- consumer chat apps,
+- screenshots and copied case notes,
+- shared inboxes with unclear access boundaries, or
+- one-off operational workarounds.
+
+Those fallbacks can increase exposure for the sender and the recipient. They can
+also fragment the evidence trail and make it harder for an organization to run a
+consistent whistleblowing process.
+
+Hush Line two-way chat is designed to keep follow-up close to the original
+disclosure workflow while preserving the most important boundary: the server
+should not need conversation plaintext to operate the product.
+
+## Design Principles
+
+Hush Line is safety-critical infrastructure for users whose operational,
+physical, and digital security may be affected by software behavior. Two-way
+chat follows the same principles used across the project:
+
+- **Usability:** users must be able to complete the disclosure and follow-up
+  workflow without specialist cryptographic knowledge.
+- **Receiver authenticity:** senders need signals that they are reaching the
+  intended person or organization.
+- **Plausible deniability:** the system should avoid unnecessary artifacts that
+  make sender participation more exposed than the selected workflow requires.
+- **Availability:** disclosure intake must remain usable even when account chat
+  is not the right path.
+- **Anonymity:** anonymous submissions must remain available without requiring
+  an account.
+- **Confidentiality and integrity:** sensitive disclosure and conversation
+  content should be protected against unnecessary server-side exposure and
+  storage tampering.
+
+These principles align with the ISO 37002 emphasis on trust, impartiality, and
+protection in whistleblowing management systems. In practical product terms,
+that means Hush Line must support communication without hiding critical limits
+from users or operators.
+
+## Two Complementary Communication Modes
+
+Hush Line now distinguishes between anonymous one-way intake and account-based
+conversation follow-up.
+
+### Anonymous Intake
+
+Anonymous intake remains the default sender-friendly path. A person can open a
+public Hush Line profile, inspect trust signals, complete a structured form, and
+submit a disclosure without creating an account. When message intake is enabled,
+recipient PGP keys protect the submission content. The sender can receive a
+one-time reply/status link after submission and return later to check progress.
+
+This mode minimizes sender friction and avoids requiring an account where an
+account would increase risk or reduce reporting likelihood.
+
+### Account Conversations
+
+Two-way account conversations are for logged-in Hush Line users. A logged-in
+sender can submit to another account and continue follow-up in a conversation
+thread when both sides have Hush Line chat keys.
+
+This mode is useful when both participants accept the account-based model and
+need ongoing follow-up inside Hush Line. It is not anonymous live chat. The
+server must know enough metadata to show inbox rows, enforce participant access,
+track unread state, and send generic notifications.
+
+## Architecture Overview
+
+Two-way chat uses browser-based cryptography and server-side participant
+controls.
+
+At a high level:
+
+1. Each participant has a Hush Line chat key separate from their PGP key.
+2. The browser encrypts conversation content for each participant.
+3. The server stores per-participant encrypted copies.
+4. Authenticated routes restrict conversation access to participants.
+5. Participants unlock their chat key in the browser to read and reply.
+
+The server stores conversation records, participant records, encrypted message
+copies, timestamps, unread/activity state, and generic notification state. The
+server does not store conversation plaintext.
+
+Administrators can govern accounts, registration, directory trust states,
+branding, and moderation settings. Admin status alone does not grant hidden
+access to conversation content.
+
+## Chat Keys and PGP Keys
+
+Hush Line uses different keys for different jobs.
+
+PGP keys protect one-way message intake, encrypted exports, and optional
+encrypted notification email content. Proton Key Lookup helps users import
+public PGP keys for those workflows.
+
+Hush Line chat keys protect account conversation messages in the browser. They
+are browser-generated in-app conversation keys and are separate from PGP keys.
+Hush Line must not ask users to export, paste, or upload Proton Mail private
+keys or any other external private key for chat.
+
+New account conversation replies require active chat keys with public encryption
+keys and public signing keys for every participant. Legacy unsigned envelopes
+may remain readable for backward compatibility, but composing new replies is
+unavailable until all participants have signing-capable chat keys.
+
+## Conversation Creation
+
+When a logged-in sender submits to another account and both sides are
+chat-capable, the browser prepares encrypted initial conversation copies for the
+sender and recipient. The initial conversation payload is bound to a one-time
+nonce and participant key metadata before the server stores it.
+
+This gives the sender a conversation thread tied to the submission while keeping
+the plaintext in the browser. The recipient sees the conversation in the inbox
+without a plaintext preview and unlocks their chat key to read it.
+
+If chat setup is unavailable, Hush Line preserves the existing submission and
+reply/status-link workflow when message intake is otherwise enabled.
+
+## Reply Envelopes
+
+Current reply envelopes use `ECDH-P256-AES-GCM` with versioned context binding.
+Each encrypted copy is specific to one recipient participant.
+
+Versioned envelopes include context for:
+
+- the conversation,
+- the sender participant,
+- the recipient participant, and
+- the envelope purpose.
+
+That context is supplied as AES-GCM additional authenticated data and is covered
+by signed envelope fields for signing-capable chat keys. This design helps
+detect attempts to replay or swap ciphertext across conversations, sender
+positions, or recipient positions.
+
+The server validates structure, participant sets, and context binding before
+storing new copies. The browser decrypts and handles signature-aware message
+processing with the participant's unlocked chat key material.
+
+## Notifications
+
+Two-way chat notifications are intentionally generic. They tell a participant
+there is new Hush Line conversation activity and instruct them to log in and
+unlock their chat key.
+
+Notifications do not include conversation plaintext or conversation ciphertext.
+This remains true even when the user has enabled message-content notifications
+for one-way tip intake.
+
+Generic notifications reduce accidental leakage into SMTP logs, mailboxes,
+forwarding rules, mobile lock screens, and third-party mail search indexes.
+
+## Password Changes, Resets, and Recovery
+
+Chat private key material must be available in the browser before a user can
+read or reply to encrypted account conversations.
+
+When a user changes their password and the active chat key is available, Hush
+Line requires the key to be rewrapped in the browser as part of the password
+change. This preserves access to existing chat history while changing account
+credentials.
+
+Password reset is different. If the old password is unavailable, Hush Line
+cannot rewrap old chat key material. Old chat history encrypted to the previous
+key remains locked unless a future recovery mechanism is explicitly designed,
+reviewed, documented, and tested.
+
+This is an intentional safety tradeoff. Server-side recovery would require a
+new trust boundary and could become a plaintext access path if designed poorly.
+
+## Security Properties
+
+Two-way chat is designed to provide the following properties.
+
+### Content Confidentiality at Rest
+
+Conversation content is stored as encrypted copies for participants. The server
+does not need plaintext to render the inbox, store messages, or send activity
+notifications.
+
+### Participant-Only Access
+
+Conversation routes are authenticated and scoped to participants. A user who is
+not part of the conversation should not be able to open the thread or append
+messages.
+
+### Context-Bound Integrity
+
+Versioned encrypted envelopes bind ciphertext to conversation and participant
+context. This limits replay and swapping attacks against stored conversation
+copies.
+
+### Signing-Capable Replies
+
+New replies require signing-capable chat keys for all participants. This avoids
+continuing legacy unsigned reply paths when the conversation cannot meet the
+current integrity policy.
+
+### Notification Minimization
+
+Conversation notifications avoid both plaintext and ciphertext. They reveal
+activity, not content.
+
+## What the Server Still Knows
+
+End-to-end encryption does not remove all metadata. Hush Line still stores and
+processes operational information needed to run the feature, including:
+
+- conversation participants,
+- message and conversation IDs,
+- timestamps,
+- unread and activity state,
+- message counts, and
+- notification delivery state.
+
+Users who need the lowest-account-footprint path should use anonymous
+submissions and reply/status links instead of account conversations.
+
+## Threats and Mitigations
+
+### Unauthorized Conversation Access
+
+An attacker may try to open a conversation they do not participate in. Hush Line
+mitigates this with authenticated participant-scoped routes.
+
+### Ciphertext Replay or Swapping
+
+An attacker with database write access may try to move encrypted payloads across
+threads or recipients. Versioned envelope context binding makes those payloads
+specific to the expected conversation, sender, and recipient.
+
+### Legacy Reply Policy Bypass
+
+Legacy chat-key material may support reading older content, but new replies
+require all participants to have signing-capable chat keys. The server and UI
+must enforce the same availability policy.
+
+### Chat Key Substitution
+
+A compromised server or account may try to present a replacement chat key.
+Fingerprints and signing-key metadata make key changes more visible, but Hush
+Line does not yet provide a full key-transparency log. Users should treat
+unexpected key changes as security-sensitive.
+
+### Client-Side Code Compromise
+
+Browser-based encryption depends on trustworthy JavaScript. A compromised
+server, malicious deployment, or compromised build pipeline could serve code
+that captures plaintext before encryption or after decryption. This remains a
+critical residual risk for web-based end-to-end encryption systems.
+
+### Metadata Exposure
+
+The server sees account participation and activity metadata. Hush Line reduces
+content exposure but does not make account conversations metadata-private.
+
+## Operational Guidance
+
+Operators and maintainers should treat two-way chat as a security-critical
+workflow.
+
+Before promoting the feature, verify:
+
+- anonymous submissions still work without account creation;
+- account conversations are available only to authenticated participants;
+- new replies are unavailable unless every participant has signing-capable chat
+  keys;
+- inbox rows and notifications do not reveal conversation plaintext;
+- password changes require chat-key rewrap;
+- password resets leave old chat history locked to the old key;
+- security headers and CSP remain enforced; and
+- accessibility and performance targets remain intact.
+
+Documentation, support materials, and launch copy should avoid saying that
+two-way account conversations are anonymous. They are encrypted account
+conversations for follow-up. Anonymous disclosures remain a separate flow.
+
+## Limitations and Future Work
+
+Hush Line two-way chat intentionally avoids server-side plaintext recovery, but
+future work could improve usability and assurance without weakening that
+boundary.
+
+Potential areas include:
+
+- clearer key-change warnings and user education,
+- stronger key-transparency or contact-verification mechanisms,
+- recovery designs that do not create hidden server access to plaintext,
+- expanded independent security review of the browser cryptography and key
+  lifecycle, and
+- more public documentation for high-risk users choosing between anonymous
+  reply links and account conversations.
+
+Any future recovery or transparency mechanism should be reviewed as a
+security-boundary change, documented in the threat model, and covered by tests.
+
+## Conclusion
+
+Hush Line two-way chat extends secure disclosure workflows from first contact to
+ongoing follow-up. It gives logged-in participants an encrypted conversation
+channel inside the product while preserving the anonymous no-account intake path
+that remains central to Hush Line.
+
+The feature is deliberately scoped. It protects conversation content from
+routine server-side plaintext storage, binds encrypted replies to conversation
+context, and keeps notifications generic. It does not hide all metadata, it does
+not make account conversations anonymous, and it depends on trustworthy client
+code.
+
+Those limits are part of the security model. By documenting them directly, Hush
+Line can launch two-way chat as a practical improvement to disclosure follow-up
+without overstating what web-based end-to-end encryption can guarantee.
+
+## References
+
+- [Two-way chat end-to-end encryption](./TWO-WAY-CHAT-E2EE.md)
+- [Use cases](./USE-CASES.md)
+- [Threat model](./THREAT-MODEL.md)
+- [Privacy policy](./PRIVACY.md)
+- [ISO 37002 grounding document](./ISO-37002.md)

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -1,11 +1,11 @@
 # Hush Line Privacy Policy
 
-Effective date: 2026-02-16
+Effective date: 2026-06-18
 
 ## Privacy Nutrition Facts
 
-- **What you provide**: usernames, optional email, optional PGP key, and message content.
-- **What we store**: encrypted message content plus the account and security records listed below.
+- **What you provide**: usernames, optional email, optional PGP key, Hush Line chat public-key metadata and encrypted private-key payloads for account conversations, and message content.
+- **What we store**: encrypted message and conversation content plus the account, conversation, and security records listed below.
 - **What we share**: DigitalOcean hosts the service; Stripe handles billing if enabled.
 - **Cookies**: an encrypted session cookie and a local flag for first‑visit anti‑censorship tips.
 - **Your control**: update or delete your account and messages in the app.
@@ -19,6 +19,7 @@ Hush Line is a 501(c)(3) non-profit in the US. This policy explains how we handl
 - **Account records**: user ID, usernames, optional display name, optional bio, and profile visibility flags for directory and verification.
 - **Security and auth data**: password hash, TOTP secret if enabled, and authentication logs with timestamp, success flag, and the TOTP code and timecode for successful 2FA logins. We do not store IP addresses or user‑agent strings in the database.
 - **Messaging data**: message IDs, public IDs, reply slugs, message status, status change time, and message content stored as encrypted field values.
+- **Conversation data**: conversation IDs, participant records, per-participant encrypted conversation message copies, timestamps, unread/activity state, and chat-key public metadata used to support account conversations.
 - **Profile field definitions**: custom field labels, types, required and enabled flags, choices, and sort order.
 - **Notification settings**: email notification toggles and SMTP configuration such as server, port, username, password, sender, and encryption mode, stored encrypted at rest.
 - **Invite codes**: invite code and expiration date when enabled.
@@ -44,17 +45,19 @@ We rely on third‑party providers to run Hush Line:
 
 These providers may collect data as part of their services. We do not control their data practices; please review their policies.
 
-If you enable email notifications, messages are sent via SMTP (either your custom SMTP settings or our configured provider). This transmits message content through email systems you choose or we operate.
+If you enable email notifications for one-way message intake, messages may be sent via SMTP (either your custom SMTP settings or our configured provider), depending on your notification settings. This can transmit message content through email systems you choose or we operate.
+
+Two-way account conversation notifications are generic activity alerts. They do not include conversation plaintext or conversation ciphertext.
 
 If you enable premium billing, payment processing is handled by Stripe. We do not store full payment details.
 
 ## 5) Security
 
-We encrypt stored message content and sensitive account fields (email, SMTP credentials, PGP key, TOTP secret). No system is perfectly secure, but we design Hush Line to minimize data exposure.
+We encrypt stored message content and sensitive account fields (email, SMTP credentials, PGP key, TOTP secret). Two-way account conversations are stored as per-participant encrypted payloads; Hush Line does not store conversation plaintext. No system is perfectly secure, but we design Hush Line to minimize data exposure.
 
 ## 6) Retention & Deletion
 
-Messages and accounts remain until you delete them. When you delete content, we remove it from active systems.
+Messages, conversations, and accounts remain until you delete them or the relevant account is deleted. When you delete content, we remove it from active systems.
 
 ## 7) Cookies & Local Storage
 
@@ -103,6 +106,10 @@ The following source files implement rights-related functionality referenced in 
 
 - Data access/export (Right of Access / Right to Know / Data Portability):
   [`hushline/settings/data_export.py`](https://github.com/scidsg/hushline/blob/main/hushline/settings/data_export.py)
+- Account conversations and chat-key records:
+  [`hushline/model/conversation.py`](https://github.com/scidsg/hushline/blob/main/hushline/model/conversation.py),
+  [`hushline/model/chat_key.py`](https://github.com/scidsg/hushline/blob/main/hushline/model/chat_key.py),
+  [`hushline/routes/message.py`](https://github.com/scidsg/hushline/blob/main/hushline/routes/message.py)
 - Account deletion (Right to Erasure / Right to Delete):
   [`hushline/settings/delete_account.py`](https://github.com/scidsg/hushline/blob/main/hushline/settings/delete_account.py)
 - Cascading deletion of related records:

--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,8 @@ This directory now includes a GitHub-first mirror of the public Hush Line Librar
 - [Architecture](./ARCHITECTURE.md)
 - [Privacy](./PRIVACY.md)
 - [Threat model](./THREAT-MODEL.md)
+- [Two-way chat end-to-end encryption](./TWO-WAY-CHAT-E2EE.md)
+- [Two-way chat E2EE whitepaper](./HUSH-LINE-TWO-WAY-CHAT-E2EE-WHITEPAPER.md)
 - [Terms](./TERMS.md)
 - [Agent automation and policy](https://github.com/scidsg/hushline-agents)
 - [Security audit hitlist](./SECURITY-AUDIT-HITLIST.md)

--- a/docs/THREAT-MODEL.md
+++ b/docs/THREAT-MODEL.md
@@ -9,6 +9,8 @@ Primary assets include:
 - Disclosure content and metadata (message status, reply slugs, timestamps).
 - Recipient accounts, password hashes, 2FA secrets, session identifiers.
 - Recipient PGP keys, SMTP credentials, and notification settings.
+- Hush Line chat public keys, chat public signing keys, encrypted chat private
+  key material, and per-participant encrypted conversation copies.
 - Public directory/profile data and verification markers.
 - Encryption/session secrets (`ENCRYPTION_KEY`, `SESSION_FERNET_KEY`) and service API keys (SMTP, Stripe).
 - Billing records, audit logs, and automation artifacts.
@@ -19,6 +21,8 @@ Primary assets include:
 
 - **Submitter browser → Hush Line app:** anonymous POSTs to `/to/<username>` and other public endpoints (`hushline/routes/profile.py`).
 - **Recipient session → Hush Line app:** authenticated inbox/settings routes (`hushline/routes/*`, `hushline/settings/*`).
+- **Conversation participant browser → Hush Line app:** authenticated
+  conversation, presence, and reply routes (`hushline/routes/message.py`).
 - **Admin session → Hush Line app:** privileged settings/admin actions (`hushline/admin.py`, `hushline/settings/branding.py`).
 - **App → Postgres:** ORM‑mediated data access (`hushline/db.py`, `hushline/model/*`).
 - **App → Blob storage:** S3 or filesystem driver (`hushline/storage.py`).
@@ -95,6 +99,12 @@ Primary assets include:
 - Mitigations: embeds require global admin enablement, a currently paid Super User account, per-profile or per-alias opt-in, exact origin allowlists, recipient PGP keys, no-referrer iframe snippets, sandboxed iframes, compact trust chrome, and CSP `frame-ancestors` limited to configured origins.
 - Abuse controls throttle submissions by profile, source network bucket, and deployment. Operational counters use hashed profile/source labels and must not log disclosure content, custom-field values, reply slugs, full referrers, parent-page titles, analytics identifiers, or sender contact details.
 - Hosted redirect links remain safer for personal servers and operators who do not understand origin allowlists, CSP, iframe sandboxing, and analytics restrictions.
+
+11. **Two-way account conversations** (`routes/profile.py`, `routes/message.py`, `model/conversation.py`):
+
+- Risks: an attacker tries to read or append to a conversation without being a participant, replay encrypted copies across conversations, substitute chat keys, force legacy unsigned reply paths, or use notifications as an abuse channel.
+- Mitigations: routes are authenticated and participant-scoped; initial conversation copies use nonce and key-fingerprint binding; reply envelopes bind conversation and participant context; new replies require all participants to have signing-capable chat keys; notifications are generic and suppress active-recipient alerts.
+- Residual exposure: conversation participants, timestamps, unread/activity state, and message counts remain server-visible metadata. Client-side chat encryption depends on trustworthy JavaScript served by Hush Line.
 
 ### Attacker stories (examples)
 

--- a/docs/TWO-WAY-CHAT-E2EE.md
+++ b/docs/TWO-WAY-CHAT-E2EE.md
@@ -1,0 +1,178 @@
+# Hush Line Two-Way Chat End-to-End Encryption
+
+This document describes the product and security model for Hush Line two-way
+account conversations. It is the implementation reference for launch materials,
+library docs, and future whitepapers.
+
+It is not a formal cryptographic proof. It explains the current design,
+intended security properties, and limits that operators and reviewers should
+understand before promoting the feature.
+
+## Scope
+
+Two-way chat is an account conversation feature for logged-in Hush Line users.
+It lets a logged-in sender submit to another account and continue follow-up
+inside Hush Line without relying only on the one-time anonymous reply link.
+
+The existing anonymous disclosure flow remains the primary low-friction sender
+path. Anonymous submissions still use the message inbox and reply/status link.
+They do not create account conversations, and Hush Line must continue to support
+users who cannot or should not create accounts.
+
+## Goals
+
+- Keep conversation plaintext out of server-side storage.
+- Preserve participant-only access: only conversation participants can open or
+  append to the conversation route.
+- Require signing-capable Hush Line chat keys for new replies.
+- Bind encrypted conversation envelopes to their intended conversation, sender,
+  and recipient so stored ciphertext cannot be silently replayed across threads.
+- Notify participants about new activity without copying conversation plaintext
+  or ciphertext into email.
+- Keep administrators outside the cryptographic trust boundary unless they are
+  explicit conversation participants.
+
+## Non-Goals
+
+- Two-way chat is not anonymous live chat. Account conversations reveal account
+  participation to the Hush Line server.
+- Two-way chat does not hide operational metadata such as participants,
+  timestamps, unread state, message counts, or recent activity.
+- Two-way chat does not protect against malicious JavaScript served by a
+  compromised application, build pipeline, or operator.
+- Hush Line does not escrow chat private keys or provide server-side plaintext
+  recovery for old chat history.
+
+## Participant Requirements
+
+New account conversation replies require every participant to have an active
+Hush Line chat key with:
+
+- a public encryption key,
+- a public signing key, and
+- unlockable private key material in the participant's browser session.
+
+Hush Line chat keys are separate from PGP keys. PGP keys remain the mechanism
+for encrypted one-way message intake, exports, and optional encrypted email
+notification content. Proton Key Lookup imports public PGP keys only; it is not
+used to import external private keys for chat.
+
+## Conversation Flow
+
+1. A user configures a Hush Line chat key in the browser.
+2. A logged-in sender submits to another Hush Line account.
+3. If the sender and recipient are chat-capable, the browser prepares encrypted
+   initial conversation copies for both participants.
+4. The server stores those encrypted copies and links the account conversation
+   to the submitted message.
+5. Each participant sees the conversation in the inbox without plaintext
+   preview content.
+6. A participant unlocks their Hush Line chat key in the browser to decrypt
+   their copy and compose replies.
+7. Replies are stored as per-participant encrypted payloads.
+8. Other participants receive generic activity notifications and must log in and
+   unlock their chat key to read the new message.
+
+If chat setup is unavailable, the sender can still use the traditional
+submission and reply-link workflow when message intake is otherwise enabled.
+
+## Cryptographic Design
+
+Conversation payloads are encrypted in the browser as structured envelopes.
+Current reply envelopes use `ECDH-P256-AES-GCM` and versioned context binding.
+
+Each encrypted copy is specific to one recipient participant. Versioned
+conversation envelopes include context for:
+
+- the conversation,
+- the sender participant,
+- the recipient participant, and
+- the envelope purpose.
+
+The context is supplied as additional authenticated data for AES-GCM and is
+also covered by the signed envelope fields for signing-capable chat keys. This
+helps prevent a database or storage attacker from replaying a valid ciphertext
+into a different conversation, sender slot, or recipient slot without detection.
+
+The server performs structural validation and participant/context checks before
+storing copies. The browser performs plaintext decryption and signature-aware
+message handling with the participant's unlocked chat key material.
+
+## Key Lifecycle
+
+Chat private key material is protected by the user's account password workflow
+and must be available in the browser before reading or replying. Password
+changes require the active chat key to be rewrapped in the browser before the
+password is changed.
+
+Password reset cannot rewrap old chat key material because the old password is
+not available. After a reset, old chat history encrypted to the previous key
+remains locked unless a future recovery mechanism is explicitly designed,
+reviewed, documented, and tested.
+
+Key rotation and old signing-key history support continuity checks for existing
+conversation history. Legacy unsigned envelopes may remain readable for
+backward compatibility, but new replies require signing-capable chat keys.
+
+## Server-Side Data Handling
+
+The server stores:
+
+- conversation and participant records,
+- per-participant encrypted message copies,
+- timestamps and activity markers,
+- unread/read cursor state, and
+- generic notification state.
+
+The server does not store conversation plaintext. Administrators can govern
+accounts, directory trust states, registration, branding, and moderation
+settings, but admin status alone does not grant conversation access.
+
+Conversation notifications are generic. They do not include conversation
+plaintext or conversation ciphertext, even when a user has enabled message
+content notifications for one-way tip intake.
+
+## Privacy and Security Properties
+
+Two-way chat is designed to provide:
+
+- **Confidentiality of conversation content at rest:** stored conversation
+  payloads are encrypted per participant.
+- **Conversation integrity checks:** versioned envelopes bind ciphertext to the
+  expected conversation and participant context.
+- **Receiver authenticity support:** public chat-key fingerprints and signing
+  keys make key changes and envelope provenance more visible to participants.
+- **Participant-only access:** authenticated routes are scoped to conversation
+  participants.
+- **Operational minimization:** notifications and inbox rows avoid plaintext
+  previews.
+
+These properties depend on users unlocking the correct chat key in a trustworthy
+browser session and on Hush Line serving uncompromised client code.
+
+## Residual Risks
+
+- A compromised server or build pipeline can serve malicious JavaScript before
+  encryption or after decryption.
+- A database or operator can observe conversation metadata, including who is
+  participating and when activity occurs.
+- Account conversations require accounts and therefore have a different
+  anonymity profile than anonymous submissions.
+- Users who lose access to old chat key material can lose access to old chat
+  history.
+- Chat key substitution remains a serious attack if a participant ignores
+  fingerprint changes or if a future key-transparency mechanism is not in place.
+
+## Review Checklist
+
+Before shipping conversation workflow changes, reviewers should verify:
+
+- anonymous submissions still use the message inbox and reply/status link;
+- conversations are available only to authenticated participants;
+- replies are unavailable unless all participants have signing-capable chat
+  keys;
+- conversation rows and notifications do not reveal plaintext;
+- password change still requires chat-key rewrap;
+- password reset still locks old chat history encrypted to the old key; and
+- accessibility remains 100 and performance remains at least 95 for affected
+  pages.

--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -79,6 +79,7 @@ The app and public directory support more than individual profiles. Current disc
 | Existing user    | Request password reset help without exposing whether my username exists        | I receive a generic response while Hush Line avoids treating notification recipients as recovery factors | Password reset flow                                   |
 | Logged-in sender | Start an account conversation with another account after submitting a message  | I can follow up inside Hush Line without relying only on the one-time anonymous reply link               | Public message form, conversation page                |
 | Logged-in sender | Unlock my Hush Line chat key in the browser before reading or replying         | Conversation plaintext stays out of server-side storage and is only decrypted in my browser              | Conversation page                                     |
+| Logged-in sender | See when account conversation follow-up is unavailable                         | I do not mistake a legacy or unkeyed conversation for a safe two-way chat                                | Public message form, conversation page                |
 
 ### Authenticated Recipients: All Users
 
@@ -172,6 +173,8 @@ The app and public directory support more than individual profiles. Current disc
 Two-way conversations are for logged-in Hush Line account holders who submit to another account while both sides can use Hush Line chat keys. Anonymous submissions continue to use the existing message inbox and reply-link flow; they do not create account conversations.
 
 Hush Line chat keys are browser-generated in-app conversation keys. They are separate from PGP keys used for message intake, exports, and notification email compatibility. Proton Key Lookup imports public PGP keys only; Hush Line must not ask users to export, paste, or upload Proton Mail private keys or any other external private key for account conversations.
+
+New account conversation replies require all participants to have active chat keys with public encryption keys and public signing keys. If any participant only has legacy chat-key material, the conversation remains readable where possible, but composing new replies is unavailable until all participants have signing-capable chat keys.
 
 Conversation plaintext is not stored by the server. Conversation messages are stored as per-participant encrypted payloads, and only conversation participants can open the route or append replies. Administrators may manage accounts and trust states, but admin status alone does not grant conversation access.
 

--- a/docs/library/getting-started/new-user-onboarding.md
+++ b/docs/library/getting-started/new-user-onboarding.md
@@ -27,6 +27,10 @@ Two supported paths:
 
 If you are using Proton Mail, Hush Line can look up your public key for you.
 
+Hush Line also uses separate chat keys for two-way account conversations. These
+keys are generated and unlocked in the browser; they are not Proton Mail private
+keys and are not a replacement for your PGP key.
+
 ## Step 3: notifications
 
 Choose where new tips should be sent. Hush Line works best when you add an email address for notifications. If you imported a Proton key in the previous step, using the same address makes email delivery easier to manage.
@@ -41,3 +45,4 @@ Choose whether to appear in the public user directory. Directory listings help w
 
 - Continue with [Prep Your Account](./prep-your-account.md) for the settings you may still want to tune.
 - Continue with [Secure Your Account](./secure-your-account.md) before broad distribution.
+- Continue with [Two-Way Conversations](../using-your-tip-line/two-way-conversations.md) if you want account-based follow-up.

--- a/docs/library/getting-started/prep-your-account.md
+++ b/docs/library/getting-started/prep-your-account.md
@@ -26,6 +26,11 @@ Supported options:
 
 Without a PGP key, people can still see your profile, but they cannot submit tips through it.
 
+Hush Line also uses separate in-browser chat keys for two-way account
+conversations. Chat keys are not Proton Mail private keys and are not the same
+as your PGP key. If you want logged-in senders to continue follow-up inside Hush
+Line, finish chat-key setup and keep your active key unlockable in your browser.
+
 ## 3. Decide how messages should reach you
 
 Hush Line can notify you about new tips in the web inbox and, optionally, by email. In Settings you can:
@@ -54,3 +59,4 @@ Turning on directory visibility makes your tip line easier to find. If you want 
 
 - [Secure Your Account](./secure-your-account.md)
 - [Share Your Tip Line](./share-your-tip-line.md)
+- [Two-Way Conversations](../using-your-tip-line/two-way-conversations.md)

--- a/docs/library/getting-started/secure-your-account.md
+++ b/docs/library/getting-started/secure-your-account.md
@@ -19,6 +19,16 @@ Hush Line supports TOTP-based 2FA.
 
 Once enabled, logins require both your password and the current TOTP code.
 
+## Understand password resets and chat history
+
+Two-way account conversations use Hush Line chat keys that are unlocked in your
+browser. If you change your password while your active chat key is available,
+Hush Line can rewrap that key as part of the password-change flow.
+
+If you reset your password because the old password is unavailable, old chat
+history encrypted to the previous key can remain locked. Treat password-manager
+recovery and account access as part of your conversation security plan.
+
 ## Secure the email account tied to notifications
 
 If tips are forwarded to your inbox, that email account becomes part of your security boundary. Apply the same care there:
@@ -34,4 +44,5 @@ Changing a verified username or display name can affect trust signals shown to s
 ## Related docs
 
 - [Prep Your Account](./prep-your-account.md)
+- [Two-Way Conversations](../using-your-tip-line/two-way-conversations.md)
 - [Account Verification](../using-your-tip-line/account-verification.md)

--- a/docs/library/getting-started/start-here.md
+++ b/docs/library/getting-started/start-here.md
@@ -6,8 +6,9 @@ This is the shortest path to a usable Hush Line account. In practice, most peopl
 
 1. Set up their public profile so sources know who they reached.
 2. Add a PGP key so incoming tips can be encrypted for them.
-3. Decide how they want new-tip notifications delivered.
-4. Publish their tip-line link where their community will actually see it.
+3. Finish Hush Line chat-key setup if they want account-based follow-up.
+4. Decide how they want new-tip notifications delivered.
+5. Publish their tip-line link where their community will actually see it.
 
 ## Recommended order
 
@@ -20,6 +21,7 @@ This is the shortest path to a usable Hush Line account. In practice, most peopl
 
 - A public-facing identity: display name, short bio, and any extra profile details you want sources to use
 - A PGP key: Proton Mail is the easiest path for many users, but manual public-key paste also works
+- A Hush Line chat key if you want logged-in senders to continue follow-up in account conversations
 - A plan for notifications: web inbox only, email notice only, or email delivery with encrypted content
 - A distribution plan: public directory listing, direct profile link, or both
 
@@ -27,4 +29,5 @@ This is the shortest path to a usable Hush Line account. In practice, most peopl
 
 - [Your Inbox](../using-your-tip-line/your-inbox.md)
 - [Reading Messages](../using-your-tip-line/reading-messages.md)
+- [Two-Way Conversations](../using-your-tip-line/two-way-conversations.md)
 - [Account Verification](../using-your-tip-line/account-verification.md)

--- a/docs/library/using-your-tip-line/README.md
+++ b/docs/library/using-your-tip-line/README.md
@@ -6,6 +6,7 @@ Source category: <https://hushline.app/library/docs/using-your-tip-line/your-inb
 
 - [Your Inbox](./your-inbox.md)
 - [Reading Messages](./reading-messages.md)
+- [Two-Way Conversations](./two-way-conversations.md)
 - [Tools](./tools.md)
 - [Email Validation](./email-validation.md)
 - [Vision Assistant](./vision-assistant.md)

--- a/docs/library/using-your-tip-line/two-way-conversations.md
+++ b/docs/library/using-your-tip-line/two-way-conversations.md
@@ -1,0 +1,54 @@
+# Two-Way Conversations
+
+Source basis: Hush Line account conversation behavior and
+[Two-way chat end-to-end encryption](../../TWO-WAY-CHAT-E2EE.md).
+
+Two-way conversations let logged-in Hush Line account holders continue follow-up
+inside Hush Line after a logged-in sender submits to another account.
+
+They are different from anonymous one-time reply links. Anonymous submissions
+still use the normal message inbox and reply/status page, and they do not
+require the sender to create an account.
+
+## When conversations are available
+
+Conversations are available when both sides are logged-in Hush Line accounts and
+all participants have active, signing-capable Hush Line chat keys.
+
+A Hush Line chat key is separate from your PGP key:
+
+- PGP keys protect one-way tip intake, exports, and optional encrypted email
+  notification content.
+- Hush Line chat keys protect account conversation messages in the browser.
+
+If a participant only has older chat-key material or has not finished chat setup,
+Hush Line may still show existing conversation history where possible, but new
+replies are unavailable until every participant has signing-capable chat keys.
+
+## Reading and replying
+
+1. Open the conversation from your inbox.
+2. Unlock your Hush Line chat key in the browser.
+3. Read the decrypted conversation content locally.
+4. Send replies only after the composer is available.
+
+Hush Line stores conversation messages as encrypted copies for each participant.
+The server does not store conversation plaintext.
+
+## Notifications
+
+Conversation notification emails are generic activity alerts. They tell you to
+log in and unlock your chat key, but they do not include conversation plaintext
+or conversation ciphertext.
+
+This is true even if you have enabled message-content notifications for one-way
+tip intake.
+
+## What conversations do not hide
+
+Two-way account conversations are not the same as anonymous submissions. The
+server still needs operational metadata such as participants, timestamps, unread
+state, and recent activity to show the inbox and send notifications.
+
+For the lowest-friction anonymous sender path, continue using the standard
+public tip form and reply/status link.

--- a/docs/library/using-your-tip-line/your-inbox.md
+++ b/docs/library/using-your-tip-line/your-inbox.md
@@ -2,7 +2,7 @@
 
 Source: <https://hushline.app/library/docs/using-your-tip-line/your-inbox/>
 
-Your inbox is where every incoming tip arrives.
+Your inbox is where incoming tips and account conversations appear.
 
 ## What you see
 
@@ -12,19 +12,26 @@ Each message row shows:
 - the date it was created
 - a link to open the full message
 
+Conversation rows appear separately from one-way tips. They do not show
+conversation plaintext previews; open the conversation and unlock your Hush Line
+chat key to read it.
+
 If you have no messages yet, Hush Line shows an empty-state screen instead.
 
-## Filter by status
+## Filter by type and status
 
-Inbox tabs let you filter messages by status, including:
+Inbox tabs let you filter one-way tips by status and account conversations by
+type, including:
 
 - `All`
 - `Waiting`
 - `Accepted`
 - `Declined`
 - `Archived`
+- `Conversations`
 
-Those filters are useful once your tip line is active and you need a simple triage view.
+Those filters are useful once your tip line is active and you need a simple
+triage view.
 
 ## Typical workflow
 
@@ -33,3 +40,6 @@ Those filters are useful once your tip line is active and you need a simple tria
 3. Open a message to review its fields and change its status.
 
 Continue with [Reading Messages](./reading-messages.md) for the per-message workflow.
+
+For account follow-up, continue with
+[Two-Way Conversations](./two-way-conversations.md).

--- a/docs/library/welcome/welcome-to-hush-line.md
+++ b/docs/library/welcome/welcome-to-hush-line.md
@@ -2,19 +2,20 @@
 
 Source basis: the public Hush Line Library welcome section and the project overview in [README.md](../../../README.md).
 
-Hush Line is an open source whistleblower platform for secure, anonymous, one-way disclosures. It is built for journalists, lawyers, educators, organizers, employers, and other trusted recipients who need a safer way to receive tips from their communities.
+Hush Line is an open source whistleblower platform for secure, anonymous disclosures and optional end-to-end encrypted account conversations. It is built for journalists, lawyers, educators, organizers, employers, and other trusted recipients who need a safer way to receive tips from their communities.
 
 ## What Hush Line is designed to protect
 
 - Anonymous submissions without requiring a sender account
 - End-to-end encrypted delivery when the receiver has a PGP key
+- End-to-end encrypted account conversations when both sides use Hush Line chat keys
 - Trust-building signals such as verified accounts and public profile details
 - Safer access paths, including Tor support and privacy-preserving defaults
 
 ## Common ways people use it
 
 - Publish a public tip line for your newsroom, law office, classroom, campaign, or company
-- Receive messages in a web inbox without turning the sender flow into a live chat
+- Receive messages in a web inbox, then continue account-based follow-up when it is appropriate
 - Share a directory listing or direct profile link so sources can verify they reached the right person
 - Run the hosted service or use a [Personal Server](../personal-server/the-hush-line-personal-server.md)
 


### PR DESCRIPTION
## What changed

- Added a canonical two-way chat E2EE reference document covering scope, goals, cryptographic design, key lifecycle, server-side data handling, residual risks, and review checklist.
- Added a launch whitepaper: `Hush Line Two-Way Chat: End-to-End Encryption for Safer Disclosures`.
- Updated README, docs index, architecture, privacy policy, threat model, use cases, and public library docs so they describe two-way account conversations consistently.
- Added library guidance for two-way conversations and updated onboarding/security docs to distinguish PGP keys from Hush Line chat keys.

## Why

Two-way chat is a new feature and the supporting docs needed a clear source of truth before publishing launch-facing whitepaper material. The updates keep anonymous no-account submissions as the primary low-friction path while documenting account-based encrypted follow-up, signing-capable chat-key requirements, metadata limits, and password-reset consequences.

## User and Developer Impact

This is documentation only. It does not change runtime behavior, workflows, CI, encryption code, models, routes, or tests.

## Validation

- Checked open Dependabot PRs: none found.
- `git diff --check origin/main...HEAD`
- `node_modules/.bin/prettier --ignore-path /dev/null --check README.md docs/README.md docs/ARCHITECTURE.md docs/PRIVACY.md docs/USE-CASES.md docs/THREAT-MODEL.md docs/TWO-WAY-CHAT-E2EE.md docs/HUSH-LINE-TWO-WAY-CHAT-E2EE-WHITEPAPER.md docs/library/getting-started/start-here.md docs/library/getting-started/new-user-onboarding.md docs/library/getting-started/prep-your-account.md docs/library/getting-started/secure-your-account.md docs/library/using-your-tip-line/README.md docs/library/using-your-tip-line/your-inbox.md docs/library/using-your-tip-line/two-way-conversations.md docs/library/welcome/welcome-to-hush-line.md`
- `docker compose run --no-deps --rm app poetry run ruff format --check`
- `docker compose run --no-deps --rm app poetry run ruff check --output-format full`
- `docker compose run --no-deps --rm app poetry run mypy --no-incremental .`

`make lint` was attempted before opening this PR but did not reach linters because another local Hush Line stack already owned `127.0.0.1:4566` for blob storage. The equivalent touched Markdown Prettier check plus no-dependency Ruff/mypy stages passed.

## Manual Testing

Not applicable for runtime behavior because this PR changes documentation only. Manual review should read the new whitepaper and canonical E2EE doc for public-claim accuracy before launch.

## Known Risks and Follow-ups

- The privacy policy effective date was updated for the new conversation-data wording.
- The whitepaper intentionally avoids claiming anonymous live chat, server-side plaintext recovery, or formal cryptographic proof.
- Future launch copy should reference these docs instead of restating the crypto model from scratch.