### PR TITLE
#2280 Close test coverage gaps from PR #2279

### DIFF
--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -7,6 +7,12 @@ from bs4 import BeautifulSoup
 from flask import Flask, url_for
 from flask.testing import FlaskClient
 
+from hushline.chat_key_lifecycle import (
+    CHAT_KEY_METADATA_MAX_LENGTH,
+    CHAT_KEY_RECOVERY_STATE_MAX_LENGTH,
+    payload_contains_forbidden_secret_field,
+    validate_chat_key_payload,
+)
 from hushline.db import db
 from hushline.model import ChatKey, User
 
@@ -34,6 +40,121 @@ def _chat_key_payload(**overrides: object) -> dict[str, object]:
 
 def _chat_key_columns() -> set[str]:
     return {column.name for column in db.metadata.tables["chat_keys"].columns}
+
+
+def test_forbidden_secret_field_detection_recurses_through_nested_lists() -> None:
+    assert payload_contains_forbidden_secret_field(
+        {"safe": [{"nested": [{"plaintext-private-key": "secret"}]}]}
+    )
+    assert not payload_contains_forbidden_secret_field({"safe": [{"nested": ["metadata"]}]})
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_error"),
+    [
+        ([], "Expected a JSON object."),
+        ({"public_key": "not-json"}, "public_key must be a P-256 ECDH public JWK."),
+        ({"public_key": "[]"}, "public_key must be a P-256 ECDH public JWK."),
+        (
+            {"public_key": '{"kty":"OKP","crv":"Ed25519","x":"public-x","y":"public-y"}'},
+            "public_key must be a P-256 ECDH public JWK.",
+        ),
+        (
+            {"public_key": '{"kty":"EC","crv":"P-256","x":"public-x"}'},
+            "public_key must be a P-256 ECDH public JWK.",
+        ),
+        (
+            {
+                "public_key": (
+                    '{"kty":"EC","crv":"P-256","x":"public-x","y":"public-y",' '"key_ops":[1]}'
+                )
+            },
+            "public_key must be a P-256 ECDH public JWK.",
+        ),
+        (
+            {
+                "public_key": (
+                    '{"kty":"EC","crv":"P-256","x":"public-x","y":"public-y",'
+                    '"key_ops":["encrypt"]}'
+                )
+            },
+            "public_key must be a P-256 ECDH public JWK.",
+        ),
+        (
+            {
+                "public_signing_key": (
+                    '{"kty":"EC","crv":"P-256","x":"signing-public-x",'
+                    '"y":"signing-public-y","key_ops":["sign"]}'
+                )
+            },
+            "public_signing_key must be a P-256 ECDSA public JWK.",
+        ),
+        ({"public_key": ""}, "public_key is required."),
+        ({"encrypted_private_key": ""}, "encrypted_private_key is required."),
+        ({"kdf_algorithm": ""}, "kdf_algorithm is required."),
+        ({"kdf_salt": ""}, "kdf_salt is required."),
+        ({"kdf_params": {}}, "kdf_params must be a non-empty object."),
+        (
+            {"kdf_params": {"iterations": True, "hash": "SHA-256"}},
+            "kdf_params.iterations must be an integer.",
+        ),
+        (
+            {"kdf_params": {"iterations": 310000, "hash": "SHA-256", "bad": object()}},
+            "kdf_params must be JSON serializable.",
+        ),
+        (
+            {
+                "kdf_params": {
+                    "iterations": 310000,
+                    "hash": "SHA-256",
+                    "metadata": "x" * CHAT_KEY_METADATA_MAX_LENGTH,
+                }
+            },
+            "kdf_params is too large.",
+        ),
+        (
+            {"recovery_state": "x" * (CHAT_KEY_RECOVERY_STATE_MAX_LENGTH + 1)},
+            "recovery_state is too large.",
+        ),
+        (
+            {"encrypted_private_key": "[]"},
+            "encrypted_private_key must be a JSON object.",
+        ),
+    ],
+)
+def test_validate_chat_key_payload_rejects_malformed_edges(
+    payload: object, expected_error: str
+) -> None:
+    if isinstance(payload, dict):
+        submitted_payload_dict = _chat_key_payload()
+        submitted_payload_dict.update(payload)
+        submitted_payload: object = submitted_payload_dict
+    else:
+        submitted_payload = payload
+
+    cleaned_payload, error = validate_chat_key_payload(submitted_payload, current_user_id=1)
+
+    assert cleaned_payload == {}
+    assert error == expected_error
+
+
+def test_validate_chat_key_payload_accepts_nested_kdf_fields() -> None:
+    payload = _chat_key_payload()
+    payload.pop("kdf_algorithm")
+    payload.pop("kdf_salt")
+    payload.pop("kdf_params")
+    payload["kdf"] = {
+        "algorithm": "PBKDF2-SHA-256",
+        "salt": "c2FsdC1zYWx0LXNhbHQtIQ==",
+        "params": {"iterations": 310000, "hash": "SHA-256"},
+    }
+
+    cleaned_payload, error = validate_chat_key_payload(payload, current_user_id=1)
+
+    assert error == ""
+    assert cleaned_payload["kdf_algorithm"] == "PBKDF2-SHA-256"
+    assert cleaned_payload["kdf_salt"] == "c2FsdC1zYWx0LXNhbHQtIQ=="
+    assert cleaned_payload["kdf_params"] == {"iterations": 310000, "hash": "SHA-256"}
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -4,6 +4,7 @@ import re
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
+import pytest
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
@@ -21,6 +22,20 @@ from hushline.model import (
     Message,
     NotificationRecipient,
     User,
+)
+from hushline.routes.message import (
+    _as_utc,
+    _canonical_chat_signature_payload,
+    _chat_ciphertext_context,
+    _chat_ciphertext_context_is_bound,
+    _chat_ciphertext_signature_is_valid,
+    _chat_ciphertext_signatures_are_valid,
+    _chat_signing_public_key,
+    _conversation_activity_timeout,
+    _conversation_notification_body,
+    _conversation_presence_heartbeat_ms,
+    _decode_jwk_coordinate,
+    _is_chat_ciphertext_envelope,
 )
 
 _SENDER_SIGNING_PRIVATE_KEY = ec.derive_private_key(1, ec.SECP256R1())
