### PR TITLE
#2283 Configurable Directory Heading

### DIFF
--- a/hushline/model/organization_setting.py
+++ b/hushline/model/organization_setting.py
@@ -23,6 +23,7 @@ class OrganizationSetting(Model):
     BRAND_SPLASH_LOGO = "brand_splash_logo"
     BRAND_SPLASH_LOGO_CACHE_BUSTER = "brand_splash_logo_cache_buster"
     BRAND_SPLASH_SCREEN_ENABLED = "brand_splash_screen_enabled"
+    DIRECTORY_HEADING = "directory_heading"
     DIRECTORY_INTRO_TEXT = "directory_intro_text"
     EMBEDDABLE_FORMS_ENABLED = "embeddable_forms_enabled"
     GUIDANCE_ENABLED = "guidance_enabled"
@@ -43,6 +44,7 @@ class OrganizationSetting(Model):
         BRAND_PRIMARY_COLOR: "#7d25c1",
         BRAND_PROFILE_HEADER_TEMPLATE: "Submit a message to {{ display_name_or_username }}",
         BRAND_SPLASH_SCREEN_ENABLED: False,
+        DIRECTORY_HEADING: "Directory",
         EMBEDDABLE_FORMS_ENABLED: False,
         GUIDANCE_ENABLED: False,
         GUIDANCE_EXIT_BUTTON_TEXT: "Leave",

