### PR TITLE
Update not_newman demo conversation

### DIFF
--- a/docs/screenshots/scenes.json
+++ b/docs/screenshots/scenes.json
@@ -28,7 +28,7 @@
       "passwordEnv": "SCREENSHOT_ARTVANDELAY_PASSWORD"
     },
     "newman": {
-      "username": "newman",
+      "username": "not_newman",
       "password": "Test-testtesttesttest-1",
       "passwordEnv": "SCREENSHOT_NEWMAN_PASSWORD"
     }
@@ -578,28 +578,28 @@
     },
     {
       "slug": "auth-newman-profile",
-      "title": "Profile - newman (authenticated)",
-      "path": "/to/newman",
+      "title": "Profile - not_newman (authenticated)",
+      "path": "/to/not_newman",
       "session": "newman",
       "waitForSelector": "h2.submit"
     },
     {
       "slug": "auth-newman-inbox",
-      "title": "Inbox - newman",
+      "title": "Inbox - not_newman",
       "path": "/inbox",
       "session": "newman",
       "waitForSelector": ".inbox-content"
     },
     {
       "slug": "auth-newman-conversation-thread",
-      "title": "Conversation thread - newman",
+      "title": "Conversation thread - not_newman",
       "path": "/conversation/33333333-3333-4333-8333-333333333333",
       "session": "newman",
-      "waitForSelector": ".conversation-message-body:has-text('Hello, Newman.')"
+      "waitForSelector": ".conversation-message-body:has-text('George Costanza may have acted without authorization')"
     },
     {
       "slug": "auth-newman-onboarding-profile",
-      "title": "Onboarding - Step 1 Profile (newman)",
+      "title": "Onboarding - Step 1 Profile (not_newman)",
       "path": "/onboarding?step=profile",
       "session": "newman",
       "waitForSelector": "#display_name",
@@ -617,70 +617,70 @@
     },
     {
       "slug": "auth-newman-onboarding-encryption",
-      "title": "Onboarding - Step 2 Encryption (newman)",
+      "title": "Onboarding - Step 2 Encryption (not_newman)",
       "path": "/onboarding?step=encryption",
       "session": "newman",
       "waitForSelector": "#searchInput"
     },
     {
       "slug": "auth-newman-onboarding-notifications",
-      "title": "Onboarding - Step 3 Notifications (newman)",
+      "title": "Onboarding - Step 3 Notifications (not_newman)",
       "path": "/onboarding?step=notifications",
       "session": "newman",
       "waitForSelector": "#email_address"
     },
     {
       "slug": "auth-newman-onboarding-directory",
-      "title": "Onboarding - Step 4 Directory (newman)",
+      "title": "Onboarding - Step 4 Directory (not_newman)",
       "path": "/onboarding?step=directory",
       "session": "newman",
       "waitForSelector": "#show_in_directory"
     },
     {
       "slug": "auth-newman-settings-profile",
-      "title": "Settings - Profile (newman)",
+      "title": "Settings - Profile (not_newman)",
       "path": "/settings/profile",
       "session": "newman",
       "waitForSelector": ".settings-tabs"
     },
     {
       "slug": "auth-newman-settings-aliases",
-      "title": "Settings - Aliases (newman)",
+      "title": "Settings - Aliases (not_newman)",
       "path": "/settings/aliases",
       "session": "newman",
       "waitForSelector": ".settings-tabs"
     },
     {
       "slug": "auth-newman-settings-auth",
-      "title": "Settings - Authentication (newman)",
+      "title": "Settings - Authentication (not_newman)",
       "path": "/settings/auth",
       "session": "newman",
       "waitForSelector": ".settings-tabs"
     },
     {
       "slug": "auth-newman-settings-encryption",
-      "title": "Settings - Encryption (newman)",
+      "title": "Settings - Encryption (not_newman)",
       "path": "/settings/encryption",
       "session": "newman",
       "waitForSelector": ".settings-tabs"
     },
     {
       "slug": "auth-newman-settings-replies",
-      "title": "Settings - Message Statuses (newman)",
+      "title": "Settings - Message Statuses (not_newman)",
       "path": "/settings/replies",
       "session": "newman",
       "waitForSelector": ".settings-tabs"
     },
     {
       "slug": "auth-newman-settings-notifications",
-      "title": "Settings - Notifications (newman)",
+      "title": "Settings - Notifications (not_newman)",
       "path": "/settings/notifications",
       "session": "newman",
       "waitForSelector": ".settings-tabs"
     },
     {
       "slug": "auth-newman-settings-advanced",
-      "title": "Settings - Advanced (newman)",
+      "title": "Settings - Advanced (not_newman)",
       "path": "/settings/advanced",
       "session": "newman",
       "waitForSelector": ".settings-tabs"
@@ -1061,8 +1061,8 @@
     },
     {
       "slug": "guest-profile-newman",
-      "title": "Profile - newman",
-      "path": "/to/newman",
+      "title": "Profile - not_newman",
+      "path": "/to/not_newman",
       "session": "guest",
       "waitForSelector": "h2.submit"
     },

