### PR TITLE
Add conversation delete action

### DIFF
--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -49,8 +49,70 @@ function navController() {
     }
   }
 
+  function setupActionMenus() {
+    const actionMenus = document.querySelectorAll(".action-menu");
+    const closeMenu = (menu, button) => {
+      menu.hidden = true;
+      menu.classList.remove("show");
+      button.setAttribute("aria-expanded", "false");
+    };
+
+    actionMenus.forEach((actionMenu) => {
+      const button = actionMenu.querySelector(".action-menu-button");
+      const menu = actionMenu.querySelector(".action-menu-content");
+      if (!button || !menu) {
+        return;
+      }
+
+      button.addEventListener("click", (event) => {
+        event.preventDefault();
+        const expanded = button.getAttribute("aria-expanded") === "true";
+        actionMenus.forEach((otherMenu) => {
+          if (otherMenu === actionMenu) {
+            return;
+          }
+          const otherButton = otherMenu.querySelector(".action-menu-button");
+          const otherContent = otherMenu.querySelector(".action-menu-content");
+          if (otherButton && otherContent) {
+            closeMenu(otherContent, otherButton);
+          }
+        });
+        menu.hidden = expanded;
+        menu.classList.toggle("show", !expanded);
+        button.setAttribute("aria-expanded", String(!expanded));
+      });
+
+      actionMenu.addEventListener("submit", (event) => {
+        const form = event.target;
+        if (
+          !(form instanceof HTMLFormElement) ||
+          !form.dataset.confirmMessage
+        ) {
+          return;
+        }
+        if (!confirm(form.dataset.confirmMessage)) {
+          event.preventDefault();
+        }
+      });
+
+      window.addEventListener("click", (event) => {
+        if (!actionMenu.contains(event.target)) {
+          closeMenu(menu, button);
+        }
+      });
+
+      window.addEventListener("keydown", (event) => {
+        if (event.key === "Escape") {
+          closeMenu(menu, button);
+          button.focus();
+        }
+      });
+    });
+  }
+
   setupDropdown();
   setupMobileNav();
