### PR TITLE
Add profile login hint for encrypted conversations

### DIFF
--- a/assets/js/directory_verified.js
+++ b/assets/js/directory_verified.js
@@ -915,7 +915,7 @@ document.addEventListener("DOMContentLoaded", function () {
   }
 
   function panelIntroMarkup(panelId) {
-    return document.getElementById(panelId)?.querySelector(".dirMeta")?.outerHTML || "";
+    return document.getElementById(panelId)?.querySelector(".contextBanner")?.outerHTML || "";
   }
 
   function buildDefaultPanelMarkup(tab) {

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -244,14 +244,14 @@
     border: none;
   }
 
-  .dirMeta,
+  .contextBanner,
   p.instr {
     background-color: rgb(255, 249, 234);
     border: 1px solid rgba(232, 212, 180, 0.8);
     color: var(--color-text-light);
   }
 
-  .directory-search.is-sticky+.tab-content .dirMeta {
+  .directory-search.is-sticky+.tab-content .contextBanner {
     margin-top: 0.125rem;
   }
 
@@ -845,8 +845,8 @@
     border: none;
   }
 
-  .dirMeta,
-  p.dirMeta.meta,
+  .contextBanner,
+  p.contextBanner.meta,
   p.instr {
     background-color: var(--color-dark-bg-alt-1);
     border: var(--border-dark-1);
@@ -2004,14 +2004,14 @@ h3+.meta {
   margin-top: 0.75rem;
 }
 
-.dirMeta,
+.contextBanner,
 p.instr {
   margin: 1rem 0;
   border-radius: 0.25rem;
   padding: 0.9125rem 1rem;
 }
 
-.dirMeta {
+.contextBanner {
   margin-top: 0;
 }
 
@@ -2019,7 +2019,7 @@ h2.submit+p.instr {
   margin: 0.75rem 0 0.5rem 0;
 }
 
-h2.submit+p.dirMeta {
+h2.submit+p.contextBanner {
   margin: 0.75rem 0 0.5rem 0;
 }
 
@@ -6087,7 +6087,7 @@ header nav ul li.dropdown ul {
   margin-top: 0 !important;
 }
 
-.directory-search.is-sticky+.tab-content .dirMeta {
+.directory-search.is-sticky+.tab-content .contextBanner {
   margin-top: 0;
 }
 

--- a/hushline/auth.py
+++ b/hushline/auth.py
@@ -51,17 +51,22 @@ def set_session_user(*, user: User, username: str, is_authenticated: bool) -> No
         session.pop(CHAT_KEY_SESSION_ID_SESSION_KEY, None)
 
 
+def stash_post_auth_redirect_target(redirect_target: str | None) -> None:
+    if not isinstance(redirect_target, str):
+        return
+    if not redirect_target.startswith("/") or redirect_target.startswith("//"):
+        return
+
+    session[POST_AUTH_REDIRECT_SESSION_KEY] = redirect_target
+
+
 def stash_post_auth_redirect() -> None:
     if request.method != "GET":
         return
     if request.endpoint == "logout":
         return
 
-    redirect_target = request.full_path.removesuffix("?")
-    if not redirect_target.startswith("/") or redirect_target.startswith("//"):
-        return
-
-    session[POST_AUTH_REDIRECT_SESSION_KEY] = redirect_target
+    stash_post_auth_redirect_target(request.full_path.removesuffix("?"))
 
 
 def pop_post_auth_redirect(*, default_endpoint: str = "inbox") -> str:

--- a/hushline/routes/auth.py
+++ b/hushline/routes/auth.py
@@ -31,6 +31,7 @@ from hushline.auth import (
     rotate_chat_key_session_id,
     rotate_user_session_id,
     set_session_user,
+    stash_post_auth_redirect_target,
 )
 from hushline.chat_key_lifecycle import retire_active_chat_key, validate_chat_key_payload
 from hushline.db import db
@@ -305,11 +306,17 @@ def _get_math_problem(force_new: bool = False) -> str:
 
 
 def register_auth_routes(app: Flask) -> None:
+    def _stash_next_post_auth_redirect() -> None:
+        if request.method == "GET":
+            stash_post_auth_redirect_target(request.args.get("next"))
+
     @app.route("/register", methods=["GET", "POST"])
     def register() -> Response | str:
         if session.get("is_authenticated", False) and get_session_user():
             flash("👉 You are already logged in.")
             return redirect(url_for("inbox"))
+
+        _stash_next_post_auth_redirect()
 
         # Check if this is the first user for template/rendering hints.
         first_user = db.session.query(User).count() == 0
@@ -444,6 +451,8 @@ def register_auth_routes(app: Flask) -> None:
         if session.get("is_authenticated", False) and get_session_user():
             flash("👉 You are already logged in.")
             return redirect(url_for("inbox"))
+
+        _stash_next_post_auth_redirect()
 
         form = LoginForm()
         if request.method == "POST" and form.validate():

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -537,6 +537,13 @@ def register_profile_routes(app: Flask) -> None:
                     not is_embedded and _chat_submission_base_available(uname, sender)
                 ),
             )
+            anonymous_tip_available = message_submission_block_reason is None
+            show_account_conversation_hint = (
+                not is_embedded
+                and sender is None
+                and message_submission_block_reason != "suspended"
+                and _chat_key_can_sign(uname.user)
+            )
             owner_guard_nonce = secrets.token_urlsafe(16)
             owner_guard_signature = _owner_guard_signature(
                 uname.username,
@@ -583,6 +590,8 @@ def register_profile_routes(app: Flask) -> None:
                 ),
                 math_problem=math_problem,
                 message_submission_block_reason=message_submission_block_reason,
+                anonymous_tip_available=anonymous_tip_available,
+                show_account_conversation_hint=show_account_conversation_hint,
                 owner_guard_nonce=owner_guard_nonce,
                 owner_guard_signature=owner_guard_signature,
                 is_embedded=is_embedded,

--- a/hushline/static/js/directory_verified.js
+++ b/hushline/static/js/directory_verified.js
@@ -1013,7 +1013,7 @@
 
     function panelIntroMarkup(panelId) {
       return (
-        document.getElementById(panelId)?.querySelector(".dirMeta")
+        document.getElementById(panelId)?.querySelector(".contextBanner")
           ?.outerHTML || ""
       );
     }

--- a/hushline/templates/directory.html
+++ b/hushline/templates/directory.html
@@ -601,7 +601,7 @@
       aria-labelledby="verified-tab"
     >
       {% if not logged_in %}
-        <p class="meta dirMeta">
+        <p class="meta contextBanner">
           ⭐️ Verified account owners have verified their identities with a member of our staff.
           <a
             href="https://hushline.app/library/docs/using-your-tip-line/account-verification"
@@ -674,7 +674,7 @@
       role="tabpanel"
       aria-labelledby="public-records-tab"
     >
-      <p class="meta dirMeta">
+      <p class="meta contextBanner">
         🧪 Beta: This tab includes self-reported attorneys and automated listings pulled from public records.
         {% if correction_contact_url %}<a href="{{ correction_contact_url }}">Request a correction</a>.{% endif %}
       </p>
@@ -736,7 +736,7 @@
 
   {% if directory_verified_tab_enabled %}
     <div id="newsrooms" class="tab-content" role="tabpanel" aria-labelledby="newsrooms-tab">
-      <p class="meta dirMeta">
+      <p class="meta contextBanner">
         🧪 Beta: This tab includes self-reported journalists, self-reported newsrooms, and automated listings from public journalism directories{% if newsroom_automated_sources %}, including {% for source in newsroom_automated_sources %}<a href="{{ source.url }}" target="_blank" rel="noopener noreferrer">{{ source.label }}</a>{% if not loop.last %}{% if loop.revindex0 == 1 %} and {% else %}, {% endif %}{% endif %}{% endfor %}{% endif %}. {% if correction_contact_url %}<a href="{{ correction_contact_url }}">Request a correction</a>.{% endif %}
       </p>
 
@@ -797,7 +797,7 @@
 
   {% if directory_verified_tab_enabled %}
     <div id="globaleaks" class="tab-content" role="tabpanel" aria-labelledby="globaleaks-tab">
-      <p class="meta dirMeta">
+      <p class="meta contextBanner">
         🧪 Beta: This list contains manual and automated entries and should not be considered exhaustive or authoritative.
         {% if correction_contact_url %}<a href="{{ correction_contact_url }}">Request a correction</a>.{% endif %}
       </p>
@@ -827,7 +827,7 @@
 
   {% if directory_verified_tab_enabled %}
     <div id="securedrop" class="tab-content" role="tabpanel" aria-labelledby="securedrop-tab">
-      <p class="meta dirMeta">
+      <p class="meta contextBanner">
         🧪 Beta: These listings are automated from the Freedom of the Press Foundation's public
         <a href="https://securedrop.org/api/v1/directory/?format=json">SecureDrop API</a>.
         {% if correction_contact_url %}<a href="{{ correction_contact_url }}">Request a correction</a>.{% endif %}
@@ -864,7 +864,7 @@
     {% if directory_verified_tab_enabled %}data-lazy-directory-panel="true"{% endif %}
   >
     {% if directory_verified_tab_enabled %}
-      <p class="meta dirMeta">
+      <p class="meta contextBanner">
         🧪 Beta: This list contains automated entries.
         {% if correction_contact_url %}<a href="{{ correction_contact_url }}">Request a correction</a>.{% endif %}
       </p>

--- a/hushline/templates/directory_globaleaks.html
+++ b/hushline/templates/directory_globaleaks.html
@@ -12,7 +12,7 @@
 
   <p class="bio">{{ listing.description }}</p>
 
-  <p class="meta dirMeta">
+  <p class="meta contextBanner">
     🧪 Beta: This listing is automated.
     {% if listing.has_onion_submission %}
       Onion addresses require

--- a/hushline/templates/directory_newsroom.html
+++ b/hushline/templates/directory_newsroom.html
@@ -12,7 +12,7 @@
 
   <p class="bio">{{ listing.description }}</p>
 
-  <p class="meta dirMeta">
+  <p class="meta contextBanner">
     🧪 Beta: This listing is automated from the public
     <a href="{{ listing.source_url }}" target="_blank" rel="noopener noreferrer">
       {{ listing.source_label }}.

--- a/hushline/templates/directory_securedrop.html
+++ b/hushline/templates/directory_securedrop.html
@@ -12,7 +12,7 @@
 
   <p class="bio">{{ listing.description }}</p>
 
-  <p class="meta dirMeta">
+  <p class="meta contextBanner">
     🧪 Beta: This listing is automated.
     Onion addresses require
     <a href="https://www.torproject.org/download/" target="_blank" rel="noopener noreferrer">Tor Browser</a>

--- a/hushline/templates/profile.html
+++ b/hushline/templates/profile.html
@@ -110,6 +110,19 @@
     </p>
   {% endif %}
 
+  {% if show_account_conversation_hint %}
+    {% set profile_auth_redirect = url_for('profile', username=username.username) %}
+    <p class="meta contextBanner">
+      🔒
+      {% if registration_enabled %}
+        <a href="{{ url_for('register', next=profile_auth_redirect) }}">Create an account</a> or
+      {% endif %}
+      <a href="{{ url_for('login', next=profile_auth_redirect) }}">log in</a> to start an
+      end-to-end encrypted conversation with {{ display_name_or_username }}{% if anonymous_tip_available %},
+      or leave an anonymous tip below{% endif %}.
+    </p>
+  {% endif %}
+
   <form
     method="POST"
     action="{% if is_embedded %}{{ url_for('embed_profile', username=username.username) }}{% else %}{{ url_for('profile', username=username.username) }}{% endif %}"

--- a/tests/test_directory.py
+++ b/tests/test_directory.py
@@ -572,7 +572,7 @@ def test_directory_public_record_banner_links_to_admin(
     public_records_panel = soup.find(id="public-records")
     assert public_records_panel is not None
 
-    banner = public_records_panel.select_one(".dirMeta")
+    banner = public_records_panel.select_one(".contextBanner")
     assert banner is not None
     banner_link = banner.select_one("a")
     assert banner_link is not None
@@ -597,7 +597,7 @@ def test_directory_securedrop_banner_links_to_admin_without_tor_copy(
     securedrop_panel = soup.find(id="securedrop")
     assert securedrop_panel is not None
 
-    banner = securedrop_panel.select_one(".dirMeta")
+    banner = securedrop_panel.select_one(".contextBanner")
     assert banner is not None
     banner_links = banner.select("a")
     links_by_text = {link.text.strip().rstrip("."): link.get("href") for link in banner_links}
@@ -626,9 +626,9 @@ def test_directory_globaleaks_banner_links_to_admin_without_tor_copy(
     globaleaks_panel = soup.find(id="globaleaks")
     assert globaleaks_panel is not None
 
-    banner = globaleaks_panel.select_one(".dirMeta")
+    banner = globaleaks_panel.select_one(".contextBanner")
     assert banner is not None
-    banner_links = globaleaks_panel.select(".dirMeta a")
+    banner_links = globaleaks_panel.select(".contextBanner a")
     links_by_text = {
         link.text.replace("\u2060", "").strip().rstrip("."): link.get("href")
         for link in banner_links
@@ -661,9 +661,9 @@ def test_directory_newsrooms_banner_links_to_admin(
     newsroom_panel = soup.find(id="newsrooms")
     assert newsroom_panel is not None
 
-    banner = newsroom_panel.select_one(".dirMeta")
+    banner = newsroom_panel.select_one(".contextBanner")
     assert banner is not None
-    banner_links = newsroom_panel.select(".dirMeta a")
+    banner_links = newsroom_panel.select(".contextBanner a")
     links_by_text = {
         link.text.replace("\u2060", "").strip().rstrip("."): link.get("href")
         for link in banner_links
@@ -701,7 +701,7 @@ def test_directory_all_tab_banner_links_to_admin(client: FlaskClient, admin_user
     all_panel = soup.find(id="all")
     assert all_panel is not None
 
-    banner = all_panel.select_one(".dirMeta")
+    banner = all_panel.select_one(".contextBanner")
     assert banner is not None
     banner_link = banner.select_one("a")
     assert banner_link is not None
@@ -726,7 +726,7 @@ def test_directory_correction_links_ignore_non_admin_admin_username(
     soup = BeautifulSoup(response.text, "html.parser")
     correction_links = [
         link.get("href")
-        for link in soup.select(".dirMeta a")
+        for link in soup.select(".contextBanner a")
         if link.get_text(strip=True) == "Request a correction"
     ]
     assert correction_links
@@ -752,7 +752,7 @@ def test_directory_hides_tab_bar_when_verified_tabs_disabled(client: FlaskClient
 
     all_panel = soup.find(id="all")
     assert all_panel is not None
-    assert all_panel.select_one(".dirMeta") is None
+    assert all_panel.select_one(".contextBanner") is None
     assert "🏛️ Public Record Attorneys" not in all_panel.get_text(" ", strip=True)
     assert "📰 Newsroom Listings" not in all_panel.get_text(" ", strip=True)
     assert "🌐 GlobaLeaks" not in all_panel.get_text(" ", strip=True)
@@ -4781,20 +4781,20 @@ def test_securedrop_listing_page_is_read_only(client: FlaskClient) -> None:
     assert 'id="messageForm"' not in response.text
     assert "Send Message" not in response.text
 
-    dir_meta = soup.select_one(".dirMeta")
-    assert dir_meta is not None
-    dir_meta_text = dir_meta.get_text(" ", strip=True)
-    assert dir_meta_text.startswith("🧪 Beta:")
-    assert "This listing is automated." in dir_meta_text
-    assert "Onion addresses require" in dir_meta_text
-    assert "Tor Browser" in dir_meta_text
-    assert "risk in your jurisdiction" in dir_meta_text
-    assert "Do your research before downloading." in dir_meta_text
+    context_banner = soup.select_one(".contextBanner")
+    assert context_banner is not None
+    context_banner_text = context_banner.get_text(" ", strip=True)
+    assert context_banner_text.startswith("🧪 Beta:")
+    assert "This listing is automated." in context_banner_text
+    assert "Onion addresses require" in context_banner_text
+    assert "Tor Browser" in context_banner_text
+    assert "risk in your jurisdiction" in context_banner_text
+    assert "Do your research before downloading." in context_banner_text
 
-    dir_meta_link = dir_meta.find("a")
-    assert dir_meta_link is not None
-    assert dir_meta_link.text.strip() == "Tor Browser"
-    assert dir_meta_link.get("href") == "https://www.torproject.org/download/"
+    context_banner_link = context_banner.find("a")
+    assert context_banner_link is not None
+    assert context_banner_link.text.strip() == "Tor Browser"
+    assert context_banner_link.get("href") == "https://www.torproject.org/download/"
 
 
 def test_globaleaks_listing_page_is_read_only(
@@ -4819,14 +4819,14 @@ def test_globaleaks_listing_page_is_read_only(
     assert 'id="messageForm"' not in response.text
     assert "Send Message" not in response.text
 
-    dir_meta = soup.select_one(".dirMeta")
-    assert dir_meta is not None
-    dir_meta_text = dir_meta.get_text(" ", strip=True)
-    assert dir_meta_text.startswith("🧪 Beta:")
-    assert "This listing is automated." in dir_meta_text
-    assert "Onion addresses require" not in dir_meta_text
-    assert "Tor Browser" not in dir_meta_text
-    assert dir_meta.find("a") is None
+    context_banner = soup.select_one(".contextBanner")
+    assert context_banner is not None
+    context_banner_text = context_banner.get_text(" ", strip=True)
+    assert context_banner_text.startswith("🧪 Beta:")
+    assert "This listing is automated." in context_banner_text
+    assert "Onion addresses require" not in context_banner_text
+    assert "Tor Browser" not in context_banner_text
+    assert context_banner.find("a") is None
 
 
 def test_globaleaks_listing_page_mentions_tor_for_onion_submission(
@@ -4842,17 +4842,17 @@ def test_globaleaks_listing_page_mentions_tor_for_onion_submission(
     assert response.status_code == 200
     soup = BeautifulSoup(response.text, "html.parser")
 
-    dir_meta = soup.select_one(".dirMeta")
-    assert dir_meta is not None
-    dir_meta_text = dir_meta.get_text(" ", strip=True)
-    assert dir_meta_text.startswith("🧪 Beta:")
-    assert "This listing is automated." in dir_meta_text
-    assert "Onion addresses require" in dir_meta_text
-    assert "Tor Browser" in dir_meta_text
-    dir_meta_link = dir_meta.find("a")
-    assert dir_meta_link is not None
-    assert dir_meta_link.text.strip() == "Tor Browser"
-    assert dir_meta_link.get("href") == "https://www.torproject.org/download/"
+    context_banner = soup.select_one(".contextBanner")
+    assert context_banner is not None
+    context_banner_text = context_banner.get_text(" ", strip=True)
+    assert context_banner_text.startswith("🧪 Beta:")
+    assert "This listing is automated." in context_banner_text
+    assert "Onion addresses require" in context_banner_text
+    assert "Tor Browser" in context_banner_text
+    context_banner_link = context_banner.find("a")
+    assert context_banner_link is not None
+    assert context_banner_link.text.strip() == "Tor Browser"
+    assert context_banner_link.get("href") == "https://www.torproject.org/download/"
 
 
 def test_globaleaks_listing_route_hidden_when_verified_tabs_disabled(
@@ -4894,12 +4894,12 @@ def test_newsroom_listing_page_is_read_only(
     assert 'id="messageForm"' not in response.text
     assert "Send Message" not in response.text
 
-    dir_meta = soup.select_one(".dirMeta")
-    assert dir_meta is not None
-    dir_meta_text = dir_meta.get_text(" ", strip=True)
-    assert dir_meta_text.startswith("🧪 Beta:")
-    assert "INN Find Your News directory" in dir_meta_text
-    source_link = dir_meta.select_one("a")
+    context_banner = soup.select_one(".contextBanner")
+    assert context_banner is not None
+    context_banner_text = context_banner.get_text(" ", strip=True)
+    assert context_banner_text.startswith("🧪 Beta:")
+    assert "INN Find Your News directory" in context_banner_text
+    source_link = context_banner.select_one("a")
     assert source_link is not None
     assert source_link.get_text(" ", strip=True) == "INN Find Your News directory."
     assert "Directory Profile" in page_text
@@ -4928,10 +4928,10 @@ def test_newsroom_listing_page_renders_source_aware_copy_for_network_entries(
     assert "France, Germany" in page_text
     assert "State / Region" not in page_text
 
-    dir_meta = soup.select_one(".dirMeta")
-    assert dir_meta is not None
-    dir_meta_text = dir_meta.get_text(" ", strip=True)
-    assert "Directory of European Journalism Networks" in dir_meta_text
+    context_banner = soup.select_one(".contextBanner")
+    assert context_banner is not None
+    context_banner_text = context_banner.get_text(" ", strip=True)
+    assert "Directory of European Journalism Networks" in context_banner_text
 
 
 def test_newsroom_listing_route_hidden_when_verified_tabs_disabled(

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -506,6 +506,76 @@ def test_logged_in_profile_submit_without_recipient_pgp_uses_chat_only_conversat
     assert msg_content not in response.text
 
 
+def test_anonymous_profile_with_chat_key_and_pgp_prompts_login_for_conversation_and_tip(
+    client: FlaskClient, user: User
+) -> None:
+    user.primary_username.display_name = "Secure Desk"
+    _set_pgp_key(user)
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+    db.session.expire_all()
+
+    response = client.get(url_for("profile", username=user.primary_username.username))
+
+    assert response.status_code == 200
+    hint = BeautifulSoup(response.text, "html.parser").select_one("p.contextBanner")
+    assert hint is not None
+    assert "instr" not in (hint.get("class") or [])
+    page_text = " ".join(BeautifulSoup(response.text, "html.parser").get_text(" ").split())
+    assert (
+        "start an end-to-end encrypted conversation with Secure Desk, "
+        "or leave an anonymous tip below"
+    ) in page_text
+    assert (
+        url_for(
+            "login",
+            next=url_for("profile", username=user.primary_username.username, _external=False),
+            _external=False,
+        )
+        in response.text
+    )
+
+
+def test_anonymous_profile_with_chat_key_without_pgp_omits_anonymous_tip_clause(
+    client: FlaskClient, user: User
+) -> None:
+    user.primary_username.display_name = "Secure Desk"
+    user.pgp_key = None
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+    db.session.expire_all()
+
+    response = client.get(url_for("profile", username=user.primary_username.username))
+
+    assert response.status_code == 200
+    page_text = " ".join(BeautifulSoup(response.text, "html.parser").get_text(" ").split())
+    assert "start an end-to-end encrypted conversation with Secure Desk" in page_text
+    assert "leave an anonymous tip below" not in page_text
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_authenticated_profile_hides_login_conversation_prompt(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    db.session.commit()
+
+    response = client.get(url_for("profile", username=user2.primary_username.username))
+
+    assert response.status_code == 200
+    assert "start an end-to-end encrypted conversation" not in response.text
+
+
+def test_anonymous_profile_without_chat_key_hides_login_conversation_prompt(
+    client: FlaskClient, user: User
+) -> None:
+    response = client.get(url_for("profile", username=user.primary_username.username))
+
+    assert response.status_code == 200
+    page_text = " ".join(BeautifulSoup(response.text, "html.parser").get_text(" ").split())
+    assert "start an end-to-end encrypted conversation" not in page_text
+
+
 @pytest.mark.usefixtures("_authenticated_user")
 def test_profile_get_does_not_persist_initial_chat_nonce(
     client: FlaskClient, user: User, user2: User

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -18,6 +18,7 @@ from hushline.auth import (
     PENDING_PASSWORD_REHASH_SOURCE_DIGEST_SESSION_KEY,
     POST_AUTH_REDIRECT_SESSION_KEY,
     stash_post_auth_redirect,
+    stash_post_auth_redirect_target,
 )
 from hushline.config import PASSWORD_HASH_REHASH_ON_AUTH_ENABLED
 from hushline.db import db
@@ -336,6 +337,41 @@ def test_login_redirects_to_original_protected_page(
         assert POST_AUTH_REDIRECT_SESSION_KEY not in sess
         assert isinstance(sess[CHAT_KEY_SESSION_ID_SESSION_KEY], str)
         assert sess[CHAT_KEY_SESSION_ID_SESSION_KEY]
+
+
+def test_login_next_redirects_after_auth(
+    client: FlaskClient, user: User, user_password: str
+) -> None:
+    target = url_for("profile", username=user.primary_username.username, _external=False)
+
+    response = client.get(url_for("login", next=target), follow_redirects=False)
+    assert response.status_code == 200
+
+    with client.session_transaction() as sess:
+        assert sess[POST_AUTH_REDIRECT_SESSION_KEY] == target
+
+    response = client.post(
+        url_for("login"),
+        data={"username": user.primary_username.username, "password": user_password},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(target)
+
+    with client.session_transaction() as sess:
+        assert POST_AUTH_REDIRECT_SESSION_KEY not in sess
+
+
+def test_register_next_stashes_post_auth_redirect(client: FlaskClient, user: User) -> None:
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_ENABLED, True)
+    db.session.commit()
+    target = url_for("profile", username=user.primary_username.username, _external=False)
+
+    response = client.get(url_for("register", next=target), follow_redirects=False)
+
+    assert response.status_code == 200
+    with client.session_transaction() as sess:
+        assert sess[POST_AUTH_REDIRECT_SESSION_KEY] == target
 
 
 def test_login_password_step_for_2fa_does_not_revoke_existing_sessions(
@@ -857,6 +893,19 @@ def test_stash_post_auth_redirect_rejects_unsafe_target_and_preserves_session(ap
             ),
         ):
             stash_post_auth_redirect()
+
+        assert session["sentinel"] == "keep"
+        assert session[POST_AUTH_REDIRECT_SESSION_KEY] == "/already-set"
+
+
+def test_stash_post_auth_redirect_target_rejects_unsafe_target(app: Flask) -> None:
+    with app.test_request_context("/login", method="GET"):
+        session["sentinel"] = "keep"
+        session[POST_AUTH_REDIRECT_SESSION_KEY] = "/already-set"
+
+        stash_post_auth_redirect_target("//example.com/phish")
+        stash_post_auth_redirect_target("https://example.com/phish")
+        stash_post_auth_redirect_target(None)
 
         assert session["sentinel"] == "keep"
         assert session[POST_AUTH_REDIRECT_SESSION_KEY] == "/already-set"


### PR DESCRIPTION
## What changed
- Adds a profile-page contextual banner for anonymous visitors on active first-party Hush Line profiles that can support account conversations.
- Links visitors to login, and to registration when registrations are enabled, with a validated same-origin return path back to `/to/<username>` after authentication.
- Keeps the anonymous-tip clause only when the anonymous form below is actually available.
- Rationalizes directory/profile contextual banner styling around the shared `contextBanner` class instead of directory-specific `dirMeta` or italic `instr` copy.
- Updates profile, auth, and directory tests for the new banner behavior and class name.

## Why
Anonymous submissions remain the standard intake flow, but two-way encrypted account conversations require logged-in Hush Line users and a signing-capable recipient chat key. The profile page now surfaces that path without changing submission behavior or pointing visitors at unavailable actions.

## Security and privacy
- Affected paths: public profile render for `/to/<username>` and login/register post-auth redirect handling.
- Auth `next` handling only accepts same-origin relative paths and rejects external or protocol-relative targets.
- No changes to message submission, encryption, CSP, recipient-key selection, or conversation creation.
- The hint is suppressed for suspended accounts, embedded profiles, authenticated visitors, and recipients without a signing-capable chat key.

## Validation
- `docker compose run --rm app poetry run pytest tests/test_profile.py tests/test_routes_auth.py -q -k "anonymous_profile_with_chat_key_and_pgp_prompts_login_for_conversation_and_tip or anonymous_profile_with_chat_key_without_pgp_omits_anonymous_tip_clause or authenticated_profile_hides_login_conversation_prompt or anonymous_profile_without_chat_key_hides_login_conversation_prompt or login_next_redirects_after_auth or register_next_stashes_post_auth_redirect or stash_post_auth_redirect_target_rejects_unsafe_target"`
- `docker compose run --rm app poetry run pytest tests/test_directory.py -q -k "directory_public_record_banner_links_to_admin or directory_securedrop_banner_links_to_admin_without_tor_copy or directory_globaleaks_banner_links_to_admin_without_tor_copy or directory_newsrooms_banner_links_to_admin or directory_all_tab_banner_links_to_admin or directory_correction_links_ignore_non_admin_admin_username or directory_hides_tab_bar_when_verified_tabs_disabled or securedrop_listing_page_is_read_only or globaleaks_listing_page_is_read_only or globaleaks_listing_page_mentions_tor_for_onion_submission or newsroom_listing_page_is_read_only or newsroom_listing_page_renders_source_aware_copy_for_network_entries"`
- `make lint`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing
- User locally tested the logged-out profile page and reviewed banner copy/styling direction.

## Known risks or follow-ups
- Local `git log --show-signature` cannot verify SSH signatures because `gpg.ssh.allowedSignersFile` is not configured, but the commit object contains an SSH `gpgsig` block.