--- a/hushline/routes/directory.py
+++ b/hushline/routes/directory.py
@@ -892,6 +892,7 @@ def register_directory_routes(app: Flask) -> None:
         )
         return render_template(
             "directory.html",
+            directory_heading=OrganizationSetting.fetch_one(OrganizationSetting.DIRECTORY_HEADING),
             intro_text=OrganizationSetting.fetch_one(OrganizationSetting.DIRECTORY_INTRO_TEXT),
             pgp_usernames=pgp_usernames,
             info_usernames=info_usernames,

--- a/hushline/settings/__init__.py
+++ b/hushline/settings/__init__.py
@@ -33,6 +33,7 @@ from hushline.settings.forms import (
     UpdateBrandAppNameForm,
     UpdateBrandLogoForm,
     UpdateBrandPrimaryColorForm,
+    UpdateDirectoryHeadingForm,
     UpdateDirectoryTextForm,
     UpdateProfileHeaderForm,
     UpdateSplashLogoForm,

--- a/hushline/settings/branding.py
+++ b/hushline/settings/branding.py
@@ -32,6 +32,7 @@ from hushline.settings.forms import (
     UpdateBrandAppNameForm,
     UpdateBrandLogoForm,
     UpdateBrandPrimaryColorForm,
+    UpdateDirectoryHeadingForm,
     UpdateDirectoryTextForm,
     UpdateProfileHeaderForm,
     UpdateSplashLogoForm,
@@ -58,6 +59,9 @@ def register_branding_routes(bp: Blueprint) -> None:
 
         update_directory_text_form = UpdateDirectoryTextForm(
             markdown=OrganizationSetting.fetch_one(OrganizationSetting.DIRECTORY_INTRO_TEXT)
+        )
+        update_directory_heading_form = UpdateDirectoryHeadingForm(
+            heading=OrganizationSetting.fetch_one(OrganizationSetting.DIRECTORY_HEADING)
         )
         update_brand_logo_form = UpdateBrandLogoForm()
         delete_brand_logo_form = DeleteBrandLogoForm()
@@ -105,6 +109,33 @@ def register_branding_routes(bp: Blueprint) -> None:
                         abort(503)
                     db.session.commit()
                     flash("👍 Directory intro text was reset to defaults.")
+            elif (
+                update_directory_heading_form.submit.name in request.form
+                and update_directory_heading_form.validate()
+            ):
+                raw_heading = update_directory_heading_form.heading.data or ""
+                if heading := raw_heading.strip():
+                    OrganizationSetting.upsert(
+                        key=OrganizationSetting.DIRECTORY_HEADING,
+                        value=heading,
+                    )
+                    db.session.commit()
+                    flash("👍 Directory heading updated.")
+                else:
+                    row_count = db.session.execute(
+                        db.delete(OrganizationSetting).where(
+                            OrganizationSetting.key == OrganizationSetting.DIRECTORY_HEADING
+                        )
+                    ).rowcount
+                    if row_count > 1:
+                        current_app.logger.error(
+                            "Would have deleted multiple rows for OrganizationSetting key="
+                            + OrganizationSetting.DIRECTORY_HEADING
+                        )
+                        db.session.rollback()
+                        abort(503)
+                    db.session.commit()
+                    flash("👍 Directory heading was reset to defaults.")
             elif (
                 update_brand_logo_form.submit.name in request.form
                 and update_brand_logo_form.validate()
@@ -306,6 +337,7 @@ def register_branding_routes(bp: Blueprint) -> None:
             "settings/branding.html",
             user=user,
             update_directory_text_form=update_directory_text_form,
+            update_directory_heading_form=update_directory_heading_form,
             update_brand_logo_form=update_brand_logo_form,
             delete_brand_logo_form=delete_brand_logo_form,
             update_splash_logo_form=update_splash_logo_form,

--- a/hushline/settings/forms.py
+++ b/hushline/settings/forms.py
@@ -480,6 +480,15 @@ class UpdateDirectoryTextForm(FlaskForm):
     submit = SubmitField("Update Text", name="update_directory_text", widget=Button())
 
 
+class UpdateDirectoryHeadingForm(FlaskForm):
+    heading = StringField(
+        "Directory Heading",
+        filters=[strip_whitespace],
+        validators=[OptionalField(), Length(max=100)],
+    )
+    submit = SubmitField("Update Heading", name="update_directory_heading", widget=Button())
+
+
 class SetHomepageUsernameForm(FlaskForm):
     username = StringField(validators=[DataRequired()])
     submit = SubmitField("Set Username", name="set_homepage_user", widget=Button())

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -86,7 +86,7 @@
 {% endmacro %}
 
 {% block content %}
-  <h2 id="directory-title">Whistleblower Support Directory</h2>
+  <h2 id="directory-title">{{ directory_heading }}</h2>
 
   {% if intro_text %}
     {{ intro_text | markdown }}

--- a/hushline/templates/settings/branding.html
+++ b/hushline/templates/settings/branding.html
@@ -3,7 +3,18 @@
 {% block settings_content %}
   <h3>Branding</h3>
 
-  <h4>Diretory Intro Text</h4>
+  <h4>Directory Heading</h4>
+  <form
+    method="POST"
+    class="formBody"
+  >
+    {{ update_directory_heading_form.hidden_tag() }}
+    {{ update_directory_heading_form.heading.label }}
+    {{ update_directory_heading_form.heading }}
+    {{ update_directory_heading_form.submit }}
+  </form>
+
+  <h4>Directory Intro Text</h4>
   <form
     method="POST"
     class="formBody"

--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -36,6 +36,7 @@ from hushline.settings.forms import (
     SetHomepageUsernameForm,
     UpdateBrandAppNameForm,
     UpdateBrandPrimaryColorForm,
+    UpdateDirectoryHeadingForm,
     UpdateDirectoryTextForm,
     UpdateProfileHeaderForm,
     UserGuidanceForm,
@@ -657,6 +658,16 @@ def test_contract_admin_branding_guidance_and_registration_controls(
     client: FlaskClient, app: Flask, admin: User, user: User
 ) -> None:
     app.config["USER_VERIFICATION_ENABLED"] = True
+
+    directory_heading = "Contract Directory"
+    heading_response = client.post(
+        url_for("settings.branding"),
+        data={"heading": directory_heading, UpdateDirectoryHeadingForm.submit.name: ""},
+        follow_redirects=True,
+    )
+    assert heading_response.status_code == 200
+    assert "Directory heading updated" in heading_response.text
+    assert OrganizationSetting.fetch_one(OrganizationSetting.DIRECTORY_HEADING) == directory_heading
 
     directory_text = "Contract directory intro"
     branding_response = client.post(

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -284,14 +284,16 @@ def _client_sorted_all_display_names(rows: list[dict[str, object | None]]) -> li
 def test_directory_accessible(client: FlaskClient) -> None:
     response = client.get(url_for("directory"))
     assert response.status_code == 200
-    assert "Whistleblower Support Directory" in response.text
+    soup = BeautifulSoup(response.text, "html.parser")
+    title = soup.find(id="directory-title")
+    assert title is not None
+    assert title.get_text(strip=True) == "Directory"
     assert "Attorneys" in response.text
     assert "Journalists" in response.text
     assert "GlobaLeaks" in response.text
     assert "SecureDrop" in response.text
     assert "🤖 Automated" in response.text
 
-    soup = BeautifulSoup(response.text, "html.parser")
     verified_panel = soup.find(id="verified")
     all_panel = soup.find(id="all")
     assert verified_panel is not None

--- a/tests/test_migrations.py
+++ b/tests/test_migrations.py
@@ -74,6 +74,32 @@ def test_linear_revision_history(app: Flask) -> None:
     assert heads[0] == ALL_REVISIONS[-1]
 
 
+def test_organization_settings_migration_supports_directory_heading(app: Flask) -> None:
+    cfg = typing.cast(alembic.config.Config, migrate.get_config())
+    command.upgrade(cfg, "0b1321c8de13")
+
+    db.session.execute(
+        text(
+            """
+            INSERT INTO organization_settings (key, value)
+            VALUES ('directory_heading', to_jsonb('Custom Directory'::text))
+            """
+        )
+    )
+    db.session.commit()
+
+    stored_value = db.session.scalar(
+        text(
+            """
+            SELECT value #>> '{}'
+            FROM organization_settings
+            WHERE key = 'directory_heading'
+            """
+        )
+    )
+    assert stored_value == "Custom Directory"
+
+
 @pytest.mark.parametrize("revision", TESTABLE_REVISIONS)
 def test_upgrade_with_data(revision: str, app: Flask) -> None:
     previous_revision = ALL_REVISIONS[ALL_REVISIONS.index(revision) - 2]

--- a/tests/test_security_headers.py
+++ b/tests/test_security_headers.py
@@ -132,6 +132,21 @@ def test_settings_profile_keeps_frame_restrictions(client: FlaskClient) -> None:
     assert response.headers["X-Frame-Options"] == "DENY"
 
 
+@pytest.mark.usefixtures("_authenticated_admin")
+def test_settings_branding_keeps_csp_enforced(client: FlaskClient) -> None:
+    response = client.get(url_for("settings.branding"))
+    assert response.status_code == 200
+
+    directives = _csp_directives(response.headers)
+    csp = response.headers["Content-Security-Policy"]
+    assert directives["script-src"] == "'self'"
+    assert directives["script-src-elem"] == "'self'"
+    assert "frame-ancestors 'none'" in csp
+    assert "https://js.stripe.com" not in csp
+    assert "https://cdn.jsdelivr.net" not in csp
+    assert "'unsafe-eval'" not in csp
+
+
 @pytest.mark.usefixtures("_authenticated_user")
 def test_vision_page_allows_jsdelivr_only_for_tooling(client: FlaskClient) -> None:
     response = client.get(url_for("vision"))

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -43,6 +43,7 @@ from hushline.settings import (
     UpdateBrandAppNameForm,
     UpdateBrandLogoForm,
     UpdateBrandPrimaryColorForm,
+    UpdateDirectoryHeadingForm,
     UpdateDirectoryTextForm,
     UpdateProfileHeaderForm,
     UpdateSplashLogoForm,
@@ -3241,7 +3242,85 @@ def test_update_guidance_prompt_rejects_text_over_expanded_length(
 
 
 @pytest.mark.usefixtures("_authenticated_admin")
-def test_diretory_intro_text(client: FlaskClient, admin: User) -> None:
+def test_directory_heading(client: FlaskClient, admin: User) -> None:
+    settings_resp = client.get(url_for("settings.branding"))
+    assert settings_resp.status_code == 200
+    settings_soup = BeautifulSoup(settings_resp.text, "html.parser")
+    heading_field = settings_soup.find("input", attrs={"name": "heading"})
+    assert heading_field is not None
+    assert heading_field["value"] == "Directory"
+
+    alert = "<script>alert(1)</script>"
+    uuid = str(uuid4())
+    custom_heading = f"Secure Contact Directory & {alert} {uuid}"
+    resp = client.post(
+        url_for("settings.branding"),
+        data={
+            "heading": f"  {custom_heading}  ",
+            UpdateDirectoryHeadingForm.submit.name: "",
+        },
+    )
+    assert resp.status_code == 200
+    assert "Directory heading updated" in resp.text
+
+    val = OrganizationSetting.fetch_one(OrganizationSetting.DIRECTORY_HEADING)
+    assert val == custom_heading
+
+    resp = client.get(url_for("directory"))
+    assert resp.status_code == 200
+    assert uuid in resp.text
+    assert alert not in resp.text
+    assert "Secure Contact Directory &amp;" in resp.text
+    assert "&lt;script&gt;" in resp.text
+
+
+@pytest.mark.usefixtures("_authenticated_admin")
+def test_directory_heading_reset_to_default(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "hushline.settings.branding.UpdateDirectoryHeadingForm.validate",
+        lambda *_a, **_k: True,
+    )
+    OrganizationSetting.upsert(OrganizationSetting.DIRECTORY_HEADING, "to be cleared")
+    db.session.commit()
+
+    resp = client.post(
+        url_for("settings.branding"),
+        data={"heading": "   ", UpdateDirectoryHeadingForm.submit.name: ""},
+        follow_redirects=True,
+    )
+    assert resp.status_code == 200
+    assert "Directory heading was reset to defaults" in resp.text
+    assert OrganizationSetting.fetch_one(OrganizationSetting.DIRECTORY_HEADING) == "Directory"
+
+
+@pytest.mark.usefixtures("_authenticated_admin")
+def test_directory_heading_reset_aborts_when_multiple_rows_would_delete(
+    client: FlaskClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        "hushline.settings.branding.UpdateDirectoryHeadingForm.validate",
+        lambda *_a, **_k: True,
+    )
+
+    class _Result:
+        rowcount = 2
+
+    monkeypatch.setattr(
+        "hushline.settings.branding.db.session.execute", lambda *_a, **_k: _Result()
+    )
+
+    resp = client.post(
+        url_for("settings.branding"),
+        data={"heading": "", UpdateDirectoryHeadingForm.submit.name: ""},
+        follow_redirects=False,
+    )
+    assert resp.status_code == 503
+
+
+@pytest.mark.usefixtures("_authenticated_admin")
+def test_directory_intro_text(client: FlaskClient, admin: User) -> None:
     alert = "<script>alert(1)</stript>"
     uuid = str(uuid4())
     data = alert + " " + uuid


### PR DESCRIPTION
This PR implements #2283 (`Configurable Directory Heading`) via the code agent with a scoped change set focused on the issue requirements.

This PR addresses the issue "Configurable Directory Heading" by updating data and model code in `hushline/model`, request-handling code in `hushline/routes`, and application code in `hushline/settings`.
The change includes both implementation work and automated tests, showing the intended behavior and how it is verified.
It touches 12 non-log file(s) (12 total including runner artifacts), primarily in hushline/model, hushline/routes, and hushline/settings.

## Summary
- Automated code agent implementation for #2283.
- Implements issue goal: Configurable Directory Heading

Closes #2283

## Context
- Issue: https://github.com/scidsg/hushline/issues/2283
- Branch: codex/daily-issue-2283
- Base branch: main
- Runner log: Retained locally by hushline-agents (not committed)

## Changed Files
- `hushline/model/organization_setting.py`
- `hushline/routes/directory.py`
- `hushline/settings/__init__.py`
- `hushline/settings/branding.py`
- `hushline/settings/forms.py`
- `hushline/templates/directory.html`
- `hushline/templates/settings/branding.html`
- `tests/test_behavior_contracts.py`
- `tests/test_directory.py`
- `tests/test_migrations.py`
- `tests/test_security_headers.py`
- `tests/test_settings.py`

## Validation
- `make lint`
- `make test` (full suite)
- Additional CI workflows run on the PR after branch push; the runner does not try to mirror the full workflow matrix locally.

## Manual Testing
- Manual testing is for reviewer-executed product checks, not a log of steps the runner or LLM took.
- In a local or staging environment, open the feature or workflow changed by this issue.
- Reproduce the issue scenario or perform the changed workflow end to end as a user.
- Verify the expected behavior from the issue description and check the nearest adjacent core flow for regressions.
