### PR TITLE
Add release governance admin check

### DIFF
--- a/.github/workflows/release-governance.yml
+++ b/.github/workflows/release-governance.yml
@@ -1,0 +1,80 @@
+---
+name: Release Governance
+
+on:
+  pull_request:
+    paths:
+      - ".github/release-allowed-signers"
+      - ".github/workflows/build-release.yml"
+      - ".github/workflows/release-governance.yml"
+      - "Makefile"
+      - "hushline/version.py"
+      - "scripts/release.py"
+  push:
+    branches:
+      - main
+    paths:
+      - ".github/release-allowed-signers"
+      - ".github/workflows/build-release.yml"
+      - ".github/workflows/release-governance.yml"
+      - "Makefile"
+      - "hushline/version.py"
+      - "scripts/release.py"
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  release-admin-check:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Require admin actor for release-governed files
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          REPOSITORY: ${{ github.repository }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          governed_path_pattern='^(\.github/release-allowed-signers|\.github/workflows/(build-release|release-governance)\.yml|Makefile|hushline/version\.py|scripts/release\.py)$'
+
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            actor="$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")"
+            pr_number="$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")"
+            files="$(
+              gh api --paginate "repos/${REPOSITORY}/pulls/${pr_number}/files" \
+                --jq '.[].filename'
+            )"
+          else
+            actor="$GITHUB_ACTOR"
+            before_sha="$(jq -r '.before' "$GITHUB_EVENT_PATH")"
+            files="$(
+              gh api "repos/${REPOSITORY}/compare/${before_sha}...${HEAD_SHA}" \
+                --jq '.files[].filename'
+            )"
+          fi
+
+          governed_files="$(printf '%s\n' "$files" | rg "$governed_path_pattern" || true)"
+          if [ -z "$governed_files" ]; then
+            echo "No release-governed files changed."
+            exit 0
+          fi
+
+          permission="$(
+            gh api "repos/${REPOSITORY}/collaborators/${actor}/permission" \
+              --jq '.permission'
+          )"
+
+          if [ "$permission" != "admin" ]; then
+            {
+              echo "Release-governed files changed by ${actor}, who has ${permission} repository permission."
+              echo "Only repository admins may author release-governed changes:"
+              printf '%s\n' "$governed_files"
+            } >&2
+            exit 1
+          fi
+
+          echo "Release-governed changes authorized for repository admin ${actor}."

--- a/.github/workflows/release-governance.yml
+++ b/.github/workflows/release-governance.yml
@@ -2,24 +2,10 @@
 name: Release Governance
 
 on:
-  pull_request:
-    paths:
-      - ".github/release-allowed-signers"
-      - ".github/workflows/build-release.yml"
-      - ".github/workflows/release-governance.yml"
-      - "Makefile"
-      - "hushline/version.py"
-      - "scripts/release.py"
+  pull_request_target:
   push:
     branches:
       - main
-    paths:
-      - ".github/release-allowed-signers"
-      - ".github/workflows/build-release.yml"
-      - ".github/workflows/release-governance.yml"
-      - "Makefile"
-      - "hushline/version.py"
-      - "scripts/release.py"
 
 permissions:
   contents: read
@@ -39,25 +25,46 @@ jobs:
         run: |
           set -euo pipefail
 
-          governed_path_pattern='^(\.github/release-allowed-signers|\.github/workflows/(build-release|release-governance)\.yml|Makefile|hushline/version\.py|scripts/release\.py)$'
+          governed_path_pattern='^(\.github/release-allowed-signers|\.github/workflows/(build-release|bump-personal-server-after-release|bump-staging-after-release|docs-screenshots|publish-docs-screenshots|release-governance)\.yml|Makefile|hushline/version\.py|scripts/release\.py)$'
 
-          if [ "$EVENT_NAME" = "pull_request" ]; then
-            actor="$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")"
+          if [ "$EVENT_NAME" = "pull_request_target" ]; then
+            actor="$(jq -r '.sender.login' "$GITHUB_EVENT_PATH")"
             pr_number="$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")"
