### PR TITLE
Require admin trigger for PR release governance

### DIFF
--- a/.github/workflows/release-governance.yml
+++ b/.github/workflows/release-governance.yml
@@ -22,6 +22,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           REPOSITORY: ${{ github.repository }}
           HEAD_SHA: ${{ github.sha }}
+          WORKFLOW_TRIGGERING_ACTOR: ${{ github.triggering_actor }}
         run: |
           set -euo pipefail
 
@@ -30,7 +31,8 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
             actor="$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")"
             event_action="$(jq -r '.action' "$GITHUB_EVENT_PATH")"
-            triggering_actor="$(jq -r '.sender.login' "$GITHUB_EVENT_PATH")"
+            event_sender="$(jq -r '.sender.login' "$GITHUB_EVENT_PATH")"
+            triggering_actor="$WORKFLOW_TRIGGERING_ACTOR"
             pr_number="$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")"
             expected_file_count="$(jq -r '.pull_request.changed_files' "$GITHUB_EVENT_PATH")"
             file_records="$(
@@ -87,17 +89,32 @@ jobs:
           fi
 
           if [ "${EVENT_NAME}" = "pull_request_target" ]; then
-            triggering_permission="$(
-              gh api "repos/${REPOSITORY}/collaborators/${triggering_actor}/permission" \
+            sender_permission="$(
+              gh api "repos/${REPOSITORY}/collaborators/${event_sender}/permission" \
                 --jq '.permission'
             )"
-            if [ "$triggering_permission" != "admin" ]; then
+            if [ "$sender_permission" != "admin" ]; then
               {
-                echo "Release-governed files triggered by ${triggering_actor} on ${event_action}, who has ${triggering_permission} repository permission."
+                echo "Release-governed files triggered by ${event_sender} on ${event_action}, who has ${sender_permission} repository permission."
                 echo "Only repository admins may update release-governed changes:"
                 printf '%s\n' "$governed_files"
               } >&2
               exit 1
+            fi
+
+            if [ "$triggering_actor" != "$event_sender" ]; then
+              rerun_permission="$(
+                gh api "repos/${REPOSITORY}/collaborators/${triggering_actor}/permission" \
+                  --jq '.permission'
+              )"
+              if [ "$rerun_permission" != "admin" ]; then
+                {
+                  echo "Release-governed files rerun by ${triggering_actor}, who has ${rerun_permission} repository permission."
+                  echo "Only repository admins may rerun release-governed checks:"
+                  printf '%s\n' "$governed_files"
+                } >&2
+                exit 1
+              fi
             fi
           fi
 

--- a/.github/workflows/release-governance.yml
+++ b/.github/workflows/release-governance.yml
@@ -30,7 +30,7 @@ jobs:
           if [ "$EVENT_NAME" = "pull_request_target" ]; then
             actor="$(jq -r '.pull_request.user.login' "$GITHUB_EVENT_PATH")"
             event_action="$(jq -r '.action' "$GITHUB_EVENT_PATH")"
-            synchronizing_actor="$(jq -r '.sender.login' "$GITHUB_EVENT_PATH")"
+            triggering_actor="$(jq -r '.sender.login' "$GITHUB_EVENT_PATH")"
             pr_number="$(jq -r '.pull_request.number' "$GITHUB_EVENT_PATH")"
             expected_file_count="$(jq -r '.pull_request.changed_files' "$GITHUB_EVENT_PATH")"
             file_records="$(
@@ -86,14 +86,14 @@ jobs:
             exit 1
           fi
 
-          if [ "${EVENT_NAME}" = "pull_request_target" ] && [ "${event_action}" = "synchronize" ]; then
-            synchronizing_permission="$(
-              gh api "repos/${REPOSITORY}/collaborators/${synchronizing_actor}/permission" \
+          if [ "${EVENT_NAME}" = "pull_request_target" ]; then
+            triggering_permission="$(
+              gh api "repos/${REPOSITORY}/collaborators/${triggering_actor}/permission" \
                 --jq '.permission'
             )"
-            if [ "$synchronizing_permission" != "admin" ]; then
+            if [ "$triggering_permission" != "admin" ]; then
               {
-                echo "Release-governed files synchronized by ${synchronizing_actor}, who has ${synchronizing_permission} repository permission."
+                echo "Release-governed files triggered by ${triggering_actor} on ${event_action}, who has ${triggering_permission} repository permission."
                 echo "Only repository admins may update release-governed changes:"
                 printf '%s\n' "$governed_files"
               } >&2

--- a/tests/test_release_governance_workflow.py
+++ b/tests/test_release_governance_workflow.py
@@ -66,13 +66,18 @@ def test_release_governance_workflow_authorizes_pr_author_not_triggering_actor()
 def test_release_governance_workflow_requires_admin_triggering_actor_for_all_pr_events() -> None:
     workflow_text = _workflow_text()
 