@@ -156,6 +171,29 @@ def _ciphertext(label: str) -> str:
             "iv": f"iv-{label}",
             "ciphertext": f"ciphertext-{label}",
         }
+    )
+
+
+def _context_bound_ciphertext(
+    conversation: Conversation,
+    sender_participant: ConversationParticipant,
+    recipient_participant: ConversationParticipant,
+    label: str,
+    *,
+    context_overrides: dict[str, str] | None = None,
+) -> str:
+    context = {
+        "purpose": "hushline.chat.message",
+        "conversation_public_id": conversation.public_id,
+        "sender_participant_id": str(sender_participant.id),
+        "recipient_participant_id": str(recipient_participant.id),
+    }
+    if context_overrides:
+        context.update(context_overrides)
+    return _bound_ciphertext(
+        context=context,
+        label=label,
+        signing_private_key=_signing_private_key_for_participant(conversation, sender_participant),
     )
 
 
@@ -301,6 +339,273 @@ def _add_conversation_message(
         db.session.add(encrypted_copy)
     db.session.commit()
     return conversation_message
+
+
+def test_conversation_timing_helpers_fall_back_to_safe_defaults(app: Flask) -> None:
+    app.config["CONVERSATION_ACTIVITY_TIMEOUT_SECONDS"] = "not-a-number"
+    app.config["CONVERSATION_PRESENCE_HEARTBEAT_SECONDS"] = "not-a-number"
+
+    assert _conversation_activity_timeout() == timedelta(seconds=120)
+    assert _conversation_presence_heartbeat_ms() == 60_000
+
+
+def test_as_utc_treats_naive_datetimes_as_utc() -> None:
+    naive_datetime = datetime(2026, 1, 1, 12, 0)
+
+    assert _as_utc(naive_datetime) == datetime(2026, 1, 1, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.parametrize(
+    "value",
+    [
+        "",
+        "{not-json",
+        "[]",
+        json.dumps({"algorithm": "ECDH-P256-AES-GCM"}),
+        json.dumps(
+            {
+                "algorithm": "AES-GCM",
+                "ephemeral_public_key": "ephemeral",
+                "iv": "iv",
+                "ciphertext": "ciphertext",
+            }
+        ),
+        json.dumps(
+            {
+                "v": 3,
+                "algorithm": "ECDH-P256-AES-GCM",
+                "ephemeral_public_key": "ephemeral",
+                "iv": "iv",
+                "ciphertext": "ciphertext",
+            }
+        ),
+        json.dumps(
+            {
+                "v": 2,
+                "algorithm": "ECDH-P256-AES-GCM",
+                "ephemeral_public_key": "ephemeral",
+                "iv": "iv",
+                "ciphertext": "ciphertext",
+                "context": {},
+            }
+        ),
+    ],
+)
+def test_chat_ciphertext_envelope_rejects_malformed_values(app: Flask, value: str) -> None:
+    _ = app
+
+    assert not _is_chat_ciphertext_envelope(value)
+
+
+def test_chat_ciphertext_context_rejects_malformed_values(app: Flask) -> None:
+    _ = app
+
+    assert _chat_ciphertext_context("{not-json") is None
+    assert _chat_ciphertext_context("[]") is None
+    assert _chat_ciphertext_context(json.dumps({"v": 1, "context": {"safe": "metadata"}})) is None
+
+
+def test_canonical_chat_signature_payload_rejects_missing_fields() -> None:
+    assert _canonical_chat_signature_payload({"v": 2}) is None
+
+
+@pytest.mark.parametrize(
+    "value",
+    ["", "not-base64", base64.urlsafe_b64encode(b"short").decode()],
+)
+def test_decode_jwk_coordinate_rejects_invalid_values(value: str) -> None:
+    assert _decode_jwk_coordinate(value) is None
+
+
+@pytest.mark.parametrize(
+    "public_signing_key",
+    [
+        None,
+        "{not-json",
+        "[]",
+        '{"kty":"OKP","crv":"Ed25519","x":"x","y":"y"}',
+        '{"kty":"EC","crv":"P-256","x":"not-base64","y":"not-base64"}',
+        json.dumps(
+            {
+                "kty": "EC",
+                "crv": "P-256",
+                "x": _b64url((0).to_bytes(32, "big")),
+                "y": _b64url((0).to_bytes(32, "big")),
+            }
+        ),
+    ],
+)
+def test_chat_signing_public_key_rejects_invalid_jwks(
+    app: Flask, public_signing_key: str | None
+) -> None:
+    _ = app
+
+    assert _chat_signing_public_key(public_signing_key) is None
+
+
+def test_chat_ciphertext_signature_rejects_invalid_payloads(app: Flask) -> None:
+    _ = app
+
+    valid_payload = _bound_ciphertext(
+        context={
+            "purpose": "hushline.chat.message",
+            "conversation_public_id": "thread-public-id",
+            "sender_participant_id": "1",
+            "recipient_participant_id": "2",
+        },
+        label="signature-branches",
+        signing_private_key=_SENDER_SIGNING_PRIVATE_KEY,
+    )
+    valid_envelope = json.loads(valid_payload)
+
+    assert not _chat_ciphertext_signature_is_valid(valid_payload, None)
+    assert not _chat_ciphertext_signature_is_valid("{not-json", _SENDER_PUBLIC_SIGNING_KEY)
+    assert not _chat_ciphertext_signature_is_valid(json.dumps({"v": 1}), _SENDER_PUBLIC_SIGNING_KEY)
+
+    missing_payload_field = dict(valid_envelope)
+    missing_payload_field.pop("ciphertext")
+    assert not _chat_ciphertext_signature_is_valid(
+        json.dumps(missing_payload_field), _SENDER_PUBLIC_SIGNING_KEY
+    )
+
+    non_string_signature = dict(valid_envelope)
+    non_string_signature["signature"] = 123
+    assert not _chat_ciphertext_signature_is_valid(
+        json.dumps(non_string_signature), _SENDER_PUBLIC_SIGNING_KEY
+    )
+
+    invalid_base64_signature = dict(valid_envelope)
+    invalid_base64_signature["signature"] = "not base64"
+    assert not _chat_ciphertext_signature_is_valid(
+        json.dumps(invalid_base64_signature), _SENDER_PUBLIC_SIGNING_KEY
+    )
+
+    wrong_length_signature = dict(valid_envelope)
+    wrong_length_signature["signature"] = base64.b64encode(b"short").decode("ascii")
+    assert not _chat_ciphertext_signature_is_valid(
+        json.dumps(wrong_length_signature), _SENDER_PUBLIC_SIGNING_KEY
+    )
+
+    bogus_signature = dict(valid_envelope)
+    bogus_signature["signature"] = base64.b64encode(b"0" * 64).decode("ascii")
+    assert not _chat_ciphertext_signature_is_valid(
+        json.dumps(bogus_signature), _SENDER_PUBLIC_SIGNING_KEY
+    )
+
+
+def test_chat_ciphertext_signatures_reject_non_string_copy(app: Flask) -> None:
+    _ = app
+
+    assert not _chat_ciphertext_signatures_are_valid(
+        {"1": object()},
+        public_signing_key=_SENDER_PUBLIC_SIGNING_KEY,
+    )
+
+
+@pytest.mark.parametrize(
+    "context_overrides",
+    [
+        {"purpose": "wrong-purpose"},
+        {"conversation_public_id": "wrong-conversation"},
+        {"sender_participant_id": "999999"},
+        {"recipient_participant_id": "999999"},
+    ],
+)
+def test_chat_ciphertext_context_binding_rejects_mismatches(
+    user: User,
+    user2: User,
+    context_overrides: dict[str, str],
+) -> None:
+    conversation = _make_conversation(user, user2)
+    sender_participant = _participant_for(conversation, user)
+    recipient_participant = _participant_for(conversation, user2)
+
+    assert not _chat_ciphertext_context_is_bound(
+        {
+            str(recipient_participant.id): _context_bound_ciphertext(
+                conversation,
+                sender_participant,
+                recipient_participant,
+                "context-mismatch",
+                context_overrides=context_overrides,
+            )
+        },
+        conversation=conversation,
+        sender_participant_id=sender_participant.id,
+    )
+
+
+def test_chat_ciphertext_context_binding_rejects_non_string_payload(
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    sender_participant = _participant_for(conversation, user)
+
+    assert not _chat_ciphertext_context_is_bound(
+        {"1": object()},
+        conversation=conversation,
+        sender_participant_id=sender_participant.id,
+    )
+
+
+def test_chat_ciphertext_context_binding_rejects_legacy_conversation_id_mismatch(
+    user: User,
+    user2: User,
+) -> None:
+    conversation = _make_conversation(user, user2)
+    sender_participant = _participant_for(conversation, user)
+    recipient_participant = _participant_for(conversation, user2)
+    encrypted_payload = _bound_ciphertext(
+        context={
+            "purpose": "hushline.chat.message",
+            "conversation_id": "999999",
+            "sender_participant_id": str(sender_participant.id),
+            "recipient_participant_id": str(recipient_participant.id),
+        },
+        label="legacy-conversation-id-mismatch",
+        signing_private_key=_SENDER_SIGNING_PRIVATE_KEY,
+    )
+
+    assert not _chat_ciphertext_context_is_bound(
+        {str(recipient_participant.id): encrypted_payload},
+        conversation=conversation,
+        sender_participant_id=sender_participant.id,
+    )
+
+
+def test_conversation_notification_body_is_generic_without_encryption_target(user: User) -> None:
+    user.email_include_message_content = True
+    user.email_encrypt_entire_body = True
+
+    body = _conversation_notification_body(user)
+
+    assert body == (
+        "You have new Hush Line conversation activity. "
+        "Log in and unlock your Hush Line chat key to read it."
+    )
+
+
+@patch("hushline.routes.message.encrypt_message")
+def test_conversation_notification_body_falls_back_when_encryption_fails(
+    mock_encrypt_message: MagicMock,
+    user: User,
+) -> None:
+    _enable_conversation_notifications(
+        user,
+        email="recipient@example.com",
+        include_content=True,
+        encrypt_entire_body=True,
+        pgp_key="recipient-pgp-key",
+    )
+    mock_encrypt_message.side_effect = RuntimeError("encryption failed")
+
+    body = _conversation_notification_body(user)
+
+    assert body == (
+        "You have new Hush Line conversation activity. "
+        "Log in and unlock your Hush Line chat key to read it."
+    )
 
 
 def test_conversation_route_authorizes_only_participants(
@@ -930,6 +1235,46 @@ def test_append_conversation_message_rejects_when_participant_deleted_their_side
     assert 'data-can-compose="false"' in page_response.text
     assert response.status_code == 400
     assert response.get_json() == {"error": "Conversation replies are unavailable."}
+
+
+def test_append_conversation_message_rejects_non_object_payload(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_reply_capable_chat_keys(user, user2)
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json=[],
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Invalid encrypted message payload."}
+    message_count = db.session.scalar(db.select(db.func.count()).select_from(ConversationMessage))
+    assert message_count == 1
+
+
+def test_append_conversation_message_rejects_non_object_encrypted_copies(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_reply_capable_chat_keys(user, user2)
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": []},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Invalid encrypted message payload."}
+    message_count = db.session.scalar(db.select(db.func.count()).select_from(ConversationMessage))
+    assert message_count == 1
 
 
 def test_participant_can_append_encrypted_conversation_message(

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -10,7 +10,16 @@ from helpers import get_profile_submission_data
 from hushline import auth
 from hushline.chat_key_lifecycle import chat_key_fingerprint
 from hushline.db import db
-from hushline.model import ChatKey, FieldValue, Message, MessageStatus, User, Username
+from hushline.model import (
+    ChatKey,
+    Conversation,
+    FieldValue,
+    Message,
+    MessageStatus,
+    User,
+    Username,
+)
+from hushline.routes.inbox import _conversation_latest_message, _inbox_conversation_summary
 
 MSG_CONTACT_METHOD = "I prefer Signal."
 MSG_CONTENT = "This is a test message."
@@ -104,6 +113,18 @@ def _initial_conversation_copies_for(
             nonce=nonce,
         ),
     }
+
+
+def test_conversation_latest_message_returns_none_for_empty_thread() -> None:
+    assert _conversation_latest_message(Conversation()) is None
+
+
+def test_inbox_conversation_summary_returns_none_for_non_participant(user: User) -> None:
+    conversation = Conversation()
+    db.session.add(conversation)
+    db.session.commit()
+
+    assert _inbox_conversation_summary(conversation, user) is None
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -605,6 +605,56 @@ def test_logged_in_profile_submit_without_pgp_rejects_misbound_initial_chat_payl
 
 
 @pytest.mark.usefixtures("_authenticated_user")
+@pytest.mark.parametrize(
+    "context_overrides",
+    [
+        {"purpose": "wrong-purpose"},
+        {"initial_conversation_nonce": "wrong-nonce"},
+        {"sender_key_version": "999999"},
+        {"sender_public_key_fingerprint": "WRONG"},
+        {"sender_public_signing_key_fingerprint": "WRONG"},
+        {"recipient_key_version": "999999"},
+    ],
+)
+def test_logged_in_profile_submit_without_pgp_rejects_other_misbound_initial_chat_payloads(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    context_overrides: dict[str, object],
+) -> None:
+    user.pgp_key = None
+    user2.pgp_key = None
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+    submission_data = get_profile_submission_data(client, user2.primary_username.username)
+
+    response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            "encrypted_conversation_copies": json.dumps(
+                _initial_conversation_copies_for(
+                    sender=user,
+                    recipient=user2,
+                    nonce=submission_data["owner_guard_nonce"],
+                    context_overrides=context_overrides,
+                )
+            ),
+            **submission_data,
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 400
+    assert "do not have any usable recipient PGP keys" in response.text
+    assert db.session.scalars(db.select(Message)).all() == []
+    assert db.session.scalars(db.select(Conversation)).all() == []
+    assert db.session.scalars(db.select(ConversationMessageCopy)).all() == []
+
+
+@pytest.mark.usefixtures("_authenticated_user")
 def test_logged_in_profile_submit_initial_chat_nonce_is_single_use(
     client: FlaskClient, user: User, user2: User
 ) -> None:
@@ -770,6 +820,40 @@ def test_logged_in_profile_submit_message_with_invalid_chat_ciphertext_skips_con
     assert db.session.scalars(db.select(ConversationMessageCopy)).all() == []
     assert "plain-private-key" not in response.text
     assert "plain-derived-key" not in response.text
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+@pytest.mark.parametrize("encrypted_conversation_copies", ["{not-json", "[]"])
+def test_logged_in_profile_submit_message_with_unusable_chat_json_skips_conversation(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    encrypted_conversation_copies: str,
+) -> None:
+    _set_pgp_key(user)
+    _set_pgp_key(user2)
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+
+    response = client.post(
+        url_for("profile", username=user2.primary_username.username),
+        data={
+            "field_0": msg_contact_method,
+            "field_1": msg_content,
+            "encrypted_conversation_copies": encrypted_conversation_copies,
+            **get_profile_submission_data(client, user2.primary_username.username),
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200, response.text
+    assert "Message submitted successfully." in response.text
+    message = db.session.scalars(
+        db.select(Message).filter_by(username_id=user2.primary_username.id)
+    ).one()
+    assert message.conversation is None
+    assert db.session.scalars(db.select(Conversation)).all() == []
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -395,6 +395,40 @@ def test_login_with_chat_key_payload_creates_missing_chat_key(
     assert created_key.kdf_salt == "bG9naW4tc2FsdC0xMjM0NQ=="
 
 
+def test_login_ignores_malformed_chat_key_payload(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    response = client.post(
+        url_for("login"),
+        data={
+            "username": user.primary_username.username,
+            "password": user_password,
+            "chat_key_payload": "{not-json",
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert db.session.scalars(db.select(ChatKey).filter_by(user_id=user.id)).all() == []
+
+
+def test_login_ignores_invalid_chat_key_payload(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    response = client.post(
+        url_for("login"),
+        data={
+            "username": user.primary_username.username,
+            "password": user_password,
+            "chat_key_payload": json.dumps(_login_chat_key_payload(private_key="plaintext")),
+        },
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert db.session.scalars(db.select(ChatKey).filter_by(user_id=user.id)).all() == []
+
+
 def test_login_with_chat_key_payload_waits_for_successful_2fa(
     client: FlaskClient, user: User, user_password: str
 ) -> None:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -621,6 +621,80 @@ def test_change_password_rewrap_rejects_plaintext_chat_key_material(
 
 
 @pytest.mark.usefixtures("_authenticated_user")
+def test_change_password_rewrap_rejects_malformed_json(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="public-chat-key",
+        encrypted_private_key='{"algorithm":"AES-GCM","iv":"old","ciphertext":"old"}',
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000, "hash": "SHA-256"},
+        kdf_salt="old-salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    db.session.add(chat_key)
+    db.session.commit()
+    original_password_hash = user.password_hash
+    data = form_to_data(
+        ChangePasswordForm(
+            data={
+                "old_password": user_password,
+                "new_password": "ChangedPassword123!!",
+            }
+        )
+    )
+    data["rewrapped_chat_key"] = "{not-json"
+
+    response = client.post(url_for("settings.auth"), data=data, follow_redirects=True)
+
+    assert response.status_code == 400
+    assert "Chat key rewrap payload is invalid." in response.text
+    db.session.refresh(user)
+    assert user.password_hash == original_password_hash
+    db.session.refresh(chat_key)
+    assert chat_key.disabled_at is None
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_change_password_rewrap_rejects_invalid_payload(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    chat_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key="public-chat-key",
+        encrypted_private_key='{"algorithm":"AES-GCM","iv":"old","ciphertext":"old"}',
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000, "hash": "SHA-256"},
+        kdf_salt="old-salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    db.session.add(chat_key)
+    db.session.commit()
+    original_password_hash = user.password_hash
+    data = form_to_data(
+        ChangePasswordForm(
+            data={
+                "old_password": user_password,
+                "new_password": "ChangedPassword123!!",
+            }
+        )
+    )
+    data["rewrapped_chat_key"] = json.dumps({"public_key": "not-json"})
+
+    response = client.post(url_for("settings.auth"), data=data, follow_redirects=True)
+
+    assert response.status_code == 400
+    assert "public_key must be a P-256 ECDH public JWK." in response.text
+    db.session.refresh(user)
+    assert user.password_hash == original_password_hash
+    db.session.refresh(chat_key)
+    assert chat_key.disabled_at is None
+
+
+@pytest.mark.usefixtures("_authenticated_user")
 def test_change_password_allows_account_access_when_chat_key_is_locked(
     client: FlaskClient, user: User, user_password: str
 ) -> None:


### PR DESCRIPTION
This PR implements #2280 (`Close test coverage gaps from PR #2279`) via the code agent with a scoped change set focused on the issue requirements.

This PR addresses the issue "Close test coverage gaps from PR #2279" by updating automated tests in `tests/test_chat_keys.py`, automated tests in `tests/test_conversation.py`, and automated tests in `tests/test_inbox.py`.
The change focuses on automated tests, confirming the expected behavior without a broader product change.
It touches 6 non-log file(s) (6 total including runner artifacts), primarily in tests/test_chat_keys.py, tests/test_conversation.py, and tests/test_inbox.py.

## Summary
- Automated code agent implementation for #2280.
- Implements issue goal: Close test coverage gaps from PR #2279

Closes #2280

## Context
- Issue: https://github.com/scidsg/hushline/issues/2280
- Branch: codex/daily-issue-2280
- Base branch: main
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `tests/test_chat_keys.py`
- `tests/test_conversation.py`
- `tests/test_inbox.py`
- `tests/test_profile.py`
- `tests/test_routes_auth.py`
- `tests/test_settings.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
