### PR TITLE
Add release Make target

### DIFF
--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,9 +1,2 @@
-# Hush Line release authorization keys.
-#
-# Add exactly the primary and backup YubiKey-backed SSH public keys here.
-# Normal software keys such as ssh-ed25519 are intentionally rejected by
-# scripts/release.py.
-#
-# Format:
-# hushline-release sk-ssh-ed25519@openssh.com AAAA... primary-release-yubikey
-# hushline-release sk-ecdsa-sha2-nistp256@openssh.com AAAA... backup-release-yubikey
+hushline-release sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBCe1ZZRjmlNx8KvLCR8S8Be5grosyqDixzbM8RrbvD11CXsuKTxEgMhLwS6Xl9VIMXv9B1S4TzTNu6wGRSnWExoAAAAEc3NoOg== primary-release-yubikey
+hushline-release sk-ecdsa-sha2-nistp256@openssh.com AAAAInNrLWVjZHNhLXNoYTItbmlzdHAyNTZAb3BlbnNzaC5jb20AAAAIbmlzdHAyNTYAAABBBECTFiCeSO785F1ZPeGGPCnj+k5eTKWwNqF1EVJMzUIwHyhKkpWMml0+PoCcv4ZOPN7TlzE9VDUUmgGioMEx6M4AAAAEc3NoOg== backup-release-yubikey

--- a/.github/release-allowed-signers
+++ b/.github/release-allowed-signers
@@ -1,0 +1,9 @@
+# Hush Line release authorization keys.
+#
+# Add exactly the primary and backup YubiKey-backed SSH public keys here.
+# Normal software keys such as ssh-ed25519 are intentionally rejected by
+# scripts/release.py.
+#
+# Format:
+# hushline-release sk-ssh-ed25519@openssh.com AAAA... primary-release-yubikey
+# hushline-release sk-ecdsa-sha2-nistp256@openssh.com AAAA... backup-release-yubikey

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ RELEASE_PROD_URL ?= https://tips.hushline.app/
 RELEASE_BRANCH ?= main
 RELEASE_ALLOWED_SIGNERS ?= .github/release-allowed-signers
 RELEASE_SIGNING_KEY ?=
+RELEASE_DRY_RUN ?=
 
 .PHONY: help
 help: ## Print the help message
@@ -164,6 +165,7 @@ release: ## Bump patch version, tag, and publish a GitHub release
 	HUSHLINE_RELEASE_BRANCH="$(RELEASE_BRANCH)" \
 	HUSHLINE_RELEASE_ALLOWED_SIGNERS="$(RELEASE_ALLOWED_SIGNERS)" \
 	HUSHLINE_RELEASE_SIGNING_KEY="$(RELEASE_SIGNING_KEY)" \
+	HUSHLINE_RELEASE_DRY_RUN="$(RELEASE_DRY_RUN)" \
 	python3 scripts/release.py
 
 .PHONY: audit-python

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,10 @@ REFRESH_PUBLIC_RECORD_CORRECTION_SUMMARY_OUTPUT ?= /tmp/public-record-quarterly-
 REFRESH_PUBLIC_RECORD_CORRECTION_REPORT_JSON_OUTPUT ?= /tmp/public-record-quarterly-refresh.json
 REFRESH_SECUREDROP_ARGS ?=
 REFRESH_GLOBALEAKS_ARGS ?=
+RELEASE_PROD_URL ?= https://tips.hushline.app/
+RELEASE_BRANCH ?= main
+RELEASE_ALLOWED_SIGNERS ?= .github/release-allowed-signers
+RELEASE_SIGNING_KEY ?=
 
 .PHONY: help
 help: ## Print the help message
@@ -153,6 +157,14 @@ refresh-globaleaks-listings: ## Refresh GlobaLeaks instance artifact from public
 .PHONY: refresh-newsroom-listings
 refresh-newsroom-listings: ## Refresh newsroom directory artifact from public source pages
 	$(CMD) poetry run python ./scripts/refresh_newsroom_directory_listings.py $(REFRESH_NEWSROOM_ARGS)
+
+.PHONY: release
+release: ## Bump patch version, tag, and publish a GitHub release
+	HUSHLINE_RELEASE_PROD_URL="$(RELEASE_PROD_URL)" \
+	HUSHLINE_RELEASE_BRANCH="$(RELEASE_BRANCH)" \
+	HUSHLINE_RELEASE_ALLOWED_SIGNERS="$(RELEASE_ALLOWED_SIGNERS)" \
+	HUSHLINE_RELEASE_SIGNING_KEY="$(RELEASE_SIGNING_KEY)" \
+	python3 scripts/release.py
 
 .PHONY: audit-python
 audit-python: ## Run Python dependency audit (CI-equivalent)

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ REFRESH_GLOBALEAKS_ARGS ?=
 RELEASE_PROD_URL ?= https://tips.hushline.app/
 RELEASE_BRANCH ?= main
 RELEASE_ALLOWED_SIGNERS ?= .github/release-allowed-signers
-RELEASE_SIGNING_KEY ?=
+RELEASE_SIGNING_KEY ?= $(HOME)/.ssh/hushline-release/primary-release-yubikey
 RELEASE_DRY_RUN ?=
 
 .PHONY: help
@@ -167,6 +167,10 @@ release: ## Bump patch version, tag, and publish a GitHub release
 	HUSHLINE_RELEASE_SIGNING_KEY="$(RELEASE_SIGNING_KEY)" \
 	HUSHLINE_RELEASE_DRY_RUN="$(RELEASE_DRY_RUN)" \
 	python3 scripts/release.py
+
+.PHONY: release-dry-run
+release-dry-run: ## Check release preflight and YubiKey authorization without publishing
+	$(MAKE) release RELEASE_DRY_RUN=1
 
 .PHONY: audit-python
 audit-python: ## Run Python dependency audit (CI-equivalent)

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -16,9 +16,14 @@ REPO_ROOT = Path(__file__).resolve().parents[1]
 VERSION_FILE = REPO_ROOT / "hushline" / "version.py"
 DEFAULT_RELEASE_ALLOWED_SIGNERS = REPO_ROOT / ".github" / "release-allowed-signers"
 DEFAULT_PROD_URL = "https://tips.hushline.app/"
+CANONICAL_REPOSITORY = "scidsg/hushline"
 SEMVER_PARTS = 3
 VERSION_PATTERN = re.compile(r'__version__\s*=\s*"(?P<version>\d+\.\d+\.\d+)"')