--- a/scripts/dev_data.py
+++ b/scripts/dev_data.py
@@ -162,11 +162,11 @@ def default_users() -> list[dict[str, object]]:
             "pgp_key": PGP_KEY,
         },
         {
-            "username": "newman",
+            "username": "not_newman",
             "password": "Test-testtesttesttest-1",
             "is_admin": False,
             "is_verified": False,
-            # Keep newman as an intentionally incomplete account for onboarding screenshots.
+            # Keep not_newman as an intentionally incomplete account for onboarding screenshots.
             "onboarding_complete": False,
         },
         {
@@ -935,7 +935,7 @@ def _seed_demo_conversation(
 
     participants = {
         "artvandelay": artvandelay_participant,
-        "newman": newman_participant,
+        "not_newman": newman_participant,
     }
     for sender_username, content, created_at in messages:
         sender_participant = participants[sender_username]
@@ -974,7 +974,7 @@ def create_sample_conversations() -> None:
     ).one_or_none()
     newman_username = db.session.scalars(
         select(Username).where(
-            func.lower(Username._username) == "newman",
+            func.lower(Username._username) == "not_newman",
             Username.is_primary.is_(True),
         )
     ).one_or_none()
@@ -983,10 +983,10 @@ def create_sample_conversations() -> None:
 
     identities = {
         "artvandelay": _demo_chat_identity(DOCS_SCREENSHOT_PASSWORD),
-        "newman": _demo_chat_identity(DOCS_SCREENSHOT_PASSWORD),
+        "not_newman": _demo_chat_identity(DOCS_SCREENSHOT_PASSWORD),
     }
     _reset_demo_chat_key(artvandelay_username.user, identities["artvandelay"])
-    _reset_demo_chat_key(newman_username.user, identities["newman"])
+    _reset_demo_chat_key(newman_username.user, identities["not_newman"])
 
     base_time = datetime(2026, 2, 16, 17, 30, tzinfo=timezone.utc)
     _seed_demo_conversation(
@@ -996,29 +996,62 @@ def create_sample_conversations() -> None:
         identities=identities,
         messages=[
             (
-                "newman",
-                'Hello, "Art" ;)',
+                "not_newman",
+                (
+                    "Hello, Mr. Vandelay. I have obtained information suggesting that your "
+                    "employee, George Costanza, distributed fraudulent Human Fund donation "
+                    "cards. Unless this matter is addressed, I intend to submit my findings "
+                    "through the USPS within twenty-four hours."
+                ),
                 base_time,
             ),
             (
                 "artvandelay",
-                "Hello, Newman.",
+                (
+                    "Thank you for bringing this to my attention, not_newman. The Human Fund "
+                    "takes allegations of misconduct very seriously. If Mr. Costanza "
+                    "misrepresented charitable donations, I assure you we will investigate the "
+                    "matter thoroughly."
+                ),
                 base_time + timedelta(minutes=8),
             ),
             (
-                "newman",
-                "I think I have information you might find interesting about the Human Fund.",
+                "not_newman",
+                (
+                    "I appreciate your professionalism. To verify the claims, I sent an "
+                    "associate to investigate. Kramer reports that the donations were "
+                    "fictitious and that no evidence of Human Fund activity could be found."
+                ),
                 base_time + timedelta(minutes=19),
             ),
             (
                 "artvandelay",
-                "The charity? Please tell me the funds are not just in a coffee can.",
+                (
+                    "I see. While I respect Mr. Kramer’s efforts, an absence of evidence is not "
+                    "necessarily evidence of absence. Many charitable organizations operate "
+                    "with limited public visibility. If you can provide any documentation, I’d "
+                    "be happy to review it."
+                ),
                 base_time + timedelta(minutes=24),
             ),
             (
-                "newman",
-                'Not a coffee can. A very official envelope labeled "miscellaneous grievances."',
+                "not_newman",
+                (
+                    "So your position is that the Human Fund is a legitimate charity and that "
+                    "George Costanza may have acted without authorization?"
+                ),
                 base_time + timedelta(minutes=37),
+            ),
+            (
+                "artvandelay",
+                (
+                    "At this stage, yes. Based on the information you’ve provided, it would be "
+                    "premature to conclude otherwise. If George has done something improper, "
+                    "we’ll address it appropriately. If not, I’m sure a careful review will "
+                    "clear up the misunderstanding. Either way, thank you for reporting it in "
+                    "good faith."
+                ),
+                base_time + timedelta(minutes=48),
             ),
         ],
     )
@@ -1029,7 +1062,7 @@ def create_sample_conversations() -> None:
         identities=identities,
         messages=[
             (
-                "newman",
+                "not_newman",
                 "I found the records-retention note. It says the backup exports run weekly.",
                 base_time - timedelta(days=1),
             ),

--- a/tests/playwright/e2ee/client-side-encryption.spec.js
+++ b/tests/playwright/e2ee/client-side-encryption.spec.js
@@ -244,12 +244,15 @@ test("logged-in account conversation stays encrypted through browser lifecycle",
 
     let capturedInitialPostBody = null;
     senderPage.on("request", (request) => {
-      if (request.method() === "POST" && request.url().endsWith("/to/newman")) {
+      if (
+        request.method() === "POST" &&
+        request.url().endsWith("/to/not_newman")
+      ) {
         capturedInitialPostBody = request.postData() || "";
       }
     });
 
-    await senderPage.goto("/to/newman", { waitUntil: "networkidle" });
+    await senderPage.goto("/to/not_newman", { waitUntil: "networkidle" });
     await suppressGuidanceModal(senderPage);
     await expect(senderPage.locator("#messageForm")).toBeVisible();
     await expect
@@ -279,7 +282,8 @@ test("logged-in account conversation stays encrypted through browser lifecycle",
     await Promise.all([
       senderPage.waitForRequest(
         (request) =>
-          request.method() === "POST" && request.url().endsWith("/to/newman"),
+          request.method() === "POST" &&
+          request.url().endsWith("/to/not_newman"),
       ),
       senderPage.locator("#submitBtn").click(),
     ]);
@@ -325,7 +329,7 @@ test("logged-in account conversation stays encrypted through browser lifecycle",
       .evaluate((element) => element.dataset.conversationPublicId);
     expect(conversationUrl).toContain(`/conversation/${conversationPublicId}`);
 
-    await login(recipientPage, "newman");
+    await login(recipientPage, "not_newman");
     const recipientPresenceResponsePromise = waitForPresenceHeartbeat(
       recipientPage,
       conversationPublicId,

--- a/tests/test_dev_data.py
+++ b/tests/test_dev_data.py
@@ -44,6 +44,17 @@ def test_default_users_seed_paid_artvandelay_with_three_notification_recipients(
     ]
 
 
+def test_default_users_seed_not_newman_for_onboarding_screenshots() -> None:
+    dev_data = _load_dev_data_module()
+    users = dev_data.default_users()
+
+    not_newman = next(user for user in users if user["username"] == "not_newman")
+
+    assert all(user["username"] != "newman" for user in users)
+    assert not_newman["is_verified"] is False
+    assert not_newman["onboarding_complete"] is False
+
+
 def test_default_users_seed_featured_verified_directory_accounts() -> None:
     dev_data = _load_dev_data_module()
     users = dev_data.default_users()

--- a/tests/test_docs_screenshots_manifest.py
+++ b/tests/test_docs_screenshots_manifest.py
@@ -162,7 +162,8 @@ def test_docs_screenshots_manifest_includes_decrypted_conversation_scenes() -> N
     )
     assert newman_thread["path"] == artvandelay_thread["path"]
     assert newman_thread["waitForSelector"] == (
-        ".conversation-message-body:has-text('Hello, Newman.')"
+        ".conversation-message-body:has-text("
+        "'George Costanza may have acted without authorization')"
     )
     assert "create_sample_conversations()" in dev_data
     assert "ECDH-P256-AES-GCM" in dev_data


### PR DESCRIPTION
## What changed

- Renamed the demo/onboarding screenshot account from `newman` to `not_newman` in seeded dev data.
- Replaced the seeded Art Vandelay conversation with the requested Human Fund exchange between Art Vandelay and `not_newman`.
- Updated screenshot scene metadata and E2EE Playwright references to use `/to/not_newman` and the renamed login.
- Added regression coverage for the `not_newman` seeded account and updated screenshot manifest expectations for the new conversation text.

## Why

The demo conversation should use the updated disclosure scenario and avoid exposing the old `newman` username as the seeded account.

## User / developer impact

Local seeded demo data and screenshot capture sessions now use `not_newman`. Existing screenshot slugs and file paths remain unchanged, so generated screenshot artifact naming is stable until screenshots are intentionally regenerated.

## Validation

- `make lint`
- `docker compose run --rm app poetry run pytest tests/test_dev_data.py tests/test_docs_screenshots_manifest.py -q`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

Not run manually; this is a deterministic seed-data and capture-metadata update covered by focused tests.

## Known risks / follow-ups

- Existing checked-in screenshot PNGs were not regenerated in this PR.
- Full Node audit was not run because frontend/runtime dependencies did not change.