### PR TITLE
Fix header menu after async login

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -980,6 +980,7 @@
     document.head.replaceWith(document.importNode(parsedDocument.head, true));
     document.body.replaceWith(document.importNode(parsedDocument.body, true));
     window.history.replaceState({}, "", responseUrl);
+    document.dispatchEvent(new CustomEvent("hushline:document-replaced"));
     bindPage();
   }
 

--- a/assets/js/global.js
+++ b/assets/js/global.js
@@ -4,6 +4,10 @@ function navController() {
     const navList = document.querySelector("header nav ul");
 
     if (mobileNavToggle && navList) {
+      if (mobileNavToggle.dataset.navControllerInit === "true") {
+        return;
+      }
+      mobileNavToggle.dataset.navControllerInit = "true";
       mobileNavToggle.addEventListener("click", function (event) {
         event.preventDefault();
         navList.classList.toggle("show");
@@ -27,6 +31,10 @@ function navController() {
       if (!button || !menu) {
         return;
       }
+      if (actionMenu.dataset.actionMenuInit === "true") {
+        return;
+      }
+      actionMenu.dataset.actionMenuInit = "true";
 
       button.addEventListener("click", (event) => {
         event.preventDefault();
@@ -528,6 +536,10 @@ document.addEventListener("DOMContentLoaded", function () {
       guidanceDiv.addEventListener("keydown", trapFocus);
     }
   }
+});
+
+document.addEventListener("hushline:document-replaced", function () {
+  navController();
 });
 
 document.addEventListener("DOMContentLoaded", () => {

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -984,6 +984,7 @@
     document.head.replaceWith(document.importNode(parsedDocument.head, true));
     document.body.replaceWith(document.importNode(parsedDocument.body, true));
     window.history.replaceState({}, "", responseUrl);
+    document.dispatchEvent(new CustomEvent("hushline:document-replaced"));
     bindPage();
   }
 

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -195,6 +195,7 @@ def test_settings_chat_key_provisioning_generates_decryptable_ecdh_key() -> None
 
 def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session() -> None:
     js = (ROOT / "assets/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
+    static_js = (ROOT / "hushline/static/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
     base_template = (ROOT / "hushline/templates/base.html").read_text(encoding="utf-8")
     login_template = (ROOT / "hushline/templates/login.html").read_text(encoding="utf-8")
     password_reset_template = (ROOT / "hushline/templates/password_reset.html").read_text(
@@ -245,6 +246,8 @@ def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session(
     assert "createChatKeyPayload(password)" in js
     assert "populateLoginChatKeyPayload(form, password)" in js
     assert "payloadInput.value = JSON.stringify(created.payload);" in js
+    assert 'new CustomEvent("hushline:document-replaced")' in js
+    assert 'new CustomEvent("hushline:document-replaced")' in static_js
     assert 'name="chat_key_payload"' in login_template
     assert 'id="login-chat-key-payload"' in login_template
     assert "pendingLoginPassword" in js
@@ -574,6 +577,9 @@ def test_global_header_account_menu_uses_shared_action_menu_treatment() -> None:
     assert 'class="dropdown-icon"' in template
     assert "setupDropdown" not in js
     assert "dropdownIcon" not in js
+    assert 'dataset.navControllerInit === "true"' in js
+    assert 'dataset.actionMenuInit === "true"' in js
+    assert 'document.addEventListener("hushline:document-replaced"' in js
     assert ".action-menu-content" in scss
     assert ".dropdown-icon" in scss
     assert "filter: invert(1);" in scss


### PR DESCRIPTION
## What changed

- Emit a `hushline:document-replaced` event when the chat key login flow swaps in authenticated HTML after a successful async login.
- Re-run the shared header/action-menu binding when that document replacement event fires.
- Make header menu binding idempotent so re-binding cannot stack duplicate listeners.
- Added frontend compatibility coverage for the document replacement event and header menu re-binding hooks.

## Why

The login flow can complete without a full browser navigation because `chat-key-lifecycle.js` fetches the authenticated page, replaces `document.head` and `document.body`, and updates history. That replacement does not fire `DOMContentLoaded`, so `global.js` never initialized the authenticated header account menu until a manual refresh.

## Validation

- `docker compose run --rm app poetry run pytest tests/test_frontend_compat.py -q -k "chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session or global_header_account_menu_uses_shared_action_menu_treatment"`
- `make lint`
- `docker compose run --rm app poetry run pytest tests/test_security_headers.py -q`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

- Rebuilt local frontend assets with `npm run build:prod` so the ignored local `hushline/static/js/global.js` used by the running app includes the fix.
- Expected check: log in through the async login flow, then click the authenticated header account dropdown before refreshing. The menu should open immediately.

## Security and privacy impact

No CSP sources, request headers, encryption defaults, or whistleblower disclosure data paths are broadened. The change only reinitializes existing header menu behavior after the already-authenticated page shell is swapped in.

## Known risks

The tracked source and tracked `chat-key-lifecycle` static bundle are updated. The generated `hushline/static/js/global.js` file remains ignored by the repository, so deployment should continue to rely on the existing asset build process for that bundle.