+    assert "WORKFLOW_TRIGGERING_ACTOR: ${{ github.triggering_actor }}" in workflow_text
     assert 'event_action="$(jq -r \'.action\' "$GITHUB_EVENT_PATH")"' in workflow_text
-    assert 'triggering_actor="$(jq -r \'.sender.login\' "$GITHUB_EVENT_PATH")"' in workflow_text
+    assert 'event_sender="$(jq -r \'.sender.login\' "$GITHUB_EVENT_PATH")"' in workflow_text
+    assert 'triggering_actor="$WORKFLOW_TRIGGERING_ACTOR"' in workflow_text
     assert 'if [ "${EVENT_NAME}" = "pull_request_target" ]; then' in workflow_text
     assert '[ "${event_action}" = "synchronize" ]' not in workflow_text
+    assert "repos/${REPOSITORY}/collaborators/${event_sender}/permission" in workflow_text
     assert "repos/${REPOSITORY}/collaborators/${triggering_actor}/permission" in workflow_text
-    assert 'if [ "$triggering_permission" != "admin" ]; then' in workflow_text
+    assert 'if [ "$sender_permission" != "admin" ]; then' in workflow_text
+    assert 'if [ "$rerun_permission" != "admin" ]; then' in workflow_text
     assert "Only repository admins may update release-governed changes" in workflow_text
+    assert "Only repository admins may rerun release-governed checks" in workflow_text
 
 
 def test_release_governance_workflow_uses_pr_files_api_with_renames() -> None:

--- a/tests/test_release_governance_workflow.py
+++ b/tests/test_release_governance_workflow.py
@@ -63,14 +63,15 @@ def test_release_governance_workflow_authorizes_pr_author_not_triggering_actor()
     assert 'actor="$(jq -r \'.pull_request.user.login\' "$GITHUB_EVENT_PATH")"' in workflow_text
 
 
-def test_release_governance_workflow_requires_admin_synchronize_actor() -> None:
+def test_release_governance_workflow_requires_admin_triggering_actor_for_all_pr_events() -> None:
     workflow_text = _workflow_text()
 
     assert 'event_action="$(jq -r \'.action\' "$GITHUB_EVENT_PATH")"' in workflow_text
-    assert 'synchronizing_actor="$(jq -r \'.sender.login\' "$GITHUB_EVENT_PATH")"' in workflow_text
-    assert '[ "${event_action}" = "synchronize" ]' in workflow_text
-    assert "repos/${REPOSITORY}/collaborators/${synchronizing_actor}/permission" in workflow_text
-    assert 'if [ "$synchronizing_permission" != "admin" ]; then' in workflow_text
+    assert 'triggering_actor="$(jq -r \'.sender.login\' "$GITHUB_EVENT_PATH")"' in workflow_text
+    assert 'if [ "${EVENT_NAME}" = "pull_request_target" ]; then' in workflow_text
+    assert '[ "${event_action}" = "synchronize" ]' not in workflow_text
+    assert "repos/${REPOSITORY}/collaborators/${triggering_actor}/permission" in workflow_text
+    assert 'if [ "$triggering_permission" != "admin" ]; then' in workflow_text
     assert "Only repository admins may update release-governed changes" in workflow_text
 
 


### PR DESCRIPTION
### Motivation
- Close a supply-chain bypass where `pull_request_target` runs for non-`synchronize` events (for example `reopened`) could authorize release-governed file changes based solely on the PR author while ignoring the actual triggering sender.
- Ensure release-governed files (workflows, `Makefile`, `hushline/version.py`, `scripts/release.py`, signer metadata) cannot be approved by a lower-privileged actor reopening, otherwise retriggering, or rerunning an admin-authored PR.

### Description
- In `.github/workflows/release-governance.yml`, the PR author, webhook sender, and workflow rerun actor are handled separately for `pull_request_target` events.
- The workflow now requires repository `admin` permission for the PR author, the webhook sender, and `github.triggering_actor` when a release-governed PR check is rerun by a different user.
- Preserved push behavior for non-PR events and the existing release-governed file coverage.
- Updated `tests/test_release_governance_workflow.py` to assert that triggering-actor authorization applies to all PR events and that rerun actors are checked through `github.triggering_actor`.

### Testing
- `docker compose run --rm --no-deps app poetry run pytest tests/test_release_governance_workflow.py -q` (`8 passed`)
- `git diff --check`
- Full `make test` was attempted for the focused file, but dependency startup failed before tests ran because local port `127.0.0.1:5432` was already allocated. The no-deps container run above was used because this test file only inspects static workflow text.

### Manual Testing
- Not applicable; this is a GitHub Actions workflow authorization guard covered by static contract tests.

### Known Risks / Follow-ups
- Full repository lint/test and dependency audit workflows should pass in CI before merge.