### PR TITLE
Clear SQLAlchemy test setup warnings

### DIFF
--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -210,12 +210,13 @@ def _add_conversation_message(
     conversation_message.conversation = conversation
     conversation_message.sender_participant = sender_participant
     conversation_message.created_at = created_at
+    db.session.add(conversation_message)
     for recipient_participant in conversation.participants:
         encrypted_copy = ConversationMessageCopy()
+        encrypted_copy.message = conversation_message
         encrypted_copy.recipient_participant = recipient_participant
         encrypted_copy.encrypted_payload = _ciphertext(f"{label}-{recipient_participant.id}")
-        conversation_message.encrypted_copies.append(encrypted_copy)
-    db.session.add(conversation_message)
+        db.session.add(encrypted_copy)
     db.session.commit()
     return conversation_message
 

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -551,8 +551,9 @@ def test_password_reset_sets_new_password_and_consumes_token(
 def test_password_reset_locks_active_chat_key_without_server_recovery(
     client: FlaskClient, user: User, user_password: str
 ) -> None:
+    user_id = user.id
     chat_key = ChatKey(
-        user=user,
+        user_id=user_id,
         key_version=1,
         public_key="public-chat-key",
         encrypted_private_key='{"algorithm":"AES-GCM","iv":"old","ciphertext":"old"}',
@@ -562,7 +563,7 @@ def test_password_reset_locks_active_chat_key_without_server_recovery(
         wrapping_algorithm="AES-GCM",
     )
     reset_token, raw_token = PasswordResetToken.create_for_user(
-        user.id,
+        user_id,
         ttl=timedelta(hours=1),
     )
     db.session.add_all([chat_key, reset_token])
@@ -592,8 +593,10 @@ def test_password_reset_locks_active_chat_key_without_server_recovery(
 def test_password_reset_leaves_existing_conversation_history_locked(
     client: FlaskClient, user: User, user2: User
 ) -> None:
+    user_id = user.id
+    user2_id = user2.id
     chat_key = ChatKey(
-        user=user,
+        user_id=user_id,
         key_version=1,
         public_key='{"kty":"EC","crv":"P-256","x":"old-sender","y":"key"}',
         encrypted_private_key='{"algorithm":"AES-GCM","iv":"old","ciphertext":"old"}',
@@ -603,7 +606,7 @@ def test_password_reset_leaves_existing_conversation_history_locked(
         wrapping_algorithm="AES-GCM",
     )
     recipient_chat_key = ChatKey(
-        user=user2,
+        user_id=user2_id,
         key_version=1,
         public_key='{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}',
         encrypted_private_key='{"algorithm":"AES-GCM","iv":"recipient","ciphertext":"wrapped"}',
@@ -615,11 +618,11 @@ def test_password_reset_leaves_existing_conversation_history_locked(
     conversation = Conversation()
     sender_participant = ConversationParticipant()
     sender_participant.conversation = conversation
-    sender_participant.user = user
+    sender_participant.user_id = user_id
     sender_participant.has_usable_public_key = True
     recipient_participant = ConversationParticipant()
     recipient_participant.conversation = conversation
-    recipient_participant.user = user2
+    recipient_participant.user_id = user2_id
     recipient_participant.has_usable_public_key = True
     conversation_message = ConversationMessage()
     conversation_message.conversation = conversation
@@ -636,7 +639,7 @@ def test_password_reset_leaves_existing_conversation_history_locked(
     )
     conversation_message.encrypted_copies.extend([sender_copy, recipient_copy])
     reset_token, raw_token = PasswordResetToken.create_for_user(
-        user.id,
+        user_id,
         ttl=timedelta(hours=1),
     )
     db.session.add_all([chat_key, recipient_chat_key, conversation, reset_token])


### PR DESCRIPTION
## What changed

- Adds pending `ConversationMessage` and `ConversationMessageCopy` test objects to the session before relationship lazy-loads can trigger autoflush.
- Uses explicit `user_id` values in password reset test setup instead of attaching unsaved `ChatKey` and `ConversationParticipant` rows through user relationships before token setup.

## Why

The previous full `make test` run passed but reported 11 SQLAlchemy `SAWarning` entries from test setup code:

- 8 warnings from conversation unread-indicator helper setup: pending `ConversationMessage` rows attached through relationships before autoflush.
- 1 warning from password-reset chat-key setup: pending `ChatKey` attached through `user` before token setup accessed ids.
- 2 warnings from password-reset conversation-history setup: pending `ConversationParticipant` / `ChatKey` rows attached through user relationships before autoflush.

This PR removes that noise without changing runtime behavior.

## Validation

- `gh pr list --author app/dependabot --state open --json number,title,url,updatedAt --limit 20` -> no open Dependabot PRs
- `docker compose run --rm app poetry run pytest tests/test_conversation.py::test_recipient_unread_indicator_clears_when_locked_thread_loads tests/test_conversation.py::test_background_thread_refresh_does_not_clear_inbox_unread_indicator tests/test_conversation.py::test_inbox_unread_indicator_uses_message_cursor_when_timestamps_match tests/test_conversation.py::test_inbox_unread_indicator_uses_latest_message_for_each_participant tests/test_routes_auth.py::test_password_reset_locks_active_chat_key_without_server_recovery tests/test_routes_auth.py::test_password_reset_leaves_existing_conversation_history_locked -W error::sqlalchemy.exc.SAWarning -q` -> 6 passed
- `make lint` -> passed
- `make test` -> 2130 passed, 1 deselected, 1 xfailed, 0 warnings, coverage 99%
- `make audit-python` -> no known vulnerabilities found
- `make audit-node-runtime` -> found 0 vulnerabilities

## Manual testing

Not applicable; test-only setup cleanup, no runtime behavior or UI changes.

## Risks / follow-ups

- Low risk: changes are confined to test setup code.