-            files="$(
+            expected_file_count="$(jq -r '.pull_request.changed_files' "$GITHUB_EVENT_PATH")"
+            file_records="$(
               gh api --paginate "repos/${REPOSITORY}/pulls/${pr_number}/files" \
-                --jq '.[].filename'
+                --jq '.[] | [.filename, (.previous_filename // "")] | @tsv'
             )"
+            returned_file_count="$(printf '%s\n' "$file_records" | sed '/^$/d' | wc -l | tr -d ' ')"
+            if [ "$expected_file_count" -ge 3000 ] || [ "$returned_file_count" -ne "$expected_file_count" ]; then
+              {
+                echo "Could not inspect the complete PR file list."
+                echo "Expected ${expected_file_count} files and received ${returned_file_count} records."
+              } >&2
+              exit 1
+            fi
           else
             actor="$GITHUB_ACTOR"
             before_sha="$(jq -r '.before' "$GITHUB_EVENT_PATH")"
-            files="$(
-              gh api "repos/${REPOSITORY}/compare/${before_sha}...${HEAD_SHA}" \
-                --jq '.files[].filename'
+            compare_json="$(
+              gh api "repos/${REPOSITORY}/compare/${before_sha}...${HEAD_SHA}"
+            )"
+            returned_file_count="$(jq -r '.files | length' <<<"$compare_json")"
+            if [ "$returned_file_count" -ge 300 ]; then
+              echo "Could not inspect the complete push file list; GitHub compare results may be truncated." >&2
+              exit 1
+            fi
+            file_records="$(
+              jq -r '.files[] | [.filename, (.previous_filename // "")] | @tsv' <<<"$compare_json"
             )"
           fi
 
-          governed_files="$(printf '%s\n' "$files" | rg "$governed_path_pattern" || true)"
+          governed_files="$(
+            printf '%s\n' "$file_records" |
+              awk -F '\t' '{ print $1; if ($2 != "") print $2 }' |
+              rg "$governed_path_pattern" ||
+              true
+          )"
           if [ -z "$governed_files" ]; then
             echo "No release-governed files changed."
             exit 0

--- a/tests/test_release_governance_workflow.py
+++ b/tests/test_release_governance_workflow.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW_PATH = REPO_ROOT / ".github" / "workflows" / "release-governance.yml"
+
+
+def _workflow_text() -> str:
+    return WORKFLOW_PATH.read_text(encoding="utf-8")
+
+
+def test_release_governance_workflow_covers_release_control_files() -> None:
+    workflow_text = _workflow_text()
+
+    expected_paths = [
+        ".github/release-allowed-signers",
+        ".github/workflows/build-release.yml",
+        ".github/workflows/release-governance.yml",
+        "Makefile",
+        "hushline/version.py",
+        "scripts/release.py",
+    ]
+
+    for path in expected_paths:
+        assert f'- "{path}"' in workflow_text
+
+
+def test_release_governance_workflow_requires_admin_permission() -> None:
+    workflow_text = _workflow_text()
+
+    assert "repos/${REPOSITORY}/collaborators/${actor}/permission" in workflow_text
+    assert "--jq '.permission'" in workflow_text
+    assert 'if [ "$permission" != "admin" ]; then' in workflow_text
+    assert "Only repository admins may author release-governed changes" in workflow_text
+
+
+def test_release_governance_workflow_avoids_checkout_for_untrusted_prs() -> None:
+    workflow_text = _workflow_text()
+
+    assert "pull_request:" in workflow_text
+    assert "actions/checkout" not in workflow_text
+    assert "github.event.pull_request.body" not in workflow_text
+    assert "github.event.pull_request.title" not in workflow_text
+
+
+def test_release_governance_workflow_uses_pr_files_api() -> None:
+    workflow_text = _workflow_text()
+
+    assert 'pr_number="$(jq -r \'.pull_request.number\' "$GITHUB_EVENT_PATH")"' in workflow_text
+    assert 'gh api --paginate "repos/${REPOSITORY}/pulls/${pr_number}/files"' in workflow_text
+    assert "GITHUB_EVENT_PATH" in workflow_text

--- a/tests/test_release_governance_workflow.py
+++ b/tests/test_release_governance_workflow.py
@@ -13,17 +13,22 @@ def _workflow_text() -> str:
 def test_release_governance_workflow_covers_release_control_files() -> None:
     workflow_text = _workflow_text()
 