+  setupActionMenus();
 }
 
 const FIRST_LOAD_SPLASH_SEEN_KEY = "hushline:first-load-splash-seen";

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -103,6 +103,11 @@ function navController() {
 
       window.addEventListener("keydown", (event) => {
         if (event.key === "Escape") {
+          const menuIsOpen = button.getAttribute("aria-expanded") === "true";
+          const focusIsInsideMenu = menu.contains(document.activeElement);
+          if (!menuIsOpen && !focusIsInsideMenu) {
+            return;
+          }
           closeMenu(menu, button);
           button.focus();
         }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2373,7 +2373,7 @@ body.conversation-body {
 
 .conversation-header {
   display: flex;
-  justify-content: flex-start;
+  justify-content: space-between;
   gap: 1rem;
   align-items: flex-start;
   position: fixed;
@@ -2384,6 +2384,84 @@ body.conversation-body {
   z-index: 4;
   border-bottom: 1px solid var(--color-border-light);
   padding: 1rem;
+}
+
+.conversation-actions {
+  position: relative;
+  flex: 0 0 auto;
+  margin-left: auto;
+}
+
+.conversation-actions-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  margin: 0;
+  border: 1px solid var(--color-border-light);
+  border-radius: 50%;
+  padding: 0;
+  background: white;
+  color: var(--color-text);
+  box-shadow: none;
+  font-family: var(--font-sans-bold);
+  font-size: 1.35rem;
+  line-height: 1;
+}
+
+.conversation-actions-button:hover,
+.conversation-actions-button:focus-visible {
+  border-color: var(--color-brand);
+  background: var(--color-brand-bg);
+}
+
+.conversation-actions-menu {
+  display: none;
+  position: absolute;
+  top: calc(100% + 0.375rem);
+  right: 0;
+  z-index: 6;
+  min-width: 11rem;
+  border: 1px solid var(--color-border-light);
+  border-radius: 0.375rem;
+  padding: 0.375rem;
+  background: white;
+  box-shadow: var(--shadow-dynamic-card);
+}
+
+.conversation-actions-menu.show {
+  display: block;
+  animation: fadeInSlideDown 0.2s ease forwards;
+}
+
+.conversation-actions-menu form {
+  margin: 0;
+}
+
+.conversation-actions-menu button {
+  width: 100%;
+  min-height: 2.5rem;
+  margin: 0;
+  border: 0;
+  border-radius: 0.25rem;
+  padding: 0.625rem 0.75rem;
+  background: transparent;
+  box-shadow: none;
+  color: var(--color-text);
+  font-family: var(--font-sans);
+  text-align: left;
+}
+
+.conversation-actions-menu button:hover,
+.conversation-actions-menu button:focus-visible {
+  background: var(--color-highlight);
+}
+
+.conversation-actions-menu .conversation-action-danger {
+  color: var(--color-error);
 }
 
 @media (prefers-color-scheme: light) {
@@ -2680,6 +2758,36 @@ body.conversation-body {
     border-color: var(--color-border-dark-1);
     background: var(--color-highlight-dark);
     color: var(--color-text-dark);
+  }
+
+  .conversation-actions-button {
+    border-color: var(--color-border-dark-1);
+    background: var(--color-dark-bg-alt);
+    color: var(--color-text-dark);
+  }
+
+  .conversation-actions-button:hover,
+  .conversation-actions-button:focus-visible {
+    border-color: var(--color-brand-dark-min-saturation);
+    background: var(--color-highlight-dark);
+  }
+
+  .conversation-actions-menu {
+    border-color: var(--color-border-dark-1);
+    background: var(--color-dark-bg-alt);
+  }
+
+  .conversation-actions-menu button {
+    color: var(--color-text-dark);
+  }
+
+  .conversation-actions-menu button:hover,
+  .conversation-actions-menu button:focus-visible {
+    background: var(--color-highlight-dark);
+  }
+
+  .conversation-actions-menu .conversation-action-danger {
+    color: var(--color-error-dark);
   }
 
   .conversation-summary {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2322,7 +2322,7 @@ a.logoutLink {
 .conversation-page {
   --conversation-content-max-width: 960px;
   --conversation-header-offset: 8rem;
-  --conversation-bottom-fade-height: 100px;
+  --conversation-bottom-fade-height: 60px;
   --conversation-content-padding-inline: max(
     var(--container-padding),
     calc((100vw - var(--conversation-content-max-width)) / 2 + var(--container-padding))

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2396,7 +2396,7 @@ body.conversation-body {
   box-sizing: border-box;
   z-index: 4;
   border-bottom: 1px solid var(--color-border-light);
-  padding: 1rem;
+  padding: 0.75rem 1.25rem;
 }
 
 .conversation-actions {
@@ -3923,6 +3923,11 @@ input#captcha_answer {
   }
 
   header {
+    padding-left: 1rem;
+    padding-right: 1rem;
+  }
+
+  .conversation-header {
     padding-left: 1rem;
     padding-right: 1rem;
   }

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2322,6 +2322,7 @@ a.logoutLink {
 .conversation-page {
   --conversation-content-max-width: 960px;
   --conversation-header-offset: 8rem;
+  --conversation-bottom-fade-height: 100px;
   --conversation-content-padding-inline: max(
     var(--container-padding),
     calc((100vw - var(--conversation-content-max-width)) / 2 + var(--container-padding))
@@ -2509,7 +2510,7 @@ body.conversation-body {
   position: absolute;
   left: 50%;
   bottom: 5rem;
-  z-index: 0;
+  z-index: 4;
   margin: 0;
   pointer-events: none;
   transform: translateX(-50%) scale(0.95);
@@ -2574,8 +2575,9 @@ body.conversation-body {
   min-height: 0;
   overflow-y: auto;
   padding: 0.75rem var(--conversation-content-padding-inline);
+  padding-bottom: var(--conversation-bottom-fade-height);
   position: relative;
-  scroll-padding-bottom: 6rem;
+  scroll-padding-bottom: var(--conversation-bottom-fade-height);
   z-index: 1;
   padding-top: 8rem;
 }
@@ -2654,6 +2656,19 @@ body.conversation-body {
   border-top: 1px solid var(--color-border-light);
 }
 
+.conversation-composer::before {
+  content: "";
+  position: absolute;
+  bottom: 100%;
+  left: 50%;
+  z-index: 1;
+  width: 100vw;
+  height: var(--conversation-bottom-fade-height);
+  pointer-events: none;
+  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), white);
+  transform: translateX(-50%);
+}
+
 .conversation-composer label.visually-hidden,
 .conversation-composer .meta {
   grid-column: 1 / -1;
@@ -2730,6 +2745,7 @@ body.conversation-body {
   .conversation-thread {
     padding: 0.625rem;
     padding-top: 8rem;
+    padding-bottom: var(--conversation-bottom-fade-height);
   }
 
   .conversation-composer {
@@ -2809,6 +2825,14 @@ body.conversation-body {
   .conversation-composer {
     border-top-color: var(--color-border-dark-1);
     background: var(--color-dark-bg-alt-transparent-1);
+  }
+
+  .conversation-composer::before {
+    background: linear-gradient(
+      to bottom,
+      rgba(39, 39, 39, 0),
+      var(--color-dark-bg-alt)
+    );
   }
 
   .conversation-composer textarea {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2322,7 +2322,7 @@ a.logoutLink {
 .conversation-page {
   --conversation-content-max-width: 960px;
   --conversation-header-offset: 8rem;
-  --conversation-bottom-fade-height: 60px;
+  --conversation-bottom-padding: 60px;
   --conversation-content-padding-inline: max(
     var(--container-padding),
     calc((100vw - var(--conversation-content-max-width)) / 2 + var(--container-padding))
@@ -2575,9 +2575,9 @@ body.conversation-body {
   min-height: 0;
   overflow-y: auto;
   padding: 0.75rem var(--conversation-content-padding-inline);
-  padding-bottom: var(--conversation-bottom-fade-height);
+  padding-bottom: var(--conversation-bottom-padding);
   position: relative;
-  scroll-padding-bottom: var(--conversation-bottom-fade-height);
+  scroll-padding-bottom: var(--conversation-bottom-padding);
   z-index: 1;
   padding-top: 8rem;
 }
@@ -2656,19 +2656,6 @@ body.conversation-body {
   border-top: 1px solid var(--color-border-light);
 }
 
-.conversation-composer::before {
-  content: "";
-  position: absolute;
-  bottom: 100%;
-  left: 50%;
-  z-index: 1;
-  width: 100vw;
-  height: var(--conversation-bottom-fade-height);
-  pointer-events: none;
-  background: linear-gradient(to bottom, rgba(255, 255, 255, 0), white);
-  transform: translateX(-50%);
-}
-
 .conversation-composer label.visually-hidden,
 .conversation-composer .meta {
   grid-column: 1 / -1;
@@ -2745,7 +2732,7 @@ body.conversation-body {
   .conversation-thread {
     padding: 0.625rem;
     padding-top: 8rem;
-    padding-bottom: var(--conversation-bottom-fade-height);
+    padding-bottom: var(--conversation-bottom-padding);
   }
 
   .conversation-composer {
@@ -2825,14 +2812,6 @@ body.conversation-body {
   .conversation-composer {
     border-top-color: var(--color-border-dark-1);
     background: var(--color-dark-bg-alt-transparent-1);
-  }
-
-  .conversation-composer::before {
-    background: linear-gradient(
-      to bottom,
-      rgba(39, 39, 39, 0),
-      var(--color-dark-bg-alt)
-    );
   }
 
   .conversation-composer textarea {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -214,7 +214,15 @@
 
   .mobileNav {
     background-image: url("../img/icon-menu.png");
+  }
+
+  .mobileNav,
+  .conversation-actions-button {
     border: var(--border-button);
+  }
+
+  .conversation-actions-button {
+    color: var(--color-text);
   }
 
   .icon.chevron {
@@ -826,6 +834,10 @@
 
   .mobileNav {
     background-image: url("../img/icon-menu-light.png");
+  }
+
+  .mobileNav,
+  .conversation-actions-button {
     color: var(--color-brand-dark-min-saturation);
     border: var(--border-button-dark);
     box-shadow: 0px 2px 0px 0px oklch(from var(--color-brand-dark-min-saturation) l c h / 0.25);
@@ -2375,7 +2387,7 @@ body.conversation-body {
   display: flex;
   justify-content: space-between;
   gap: 1rem;
-  align-items: flex-start;
+  align-items: center;
   position: fixed;
   top: var(--conversation-top-offset);
   left: 0;
@@ -2390,6 +2402,7 @@ body.conversation-body {
   position: relative;
   flex: 0 0 auto;
   margin-left: auto;
+  align-self: center;
 }
 
 .conversation-actions-button {
@@ -2401,21 +2414,11 @@ body.conversation-body {
   min-width: 2.75rem;
   min-height: 2.75rem;
   margin: 0;
-  border: 1px solid var(--color-border-light);
   border-radius: 50%;
   padding: 0;
-  background: white;
-  color: var(--color-text);
-  box-shadow: none;
-  font-family: var(--font-sans-bold);
+  background-color: transparent;
   font-size: 1.35rem;
   line-height: 1;
-}
-
-.conversation-actions-button:hover,
-.conversation-actions-button:focus-visible {
-  border-color: var(--color-brand);
-  background: var(--color-brand-bg);
 }
 
 .conversation-actions-menu {
@@ -2758,18 +2761,6 @@ body.conversation-body {
     border-color: var(--color-border-dark-1);
     background: var(--color-highlight-dark);
     color: var(--color-text-dark);
-  }
-
-  .conversation-actions-button {
-    border-color: var(--color-border-dark-1);
-    background: var(--color-dark-bg-alt);
-    color: var(--color-text-dark);
-  }
-
-  .conversation-actions-button:hover,
-  .conversation-actions-button:focus-visible {
-    border-color: var(--color-brand-dark-min-saturation);
-    background: var(--color-highlight-dark);
   }
 
   .conversation-actions-menu {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -2322,7 +2322,7 @@ a.logoutLink {
 .conversation-page {
   --conversation-content-max-width: 960px;
   --conversation-header-offset: 8rem;
-  --conversation-bottom-padding: 60px;
+  --conversation-bottom-padding: 52px;
   --conversation-content-padding-inline: max(
     var(--container-padding),
     calc((100vw - var(--conversation-content-max-width)) / 2 + var(--container-padding))

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -8,7 +8,7 @@ Effective date: 2026-06-18
 - **What we store**: encrypted message and conversation content plus the account, conversation, and security records listed below.
 - **What we share**: DigitalOcean hosts the service; Stripe handles billing if enabled.
 - **Cookies**: an encrypted session cookie and a local flag for first‑visit anti‑censorship tips.
-- **Your control**: update or delete your account and messages in the app.
+- **Your control**: update or delete your account, messages, and conversations in the app.
 
 ## 1) Who We Are
 

--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -110,6 +110,7 @@ The app and public directory support more than individual profiles. Current disc
 | Recipient     | Delete a message                                                                    | I can remove data I no longer need to retain in the web UI                                         | Message delete                     |
 | Recipient     | See account conversations in my inbox                                               | I can distinguish ongoing account follow-up from anonymous one-time tips                           | Inbox conversation list            |
 | Recipient     | Reply to an account sender after unlocking my chat key                              | I can ask follow-up questions without receiving plaintext on the server                            | Conversation page                  |
+| Recipient     | Delete an account conversation                                                      | I can remove an encrypted follow-up thread I no longer need to retain                              | Conversation action menu           |
 | Recipient     | Receive only generic conversation email alerts                                      | Conversation ciphertext and plaintext are not copied into notification email                       | Conversation notifications         |
 | Recipient     | Change my username                                                                  | I can correct or improve my published address                                                      | Settings -> Authentication         |
 | Recipient     | Change my password                                                                  | I can recover from credential hygiene issues or rotation needs while rewrapping my active chat key | Settings -> Authentication         |
@@ -177,6 +178,8 @@ Hush Line chat keys are browser-generated in-app conversation keys. They are sep
 New account conversation replies require all participants to have active chat keys with public encryption keys and public signing keys. If any participant only has legacy chat-key material, the conversation remains readable where possible, but composing new replies is unavailable until all participants have signing-capable chat keys.
 
 Conversation plaintext is not stored by the server. Conversation messages are stored as per-participant encrypted payloads, and only conversation participants can open the route or append replies. Administrators may manage accounts and trust states, but admin status alone does not grant conversation access.
+
+Deleting an account conversation removes the conversation thread, participant records, and per-participant encrypted conversation message copies. If the conversation began from a one-way intake message, that original message remains in the recipient's inbox without an attached account conversation link.
 
 Password changes require the active Hush Line chat key to be rewrapped in the browser before the password is changed. Password reset cannot rewrap an active chat key because the old password is unavailable; reset locks old chat history encrypted to that key. Old chat history remains unavailable unless a future recovery mechanism is explicitly designed, reviewed, documented, and tested.
 

--- a/docs/library/using-your-tip-line/two-way-conversations.md
+++ b/docs/library/using-your-tip-line/two-way-conversations.md
@@ -35,6 +35,14 @@ replies are unavailable until every participant has signing-capable chat keys.
 Hush Line stores conversation messages as encrypted copies for each participant.
 The server does not store conversation plaintext.
 
+## Deleting conversations
+
+Use the conversation action menu to delete a conversation you no longer need to
+retain. Deleting a conversation removes the encrypted follow-up thread and its
+participant message copies. If the conversation began from a one-way intake
+message, the original inbox message remains without an attached conversation
+link.
+
 ## Notifications
 
 Conversation notification emails are generic activity alerts. They tell you to

--- a/hushline/forms.py
+++ b/hushline/forms.py
@@ -110,6 +110,10 @@ class DeleteMessageForm(FlaskForm):
     submit = SubmitField("Delete", widget=Button())
 
 
+class DeleteConversationForm(FlaskForm):
+    submit = SubmitField("Delete", widget=Button())
+
+
 class ResendMessageForm(FlaskForm):
     submit = SubmitField("Resend to Email", widget=Button())
 

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -48,6 +48,7 @@ from hushline.routes.common import (
 
 _CHAT_CIPHERTEXT_MAX_LENGTH = 200_000
 _CHAT_CIPHERTEXT_CONTEXT_VERSION = 2
+_CHAT_ONLY_MESSAGE_PLACEHOLDER = "Stored in encrypted conversation."
 _CONVERSATION_ACTIVITY_TIMEOUT_SECONDS = 120
 _CONVERSATION_PRESENCE_HEARTBEAT_SECONDS = 60
 _CONVERSATION_NOTIFICATION_BODY = (
@@ -117,6 +118,13 @@ def _mark_conversation_participant_active(
     participant: ConversationParticipant, now: datetime | None = None
 ) -> None:
     participant.last_active_at = now or datetime.now(UTC)
+
+
+def _message_is_chat_only_placeholder(message: Message) -> bool:
+    return bool(message.field_values) and all(
+        field_value.encrypted is False and field_value.value == _CHAT_ONLY_MESSAGE_PLACEHOLDER
+        for field_value in message.field_values
+    )
 
 
 def _conversation_participant_is_active(
@@ -543,8 +551,12 @@ def register_message_routes(app: Flask) -> None:
         if not delete_conversation_form.validate_on_submit():
             abort(400)
 
-        if thread.initial_message is not None:
-            thread.initial_message.conversation = None
+        initial_message = thread.initial_message
+        if initial_message is not None:
+            if _message_is_chat_only_placeholder(initial_message):
+                db.session.delete(initial_message)
+            else:
+                initial_message.conversation = None
         db.session.delete(thread)
         db.session.commit()
         flash("Conversation deleted successfully.")

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -25,6 +25,7 @@ from hushline.crypto import encrypt_message
 from hushline.db import db
 from hushline.forms import (
     ConversationMessageForm,
+    DeleteConversationForm,
     DeleteMessageForm,
     ResendMessageForm,
     UpdateMessageStatusForm,
@@ -404,6 +405,7 @@ def register_message_routes(app: Flask) -> None:
         ]
         can_compose = len(participant_public_keys) == len(thread.participants)
         conversation_message_form = ConversationMessageForm()
+        delete_conversation_form = DeleteConversationForm()
 
         return render_template(
             "conversation.html",
@@ -420,6 +422,7 @@ def register_message_routes(app: Flask) -> None:
             conversation_username=conversation_username,
             conversation_presence_interval_ms=_conversation_presence_heartbeat_ms(),
             conversation_message_form=conversation_message_form,
+            delete_conversation_form=delete_conversation_form,
         )
 
     @app.route("/conversation/<public_id>/presence", methods=["POST"])
@@ -522,6 +525,30 @@ def register_message_routes(app: Flask) -> None:
             ),
             201,
         )
+
+    @app.route("/conversation/<public_id>/delete", methods=["POST"])
+    @authentication_required
+    def delete_conversation(public_id: str) -> Response:
+        user = db.session.get(User, session["user_id"])
+        if not user:
+            abort(404)
+
+        thread = db.session.scalars(
+            Conversation.for_user_id(user.id).where(Conversation.public_id == public_id)
+        ).one_or_none()
+        if not thread or not thread.participant_for_user_id(user.id):
+            abort(404)
+
+        delete_conversation_form = DeleteConversationForm()
+        if not delete_conversation_form.validate_on_submit():
+            abort(400)
+
+        if thread.initial_message is not None:
+            thread.initial_message.conversation = None
+        db.session.delete(thread)
+        db.session.commit()
+        flash("Conversation deleted successfully.")
+        return redirect(url_for("inbox", type="conversations"))
 
     @app.route("/reply/<slug>")
     def message_reply(slug: str) -> str:

--- a/hushline/templates/conversation.html
+++ b/hushline/templates/conversation.html
@@ -20,6 +20,33 @@
         </a>
       {% endif %}
     </div>
+    <div class="conversation-actions action-menu">
+      <button
+        type="button"
+        class="conversation-actions-button action-menu-button"
+        aria-label="Conversation actions"
+        aria-haspopup="menu"
+        aria-expanded="false"
+        aria-controls="conversation-actions-menu"
+      >
+        <span aria-hidden="true">&#8942;</span>
+      </button>
+      <div
+        id="conversation-actions-menu"
+        class="conversation-actions-menu action-menu-content"
+        role="menu"
+        hidden
+      >
+        <form
+          method="POST"
+          action="{{ url_for('delete_conversation', public_id=conversation.public_id) }}"
+          data-confirm-message="Delete this conversation for all participants? This cannot be undone."
+        >
+          {{ delete_conversation_form.hidden_tag() }}
+          {{ delete_conversation_form.submit(class="conversation-action-danger", role="menuitem") }}
+        </form>
+      </div>
+    </div>
   </div>
 
   {% set append_message_url = url_for('append_conversation_message', public_id=conversation.public_id) %}

--- a/hushline/templates/conversation.html
+++ b/hushline/templates/conversation.html
@@ -42,7 +42,12 @@
           action="{{ url_for('delete_conversation', public_id=conversation.public_id) }}"
           data-confirm-message="Delete this conversation for all participants? This cannot be undone."
         >
-          {{ delete_conversation_form.hidden_tag() }}
+          <input
+            id="delete_conversation_csrf_token"
+            name="csrf_token"
+            type="hidden"
+            value="{{ global_csrf_token }}"
+          />
           {{ delete_conversation_form.submit(class="conversation-action-danger", role="menuitem") }}
         </form>
       </div>

--- a/scripts/dev_data.py
+++ b/scripts/dev_data.py
@@ -997,27 +997,27 @@ def create_sample_conversations() -> None:
         messages=[
             (
                 "newman",
-                "The procurement file has three dates that do not match the public agenda.",
+                'Hello, "Art" ;)',
                 base_time,
             ),
             (
                 "artvandelay",
-                "I am in the thread now. Share only what you can safely document.",
+                "Hello, Newman.",
                 base_time + timedelta(minutes=8),
             ),
             (
                 "newman",
-                "I can confirm the Feb 9 shipment was approved before the safety review closed.",
+                "I think I have information you might find interesting about the Human Fund.",
                 base_time + timedelta(minutes=19),
             ),
             (
                 "artvandelay",
-                "Received. I will cross-check the contract number and keep this conversation here.",
+                "The charity? Please tell me the funds are not just in a coffee can.",
                 base_time + timedelta(minutes=24),
             ),
             (
                 "newman",
-                "There is also an internal memo saying the vendor was preselected.",
+                "Not a coffee can. A very official envelope labeled \"miscellaneous grievances.\"",
                 base_time + timedelta(minutes=37),
             ),
         ],

--- a/scripts/dev_data.py
+++ b/scripts/dev_data.py
@@ -1017,7 +1017,7 @@ def create_sample_conversations() -> None:
             ),
             (
                 "newman",
-                "Not a coffee can. A very official envelope labeled \"miscellaneous grievances.\"",
+                'Not a coffee can. A very official envelope labeled "miscellaneous grievances."',
                 base_time + timedelta(minutes=37),
             ),
         ],

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -13,6 +13,7 @@ from hushline.model import (
     ConversationMessage,
     ConversationMessageCopy,
     ConversationParticipant,
+    FieldValue,
     Message,
     NotificationRecipient,
     User,
@@ -612,6 +613,40 @@ def test_participant_can_delete_conversation(
     assert retained_message.conversation_id is None
 
 
+def test_delete_conversation_removes_chat_only_placeholder_initial_message(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    conversation_id = conversation.id
+    initial_message = Message(username_id=user2.primary_username.id)
+    initial_message.conversation = conversation
+    db.session.add(initial_message)
+    db.session.flush()
+    placeholder_value = FieldValue(
+        user2.primary_username.message_fields[-1],
+        initial_message,
+        "Stored in encrypted conversation.",
+        False,
+    )
+    db.session.add(placeholder_value)
+    db.session.commit()
+    initial_message_id = initial_message.id
+    placeholder_value_id = placeholder_value.id
+    _authenticate_as(client, user)
+
+    response = client.post(
+        url_for("delete_conversation", public_id=conversation.public_id),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert db.session.get(Conversation, conversation_id) is None
+    assert db.session.get(Message, initial_message_id) is None
+    assert db.session.get(FieldValue, placeholder_value_id) is None
+
+
 def test_delete_conversation_requires_participant(
     client: FlaskClient,
     user: User,
@@ -674,8 +709,13 @@ def test_delete_conversation_accepts_rendered_csrf_token(
     app.config["WTF_CSRF_ENABLED"] = True
     try:
         page_response = client.get(url_for("conversation", public_id=conversation.public_id))
+        assert page_response.text.count('id="csrf_token"') == 1
+        assert 'id="delete_conversation_csrf_token"' in page_response.text
         token_match = re.search(
-            r'<input id="csrf_token" name="csrf_token" type="hidden" value="([^"]+)">',
+            (
+                r'<input\s+[^>]*id="delete_conversation_csrf_token"'
+                r'[^>]*name="csrf_token"[^>]*value="([^"]+)"'
+            ),
             page_response.text,
         )
         assert token_match is not None

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -13,6 +13,7 @@ from hushline.model import (
     ConversationMessage,
     ConversationMessageCopy,
     ConversationParticipant,
+    Message,
     NotificationRecipient,
     User,
 )
@@ -311,6 +312,28 @@ def test_conversation_view_shows_locked_chat_key_state(
     assert url_for("conversation_presence", public_id=conversation.public_id) in response.text
 
 
+def test_conversation_header_includes_actions_menu(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    response = client.get(url_for("conversation", public_id=conversation.public_id))
+
+    assert response.status_code == 200
+    assert 'class="conversation-actions action-menu"' in response.text
+    assert 'aria-label="Conversation actions"' in response.text
+    assert 'aria-haspopup="menu"' in response.text
+    assert 'id="conversation-actions-menu"' in response.text
+    assert 'role="menu"' in response.text
+    assert url_for("delete_conversation", public_id=conversation.public_id) in response.text
+    assert "Delete this conversation for all participants? This cannot be undone." in response.text
+    assert 'role="menuitem"' in response.text
+    assert ">Delete</button>" in response.text
+
+
 def test_conversation_view_disables_composer_when_participant_key_cannot_sign(
     client: FlaskClient,
     user: User,
@@ -538,6 +561,135 @@ def test_conversation_presence_requires_csrf_when_enabled(
 
     assert response.status_code == 400
     assert "Invalid CSRF token." in response.text
+
+
+def test_participant_can_delete_conversation(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    conversation_id = conversation.id
+    initial_message = Message(username_id=user2.primary_username.id)
+    initial_message.conversation = conversation
+    db.session.add(initial_message)
+    db.session.commit()
+    initial_message_id = initial_message.id
+    conversation_message_ids = [message.id for message in conversation.messages]
+    conversation_copy_ids = [
+        encrypted_copy.id
+        for message in conversation.messages
+        for encrypted_copy in message.encrypted_copies
+    ]
+    _authenticate_as(client, user)
+
+    response = client.post(
+        url_for("delete_conversation", public_id=conversation.public_id),
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(url_for("inbox", type="conversations"))
+    assert db.session.get(Conversation, conversation_id) is None
+    assert (
+        db.session.scalar(
+            db.select(db.func.count())
+            .select_from(ConversationParticipant)
+            .where(ConversationParticipant.conversation_id == conversation_id)
+        )
+        == 0
+    )
+    assert all(
+        db.session.get(ConversationMessage, message_id) is None
+        for message_id in conversation_message_ids
+    )
+    assert all(
+        db.session.get(ConversationMessageCopy, copy_id) is None
+        for copy_id in conversation_copy_ids
+    )
+    retained_message = db.session.get(Message, initial_message_id)
+    assert retained_message is not None
+    assert retained_message.conversation_id is None
+
+
+def test_delete_conversation_requires_participant(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    admin_user: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    conversation_id = conversation.id
+    _authenticate_as(client, admin_user)
+
+    response = client.post(url_for("delete_conversation", public_id=conversation.public_id))
+
+    assert response.status_code == 404
+    assert db.session.get(Conversation, conversation_id) is not None
+
+
+def test_delete_conversation_redirects_unauthenticated_user(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+
+    response = client.post(url_for("delete_conversation", public_id=conversation.public_id))
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(url_for("login"))
+    assert db.session.get(Conversation, conversation.id) is not None
+
+
+def test_delete_conversation_requires_csrf_when_enabled(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+    prior_setting = app.config.get("WTF_CSRF_ENABLED")
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        response = client.post(url_for("delete_conversation", public_id=conversation.public_id))
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = prior_setting
+
+    assert response.status_code == 400
+    assert db.session.get(Conversation, conversation.id) is not None
+
+
+def test_delete_conversation_accepts_rendered_csrf_token(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    conversation_id = conversation.id
+    _authenticate_as(client, user)
+    prior_setting = app.config.get("WTF_CSRF_ENABLED")
+    app.config["WTF_CSRF_ENABLED"] = True
+    try:
+        page_response = client.get(url_for("conversation", public_id=conversation.public_id))
+        token_match = re.search(
+            r'<input id="csrf_token" name="csrf_token" type="hidden" value="([^"]+)">',
+            page_response.text,
+        )
+        assert token_match is not None
+
+        response = client.post(
+            url_for("delete_conversation", public_id=conversation.public_id),
+            data={"csrf_token": token_match.group(1)},
+            follow_redirects=False,
+        )
+    finally:
+        app.config["WTF_CSRF_ENABLED"] = prior_setting
+
+    assert response.status_code == 302
+    assert db.session.get(Conversation, conversation_id) is None
 
 
 def test_participant_can_append_encrypted_conversation_message(

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -535,6 +535,15 @@ def test_submit_spinner_hooks_exist_for_scoped_forms() -> None:
     assert "@keyframes submit-button-spinner-rotate" in scss
 
 
+def test_action_menu_escape_handling_is_scoped_to_open_menu() -> None:
+    js = (ROOT / "assets/js/global.js").read_text(encoding="utf-8")
+
+    assert 'const menuIsOpen = button.getAttribute("aria-expanded") === "true";' in js
+    assert "const focusIsInsideMenu = menu.contains(document.activeElement);" in js
+    assert "if (!menuIsOpen && !focusIsInsideMenu)" in js
+    assert "closeMenu(menu, button);" in js
+
+
 def test_first_load_splash_hooks_exist() -> None:
     template = (ROOT / "hushline/templates/base.html").read_text(encoding="utf-8")
     js = (ROOT / "assets/js/global.js").read_text(encoding="utf-8")


### PR DESCRIPTION
## What changed

- Added a circular three-dot action menu to the conversation header.
- Added a `Delete` action that submits a CSRF-protected form to delete the account conversation.
- Added a participant-scoped delete route that removes the conversation thread, participant records, conversation messages, and encrypted message copies.
- Preserved the original one-way intake `Message` when present by clearing its conversation link before deleting the conversation.
- Delete now removes chat-only placeholder initial messages instead of surfacing `Stored in encrypted conversation.` as a retained one-way tip.
- Scoped action-menu Escape handling so hidden menus do not steal focus from the composer.
- Rendered the delete form CSRF token with a unique input id backed by the page-level CSRF token.
- Updated user-facing and grounding docs to describe conversation deletion behavior.

## Why

Users need a way to remove two-way account conversation threads they no longer need to retain. The action is placed behind the conversation header menu so the header can host additional conversation actions later without adding visible clutter.

## Threat / Risk Summary

Conversation deletion touches encrypted follow-up data and participant-scoped routes. The new route reuses `Conversation.for_user_id(...)` participant scoping, requires an authenticated session, and validates the rendered CSRF token before deleting. The delete operation is intentionally thread-wide, not per-user archival; the confirmation text says it deletes for all participants.

## Affected Data Paths

- `Conversation`, `ConversationParticipant`, `ConversationMessage`, and `ConversationMessageCopy` deletion cascade.
- Linked one-way `Message.conversation_id` is set to `NULL` before deletion.
- Chat-only placeholder initial `Message` rows are deleted with their encrypted conversation instead of being retained as visible one-way tips.
- Conversation header template, global action-menu JS, and conversation header styles.

## Validation

- `docker compose run --no-deps --rm app poetry run ruff format --check hushline/routes/message.py tests/test_conversation.py tests/test_frontend_compat.py` (passed)
- `docker compose run --no-deps --rm app poetry run ruff check --output-format full hushline/routes/message.py tests/test_conversation.py tests/test_frontend_compat.py` (passed)
- `docker compose run --no-deps --rm app poetry run pytest tests/test_conversation.py tests/test_frontend_compat.py -q` (78 passed, 8 existing SQLAlchemy warnings)
- `docker compose run --no-deps --rm app poetry run ruff format --check`
- `docker compose run --no-deps --rm app poetry run ruff check --output-format full`
- `docker compose run --no-deps --rm app poetry run mypy --no-incremental .`
- `node_modules/.bin/prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./package.json ./playwright.e2ee.config.js ./tests/playwright ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js`
- `docker compose -p hushline-delete-chat-test -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.compose.yaml run --no-deps --rm app poetry run pytest tests/test_conversation.py -q` (41 passed)
- `docker compose -p hushline-delete-chat-test -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.compose.yaml run --no-deps --rm app poetry run pytest tests/test_frontend_compat.py -q` (35 passed)
- `docker compose -p hushline-delete-chat-test -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.compose.yaml run --no-deps --rm app poetry run pytest --cov hushline --cov-report term-missing --cov-report html:/tmp/hushline-htmlcov -vv -m "not external_network" ./tests/` (2119 passed, 1 deselected, 1 xfailed, 2 S3 storage setup errors because blob-storage was not running in that isolated project)
- `docker compose -p hushline-delete-chat-test -f docker-compose.yaml -f /private/tmp/hushline-no-host-ports.compose.yaml run --no-deps --rm app poetry run pytest tests/test_storage.py -q` after starting isolated blob-storage (13 passed)
- Python dependency audit: no known vulnerabilities found
- `npm audit --omit=dev --package-lock-only` (0 vulnerabilities)

`make lint` itself could not run as a wrapper in this local checkout because another running local Hush Line Compose project owns `127.0.0.1:5432`; the underlying lint commands above passed with service startup disabled.

## Manual Testing

Not performed in a browser. The rendered action-menu markup, participant-only delete behavior, unauthenticated redirect, CSRF rejection, rendered CSRF acceptance, chat-only placeholder cleanup, and data-retention semantics are covered by route/frontend compatibility tests.

## Known Risks / Follow-ups

- This implements whole-thread deletion for all participants. Per-user hiding/archiving would require a separate data model change.
- CI should provide the final single-run `make lint` / `make test` confirmation on a clean runner without the local port conflict.