### PR TITLE
Harden post-auth redirect targets

### DIFF
--- a/hushline/auth.py
+++ b/hushline/auth.py
@@ -2,6 +2,7 @@ import secrets
 from functools import wraps
 from hmac import compare_digest
 from typing import Any, Callable
+from urllib.parse import unquote, urlsplit
 
 from flask import abort, current_app, flash, redirect, request, session, url_for
 
@@ -12,6 +13,8 @@ PENDING_PASSWORD_REHASH_SESSION_KEY = "pending_password_rehash"  # noqa: S105
 PENDING_PASSWORD_REHASH_SOURCE_DIGEST_SESSION_KEY = "pending_password_rehash_source_digest"  # noqa: S105
 POST_AUTH_REDIRECT_SESSION_KEY = "post_auth_redirect"
 CHAT_KEY_SESSION_ID_SESSION_KEY = "chat_key_session_id"
+ASCII_CONTROL_MAX = 31
+ASCII_DELETE = 127
 AUTH_SESSION_KEYS = (
     "user_id",
     "session_id",
@@ -51,10 +54,26 @@ def set_session_user(*, user: User, username: str, is_authenticated: bool) -> No
         session.pop(CHAT_KEY_SESSION_ID_SESSION_KEY, None)
 
 
-def stash_post_auth_redirect_target(redirect_target: str | None) -> None:
+def _is_safe_post_auth_redirect_target(redirect_target: str | None) -> bool:
     if not isinstance(redirect_target, str):
-        return
+        return False
     if not redirect_target.startswith("/") or redirect_target.startswith("//"):
+        return False
+
+    parsed_target = urlsplit(redirect_target)
+    if parsed_target.scheme or parsed_target.netloc:
+        return False
+
+    decoded_target = unquote(redirect_target)
+    if "\\" in redirect_target or "\\" in decoded_target:
+        return False
+    return not any(
+        ord(char) <= ASCII_CONTROL_MAX or ord(char) == ASCII_DELETE for char in decoded_target
+    )
+
+
+def stash_post_auth_redirect_target(redirect_target: str | None) -> None:
+    if not _is_safe_post_auth_redirect_target(redirect_target):
         return
 
     session[POST_AUTH_REDIRECT_SESSION_KEY] = redirect_target
@@ -71,11 +90,7 @@ def stash_post_auth_redirect() -> None:
 
 def pop_post_auth_redirect(*, default_endpoint: str = "inbox") -> str:
     redirect_target = session.pop(POST_AUTH_REDIRECT_SESSION_KEY, None)
-    if (
-        isinstance(redirect_target, str)
-        and redirect_target.startswith("/")
-        and not redirect_target.startswith("//")
-    ):
+    if _is_safe_post_auth_redirect_target(redirect_target):
         return redirect_target
 
     return url_for(default_endpoint)

--- a/tests/test_routes_auth.py
+++ b/tests/test_routes_auth.py
@@ -17,6 +17,7 @@ from hushline.auth import (
     PENDING_PASSWORD_REHASH_SESSION_KEY,
     PENDING_PASSWORD_REHASH_SOURCE_DIGEST_SESSION_KEY,
     POST_AUTH_REDIRECT_SESSION_KEY,
+    pop_post_auth_redirect,
     stash_post_auth_redirect,
     stash_post_auth_redirect_target,
 )
@@ -372,6 +373,52 @@ def test_register_next_stashes_post_auth_redirect(client: FlaskClient, user: Use
     assert response.status_code == 200
     with client.session_transaction() as sess:
         assert sess[POST_AUTH_REDIRECT_SESSION_KEY] == target
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        r"/\attacker.example/path",
+        "/%5Cattacker.example/path",
+    ],
+)
+def test_login_next_rejects_backslash_redirect_target(
+    client: FlaskClient, user: User, user_password: str, target: str
+) -> None:
+    response = client.get(url_for("login", next=target), follow_redirects=False)
+    assert response.status_code == 200
+
+    with client.session_transaction() as sess:
+        assert POST_AUTH_REDIRECT_SESSION_KEY not in sess
+
+    response = client.post(
+        url_for("login"),
+        data={"username": user.primary_username.username, "password": user_password},
+        follow_redirects=False,
+    )
+
+    assert response.status_code == 302
+    assert response.headers["Location"].endswith(url_for("inbox"))
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        r"/\attacker.example/path",
+        "/%5Cattacker.example/path",
+    ],
+)
+def test_register_next_rejects_backslash_redirect_target(
+    client: FlaskClient, user: User, target: str
+) -> None:
+    OrganizationSetting.upsert(OrganizationSetting.REGISTRATION_ENABLED, True)
+    db.session.commit()
+
+    response = client.get(url_for("register", next=target), follow_redirects=False)
+
+    assert response.status_code == 200
+    with client.session_transaction() as sess:
+        assert POST_AUTH_REDIRECT_SESSION_KEY not in sess
 
 
 def test_login_password_step_for_2fa_does_not_revoke_existing_sessions(
@@ -905,10 +952,30 @@ def test_stash_post_auth_redirect_target_rejects_unsafe_target(app: Flask) -> No
 
         stash_post_auth_redirect_target("//example.com/phish")
         stash_post_auth_redirect_target("https://example.com/phish")
+        stash_post_auth_redirect_target(r"/\example.com/phish")
+        stash_post_auth_redirect_target("/%5Cexample.com/phish")
         stash_post_auth_redirect_target(None)
 
         assert session["sentinel"] == "keep"
         assert session[POST_AUTH_REDIRECT_SESSION_KEY] == "/already-set"
+
+
+@pytest.mark.parametrize(
+    "target",
+    [
+        "//example.com/phish",
+        "https://example.com/phish",
+        r"/\example.com/phish",
+        "/%5Cexample.com/phish",
+        "/safe-path\r\nLocation: https://example.com/phish",
+    ],
+)
+def test_pop_post_auth_redirect_rejects_unsafe_target(app: Flask, target: str) -> None:
+    with app.test_request_context("/login", method="POST"):
+        session[POST_AUTH_REDIRECT_SESSION_KEY] = target
+
+        assert pop_post_auth_redirect() == url_for("inbox")
+        assert POST_AUTH_REDIRECT_SESSION_KEY not in session
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What changed
- Added one shared post-auth redirect validator for login/register `next` targets and the post-auth redirect sink.
- Rejects absolute URLs, scheme-relative URLs, raw or percent-decoded backslashes, and percent-decoded control characters before storing or returning a post-auth redirect target.
- Added focused tests for login/register backslash payloads and unsafe session values popped after auth.

## Why
A new informational security finding traced attacker-controlled `next` values from `/login` and `/register` into the post-auth redirect sink. The finding's dynamic validation showed Flask/Werkzeug percent-encodes the reported backslash payload in the emitted `Location` header, so the claimed browser off-site redirect was not validated in the current stack.

This still tightens the local redirect validation so the auth flow does not rely on response-header encoding or proxy behavior for safety.

## Security and privacy impact
- Affected path: unauthenticated login/register `next` parameter, password login redirect, and 2FA completion redirect.
- No CSP, cookie, cryptography, or disclosure handling changes.
- Legitimate same-origin local paths continue to work; malformed backslash/control-character targets now fall back to the inbox.

## Validation
- `docker compose run --rm app poetry run pytest tests/test_routes_auth.py -q -k "login_next_redirects_after_auth or register_next_stashes_post_auth_redirect or login_next_rejects_backslash_redirect_target or register_next_rejects_backslash_redirect_target or stash_post_auth_redirect_target_rejects_unsafe_target or pop_post_auth_redirect_rejects_unsafe_target"`
- `docker compose run --rm app poetry run pytest tests/test_security_headers.py -q`
- `make lint`
- `make audit-node-runtime`
- `make audit-python`

## Manual testing
- `/login?next=/\\attacker.example/path` then login redirects to the inbox.
- `/login?next=/%5Cattacker.example/path` then login redirects to the inbox.
- Safe local `next` targets still redirect after successful auth.
- `/register?next=/\\attacker.example/path` and `/register?next=/%5Cattacker.example/path` are not stashed in the session.

## Known risks
Low. This rejects backslash and control-character post-auth redirect targets, which are not expected legitimate local post-auth destinations.