-    expected_paths = [
-        ".github/release-allowed-signers",
-        ".github/workflows/build-release.yml",
-        ".github/workflows/release-governance.yml",
+    expected_path_fragments = [
+        r"\.github/release-allowed-signers",
+        r"\.github/workflows/",
+        "build-release",
+        "bump-personal-server-after-release",
+        "bump-staging-after-release",
+        "docs-screenshots",
+        "publish-docs-screenshots",
+        "release-governance",
         "Makefile",
-        "hushline/version.py",
-        "scripts/release.py",
+        r"hushline/version\.py",
+        r"scripts/release\.py",
     ]
 
-    for path in expected_paths:
-        assert f'- "{path}"' in workflow_text
+    for path_fragment in expected_path_fragments:
+        assert path_fragment in workflow_text
 
 
 def test_release_governance_workflow_requires_admin_permission() -> None:
@@ -38,15 +43,40 @@ def test_release_governance_workflow_requires_admin_permission() -> None:
 def test_release_governance_workflow_avoids_checkout_for_untrusted_prs() -> None:
     workflow_text = _workflow_text()
 
-    assert "pull_request:" in workflow_text
+    assert "pull_request_target:" in workflow_text
+    assert "pull_request:" not in workflow_text
     assert "actions/checkout" not in workflow_text
     assert "github.event.pull_request.body" not in workflow_text
     assert "github.event.pull_request.title" not in workflow_text
 
 
-def test_release_governance_workflow_uses_pr_files_api() -> None:
+def test_release_governance_workflow_runs_for_every_pr() -> None:
+    workflow_text = _workflow_text()
+    trigger_section = workflow_text.split("permissions:", 1)[0]
+
+    assert "paths:" not in trigger_section
+
+
+def test_release_governance_workflow_uses_triggering_actor() -> None:
+    workflow_text = _workflow_text()
+
+    assert 'actor="$(jq -r \'.sender.login\' "$GITHUB_EVENT_PATH")"' in workflow_text
+    assert ".pull_request.user.login" not in workflow_text
+
+
+def test_release_governance_workflow_uses_pr_files_api_with_renames() -> None:
     workflow_text = _workflow_text()
 
     assert 'pr_number="$(jq -r \'.pull_request.number\' "$GITHUB_EVENT_PATH")"' in workflow_text
     assert 'gh api --paginate "repos/${REPOSITORY}/pulls/${pr_number}/files"' in workflow_text
+    assert '(.previous_filename // "")' in workflow_text
+    assert "awk -F '\\t'" in workflow_text
     assert "GITHUB_EVENT_PATH" in workflow_text
+
+
+def test_release_governance_workflow_fails_closed_on_truncated_file_lists() -> None:
+    workflow_text = _workflow_text()
+
+    assert "expected_file_count=\"$(jq -r '.pull_request.changed_files'" in workflow_text
+    assert 'if [ "$expected_file_count" -ge 3000 ]' in workflow_text
+    assert 'if [ "$returned_file_count" -ge 300 ]; then' in workflow_text


### PR DESCRIPTION
## What changed
- Added a `Release Governance` workflow for PRs and pushes touching release-controlled files.
- The workflow checks the actor's repository permission through the GitHub API and fails when release-governed files are authored by someone without `admin` permission.
- Added regression tests to lock the governed file list, admin-permission check, and no-checkout behavior for PRs.

## Why
Release changes should not be possible through ordinary file edits or manual release-path changes by non-admin repository users. This adds a required-check candidate for branch protection/rulesets around `hushline/version.py`, release scripts, signing keys, and release workflows.

## Validation
- `docker compose run --rm app poetry run pytest tests/test_release_governance_workflow.py tests/test_workflow_pr_head_qualification.py -q`
- `make lint`

## Manual testing
Not applicable; this is a GitHub Actions governance workflow and static regression tests.

## Known risks / follow-ups
- This should be added as a required branch-protection/ruleset check to become a hard gate.
- A `v*` tag ruleset should also restrict release tag creation/update/delete to repo admins or a dedicated release app.