-LIVE_VERSION_PATTERN = re.compile(r">\s*v(?P<version>\d+\.\d+\.\d+)\s*<")
+LIVE_VERSION_PATTERN = re.compile(
+    r'<a\b(?=[^>]*\bhref=["\']https://github\.com/scidsg/hushline["\'])'
+    r"[^>]*>\s*v(?P<version>\d+\.\d+\.\d+)\s*</a\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
 RELEASE_AUTH_NAMESPACE = "hushline-release"
 RELEASE_AUTH_PRINCIPAL = "hushline-release"
 MIN_ALLOWED_SIGNER_PARTS = 3
@@ -138,7 +143,52 @@ def ensure_release_branch(runner: Runner, expected_branch: str) -> str:
     return branch
 
 
-def ensure_tag_and_release_available(runner: Runner, tag: str) -> None:
+def _normalize_github_repository(remote_url: str) -> str | None:
+    normalized = remote_url.strip()
+    if normalized.endswith(".git"):
+        normalized = normalized.removesuffix(".git")
+    if normalized.startswith("git@github.com:"):
+        return normalized.removeprefix("git@github.com:")
+    if normalized.startswith("ssh://git@github.com/"):
+        return normalized.removeprefix("ssh://git@github.com/")
+    if normalized.startswith("https://github.com/"):
+        return normalized.removeprefix("https://github.com/")
+    return None
+
+
+def ensure_canonical_origin(
+    runner: Runner,
+    canonical_repository: str = CANONICAL_REPOSITORY,
+) -> None:
+    remote_url = runner(["git", "remote", "get-url", "origin"], True, None).stdout.strip()
+    if _normalize_github_repository(remote_url) != canonical_repository:
+        raise ReleaseError(
+            "make release must run from the canonical origin remote "
+            f"{canonical_repository!r}; origin is {remote_url!r}."
+        )
+
+
+def ensure_release_branch_synced(runner: Runner, branch: str, remote: str = "origin") -> None:
+    runner(["git", "fetch", remote, branch], True, None)
+    local_sha = runner(["git", "rev-parse", branch], True, None).stdout.strip()
+    remote_sha = runner(["git", "rev-parse", f"{remote}/{branch}"], True, None).stdout.strip()
+    if local_sha != remote_sha:
+        raise ReleaseError(
+            f"Local {branch!r} must match {remote}/{branch} before running make release. "
+            f"Run `git fetch {remote} && git pull --ff-only` first."
+        )
+
+
+def _gh_release_view_not_found(result: CommandResult) -> bool:
+    output = f"{result.stdout}\n{result.stderr}".lower()
+    return "release not found" in output or "http 404" in output or "not found" in output
+
+
+def ensure_tag_and_release_available(
+    runner: Runner,
+    tag: str,
+    canonical_repository: str = CANONICAL_REPOSITORY,
+) -> None:
     local_tag = runner(["git", "rev-parse", "--verify", f"refs/tags/{tag}"], False, None)
     if local_tag.returncode == 0:
         raise ReleaseError(f"Local tag already exists: {tag}")
@@ -153,9 +203,18 @@ def ensure_tag_and_release_available(runner: Runner, tag: str) -> None:
     if remote_tag.returncode not in {2}:
         raise ReleaseError((remote_tag.stderr or remote_tag.stdout).strip())
 
-    existing_release = runner(["gh", "release", "view", tag], False, None)
+    existing_release = runner(
+        ["gh", "release", "view", tag, "--repo", canonical_repository],
+        False,
+        None,
+    )
     if existing_release.returncode == 0:
         raise ReleaseError(f"GitHub release already exists: {tag}")
+    if not _gh_release_view_not_found(existing_release):
+        raise ReleaseError(
+            "Could not confirm GitHub release availability before mutating the repository: "
+            f"{(existing_release.stderr or existing_release.stdout).strip()}"
+        )
 
 
 def _release_path_from_env(name: str, default: Path | None = None) -> Path | None:
@@ -305,6 +364,8 @@ def release(
 
     ensure_clean_worktree(runner)
     branch = ensure_release_branch(runner, release_branch)
+    ensure_canonical_origin(runner)
+    ensure_release_branch_synced(runner, branch)
 
     local_version = read_local_version()
     live_version = extract_live_version(fetcher(prod_url))
@@ -330,12 +391,23 @@ def release(
 
     write_local_version(next_version)
     runner(["git", "add", str(VERSION_FILE.relative_to(REPO_ROOT))], True, None)
-    runner(["git", "commit", "-m", f"Update version to {tag}"], True, None)
+    runner(["git", "commit", "-S", "-m", f"Update version to {tag}"], True, None)
     runner(["git", "tag", tag], True, None)
     runner(["git", "push", "origin", branch], True, None)
     runner(["git", "push", "origin", tag], True, None)
     runner(
-        ["gh", "release", "create", tag, "--title", tag, "--generate-notes", "--latest"],
+        [
+            "gh",
+            "release",
+            "create",
+            tag,
+            "--repo",
+            CANONICAL_REPOSITORY,
+            "--title",
+            tag,
+            "--generate-notes",
+            "--latest",
+        ],
         True,
         None,
     )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -163,6 +163,20 @@ def _release_path_from_env(name: str, default: Path | None = None) -> Path | Non
     return Path(value).expanduser()
 
 
+def _release_bool_from_env(name: str) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return False
+    normalized = value.strip().lower()
+    if not normalized:
+        return False
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ReleaseError(f"{name} must be one of: 1, true, yes, on, 0, false, no, off.")
+
+
 def _validate_release_allowed_signers(
     allowed_signers: Path,
     principal: str = RELEASE_AUTH_PRINCIPAL,
@@ -273,10 +287,17 @@ def release_auth_config_from_env() -> ReleaseAuthConfig:
     return ReleaseAuthConfig(signing_key=signing_key, allowed_signers=allowed_signers)
 
 
-def release(runner: Runner = run_command, fetcher: Fetcher = fetch_url) -> str:
+def release(
+    runner: Runner = run_command,
+    fetcher: Fetcher = fetch_url,
+    *,
+    dry_run: bool | None = None,
+) -> str:
     prod_url = os.environ.get("HUSHLINE_RELEASE_PROD_URL", DEFAULT_PROD_URL)
     release_branch = os.environ.get("HUSHLINE_RELEASE_BRANCH", "main")
     auth_config = release_auth_config_from_env()
+    if dry_run is None:
+        dry_run = _release_bool_from_env("HUSHLINE_RELEASE_DRY_RUN")
 
     ensure_clean_worktree(runner)
     branch = ensure_release_branch(runner, release_branch)
@@ -300,6 +321,9 @@ def release(runner: Runner = run_command, fetcher: Fetcher = fetch_url) -> str:
         config=auth_config,
     )
 
+    if dry_run:
+        return tag
+
     write_local_version(next_version)
     runner(["git", "add", str(VERSION_FILE.relative_to(REPO_ROOT))], True, None)
     runner(["git", "commit", "-m", f"Update version to {tag}"], True, None)
@@ -316,12 +340,19 @@ def release(runner: Runner = run_command, fetcher: Fetcher = fetch_url) -> str:
 
 def main() -> int:
     try:
-        tag = release()
+        dry_run = _release_bool_from_env("HUSHLINE_RELEASE_DRY_RUN")
+        tag = release(dry_run=dry_run)
     except ReleaseError as error:
         print(f"release failed: {error}", file=sys.stderr)
         return 1
 
-    print(f"Published Hush Line release {tag}")
+    if dry_run:
+        print(
+            f"Dry run passed for Hush Line release {tag}; "
+            "no version, tag, push, or GitHub release was created."
+        )
+    else:
+        print(f"Published Hush Line release {tag}")
     return 0
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -9,6 +9,7 @@ import tempfile
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
 from pathlib import Path
+from urllib.error import URLError
 from urllib.request import urlopen
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -78,8 +79,11 @@ def run_command(
 
 
 def fetch_url(url: str) -> str:
-    with urlopen(url, timeout=15) as response:  # noqa: S310
-        return response.read().decode("utf-8", errors="replace")
+    try:
+        with urlopen(url, timeout=15) as response:  # noqa: S310
+            return response.read().decode("utf-8", errors="replace")
+    except URLError as error:
+        raise ReleaseError(f"Could not fetch production URL {url}: {error}") from error
 
 
 def read_local_version(version_file: Path | None = None) -> str:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,329 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections.abc import Callable, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from urllib.request import urlopen
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+VERSION_FILE = REPO_ROOT / "hushline" / "version.py"
+DEFAULT_RELEASE_ALLOWED_SIGNERS = REPO_ROOT / ".github" / "release-allowed-signers"
+DEFAULT_PROD_URL = "https://tips.hushline.app/"
+SEMVER_PARTS = 3
+VERSION_PATTERN = re.compile(r'__version__\s*=\s*"(?P<version>\d+\.\d+\.\d+)"')
+LIVE_VERSION_PATTERN = re.compile(r">\s*v(?P<version>\d+\.\d+\.\d+)\s*<")
+RELEASE_AUTH_NAMESPACE = "hushline-release"
+RELEASE_AUTH_PRINCIPAL = "hushline-release"
+MIN_ALLOWED_SIGNER_PARTS = 3
+HARDWARE_SSH_KEY_TYPES = frozenset(
+    {
+        "sk-ecdsa-sha2-nistp256@openssh.com",
+        "sk-ssh-ed25519@openssh.com",
+    }
+)
+
+
+class ReleaseError(RuntimeError):
+    pass
+
+
+@dataclass(frozen=True)
+class CommandResult:
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+
+@dataclass(frozen=True)
+class ReleaseAuthConfig:
+    signing_key: Path | None
+    allowed_signers: Path
+    principal: str = RELEASE_AUTH_PRINCIPAL
+    namespace: str = RELEASE_AUTH_NAMESPACE
+
+
+Runner = Callable[[Sequence[str], bool, str | None], CommandResult]
+Fetcher = Callable[[str], str]
+
+
+def run_command(
+    args: Sequence[str],
+    check: bool = True,
+    stdin: str | None = None,
+) -> CommandResult:
+    result = subprocess.run(
+        list(args),  # noqa: S603 - Release commands are fixed argv lists built by this helper.
+        cwd=REPO_ROOT,
+        capture_output=True,
+        check=False,
+        input=stdin,
+        text=True,
+    )
+    command_result = CommandResult(
+        returncode=result.returncode,
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )
+    if check and result.returncode != 0:
+        raise ReleaseError(
+            f"Command failed: {' '.join(args)}\n{result.stderr or result.stdout}".rstrip()
+        )
+    return command_result
+
+
+def fetch_url(url: str) -> str:
+    with urlopen(url, timeout=15) as response:  # noqa: S310
+        return response.read().decode("utf-8", errors="replace")
+
+
+def read_local_version(version_file: Path | None = None) -> str:
+    version_file = version_file or VERSION_FILE
+    source = version_file.read_text(encoding="utf-8")
+    match = VERSION_PATTERN.search(source)
+    if not match:
+        raise ReleaseError(f"Could not find __version__ in {version_file}")
+    return match.group("version")
+
+
+def write_local_version(version: str, version_file: Path | None = None) -> None:
+    version_file = version_file or VERSION_FILE
+    source = version_file.read_text(encoding="utf-8")
+    next_source, replacements = VERSION_PATTERN.subn(
+        f'__version__ = "{version}"',
+        source,
+        count=1,
+    )
+    if replacements != 1:
+        raise ReleaseError(f"Could not update __version__ in {version_file}")
+    version_file.write_text(next_source, encoding="utf-8")
+
+
+def extract_live_version(html: str) -> str:
+    match = LIVE_VERSION_PATTERN.search(html)
+    if not match:
+        raise ReleaseError("Could not find live Hush Line version in production HTML")
+    return match.group("version")
+
+
+def next_patch_version(version: str) -> str:
+    parts = version.split(".")
+    if len(parts) != SEMVER_PARTS or not all(part.isdigit() for part in parts):
+        raise ReleaseError(f"Invalid semantic version: {version}")
+    major, minor, patch = (int(part) for part in parts)
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def ensure_clean_worktree(runner: Runner) -> None:
+    status = runner(["git", "status", "--porcelain"], True, None).stdout.strip()
+    if status:
+        raise ReleaseError("Working tree must be clean before running make release.")
+
+
+def ensure_release_branch(runner: Runner, expected_branch: str) -> str:
+    branch = runner(["git", "branch", "--show-current"], True, None).stdout.strip()
+    if branch != expected_branch:
+        raise ReleaseError(
+            f"make release must run from {expected_branch!r}; current branch is {branch!r}."
+        )
+    return branch
+
+
+def ensure_tag_and_release_available(runner: Runner, tag: str) -> None:
+    local_tag = runner(["git", "rev-parse", "--verify", f"refs/tags/{tag}"], False, None)
+    if local_tag.returncode == 0:
+        raise ReleaseError(f"Local tag already exists: {tag}")
+
+    remote_tag = runner(
+        ["git", "ls-remote", "--exit-code", "--tags", "origin", tag],
+        False,
+        None,
+    )
+    if remote_tag.returncode == 0:
+        raise ReleaseError(f"Remote tag already exists: {tag}")
+    if remote_tag.returncode not in {2}:
+        raise ReleaseError((remote_tag.stderr or remote_tag.stdout).strip())
+
+    existing_release = runner(["gh", "release", "view", tag], False, None)
+    if existing_release.returncode == 0:
+        raise ReleaseError(f"GitHub release already exists: {tag}")
+
+
+def _release_path_from_env(name: str, default: Path | None = None) -> Path | None:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    if not value.strip():
+        return None
+    return Path(value).expanduser()
+
+
+def _validate_release_allowed_signers(
+    allowed_signers: Path,
+    principal: str = RELEASE_AUTH_PRINCIPAL,
+) -> None:
+    if not allowed_signers.is_file():
+        raise ReleaseError(
+            "Release YubiKey allowlist is missing: "
+            f"{allowed_signers}. Add the primary and backup YubiKey public keys first."
+        )
+
+    entries = [
+        line.strip()
+        for line in allowed_signers.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+    if not entries:
+        raise ReleaseError(
+            "Release YubiKey allowlist does not contain any allowed YubiKey public keys."
+        )
+
+    for line in entries:
+        parts = line.split()
+        if len(parts) < MIN_ALLOWED_SIGNER_PARTS:
+            raise ReleaseError("Release YubiKey allowlist contains a malformed signer entry.")
+        principals, key_type = parts[0], parts[1]
+        if principal not in principals.split(","):
+            raise ReleaseError(f"Release YubiKey signer entry must use principal {principal!r}.")
+        if key_type not in HARDWARE_SSH_KEY_TYPES:
+            raise ReleaseError(
+                "Release YubiKey allowlist must contain only OpenSSH security-key "
+                "public keys, such as sk-ssh-ed25519@openssh.com."
+            )
+
+
+def ensure_release_yubikey_authorized(
+    runner: Runner,
+    *,
+    tag: str,
+    branch: str,
+    local_version: str,
+    config: ReleaseAuthConfig,
+) -> None:
+    if config.signing_key is None:
+        raise ReleaseError(
+            "RELEASE_SIGNING_KEY must point to the primary or backup YubiKey SSH identity."
+        )
+    if not config.signing_key.exists():
+        raise ReleaseError(f"Release signing key does not exist: {config.signing_key}")
+
+    _validate_release_allowed_signers(config.allowed_signers, config.principal)
+
+    challenge = "\n".join(
+        (
+            "hushline-release-authorization-v1",
+            f"tag={tag}",
+            f"branch={branch}",
+            f"local_version={local_version}",
+            "",
+        )
+    )
+    with tempfile.TemporaryDirectory(prefix="hushline-release-auth-") as temp_dir:
+        challenge_path = Path(temp_dir) / "release-challenge.txt"
+        challenge_path.write_text(challenge, encoding="utf-8")
+        runner(
+            [
+                "ssh-keygen",
+                "-Y",
+                "sign",
+                "-f",
+                str(config.signing_key),
+                "-n",
+                config.namespace,
+                str(challenge_path),
+            ],
+            True,
+            None,
+        )
+        signature_path = Path(f"{challenge_path}.sig")
+        if not signature_path.is_file():
+            raise ReleaseError("Release YubiKey signing did not create a signature.")
+        runner(
+            [
+                "ssh-keygen",
+                "-Y",
+                "verify",
+                "-f",
+                str(config.allowed_signers),
+                "-I",
+                config.principal,
+                "-n",
+                config.namespace,
+                "-s",
+                str(signature_path),
+            ],
+            True,
+            challenge,
+        )
+
+
+def release_auth_config_from_env() -> ReleaseAuthConfig:
+    signing_key = _release_path_from_env("HUSHLINE_RELEASE_SIGNING_KEY")
+    allowed_signers = _release_path_from_env(
+        "HUSHLINE_RELEASE_ALLOWED_SIGNERS",
+        DEFAULT_RELEASE_ALLOWED_SIGNERS,
+    )
+    if allowed_signers is None:
+        raise ReleaseError("HUSHLINE_RELEASE_ALLOWED_SIGNERS must not be empty.")
+    return ReleaseAuthConfig(signing_key=signing_key, allowed_signers=allowed_signers)
+
+
+def release(runner: Runner = run_command, fetcher: Fetcher = fetch_url) -> str:
+    prod_url = os.environ.get("HUSHLINE_RELEASE_PROD_URL", DEFAULT_PROD_URL)
+    release_branch = os.environ.get("HUSHLINE_RELEASE_BRANCH", "main")
+    auth_config = release_auth_config_from_env()
+
+    ensure_clean_worktree(runner)
+    branch = ensure_release_branch(runner, release_branch)
+
+    local_version = read_local_version()
+    live_version = extract_live_version(fetcher(prod_url))
+    if live_version != local_version:
+        raise ReleaseError(
+            "Production version does not match local version: "
+            f"production v{live_version}, local v{local_version}."
+        )
+
+    next_version = next_patch_version(local_version)
+    tag = f"v{next_version}"
+    ensure_tag_and_release_available(runner, tag)
+    ensure_release_yubikey_authorized(
+        runner,
+        tag=tag,
+        branch=branch,
+        local_version=local_version,
+        config=auth_config,
+    )
+
+    write_local_version(next_version)
+    runner(["git", "add", str(VERSION_FILE.relative_to(REPO_ROOT))], True, None)
+    runner(["git", "commit", "-m", f"Update version to {tag}"], True, None)
+    runner(["git", "tag", tag], True, None)
+    runner(["git", "push", "origin", branch], True, None)
+    runner(["git", "push", "origin", tag], True, None)
+    runner(
+        ["gh", "release", "create", tag, "--title", tag, "--generate-notes", "--latest"],
+        True,
+        None,
+    )
+    return tag
+
+
+def main() -> int:
+    try:
+        tag = release()
+    except ReleaseError as error:
+        print(f"release failed: {error}", file=sys.stderr)
+        return 1
+
+    print(f"Published Hush Line release {tag}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -57,8 +57,7 @@ def test_release_target_invokes_release_helper_with_prod_defaults() -> None:
     assert "RELEASE_BRANCH ?= main" in make_text
     assert "RELEASE_ALLOWED_SIGNERS ?= .github/release-allowed-signers" in make_text
     assert (
-        "RELEASE_SIGNING_KEY ?= $(HOME)/.ssh/hushline-release/primary-release-yubikey"
-        in make_text
+        "RELEASE_SIGNING_KEY ?= $(HOME)/.ssh/hushline-release/primary-release-yubikey" in make_text
     )
     assert "RELEASE_DRY_RUN ?=" in make_text
     assert "release: ## Bump patch version, tag, and publish a GitHub release" in target_section

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -56,7 +56,10 @@ def test_release_target_invokes_release_helper_with_prod_defaults() -> None:
     assert "RELEASE_PROD_URL ?= https://tips.hushline.app/" in make_text
     assert "RELEASE_BRANCH ?= main" in make_text
     assert "RELEASE_ALLOWED_SIGNERS ?= .github/release-allowed-signers" in make_text
-    assert "RELEASE_SIGNING_KEY ?=" in make_text
+    assert (
+        "RELEASE_SIGNING_KEY ?= $(HOME)/.ssh/hushline-release/primary-release-yubikey"
+        in make_text
+    )
     assert "RELEASE_DRY_RUN ?=" in make_text
     assert "release: ## Bump patch version, tag, and publish a GitHub release" in target_section
     assert 'HUSHLINE_RELEASE_PROD_URL="$(RELEASE_PROD_URL)"' in target_section
@@ -65,3 +68,13 @@ def test_release_target_invokes_release_helper_with_prod_defaults() -> None:
     assert 'HUSHLINE_RELEASE_SIGNING_KEY="$(RELEASE_SIGNING_KEY)"' in target_section
     assert 'HUSHLINE_RELEASE_DRY_RUN="$(RELEASE_DRY_RUN)"' in target_section
     assert "python3 scripts/release.py" in target_section
+
+
+def test_release_dry_run_target_invokes_release_with_dry_run_enabled() -> None:
+    target_section = _target_section("release-dry-run")
+
+    assert (
+        "release-dry-run: ## Check release preflight and YubiKey authorization without publishing"
+        in target_section
+    )
+    assert "$(MAKE) release RELEASE_DRY_RUN=1" in target_section

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -47,3 +47,19 @@ def test_test_target_writes_html_coverage_to_tmp_by_default() -> None:
     )
     assert "--cov-report term-missing" in target_section
     assert "--cov-report html:$(COVERAGE_HTML_DIR)" in target_section
+
+
+def test_release_target_invokes_release_helper_with_prod_defaults() -> None:
+    make_text = (REPO_ROOT / "Makefile").read_text(encoding="utf-8")
+    target_section = _target_section("release")
+
+    assert "RELEASE_PROD_URL ?= https://tips.hushline.app/" in make_text
+    assert "RELEASE_BRANCH ?= main" in make_text
+    assert "RELEASE_ALLOWED_SIGNERS ?= .github/release-allowed-signers" in make_text
+    assert "RELEASE_SIGNING_KEY ?=" in make_text
+    assert "release: ## Bump patch version, tag, and publish a GitHub release" in target_section
+    assert 'HUSHLINE_RELEASE_PROD_URL="$(RELEASE_PROD_URL)"' in target_section
+    assert 'HUSHLINE_RELEASE_BRANCH="$(RELEASE_BRANCH)"' in target_section
+    assert 'HUSHLINE_RELEASE_ALLOWED_SIGNERS="$(RELEASE_ALLOWED_SIGNERS)"' in target_section
+    assert 'HUSHLINE_RELEASE_SIGNING_KEY="$(RELEASE_SIGNING_KEY)"' in target_section
+    assert "python3 scripts/release.py" in target_section

--- a/tests/test_makefile.py
+++ b/tests/test_makefile.py
@@ -57,9 +57,11 @@ def test_release_target_invokes_release_helper_with_prod_defaults() -> None:
     assert "RELEASE_BRANCH ?= main" in make_text
     assert "RELEASE_ALLOWED_SIGNERS ?= .github/release-allowed-signers" in make_text
     assert "RELEASE_SIGNING_KEY ?=" in make_text
+    assert "RELEASE_DRY_RUN ?=" in make_text
     assert "release: ## Bump patch version, tag, and publish a GitHub release" in target_section
     assert 'HUSHLINE_RELEASE_PROD_URL="$(RELEASE_PROD_URL)"' in target_section
     assert 'HUSHLINE_RELEASE_BRANCH="$(RELEASE_BRANCH)"' in target_section
     assert 'HUSHLINE_RELEASE_ALLOWED_SIGNERS="$(RELEASE_ALLOWED_SIGNERS)"' in target_section
     assert 'HUSHLINE_RELEASE_SIGNING_KEY="$(RELEASE_SIGNING_KEY)"' in target_section
+    assert 'HUSHLINE_RELEASE_DRY_RUN="$(RELEASE_DRY_RUN)"' in target_section
     assert "python3 scripts/release.py" in target_section

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_release_module() -> ModuleType:
+    spec = importlib.util.spec_from_file_location(
+        "hushline_release_script",
+        REPO_ROOT / "scripts" / "release.py",
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_extract_live_version_reads_footer_version() -> None:
+    release_script = _load_release_module()
+
+    assert (
+        release_script.extract_live_version(
+            '<footer><a href="https://github.com/scidsg/hushline">v0.7.4</a></footer>'
+        )
+        == "0.7.4"
+    )
+
+
+def test_next_patch_version_increments_patch_component() -> None:
+    release_script = _load_release_module()
+
+    assert release_script.next_patch_version("0.7.4") == "0.7.5"
+
+
+def test_release_checks_live_version_bumps_commits_tags_pushes_and_publishes(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_script = _load_release_module()
+    repo_root = tmp_path
+    version_file = repo_root / "hushline" / "version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "0.7.4"\n', encoding="utf-8")
+    allowed_signers = repo_root / ".github" / "release-allowed-signers"
+    allowed_signers.parent.mkdir()
+    allowed_signers.write_text(
+        "\n".join(
+            (
+                "hushline-release sk-ssh-ed25519@openssh.com AAAAC3NzaPrimary primary-yubikey",
+                "hushline-release sk-ecdsa-sha2-nistp256@openssh.com "
+                "AAAAC3NzaBackup backup-yubikey",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    signing_key = repo_root / "primary-yubikey"
+    signing_key.write_text("private key handle placeholder", encoding="utf-8")
+    commands: list[tuple[str, ...]] = []
+    verification_challenges: list[str] = []
+    fetched_urls: list[str] = []
+
+    monkeypatch.setattr(release_script, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(release_script, "VERSION_FILE", version_file)
+    monkeypatch.setenv("HUSHLINE_RELEASE_PROD_URL", "https://tips.hushline.app/")
+    monkeypatch.setenv("HUSHLINE_RELEASE_ALLOWED_SIGNERS", str(allowed_signers))
+    monkeypatch.setenv("HUSHLINE_RELEASE_SIGNING_KEY", str(signing_key))
+
+    def runner(args: Sequence[str], check: bool, stdin: str | None = None) -> object:
+        command = tuple(args)
+        commands.append(command)
+        if command == ("git", "status", "--porcelain"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "branch", "--show-current"):
+            return release_script.CommandResult(0, "main\n")
+        if command == ("git", "rev-parse", "--verify", "refs/tags/v0.7.5"):
+            return release_script.CommandResult(1, "", "not found")
+        if command == ("git", "ls-remote", "--exit-code", "--tags", "origin", "v0.7.5"):
+            return release_script.CommandResult(2, "", "")
+        if command == ("gh", "release", "view", "v0.7.5"):
+            return release_script.CommandResult(1, "", "not found")
+        if command[:3] == ("ssh-keygen", "-Y", "sign"):
+            challenge_path = Path(command[-1])
+            Path(f"{challenge_path}.sig").write_text("fake signature", encoding="utf-8")
+            return release_script.CommandResult(0, "")
+        if command[:3] == ("ssh-keygen", "-Y", "verify"):
+            assert stdin is not None
+            verification_challenges.append(stdin)
+            return release_script.CommandResult(0, "Good signature")
+        return release_script.CommandResult(0, "")
+
+    def fetcher(url: str) -> str:
+        fetched_urls.append(url)
+        return '<a href="https://github.com/scidsg/hushline">v0.7.4</a>'
+
+    assert release_script.release(runner=runner, fetcher=fetcher) == "v0.7.5"
+    assert version_file.read_text(encoding="utf-8") == '__version__ = "0.7.5"\n'
+    assert fetched_urls == ["https://tips.hushline.app/"]
+    assert verification_challenges == [
+        "hushline-release-authorization-v1\n" "tag=v0.7.5\n" "branch=main\n" "local_version=0.7.4\n"
+    ]
+    assert commands[:5] == [
+        ("git", "status", "--porcelain"),
+        ("git", "branch", "--show-current"),
+        ("git", "rev-parse", "--verify", "refs/tags/v0.7.5"),
+        ("git", "ls-remote", "--exit-code", "--tags", "origin", "v0.7.5"),
+        ("gh", "release", "view", "v0.7.5"),
+    ]
+    assert commands[5][:6] == (
+        "ssh-keygen",
+        "-Y",
+        "sign",
+        "-f",
+        str(signing_key),
+        "-n",
+    )
+    assert commands[5][6] == "hushline-release"
+    assert commands[6][:-1] == (
+        "ssh-keygen",
+        "-Y",
+        "verify",
+        "-f",
+        str(allowed_signers),
+        "-I",
+        "hushline-release",
+        "-n",
+        "hushline-release",
+        "-s",
+    )
+    assert commands[7:] == [
+        ("git", "add", "hushline/version.py"),
+        ("git", "commit", "-m", "Update version to v0.7.5"),
+        ("git", "tag", "v0.7.5"),
+        ("git", "push", "origin", "main"),
+        ("git", "push", "origin", "v0.7.5"),
+        ("gh", "release", "create", "v0.7.5", "--title", "v0.7.5", "--generate-notes", "--latest"),
+    ]
+
+
+def test_release_blocks_when_live_version_does_not_match_local(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_script = _load_release_module()
+    version_file = tmp_path / "hushline" / "version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "0.7.4"\n', encoding="utf-8")
+
+    monkeypatch.setattr(release_script, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(release_script, "VERSION_FILE", version_file)
+
+    def runner(args: Sequence[str], check: bool, stdin: str | None = None) -> object:
+        assert stdin is None
+        command = tuple(args)
+        if command == ("git", "status", "--porcelain"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "branch", "--show-current"):
+            return release_script.CommandResult(0, "main\n")
+        raise AssertionError(f"unexpected command: {command}")
+
+    with pytest.raises(
+        release_script.ReleaseError,
+        match="Production version does not match local version",
+    ):
+        release_script.release(
+            runner=runner,
+            fetcher=lambda _url: '<a href="https://github.com/scidsg/hushline">v0.7.3</a>',
+        )
+
+    assert version_file.read_text(encoding="utf-8") == '__version__ = "0.7.4"\n'
+
+
+def test_release_yubikey_authorization_rejects_software_keys(tmp_path: Path) -> None:
+    release_script = _load_release_module()
+    allowed_signers = tmp_path / "release-allowed-signers"
+    allowed_signers.write_text(
+        "hushline-release ssh-ed25519 AAAAC3NzaSoftware software-key\n",
+        encoding="utf-8",
+    )
+    signing_key = tmp_path / "release-yubikey"
+    signing_key.write_text("private key handle placeholder", encoding="utf-8")
+
+    def runner(args: Sequence[str], check: bool, stdin: str | None = None) -> object:
+        raise AssertionError(f"unexpected command: {tuple(args)}")
+
+    with pytest.raises(
+        release_script.ReleaseError,
+        match="must contain only OpenSSH security-key public keys",
+    ):
+        release_script.ensure_release_yubikey_authorized(
+            runner,
+            tag="v0.7.5",
+            branch="main",
+            local_version="0.7.4",
+            config=release_script.ReleaseAuthConfig(
+                signing_key=signing_key,
+                allowed_signers=allowed_signers,
+            ),
+        )
+
+
+def test_release_yubikey_authorization_requires_signing_key(tmp_path: Path) -> None:
+    release_script = _load_release_module()
+    allowed_signers = tmp_path / "release-allowed-signers"
+    allowed_signers.write_text(
+        "hushline-release sk-ssh-ed25519@openssh.com AAAAC3NzaPrimary primary-yubikey\n",
+        encoding="utf-8",
+    )
+
+    def runner(args: Sequence[str], check: bool, stdin: str | None = None) -> object:
+        raise AssertionError(f"unexpected command: {tuple(args)}")
+
+    with pytest.raises(
+        release_script.ReleaseError,
+        match="RELEASE_SIGNING_KEY must point to the primary or backup YubiKey SSH identity",
+    ):
+        release_script.ensure_release_yubikey_authorized(
+            runner,
+            tag="v0.7.5",
+            branch="main",
+            local_version="0.7.4",
+            config=release_script.ReleaseAuthConfig(
+                signing_key=None,
+                allowed_signers=allowed_signers,
+            ),
+        )

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -5,6 +5,7 @@ import sys
 from collections.abc import Sequence
 from pathlib import Path
 from types import ModuleType
+from urllib.error import URLError
 
 import pytest
 
@@ -39,6 +40,23 @@ def test_next_patch_version_increments_patch_component() -> None:
     release_script = _load_release_module()
 
     assert release_script.next_patch_version("0.7.4") == "0.7.5"
+
+
+def test_fetch_url_reports_release_error_on_url_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    release_script = _load_release_module()
+
+    def failing_urlopen(url: str, timeout: int) -> object:
+        assert url == "https://tips.hushline.app/"
+        assert timeout == 15
+        raise URLError("temporary name resolution failure")
+
+    monkeypatch.setattr(release_script, "urlopen", failing_urlopen)
+
+    with pytest.raises(
+        release_script.ReleaseError,
+        match="Could not fetch production URL https://tips.hushline.app/",
+    ):
+        release_script.fetch_url("https://tips.hushline.app/")
 
 
 def test_release_checks_live_version_bumps_commits_tags_pushes_and_publishes(

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -146,6 +146,103 @@ def test_release_checks_live_version_bumps_commits_tags_pushes_and_publishes(
     ]
 
 
+def test_release_dry_run_checks_authorization_without_side_effects(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_script = _load_release_module()
+    repo_root = tmp_path
+    version_file = repo_root / "hushline" / "version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "0.7.4"\n', encoding="utf-8")
+    allowed_signers = repo_root / ".github" / "release-allowed-signers"
+    allowed_signers.parent.mkdir()
+    allowed_signers.write_text(
+        "\n".join(
+            (
+                "hushline-release sk-ssh-ed25519@openssh.com AAAAC3NzaPrimary primary-yubikey",
+                "hushline-release sk-ecdsa-sha2-nistp256@openssh.com "
+                "AAAAC3NzaBackup backup-yubikey",
+                "",
+            )
+        ),
+        encoding="utf-8",
+    )
+    signing_key = repo_root / "primary-yubikey"
+    signing_key.write_text("private key handle placeholder", encoding="utf-8")
+    commands: list[tuple[str, ...]] = []
+    verification_challenges: list[str] = []
+
+    monkeypatch.setattr(release_script, "REPO_ROOT", repo_root)
+    monkeypatch.setattr(release_script, "VERSION_FILE", version_file)
+    monkeypatch.setenv("HUSHLINE_RELEASE_ALLOWED_SIGNERS", str(allowed_signers))
+    monkeypatch.setenv("HUSHLINE_RELEASE_SIGNING_KEY", str(signing_key))
+
+    def runner(args: Sequence[str], check: bool, stdin: str | None = None) -> object:
+        command = tuple(args)
+        commands.append(command)
+        if command == ("git", "status", "--porcelain"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "branch", "--show-current"):
+            return release_script.CommandResult(0, "main\n")
+        if command == ("git", "rev-parse", "--verify", "refs/tags/v0.7.5"):
+            return release_script.CommandResult(1, "", "not found")
+        if command == ("git", "ls-remote", "--exit-code", "--tags", "origin", "v0.7.5"):
+            return release_script.CommandResult(2, "", "")
+        if command == ("gh", "release", "view", "v0.7.5"):
+            return release_script.CommandResult(1, "", "not found")
+        if command[:3] == ("ssh-keygen", "-Y", "sign"):
+            challenge_path = Path(command[-1])
+            Path(f"{challenge_path}.sig").write_text("fake signature", encoding="utf-8")
+            return release_script.CommandResult(0, "")
+        if command[:3] == ("ssh-keygen", "-Y", "verify"):
+            assert stdin is not None
+            verification_challenges.append(stdin)
+            return release_script.CommandResult(0, "Good signature")
+        raise AssertionError(f"unexpected dry-run command: {command}")
+
+    assert (
+        release_script.release(
+            runner=runner,
+            fetcher=lambda _url: '<a href="https://github.com/scidsg/hushline">v0.7.4</a>',
+            dry_run=True,
+        )
+        == "v0.7.5"
+    )
+    assert version_file.read_text(encoding="utf-8") == '__version__ = "0.7.4"\n'
+    assert verification_challenges == [
+        "hushline-release-authorization-v1\n" "tag=v0.7.5\n" "branch=main\n" "local_version=0.7.4\n"
+    ]
+    assert len(commands) == 7
+    assert commands[:5] == [
+        ("git", "status", "--porcelain"),
+        ("git", "branch", "--show-current"),
+        ("git", "rev-parse", "--verify", "refs/tags/v0.7.5"),
+        ("git", "ls-remote", "--exit-code", "--tags", "origin", "v0.7.5"),
+        ("gh", "release", "view", "v0.7.5"),
+    ]
+    assert commands[5][:6] == (
+        "ssh-keygen",
+        "-Y",
+        "sign",
+        "-f",
+        str(signing_key),
+        "-n",
+    )
+    assert commands[6][:-1] == (
+        "ssh-keygen",
+        "-Y",
+        "verify",
+        "-f",
+        str(allowed_signers),
+        "-I",
+        "hushline-release",
+        "-n",
+        "hushline-release",
+        "-s",
+    )
+
+
 def test_release_blocks_when_live_version_does_not_match_local(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_release_script.py
+++ b/tests/test_release_script.py
@@ -36,6 +36,25 @@ def test_extract_live_version_reads_footer_version() -> None:
     )
 
 
+def test_extract_live_version_ignores_profile_text_before_footer() -> None:
+    release_script = _load_release_module()
+
+    assert (
+        release_script.extract_live_version(
+            """
+            <main>
+              <h1>v0.7.3</h1>
+              <p>user-controlled bio says v0.7.2</p>
+            </main>
+            <footer>
+              <a href="https://github.com/scidsg/hushline">v0.7.4</a>
+            </footer>
+            """
+        )
+        == "0.7.4"
+    )
+
+
 def test_next_patch_version_increments_patch_component() -> None:
     release_script = _load_release_module()
 
@@ -100,12 +119,20 @@ def test_release_checks_live_version_bumps_commits_tags_pushes_and_publishes(
             return release_script.CommandResult(0, "")
         if command == ("git", "branch", "--show-current"):
             return release_script.CommandResult(0, "main\n")
+        if command == ("git", "remote", "get-url", "origin"):
+            return release_script.CommandResult(0, "https://github.com/scidsg/hushline.git\n")
+        if command == ("git", "fetch", "origin", "main"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "rev-parse", "main"):
+            return release_script.CommandResult(0, "abc123\n")
+        if command == ("git", "rev-parse", "origin/main"):
+            return release_script.CommandResult(0, "abc123\n")
         if command == ("git", "rev-parse", "--verify", "refs/tags/v0.7.5"):
             return release_script.CommandResult(1, "", "not found")
         if command == ("git", "ls-remote", "--exit-code", "--tags", "origin", "v0.7.5"):
             return release_script.CommandResult(2, "", "")
-        if command == ("gh", "release", "view", "v0.7.5"):
-            return release_script.CommandResult(1, "", "not found")
+        if command == ("gh", "release", "view", "v0.7.5", "--repo", "scidsg/hushline"):
+            return release_script.CommandResult(1, "", "release not found")
         if command[:3] == ("ssh-keygen", "-Y", "sign"):
             challenge_path = Path(command[-1])
             Path(f"{challenge_path}.sig").write_text("fake signature", encoding="utf-8")
@@ -126,14 +153,18 @@ def test_release_checks_live_version_bumps_commits_tags_pushes_and_publishes(
     assert verification_challenges == [
         "hushline-release-authorization-v1\n" "tag=v0.7.5\n" "branch=main\n" "local_version=0.7.4\n"
     ]
-    assert commands[:5] == [
+    assert commands[:9] == [
         ("git", "status", "--porcelain"),
         ("git", "branch", "--show-current"),
+        ("git", "remote", "get-url", "origin"),
+        ("git", "fetch", "origin", "main"),
+        ("git", "rev-parse", "main"),
+        ("git", "rev-parse", "origin/main"),
         ("git", "rev-parse", "--verify", "refs/tags/v0.7.5"),
         ("git", "ls-remote", "--exit-code", "--tags", "origin", "v0.7.5"),
-        ("gh", "release", "view", "v0.7.5"),
+        ("gh", "release", "view", "v0.7.5", "--repo", "scidsg/hushline"),
     ]
-    assert commands[5][:6] == (
+    assert commands[9][:6] == (
         "ssh-keygen",
         "-Y",
         "sign",
@@ -141,8 +172,8 @@ def test_release_checks_live_version_bumps_commits_tags_pushes_and_publishes(
         str(signing_key),
         "-n",
     )
-    assert commands[5][6] == "hushline-release"
-    assert commands[6][:-1] == (
+    assert commands[9][6] == "hushline-release"
+    assert commands[10][:-1] == (
         "ssh-keygen",
         "-Y",
         "verify",
@@ -154,13 +185,24 @@ def test_release_checks_live_version_bumps_commits_tags_pushes_and_publishes(
         "hushline-release",
         "-s",
     )
-    assert commands[7:] == [
+    assert commands[11:] == [
         ("git", "add", "hushline/version.py"),
-        ("git", "commit", "-m", "Update version to v0.7.5"),
+        ("git", "commit", "-S", "-m", "Update version to v0.7.5"),
         ("git", "tag", "v0.7.5"),
         ("git", "push", "origin", "main"),
         ("git", "push", "origin", "v0.7.5"),
-        ("gh", "release", "create", "v0.7.5", "--title", "v0.7.5", "--generate-notes", "--latest"),
+        (
+            "gh",
+            "release",
+            "create",
+            "v0.7.5",
+            "--repo",
+            "scidsg/hushline",
+            "--title",
+            "v0.7.5",
+            "--generate-notes",
+            "--latest",
+        ),
     ]
 
 
@@ -203,12 +245,20 @@ def test_release_dry_run_checks_authorization_without_side_effects(
             return release_script.CommandResult(0, "")
         if command == ("git", "branch", "--show-current"):
             return release_script.CommandResult(0, "main\n")
+        if command == ("git", "remote", "get-url", "origin"):
+            return release_script.CommandResult(0, "https://github.com/scidsg/hushline.git\n")
+        if command == ("git", "fetch", "origin", "main"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "rev-parse", "main"):
+            return release_script.CommandResult(0, "abc123\n")
+        if command == ("git", "rev-parse", "origin/main"):
+            return release_script.CommandResult(0, "abc123\n")
         if command == ("git", "rev-parse", "--verify", "refs/tags/v0.7.5"):
             return release_script.CommandResult(1, "", "not found")
         if command == ("git", "ls-remote", "--exit-code", "--tags", "origin", "v0.7.5"):
             return release_script.CommandResult(2, "", "")
-        if command == ("gh", "release", "view", "v0.7.5"):
-            return release_script.CommandResult(1, "", "not found")
+        if command == ("gh", "release", "view", "v0.7.5", "--repo", "scidsg/hushline"):
+            return release_script.CommandResult(1, "", "release not found")
         if command[:3] == ("ssh-keygen", "-Y", "sign"):
             challenge_path = Path(command[-1])
             Path(f"{challenge_path}.sig").write_text("fake signature", encoding="utf-8")
@@ -231,15 +281,19 @@ def test_release_dry_run_checks_authorization_without_side_effects(
     assert verification_challenges == [
         "hushline-release-authorization-v1\n" "tag=v0.7.5\n" "branch=main\n" "local_version=0.7.4\n"
     ]
-    assert len(commands) == 7
-    assert commands[:5] == [
+    assert len(commands) == 11
+    assert commands[:9] == [
         ("git", "status", "--porcelain"),
         ("git", "branch", "--show-current"),
+        ("git", "remote", "get-url", "origin"),
+        ("git", "fetch", "origin", "main"),
+        ("git", "rev-parse", "main"),
+        ("git", "rev-parse", "origin/main"),
         ("git", "rev-parse", "--verify", "refs/tags/v0.7.5"),
         ("git", "ls-remote", "--exit-code", "--tags", "origin", "v0.7.5"),
-        ("gh", "release", "view", "v0.7.5"),
+        ("gh", "release", "view", "v0.7.5", "--repo", "scidsg/hushline"),
     ]
-    assert commands[5][:6] == (
+    assert commands[9][:6] == (
         "ssh-keygen",
         "-Y",
         "sign",
@@ -247,7 +301,7 @@ def test_release_dry_run_checks_authorization_without_side_effects(
         str(signing_key),
         "-n",
     )
-    assert commands[6][:-1] == (
+    assert commands[10][:-1] == (
         "ssh-keygen",
         "-Y",
         "verify",
@@ -280,6 +334,14 @@ def test_release_blocks_when_live_version_does_not_match_local(
             return release_script.CommandResult(0, "")
         if command == ("git", "branch", "--show-current"):
             return release_script.CommandResult(0, "main\n")
+        if command == ("git", "remote", "get-url", "origin"):
+            return release_script.CommandResult(0, "https://github.com/scidsg/hushline.git\n")
+        if command == ("git", "fetch", "origin", "main"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "rev-parse", "main"):
+            return release_script.CommandResult(0, "abc123\n")
+        if command == ("git", "rev-parse", "origin/main"):
+            return release_script.CommandResult(0, "abc123\n")
         raise AssertionError(f"unexpected command: {command}")
 
     with pytest.raises(
@@ -289,6 +351,107 @@ def test_release_blocks_when_live_version_does_not_match_local(
         release_script.release(
             runner=runner,
             fetcher=lambda _url: '<a href="https://github.com/scidsg/hushline">v0.7.3</a>',
+        )
+
+    assert version_file.read_text(encoding="utf-8") == '__version__ = "0.7.4"\n'
+
+
+def test_release_blocks_noncanonical_origin() -> None:
+    release_script = _load_release_module()
+
+    def runner(args: Sequence[str], check: bool, stdin: str | None = None) -> object:
+        assert stdin is None
+        command = tuple(args)
+        if command == ("git", "status", "--porcelain"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "branch", "--show-current"):
+            return release_script.CommandResult(0, "main\n")
+        if command == ("git", "remote", "get-url", "origin"):
+            return release_script.CommandResult(0, "git@github.com:someone/fork.git\n")
+        raise AssertionError(f"unexpected command: {command}")
+
+    with pytest.raises(
+        release_script.ReleaseError,
+        match="canonical origin remote",
+    ):
+        release_script.release(
+            runner=runner,
+            fetcher=lambda _url: pytest.fail("production should not be fetched"),
+        )
+
+
+def test_release_blocks_when_local_branch_does_not_match_origin() -> None:
+    release_script = _load_release_module()
+
+    def runner(args: Sequence[str], check: bool, stdin: str | None = None) -> object:
+        assert stdin is None
+        command = tuple(args)
+        if command == ("git", "status", "--porcelain"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "branch", "--show-current"):
+            return release_script.CommandResult(0, "main\n")
+        if command == ("git", "remote", "get-url", "origin"):
+            return release_script.CommandResult(0, "https://github.com/scidsg/hushline.git\n")
+        if command == ("git", "fetch", "origin", "main"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "rev-parse", "main"):
+            return release_script.CommandResult(0, "local-sha\n")
+        if command == ("git", "rev-parse", "origin/main"):
+            return release_script.CommandResult(0, "remote-sha\n")
+        raise AssertionError(f"unexpected command: {command}")
+
+    with pytest.raises(
+        release_script.ReleaseError,
+        match="must match origin/main",
+    ):
+        release_script.release(
+            runner=runner,
+            fetcher=lambda _url: pytest.fail("production should not be fetched"),
+        )
+
+
+def test_release_blocks_ambiguous_github_release_view_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release_script = _load_release_module()
+    version_file = tmp_path / "hushline" / "version.py"
+    version_file.parent.mkdir()
+    version_file.write_text('__version__ = "0.7.4"\n', encoding="utf-8")
+
+    monkeypatch.setattr(release_script, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(release_script, "VERSION_FILE", version_file)
+
+    def runner(args: Sequence[str], check: bool, stdin: str | None = None) -> object:
+        assert stdin is None
+        command = tuple(args)
+        if command == ("git", "status", "--porcelain"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "branch", "--show-current"):
+            return release_script.CommandResult(0, "main\n")
+        if command == ("git", "remote", "get-url", "origin"):
+            return release_script.CommandResult(0, "https://github.com/scidsg/hushline.git\n")
+        if command == ("git", "fetch", "origin", "main"):
+            return release_script.CommandResult(0, "")
+        if command == ("git", "rev-parse", "main"):
+            return release_script.CommandResult(0, "abc123\n")
+        if command == ("git", "rev-parse", "origin/main"):
+            return release_script.CommandResult(0, "abc123\n")
+        if command == ("git", "rev-parse", "--verify", "refs/tags/v0.7.5"):
+            return release_script.CommandResult(1, "", "not found")
+        if command == ("git", "ls-remote", "--exit-code", "--tags", "origin", "v0.7.5"):
+            return release_script.CommandResult(2, "", "")
+        if command == ("gh", "release", "view", "v0.7.5", "--repo", "scidsg/hushline"):
+            return release_script.CommandResult(1, "", "HTTP 403: forbidden")
+        raise AssertionError(f"unexpected command: {command}")
+
+    with pytest.raises(
+        release_script.ReleaseError,
+        match="Could not confirm GitHub release availability",
+    ):
+        release_script.release(
+            runner=runner,
+            fetcher=lambda _url: '<a href="https://github.com/scidsg/hushline">v0.7.4</a>',
         )
 
     assert version_file.read_text(encoding="utf-8") == '__version__ = "0.7.4"\n'


### PR DESCRIPTION
## What changed

Adds a `make release` target backed by `scripts/release.py`.

The helper:
- reads the live production version from `https://tips.hushline.app/`
- reads the local bare semver from `hushline/version.py`, e.g. `__version__ = "0.7.4"`
- requires the live and local versions to match before proceeding
- requires a fresh local SSH signature from an allowlisted YubiKey-backed OpenSSH security key before any release side effects
- bumps the local patch version without a leading `v`
- creates and pushes the corresponding `vX.Y.Z` tag
- creates a published GitHub release using generated release notes

The default allowlist is `.github/release-allowed-signers`. It is intentionally a fail-closed template until the release computer's primary and backup YubiKey public keys are added. Normal software keys such as `ssh-ed25519` are rejected by the helper.

## Why

This gives Hush Line a single release command that checks production state, requires a release YubiKey, then bumps, tags, and publishes a release.

## Usage

On the release computer, after adding the primary and backup YubiKey public keys to `.github/release-allowed-signers`:

```sh
RELEASE_SIGNING_KEY=/path/to/yubikey-backed-ssh-identity make release
```

## Validation

Completed before the YubiKey enhancement:
- `make lint`
- `make test` (`2135 passed, 1 deselected, 1 xfailed`)
- `make audit-python`
- `make audit-node-runtime`

Completed after the YubiKey enhancement:
- `docker compose run --rm app poetry run ruff format scripts/release.py tests/test_release_script.py tests/test_makefile.py`
- `docker compose run --rm app poetry run ruff check --output-format full scripts/release.py tests/test_release_script.py tests/test_makefile.py`
- `docker compose run --rm app poetry run mypy --no-incremental scripts/release.py tests/test_release_script.py tests/test_makefile.py`
- `make test TESTS='tests/test_makefile.py tests/test_release_script.py'`
- `make lint`

## Manual testing

Not manually exercised against GitHub production release creation. The release command's git, `ssh-keygen`, and `gh release` calls are covered by unit tests with a fake command runner to avoid creating real signatures, tags, or releases.

## Risks / follow-ups

The command performs real release side effects after authorization: it commits `hushline/version.py`, creates a local tag, pushes the branch/tag, and publishes the GitHub release. It requires a clean worktree and defaults to running only from `main` to reduce accidental use.

Before the first real release, populate `.github/release-allowed-signers` with the primary and backup YubiKey public keys from the release computer.