### PR TITLE
Add chat message rate limits

### DIFF
--- a/hushline/model/__init__.py
+++ b/hushline/model/__init__.py
@@ -2,6 +2,7 @@
 
 from hushline.model.authentication_log import AuthenticationLog
 from hushline.model.chat_key import ChatKey
+from hushline.model.chat_rate_limit_attempt import ChatRateLimitAttempt
 from hushline.model.conversation import (
     Conversation,
     ConversationMessage,

--- a/hushline/model/chat_rate_limit_attempt.py
+++ b/hushline/model/chat_rate_limit_attempt.py
@@ -1,0 +1,67 @@
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from sqlalchemy import Index
+from sqlalchemy.orm import Mapped, mapped_column
+
+from hushline.db import db
+
+if TYPE_CHECKING:
+    from flask_sqlalchemy.model import Model
+else:
+    Model = db.Model
+
+
+class ChatRateLimitAttempt(Model):
+    __tablename__ = "chat_rate_limit_attempts"
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    conversation_id: Mapped[int] = mapped_column(
+        db.ForeignKey("conversations.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    sender_participant_id: Mapped[int] = mapped_column(
+        db.ForeignKey("conversation_participants.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[int] = mapped_column(
+        db.ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True
+    )
+    created_at: Mapped[datetime] = mapped_column(default=datetime.now, nullable=False)
+
+    __table_args__ = (
+        Index(
+            "idx_chat_rate_limit_attempts_sender_conversation_created",
+            "sender_participant_id",
+            "conversation_id",
+            "created_at",
+        ),
+        Index(
+            "idx_chat_rate_limit_attempts_user_created",
+            "user_id",
+            "created_at",
+        ),
+        Index(
+            "idx_chat_rate_limit_attempts_conversation_created",
+            "conversation_id",
+            "created_at",
+        ),
+        Index("idx_chat_rate_limit_attempts_created", "created_at"),
+    )
+
+    def __init__(
+        self,
+        *,
+        conversation_id: int,
+        sender_participant_id: int,
+        user_id: int,
+        created_at: datetime,
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            conversation_id=conversation_id,  # type: ignore[call-arg]
+            sender_participant_id=sender_participant_id,  # type: ignore[call-arg]
+            user_id=user_id,  # type: ignore[call-arg]
+            created_at=created_at,  # type: ignore[call-arg]
+            **kwargs,
+        )

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -38,6 +38,7 @@ from hushline.forms import (
     UpdateMessageStatusForm,
 )
 from hushline.model import (
+    ChatRateLimitAttempt,
     Conversation,
     ConversationMessage,
     ConversationMessageCopy,
@@ -60,6 +61,12 @@ _P256_RAW_SIGNATURE_LENGTH_BYTES = 64
 _CHAT_ONLY_MESSAGE_PLACEHOLDER = "Stored in encrypted conversation."
 _CONVERSATION_ACTIVITY_TIMEOUT_SECONDS = 120
 _CONVERSATION_PRESENCE_HEARTBEAT_SECONDS = 60
+_CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_WINDOW_SECONDS = 60
+_CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_MAX = 10
+_CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_WINDOW_SECONDS = 60
+_CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_MAX = 30
+_CONVERSATION_MESSAGE_RATE_LIMIT_USER_WINDOW_SECONDS = 3600
+_CONVERSATION_MESSAGE_RATE_LIMIT_USER_MAX = 200
 _CONVERSATION_NOTIFICATION_BODY = (
     "You have new Hush Line conversation activity. "
     "Log in and unlock your Hush Line chat key to read it."
@@ -134,6 +141,119 @@ def _conversation_presence_heartbeat_ms() -> int:
     except (TypeError, ValueError):
         seconds = _CONVERSATION_PRESENCE_HEARTBEAT_SECONDS
     return max(1, seconds) * 1000
+
+
+def _conversation_rate_limit_config(name: str, default: int) -> int:
+    value = current_app.config.get(name, default)
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _conversation_message_rate_limit_exceeded(
+    *,
+    thread: Conversation,
+    participant: ConversationParticipant,
+    user: User,
+) -> bool:
+    windows = {
+        "participant": max(
+            _conversation_rate_limit_config(
+                "CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_WINDOW_SECONDS",
+                _CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_WINDOW_SECONDS,
+            ),
+            1,
+        ),
+        "conversation": max(
+            _conversation_rate_limit_config(
+                "CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_WINDOW_SECONDS",
+                _CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_WINDOW_SECONDS,
+            ),
+            1,
+        ),
+        "user": max(
+            _conversation_rate_limit_config(
+                "CONVERSATION_MESSAGE_RATE_LIMIT_USER_WINDOW_SECONDS",
+                _CONVERSATION_MESSAGE_RATE_LIMIT_USER_WINDOW_SECONDS,
+            ),
+            1,
+        ),
+    }
+    limits = {
+        "participant": _conversation_rate_limit_config(
+            "CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_MAX",
+            _CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_MAX,
+        ),
+        "conversation": _conversation_rate_limit_config(
+            "CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_MAX",
+            _CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_MAX,
+        ),
+        "user": _conversation_rate_limit_config(
+            "CONVERSATION_MESSAGE_RATE_LIMIT_USER_MAX",
+            _CONVERSATION_MESSAGE_RATE_LIMIT_USER_MAX,
+        ),
+    }
+    now = datetime.now(UTC)
+    oldest_window = now - timedelta(seconds=max(windows.values()))
+    db.session.execute(
+        db.delete(ChatRateLimitAttempt).where(ChatRateLimitAttempt.created_at < oldest_window)
+    )
+
+    participant_count = db.session.scalar(
+        db.select(db.func.count())
+        .select_from(ChatRateLimitAttempt)
+        .where(
+            ChatRateLimitAttempt.sender_participant_id == participant.id,
+            ChatRateLimitAttempt.conversation_id == thread.id,
+            ChatRateLimitAttempt.created_at >= now - timedelta(seconds=windows["participant"]),
+        )
+    )
+    conversation_count = db.session.scalar(
+        db.select(db.func.count())
+        .select_from(ChatRateLimitAttempt)
+        .where(
+            ChatRateLimitAttempt.conversation_id == thread.id,
+            ChatRateLimitAttempt.created_at >= now - timedelta(seconds=windows["conversation"]),
+        )
+    )
+    user_count = db.session.scalar(
+        db.select(db.func.count())
+        .select_from(ChatRateLimitAttempt)
+        .where(
+            ChatRateLimitAttempt.user_id == user.id,
+            ChatRateLimitAttempt.created_at >= now - timedelta(seconds=windows["user"]),
+        )
+    )
+    return (
+        (
+            limits["participant"] > 0
+            and participant_count is not None
+            and participant_count >= limits["participant"]
+        )
+        or (
+            limits["conversation"] > 0
+            and conversation_count is not None
+            and conversation_count >= limits["conversation"]
+        )
+        or (limits["user"] > 0 and user_count is not None and user_count >= limits["user"])
+    )
+
+
+def _record_conversation_message_rate_limit_attempt(
+    *,
+    thread: Conversation,
+    participant: ConversationParticipant,
+    user: User,
+) -> None:
+    db.session.add(
+        ChatRateLimitAttempt(
+            conversation_id=thread.id,
+            sender_participant_id=participant.id,
+            user_id=user.id,
+            created_at=datetime.now(UTC),
+        )
+    )
 
 
 def _as_utc(value: datetime) -> datetime:
@@ -645,6 +765,20 @@ def register_message_routes(app: Flask) -> None:
         if set(encrypted_copies.keys()) != reply_capable_participant_ids:
             return jsonify({"error": "Invalid encrypted message payload."}), 400
 
+        if _conversation_message_rate_limit_exceeded(
+            thread=thread, participant=participant, user=user
+        ):
+            return (
+                jsonify(
+                    {
+                        "error": (
+                            "Too many chat messages. " "Please wait before sending another reply."
+                        )
+                    }
+                ),
+                429,
+            )
+
         if not all(_is_chat_ciphertext_envelope(value) for value in encrypted_copies.values()):
             return jsonify({"error": "Invalid encrypted message payload."}), 400
         if not _chat_ciphertext_context_is_bound(
@@ -661,16 +795,21 @@ def register_message_routes(app: Flask) -> None:
         ):
             return jsonify({"error": "Invalid encrypted message payload."}), 400
 
+        _record_conversation_message_rate_limit_attempt(
+            thread=thread,
+            participant=participant,
+            user=user,
+        )
         conversation_message = ConversationMessage()
         conversation_message.conversation = thread
         conversation_message.sender_participant = participant
+        db.session.add(conversation_message)
         _mark_conversation_participant_active(participant)
         for recipient_participant in thread.participants:
             encrypted_copy = ConversationMessageCopy()
+            conversation_message.encrypted_copies.append(encrypted_copy)
             encrypted_copy.recipient_participant = recipient_participant
             encrypted_copy.encrypted_payload = encrypted_copies[str(recipient_participant.id)]
-            conversation_message.encrypted_copies.append(encrypted_copy)
-        db.session.add(conversation_message)
         db.session.commit()
         _notify_conversation_participants(thread, participant)
 

--- a/migrations/versions/4d2a7c9e1b64_add_chat_rate_limit_attempts.py
+++ b/migrations/versions/4d2a7c9e1b64_add_chat_rate_limit_attempts.py
@@ -1,0 +1,80 @@
+"""add chat rate limit attempts
+
+Revision ID: 4d2a7c9e1b64
+Revises: 2f9a7c8d1e6b
+Create Date: 2026-06-19 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "4d2a7c9e1b64"
+down_revision = "2f9a7c8d1e6b"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "chat_rate_limit_attempts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("conversation_id", sa.Integer(), nullable=False),
+        sa.Column("sender_participant_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["conversation_id"], ["conversations.id"], ondelete="CASCADE"),
+        sa.ForeignKeyConstraint(
+            ["sender_participant_id"],
+            ["conversation_participants.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index(
+        "idx_chat_rate_limit_attempts_sender_conversation_created",
+        "chat_rate_limit_attempts",
+        ["sender_participant_id", "conversation_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_chat_rate_limit_attempts_user_created",
+        "chat_rate_limit_attempts",
+        ["user_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_chat_rate_limit_attempts_conversation_created",
+        "chat_rate_limit_attempts",
+        ["conversation_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "idx_chat_rate_limit_attempts_created",
+        "chat_rate_limit_attempts",
+        ["created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "idx_chat_rate_limit_attempts_created",
+        table_name="chat_rate_limit_attempts",
+    )
+    op.drop_index(
+        "idx_chat_rate_limit_attempts_conversation_created",
+        table_name="chat_rate_limit_attempts",
+    )
+    op.drop_index(
+        "idx_chat_rate_limit_attempts_user_created",
+        table_name="chat_rate_limit_attempts",
+    )
+    op.drop_index(
+        "idx_chat_rate_limit_attempts_sender_conversation_created",
+        table_name="chat_rate_limit_attempts",
+    )
+    op.drop_table("chat_rate_limit_attempts")

--- a/tests/migrations/revision_4d2a7c9e1b64.py
+++ b/tests/migrations/revision_4d2a7c9e1b64.py
@@ -1,0 +1,181 @@
+from sqlalchemy import text
+
+from hushline.db import db
+
+USER_ID = 9701
+CONVERSATION_ID = 9701
+PARTICIPANT_ID = 9701
+ATTEMPT_ID = 9701
+
+
+def _chat_rate_limit_attempt_table_count() -> int:
+    return db.session.scalar(
+        text(
+            """
+            SELECT count(*)
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_name = 'chat_rate_limit_attempts'
+            """
+        )
+    )
+
+
+def _insert_conversation_participant() -> None:
+    db.session.execute(
+        text(
+            """
+            INSERT INTO users (
+                id,
+                is_admin,
+                is_suspended,
+                password_hash,
+                session_id
+            )
+            VALUES (:user_id, false, false, '$scrypt$', 'session-9701')
+            """
+        ),
+        {"user_id": USER_ID},
+    )
+    db.session.execute(
+        text(
+            """
+            INSERT INTO conversations (id, public_id)
+            VALUES (:conversation_id, '00000000-0000-0000-0000-000000009701')
+            """
+        ),
+        {"conversation_id": CONVERSATION_ID},
+    )
+    db.session.execute(
+        text(
+            """
+            INSERT INTO conversation_participants (
+                id,
+                conversation_id,
+                user_id
+            )
+            VALUES (:participant_id, :conversation_id, :user_id)
+            """
+        ),
+        {
+            "participant_id": PARTICIPANT_ID,
+            "conversation_id": CONVERSATION_ID,
+            "user_id": USER_ID,
+        },
+    )
+    db.session.commit()
+
+
+class UpgradeTester:
+    def load_data(self) -> None:
+        _insert_conversation_participant()
+
+    def check_upgrade(self) -> None:
+        assert _chat_rate_limit_attempt_table_count() == 1
+        columns = db.session.execute(
+            text(
+                """
+                SELECT column_name, is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = 'chat_rate_limit_attempts'
+                ORDER BY column_name
+                """
+            )
+        ).all()
+        assert columns == [
+            ("conversation_id", "NO"),
+            ("created_at", "NO"),
+            ("id", "NO"),
+            ("sender_participant_id", "NO"),
+            ("user_id", "NO"),
+        ]
+
+        db.session.execute(
+            text(
+                """
+                INSERT INTO chat_rate_limit_attempts (
+                    id,
+                    conversation_id,
+                    sender_participant_id,
+                    user_id,
+                    created_at
+                )
+                VALUES (
+                    :attempt_id,
+                    :conversation_id,
+                    :participant_id,
+                    :user_id,
+                    timestamp with time zone '2026-06-19 12:00:00+00'
+                )
+                """
+            ),
+            {
+                "attempt_id": ATTEMPT_ID,
+                "conversation_id": CONVERSATION_ID,
+                "participant_id": PARTICIPANT_ID,
+                "user_id": USER_ID,
+            },
+        )
+        db.session.commit()
+        assert (
+            db.session.scalar(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM chat_rate_limit_attempts
+                    WHERE id = :attempt_id
+                    """
+                ),
+                {"attempt_id": ATTEMPT_ID},
+            )
+            == 1
+        )
+
+
+class DowngradeTester:
+    def load_data(self) -> None:
+        _insert_conversation_participant()
+        db.session.execute(
+            text(
+                """
+                INSERT INTO chat_rate_limit_attempts (
+                    id,
+                    conversation_id,
+                    sender_participant_id,
+                    user_id,
+                    created_at
+                )
+                VALUES (
+                    :attempt_id,
+                    :conversation_id,
+                    :participant_id,
+                    :user_id,
+                    timestamp with time zone '2026-06-19 12:00:00+00'
+                )
+                """
+            ),
+            {
+                "attempt_id": ATTEMPT_ID,
+                "conversation_id": CONVERSATION_ID,
+                "participant_id": PARTICIPANT_ID,
+                "user_id": USER_ID,
+            },
+        )
+        db.session.commit()
+
+    def check_downgrade(self) -> None:
+        assert _chat_rate_limit_attempt_table_count() == 0
+        assert (
+            db.session.scalar(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM conversation_participants
+                    WHERE id = :participant_id
+                    """
+                ),
+                {"participant_id": PARTICIPANT_ID},
+            )
+            == 1
+        )

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -14,6 +14,7 @@ from flask.testing import FlaskClient
 from hushline.db import db
 from hushline.model import (
     ChatKey,
+    ChatRateLimitAttempt,
     Conversation,
     ConversationMessage,
     ConversationMessageCopy,
@@ -1304,6 +1305,208 @@ def test_participant_can_append_encrypted_conversation_message(
     for encrypted_copy in messages[-1].encrypted_copies:
         assert "ECDH-P256-AES-GCM" in encrypted_copy.encrypted_payload
         assert plaintext not in encrypted_copy.encrypted_payload
+
+
+@patch("hushline.routes.message.send_email_to_user_recipients")
+def test_append_conversation_message_rate_limits_participant_without_persistence_or_notification(
+    mock_send_email_to_user_recipients: MagicMock,
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_MAX"] = 1
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_MAX"] = 20
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_USER_MAX"] = 20
+    _add_reply_capable_chat_keys(user, user2)
+    _enable_conversation_notifications(
+        user2,
+        email="recipient@example.com",
+        include_content=False,
+        encrypt_entire_body=False,
+    )
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    first_response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "first-rate-limited")},
+    )
+    mock_send_email_to_user_recipients.reset_mock()
+    second_response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "second-rate-limited")},
+    )
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 429
+    assert second_response.get_json() == {
+        "error": "Too many chat messages. Please wait before sending another reply."
+    }
+    message_count = db.session.scalar(
+        db.select(db.func.count())
+        .select_from(ConversationMessage)
+        .where(ConversationMessage.conversation_id == conversation.id)
+    )
+    copy_count = db.session.scalar(
+        db.select(db.func.count())
+        .select_from(ConversationMessageCopy)
+        .join(ConversationMessage)
+        .where(ConversationMessage.conversation_id == conversation.id)
+    )
+    attempt_count = db.session.scalar(db.select(db.func.count()).select_from(ChatRateLimitAttempt))
+    assert message_count == 2
+    assert copy_count == 4
+    assert attempt_count == 1
+    mock_send_email_to_user_recipients.assert_not_called()
+
+
+def test_append_conversation_message_rate_limit_is_scoped_to_sender_participant(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_MAX"] = 1
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_MAX"] = 20
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_USER_MAX"] = 20
+    _add_reply_capable_chat_keys(user, user2)
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    first_response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "sender-one")},
+    )
+    _authenticate_as(client, user2)
+    second_response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(conversation, user2, "sender-two")},
+    )
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 201
+
+
+def test_append_conversation_message_rate_limits_user_across_conversations(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_MAX"] = 20
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_MAX"] = 20
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_USER_MAX"] = 1
+    _add_reply_capable_chat_keys(user, user2)
+    first_conversation = _make_conversation(user, user2)
+    second_conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    first_response = client.post(
+        url_for("append_conversation_message", public_id=first_conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(first_conversation, user, "first-chat")},
+    )
+    second_response = client.post(
+        url_for("append_conversation_message", public_id=second_conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(second_conversation, user, "second-chat")},
+    )
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 429
+
+
+def test_append_conversation_message_rate_limits_conversation_bursts(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_MAX"] = 20
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_MAX"] = 1
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_USER_MAX"] = 20
+    _add_reply_capable_chat_keys(user, user2)
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    first_response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "first-burst")},
+    )
+    _authenticate_as(client, user2)
+    second_response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(conversation, user2, "second-burst")},
+    )
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 429
+
+
+def test_append_conversation_message_rate_limit_resets_after_window(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_WINDOW_SECONDS"] = 1
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_WINDOW_SECONDS"] = 1
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_USER_WINDOW_SECONDS"] = 1
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_MAX"] = 1
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_MAX"] = 20
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_USER_MAX"] = 20
+    _add_reply_capable_chat_keys(user, user2)
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    first_response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "old-window")},
+    )
+    db.session.execute(
+        db.update(ChatRateLimitAttempt).values(
+            created_at=datetime.now(timezone.utc) - timedelta(seconds=5)
+        )
+    )
+    db.session.commit()
+    second_response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "new-window")},
+    )
+
+    assert first_response.status_code == 201
+    assert second_response.status_code == 201
+
+
+def test_append_conversation_message_invalid_payload_does_not_burn_send_quota(
+    app: Flask,
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_PARTICIPANT_MAX"] = 1
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_CONVERSATION_MAX"] = 1
+    app.config["CONVERSATION_MESSAGE_RATE_LIMIT_USER_MAX"] = 1
+    _add_reply_capable_chat_keys(user, user2)
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+    invalid_copies = _reply_copies_for(conversation, user, "invalid-retry")
+    recipient_participant = conversation.participant_for_user_id(user2.id)
+    assert recipient_participant is not None
+    invalid_copies[str(recipient_participant.id)] = "{}"
+
+    invalid_response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": invalid_copies},
+    )
+    corrected_response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "corrected-retry")},
+    )
+
+    assert invalid_response.status_code == 400
+    assert corrected_response.status_code == 201
+    attempt_count = db.session.scalar(db.select(db.func.count()).select_from(ChatRateLimitAttempt))
+    assert attempt_count == 1
 
 
 def test_append_conversation_message_rejects_unsigned_legacy_envelopes(


### PR DESCRIPTION
## What changed

- Adds a database-backed chat message rate-limit attempt model and migration.
- Enforces per-participant, per-conversation, and per-user chat send limits before expensive envelope validation, message storage, and participant notifications.
- Adds conversation route tests plus migration smoke coverage for the new table.

## Why

Chat replies needed server-side abuse resistance so an authenticated participant cannot flood a conversation with excessive messages or trigger unbounded notification work.

## Security notes

Affected data path: `POST /conversation/<public_id>/messages`.

The mitigation records accepted send attempts and rejects bursts with HTTP 429 before ciphertext parsing/signature verification and before notification dispatch. The limits are configurable through app config.

Residual risk: the limiter uses count-and-insert database checks, so extreme concurrent bursts may exceed the exact threshold by a small amount. This is a bounded mitigation intended to reduce practical abuse and notification spam, not a global anti-automation control.

## Validation

- `make lint` passed
- `make test TESTS="tests/test_conversation.py"` passed: 84 passed
- `make test-migration-smoke` passed: 94 passed, 1 xfailed
- `git log --show-signature -1 --oneline` verified the commit signature locally

Full `make test` was started, but while it was still running it began erroring in `tests/test_settings.py`; per maintainer direction, this PR was opened immediately instead of waiting on or triaging that unrelated-looking settings block.

## Manual testing

Not separately performed. The route behavior is covered by focused Flask tests and the migration is covered by the migration smoke harness.