### PR TITLE
Show pending chat activation on profiles

### DIFF
--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -537,6 +537,7 @@ def register_profile_routes(app: Flask) -> None:
                     not is_embedded and _chat_submission_base_available(uname, sender)
                 ),
             )
+            normal_tip_available = _message_submission_block_reason(uname) is None
             anonymous_tip_available = message_submission_block_reason is None
             show_account_conversation_hint = (
                 not is_embedded
@@ -598,6 +599,7 @@ def register_profile_routes(app: Flask) -> None:
                 math_problem=math_problem,
                 message_submission_block_reason=message_submission_block_reason,
                 anonymous_tip_available=anonymous_tip_available,
+                normal_tip_available=normal_tip_available,
                 show_account_conversation_hint=show_account_conversation_hint,
                 show_chat_key_pending_activation_hint=show_chat_key_pending_activation_hint,
                 owner_guard_nonce=owner_guard_nonce,

--- a/hushline/routes/profile.py
+++ b/hushline/routes/profile.py
@@ -544,6 +544,13 @@ def register_profile_routes(app: Flask) -> None:
                 and message_submission_block_reason != "suspended"
                 and _chat_key_can_sign(uname.user)
             )
+            show_chat_key_pending_activation_hint = (
+                not is_embedded
+                and sender is not None
+                and sender.id != uname.user_id
+                and message_submission_block_reason != "suspended"
+                and not _chat_key_can_sign(uname.user)
+            )
             owner_guard_nonce = secrets.token_urlsafe(16)
             owner_guard_signature = _owner_guard_signature(
                 uname.username,
@@ -592,6 +599,7 @@ def register_profile_routes(app: Flask) -> None:
                 message_submission_block_reason=message_submission_block_reason,
                 anonymous_tip_available=anonymous_tip_available,
                 show_account_conversation_hint=show_account_conversation_hint,
+                show_chat_key_pending_activation_hint=show_chat_key_pending_activation_hint,
                 owner_guard_nonce=owner_guard_nonce,
                 owner_guard_signature=owner_guard_signature,
                 is_embedded=is_embedded,

--- a/hushline/templates/profile.html
+++ b/hushline/templates/profile.html
@@ -125,7 +125,7 @@
 
   {% if show_chat_key_pending_activation_hint %}
     <p class="meta contextBanner">
-      ⏳ Two-way conversations pending activation.{% if anonymous_tip_available %} Submit a tip below.{% endif %}
+      ⏳ Two-way conversations pending activation.{% if normal_tip_available %} Submit a tip below.{% endif %}
     </p>
   {% endif %}
 

--- a/hushline/templates/profile.html
+++ b/hushline/templates/profile.html
@@ -123,6 +123,12 @@
     </p>
   {% endif %}
 
+  {% if show_chat_key_pending_activation_hint %}
+    <p class="meta contextBanner">
+      ⏳ Two-way conversations pending activation.{% if anonymous_tip_available %} Submit a tip below.{% endif %}
+    </p>
+  {% endif %}
+
   <form
     method="POST"
     action="{% if is_embedded %}{{ url_for('embed_profile', username=username.username) }}{% else %}{{ url_for('profile', username=username.username) }}{% endif %}"

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -557,6 +557,7 @@ def test_anonymous_profile_with_chat_key_without_pgp_omits_anonymous_tip_clause(
 def test_authenticated_profile_hides_login_conversation_prompt(
     client: FlaskClient, user: User, user2: User
 ) -> None:
+    _set_pgp_key(user2)
     _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
     db.session.commit()
 
@@ -564,6 +565,40 @@ def test_authenticated_profile_hides_login_conversation_prompt(
 
     assert response.status_code == 200
     assert "start an end-to-end encrypted conversation" not in response.text
+    assert "Two-way conversations pending activation" not in response.text
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_authenticated_profile_without_recipient_chat_key_shows_pending_activation_banner(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    _set_pgp_key(user2)
+    db.session.commit()
+
+    response = client.get(url_for("profile", username=user2.primary_username.username))
+
+    assert response.status_code == 200
+    banner = BeautifulSoup(response.text, "html.parser").select_one("p.contextBanner")
+    assert banner is not None
+    assert banner.get_text(" ", strip=True) == (
+        "⏳ Two-way conversations pending activation. Submit a tip below."
+    )
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_authenticated_info_only_profile_omits_pending_activation_tip_clause(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    user2.pgp_key = None
+    db.session.commit()
+
+    response = client.get(url_for("profile", username=user2.primary_username.username))
+
+    assert response.status_code == 200
+    banner = BeautifulSoup(response.text, "html.parser").select_one("p.contextBanner")
+    assert banner is not None
+    assert banner.get_text(" ", strip=True) == "⏳ Two-way conversations pending activation."
+    assert "Submit a tip below" not in banner.get_text(" ", strip=True)
 
 
 def test_anonymous_profile_without_chat_key_hides_login_conversation_prompt(

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -601,6 +601,32 @@ def test_authenticated_info_only_profile_omits_pending_activation_tip_clause(
     assert "Submit a tip below" not in banner.get_text(" ", strip=True)
 
 
+@pytest.mark.usefixtures("_authenticated_user")
+def test_authenticated_legacy_chat_only_profile_omits_pending_activation_tip_clause(
+    client: FlaskClient, user: User, user2: User
+) -> None:
+    user2.pgp_key = None
+    _add_chat_key(user, '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}')
+    _add_chat_key(
+        user2,
+        '{"kty":"EC","crv":"P-256","x":"legacy-recipient","y":"key"}',
+        public_signing_key=None,
+    )
+    assert user2.active_chat_key is not None
+    user2.active_chat_key.public_signing_key = None
+    db.session.commit()
+
+    response = client.get(url_for("profile", username=user2.primary_username.username))
+
+    assert response.status_code == 200
+    banner = BeautifulSoup(response.text, "html.parser").select_one("p.contextBanner")
+    assert banner is not None
+    assert banner.get_text(" ", strip=True) == "⏳ Two-way conversations pending activation."
+    assert "Submit a tip below" not in banner.get_text(" ", strip=True)
+    assert 'id="messageForm"' in response.text
+    assert "pgp-disabled-overlay" not in response.text
+
+
 def test_anonymous_profile_without_chat_key_hides_login_conversation_prompt(
     client: FlaskClient, user: User
 ) -> None:


### PR DESCRIPTION
## What changed

- Added a profile-page banner for logged-in users viewing another profile whose two-way conversation chat keys are not active yet.
- The banner uses the existing `contextBanner` treatment.
- When normal tip intake is available, the copy is: `⏳ Two-way conversations pending activation. Submit a tip below.`
- On info-only or legacy chat-only profiles where normal tip intake is unavailable, the copy is: `⏳ Two-way conversations pending activation.`
- Added profile route coverage for the active, pending-with-tip, pending-info-only, and pending-legacy-chat-only cases.

## Why

A logged-in sender can land on a recipient profile where account two-way conversations cannot start because the recipient has not generated signing-capable chat keys. The page should make that state explicit and only direct the sender to the normal tip flow when that flow is actually available.

## Behavior

The banner appears only on non-embedded profile pages when:

- the viewer is logged in,
- the viewer is not viewing their own profile,
- the profile is not suspended, and
- the profile owner does not have signing-capable chat keys.

It does not replace the existing logged-out account-conversation prompt. It omits `Submit a tip below.` when normal PGP-backed tip intake is unavailable, including info-only and legacy chat-only profiles.

## Validation

- `docker compose run --rm app poetry run pytest tests/test_profile.py -q -k "authenticated_profile_hides_login_conversation_prompt or authenticated_profile_without_recipient_chat_key_shows_pending_activation_banner or authenticated_info_only_profile_omits_pending_activation_tip_clause or authenticated_legacy_chat_only_profile_omits_pending_activation_tip_clause or anonymous_profile_with_chat_key_and_pgp_prompts_login_for_conversation_and_tip or anonymous_profile_without_chat_key_hides_login_conversation_prompt"`
- `docker compose run --rm app poetry run pytest tests/test_security_headers.py -q`
- `make lint`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

- Expected check: log in, visit another account profile that has usable PGP intake but no active chat key, and confirm the pending activation banner includes `Submit a tip below.` above the message form.
- Expected check: log in, visit an info-only account profile with no usable PGP intake and no active chat key, and confirm the banner omits `Submit a tip below.`
- Expected check: log in, visit a legacy chat-only profile with no PGP intake and an unsigned recipient chat key, and confirm the banner omits `Submit a tip below.`
- Expected check: visit a profile with active signing-capable chat keys and confirm this pending banner is absent.

## Security and privacy impact

No CSP sources, headers, cryptographic behavior, or message submission data paths are broadened. The change only surfaces an existing availability state before the user submits through existing flows.

## Known risks

None known. The copy intentionally points users to the tip form only when normal tip submission is available.