### PR TITLE
Serialize chat message rate limit checks

### DIFF
--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -23,6 +23,7 @@ from flask import (
     url_for,
 )
 from flask_wtf.csrf import validate_csrf
+from sqlalchemy import text
 from werkzeug.wrappers.response import Response
 from wtforms.validators import ValidationError
 
@@ -151,6 +152,28 @@ def _conversation_rate_limit_config(name: str, default: int) -> int:
         return default
 
 
+def _lock_conversation_message_rate_limit(
+    *,
+    thread: Conversation,
+    user: User,
+) -> None:
+    bind = db.session.get_bind()
+    if bind is None or bind.dialect.name != "postgresql":
+        return
+
+    lock_keys = sorted(
+        (
+            (1, thread.id),
+            (2, user.id),
+        )
+    )
+    for namespace, lock_id in lock_keys:
+        db.session.execute(
+            text("SELECT pg_advisory_xact_lock(:namespace, :lock_id)"),
+            {"namespace": namespace, "lock_id": lock_id},
+        )
+
+
 def _conversation_message_rate_limit_exceeded(
     *,
     thread: Conversation,
@@ -194,6 +217,7 @@ def _conversation_message_rate_limit_exceeded(
             _CONVERSATION_MESSAGE_RATE_LIMIT_USER_MAX,
         ),
     }
+    _lock_conversation_message_rate_limit(thread=thread, user=user)
     now = datetime.now(UTC)
     oldest_window = now - timedelta(seconds=max(windows.values()))
     db.session.execute(

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -2,6 +2,7 @@ import base64
 import json
 import re
 from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -37,6 +38,7 @@ from hushline.routes.message import (
     _conversation_presence_heartbeat_ms,
     _decode_jwk_coordinate,
     _is_chat_ciphertext_envelope,
+    _lock_conversation_message_rate_limit,
 )
 
 _SENDER_SIGNING_PRIVATE_KEY = ec.derive_private_key(1, ec.SECP256R1())
@@ -1307,6 +1309,29 @@ def test_participant_can_append_encrypted_conversation_message(
     for encrypted_copy in messages[-1].encrypted_copies:
         assert "ECDH-P256-AES-GCM" in encrypted_copy.encrypted_payload
         assert plaintext not in encrypted_copy.encrypted_payload
+
+
+def test_conversation_message_rate_limit_uses_postgres_transaction_advisory_locks(
+    app: Flask,
+    user: User,
+    user2: User,
+) -> None:
+    _add_reply_capable_chat_keys(user, user2)
+    conversation = _make_conversation(user, user2)
+
+    with app.app_context(), patch.object(
+        db.session,
+        "get_bind",
+        return_value=SimpleNamespace(dialect=SimpleNamespace(name="postgresql")),
+    ), patch.object(db.session, "execute") as mock_execute:
+        _lock_conversation_message_rate_limit(thread=conversation, user=user)
+
+    assert mock_execute.call_count == 2
+    assert [call.args[1] for call in mock_execute.call_args_list] == [
+        {"namespace": 1, "lock_id": conversation.id},
+        {"namespace": 2, "lock_id": user.id},
+    ]
+    assert all("pg_advisory_xact_lock" in str(call.args[0]) for call in mock_execute.call_args_list)
 
 
 @patch("hushline.routes.message.send_email_to_user_recipients")


### PR DESCRIPTION
### Motivation
- Close a race in the chat message rate-limiter where concurrent requests could all observe the same pre-insert counts and bypass per-participant, per-conversation, or per-user limits.
- Preserve the existing rate-limit windows, attempt persistence, and notification behavior while adding a lightweight DB-level serialization primitive.

### Description
- Added `_lock_conversation_message_rate_limit` which obtains transaction-scoped PostgreSQL advisory locks (`pg_advisory_xact_lock`) keyed by conversation and user when the DB dialect is PostgreSQL.
- Call the new lock function at the start of `_conversation_message_rate_limit_exceeded` so cleanup and count queries are executed while the advisory lock is held, preventing the read-committed count-before-insert race.
- Imported `sqlalchemy.text` and added a regression unit test `test_conversation_message_rate_limit_uses_postgres_transaction_advisory_locks` that patches `db.session.get_bind` and `db.session.execute` to verify the expected lock calls are issued.
- Applied formatting and static type checks fixes to satisfy linters and `mypy` for the modified files.

### Testing
- Ran `python -m compileall` on the modified files and the compile check succeeded.
- Ran `ruff` formatting/fixes and `mypy` which passed on the modified files.
- Added a regression test that verifies advisory locks are requested, but executing the test suite failed with an `OperationalError` because the test PostgreSQL host `postgres:5432` was not resolvable in this environment so the new test could not be run end-to-end here.
- `make lint`, `make test`, and dependency audit targets could not be executed in this environment because Docker is not available, so full CI-style validation was not performed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35db4169c88330a3c7128ae546449d)