### PR TITLE
Let admin broadcasts skip incompatible recipient keys

### DIFF
--- a/assets/js/admin-broadcasts.js
+++ b/assets/js/admin-broadcasts.js
@@ -51,11 +51,19 @@ function recipients() {
 
 async function encryptMessage(publicKeys, message) {
   const keys = Array.isArray(publicKeys) ? publicKeys : [publicKeys];
-  const encryptionKeys = await Promise.all(
+  const parsedKeys = await Promise.all(
     keys
       .filter((key) => typeof key === "string" && key.trim())
-      .map((armoredKey) => openpgp.readKey({ armoredKey })),
+      .map(async (armoredKey) => {
+        try {
+          return await openpgp.readKey({ armoredKey });
+        } catch (error) {
+          console.error("Skipping unusable recipient encryption key.", error);
+          return null;
+        }
+      }),
   );
+  const encryptionKeys = parsedKeys.filter(Boolean);
   if (encryptionKeys.length === 0) {
     throw new Error("Recipient encryption keys are missing.");
   }
@@ -101,8 +109,11 @@ document.addEventListener("DOMContentLoaded", function () {
     const payloadTarget = payloadTargetId
       ? document.getElementById(payloadTargetId)
       : null;
+    const failureTarget = form.querySelector(
+      "input[name='encryption_failures']",
+    );
     const recipientEntries = recipients();
-    if (!payloadTarget || recipientEntries.length === 0) {
+    if (!payloadTarget || !failureTarget || recipientEntries.length === 0) {
       alert("No users with PGP message keys match this audience.");
       return;
     }
@@ -118,15 +129,28 @@ document.addEventListener("DOMContentLoaded", function () {
       }
 
       const encryptedPayloads = {};
+      const encryptionFailures = [];
       await Promise.all(
         recipientEntries.map(async (recipient) => {
-          encryptedPayloads[recipient.user_id] = await encryptMessage(
-            recipient.public_keys,
-            body,
-          );
+          try {
+            encryptedPayloads[recipient.user_id] = await encryptMessage(
+              recipient.public_keys,
+              body,
+            );
+          } catch (error) {
+            encryptionFailures.push(recipient.user_id);
+            console.error(
+              `Broadcast encryption failed for user ${recipient.user_id}.`,
+              error,
+            );
+          }
         }),
       );
+      if (Object.keys(encryptedPayloads).length === 0) {
+        throw new Error("No recipient messages could be encrypted.");
+      }
       payloadTarget.value = JSON.stringify(encryptedPayloads);
+      failureTarget.value = JSON.stringify(encryptionFailures);
       plaintext.value = "";
 
       const submitIntent = document.createElement("input");
@@ -137,8 +161,11 @@ document.addEventListener("DOMContentLoaded", function () {
       form.submit();
     } catch (error) {
       console.error("Broadcast encryption failed.", error);
-      alert("Message encryption failed. No messages were submitted.");
+      alert(
+        `Message encryption failed: ${error.message} No messages were submitted.`,
+      );
       payloadTarget.value = "";
+      failureTarget.value = "";
       form.dataset.encryptionInProgress = "false";
       setButtonsDisabled(form, false);
     }

--- a/hushline/settings/broadcast.py
+++ b/hushline/settings/broadcast.py
@@ -1,8 +1,18 @@
 import json
+import threading
 from dataclasses import dataclass
 from typing import cast
 
-from flask import Blueprint, flash, redirect, render_template, request, session, url_for
+from flask import (
+    Blueprint,
+    current_app,
+    flash,
+    redirect,
+    render_template,
+    request,
+    session,
+    url_for,
+)
 from flask_wtf import FlaskForm
 from sqlalchemy import and_, exists, or_
 from sqlalchemy.orm import selectinload
@@ -14,7 +24,6 @@ from hushline.auth import admin_authentication_required
 from hushline.db import db
 from hushline.forms import Button
 from hushline.model import (
-    ChatKey,
     FieldDefinition,
     FieldValue,
     Message,
@@ -28,6 +37,7 @@ BROADCAST_SEND_SUBMIT = "send_broadcast"
 
 class AdminBroadcastForm(FlaskForm):
     encrypted_payloads = HiddenField("Encrypted payloads")
+    encryption_failures = HiddenField("Encryption failures")
     confirm_send = BooleanField(
         "I understand this will create encrypted inbox submissions for all eligible users above."
     )
@@ -46,14 +56,6 @@ class BroadcastAudience:
             if user.primary_username is not None
             and user.message_encryption_target
             and _message_field_for(user) is not None
-        ]
-
-    @property
-    def chat_only_users(self) -> list[User]:
-        return [
-            user
-            for user in self.target_users
-            if user.active_chat_key is not None and not user.message_encryption_target
         ]
 
     @property
@@ -81,13 +83,6 @@ class BroadcastAudience:
         return recipients
 
 
-def _active_chat_key_exists() -> ColumnElement[bool]:
-    return cast(
-        ColumnElement[bool],
-        exists().where(and_(ChatKey.user_id == User.id, ChatKey.disabled_at.is_(None))),
-    )
-
-
 def _recipient_pgp_key_exists() -> ColumnElement[bool]:
     return cast(
         ColumnElement[bool],
@@ -104,8 +99,7 @@ def _recipient_pgp_key_exists() -> ColumnElement[bool]:
 def _audience_predicate() -> ColumnElement[bool]:
     has_pgp_key = User._pgp_key.is_not(None)
     has_recipient_pgp_key = _recipient_pgp_key_exists()
-    has_chat_key = _active_chat_key_exists()
-    return and_(User.is_suspended.is_(False), or_(has_pgp_key, has_recipient_pgp_key, has_chat_key))
+    return and_(User.is_suspended.is_(False), or_(has_pgp_key, has_recipient_pgp_key))
 
 
 def _load_audience() -> BroadcastAudience:
@@ -115,7 +109,6 @@ def _load_audience() -> BroadcastAudience:
             .where(_audience_predicate())
             .options(
                 selectinload(User.notification_recipients),
-                selectinload(User.chat_keys),
                 selectinload(User.primary_username),
             )
             .order_by(User.id)
@@ -160,6 +153,23 @@ def _encrypted_payloads_by_user(raw_payloads: str) -> dict[int, str]:
     return encrypted_payloads
 
 
+def _encryption_failure_user_ids(raw_failures: str) -> set[int]:
+    try:
+        failures = json.loads(raw_failures)
+    except json.JSONDecodeError:
+        return set()
+    if not isinstance(failures, list):
+        return set()
+
+    failed_user_ids: set[int] = set()
+    for user_id in failures:
+        try:
+            failed_user_ids.add(int(user_id))
+        except (TypeError, ValueError):
+            continue
+    return failed_user_ids
+
+
 def _message_field_for(user: User) -> FieldDefinition | None:
     username = user.primary_username
     if username is None:
@@ -174,7 +184,7 @@ def _submit_encrypted_broadcast_messages(
     users: list[User], encrypted_payloads: dict[int, str]
 ) -> int:
     submitted_count = 0
-    submitted_user_ids: set[int] = set()
+    submitted_notification_user_ids: list[int] = []
     for user in users:
         encrypted_payload = encrypted_payloads.get(user.id)
         field_definition = _message_field_for(user)
@@ -188,17 +198,45 @@ def _submit_encrypted_broadcast_messages(
         db.session.flush()
         db.session.add(FieldValue(field_definition, message, encrypted_payload, True))
         submitted_count += 1
-        submitted_user_ids.add(user.id)
+        submitted_notification_user_ids.append(user.id)
 
     if submitted_count:
         db.session.commit()
-
-    notification_body = "You have a new Hush Line message! Please log in to read it."
-    for user in users:
-        if user.id in submitted_user_ids:
-            do_send_email(user, notification_body)
+        _queue_broadcast_notification_emails(tuple(submitted_notification_user_ids))
 
     return submitted_count
+
+
+def _send_broadcast_notification_emails(user_ids: tuple[int, ...]) -> None:
+    notification_body = "You have a new Hush Line message! Please log in to read it."
+    users = list(
+        db.session.scalars(
+            db.select(User)
+            .where(User.id.in_(user_ids))
+            .options(selectinload(User.notification_recipients))
+            .order_by(User.id)
+        ).all()
+    )
+    for user in users:
+        do_send_email(user, notification_body)
+
+
+def _queue_broadcast_notification_emails(user_ids: tuple[int, ...]) -> None:
+    app = current_app._get_current_object()
+
+    def send_notifications() -> None:
+        with app.app_context():
+            try:
+                _send_broadcast_notification_emails(user_ids)
+            finally:
+                db.session.remove()
+
+    thread = threading.Thread(
+        target=send_notifications,
+        name="hushline-admin-broadcast-notifications",
+        daemon=True,
+    )
+    thread.start()
 
 
 def register_broadcast_routes(bp: Blueprint) -> None:
@@ -228,18 +266,37 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                         encrypted_payloads = _encrypted_payloads_by_user(
                             form.encrypted_payloads.data or ""
                         )
+                        failed_user_ids = _encryption_failure_user_ids(
+                            form.encryption_failures.data or ""
+                        )
                         expected_user_ids = {
                             user.id for user in audience.encrypted_submission_users
                         }
-                        if set(encrypted_payloads) != expected_user_ids:
+                        submitted_user_ids = set(encrypted_payloads)
+                        if not submitted_user_ids:
+                            form.encrypted_payloads.errors.append(
+                                "No recipient messages could be encrypted."
+                            )
+                            status_code = 400
+                        elif submitted_user_ids & failed_user_ids:
+                            form.encrypted_payloads.errors.append(
+                                "Encrypted payloads conflict with reported encryption failures."
+                            )
+                            status_code = 400
+                        elif submitted_user_ids | failed_user_ids != expected_user_ids:
                             form.encrypted_payloads.errors.append(
                                 "Encrypted payloads are missing or incomplete."
                             )
                             status_code = 400
                         else:
+                            submitted_users = [
+                                user
+                                for user in audience.encrypted_submission_users
+                                if user.id in submitted_user_ids
+                            ]
                             try:
                                 submitted_count = _submit_encrypted_broadcast_messages(
-                                    audience.encrypted_submission_users,
+                                    submitted_users,
                                     encrypted_payloads,
                                 )
                             except ValueError:
@@ -255,10 +312,21 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                     audience=audience,
                                     encryption_recipients=audience.encryption_recipients,
                                 ), status_code
-                            flash(
-                                f"Encrypted messages submitted to {submitted_count} users.",
-                                "success",
-                            )
+                            skipped_count = len(failed_user_ids)
+                            if skipped_count:
+                                flash(
+                                    (
+                                        "Encrypted messages submitted to "
+                                        f"{submitted_count} users. Skipped {skipped_count} "
+                                        "users whose keys could not be used in this browser."
+                                    ),
+                                    "warning",
+                                )
+                            else:
+                                flash(
+                                    f"Encrypted messages submitted to {submitted_count} users.",
+                                    "success",
+                                )
                             return redirect(url_for(".broadcasts"))
             else:
                 status_code = 400

--- a/hushline/templates/settings/broadcasts.html
+++ b/hushline/templates/settings/broadcasts.html
@@ -13,7 +13,7 @@
 {% block settings_content %}
   <h3>Broadcasts</h3>
   <p>
-    Submit an encrypted administrative update to every eligible recipient.
+    Submit an encrypted administrative update to every eligible message-key recipient.
   </p>
 
   <div class="admin-highlights broadcast-summary">
@@ -24,10 +24,6 @@
     <div class="metric">
       <p>Encrypted Submissions</p>
       <p>{{ audience.encrypted_submission_users|length }}</p>
-    </div>
-    <div class="metric">
-      <p>Chat Key Only</p>
-      <p>{{ audience.chat_only_users|length }}</p>
     </div>
     <div class="metric">
       <p>Notification Emails</p>
@@ -46,6 +42,7 @@
       data-encrypted-payload-target="{{ form.encrypted_payloads.id }}"
     ></textarea>
     {{ form.encrypted_payloads }}
+    {{ form.encryption_failures }}
     {{ field_errors(form.encrypted_payloads) }}
 
     <div class="checkbox-group">

--- a/tests/playwright/e2ee/client-side-encryption.spec.js
+++ b/tests/playwright/e2ee/client-side-encryption.spec.js
@@ -218,6 +218,98 @@ test("JS-enabled profile submissions encrypt fields before the POST leaves the b
   expect(encryptedEmailBody).not.toContain(messagePlaintext);
 });
 
+test("admin broadcasts encrypt usable recipients and report malformed keys before POST", async ({
+  page,
+}) => {
+  const broadcastPlaintext =
+    "P0 frontend e2ee admin broadcast sentinel for chat launch";
+  let capturedPostBody = null;
+  const dialogs = [];
+
+  page.on("dialog", async (dialog) => {
+    dialogs.push(dialog.message());
+    await dialog.dismiss();
+  });
+  page.on("request", (request) => {
+    if (
+      request.method() === "POST" &&
+      request.url().endsWith("/settings/broadcasts")
+    ) {
+      capturedPostBody = request.postData() || "";
+    }
+  });
+
+  await login(page, "admin");
+  await page.goto("/settings/broadcasts", { waitUntil: "networkidle" });
+  await expect(
+    page.locator("form[data-admin-broadcast-form='true']"),
+  ).toBeVisible();
+  await expect(
+    page.locator('script[src$="/static/js/admin-broadcasts.js"]'),
+  ).toHaveCount(1);
+  await expect
+    .poll(() => page.evaluate(() => window.isSecureContext))
+    .toBe(true);
+
+  const { failedRecipientId, mixedRecipientId } = await page.evaluate(() => {
+    const script = document.getElementById("broadcastEncryptionRecipients");
+    const recipients = JSON.parse(script.textContent || "[]");
+    if (recipients.length < 2) {
+      throw new Error(
+        "Admin broadcast E2EE test requires at least two recipients.",
+      );
+    }
+    const fallbackKey = recipients[1].public_keys.find(
+      (key) => typeof key === "string" && key.trim(),
+    );
+    if (!fallbackKey) {
+      throw new Error("Admin broadcast E2EE test requires a fallback key.");
+    }
+    recipients[0].public_keys = ["not armored pgp", fallbackKey];
+    recipients[1].public_keys = ["not armored pgp"];
+    script.textContent = JSON.stringify(recipients);
+    return {
+      failedRecipientId: recipients[1].user_id,
+      mixedRecipientId: recipients[0].user_id,
+    };
+  });
+
+  await page.fill("#broadcast_plaintext", broadcastPlaintext);
+  await page.check("input[name='confirm_send']");
+
+  await Promise.all([
+    page.waitForRequest(
+      (request) =>
+        request.method() === "POST" &&
+        request.url().endsWith("/settings/broadcasts"),
+    ),
+    page.locator("[name='send_broadcast']").click(),
+  ]);
+
+  expect(dialogs).toEqual([]);
+  expect(capturedPostBody).toBeTruthy();
+  expect(capturedPostBody).not.toContain(broadcastPlaintext);
+
+  const encryptedPayloads = JSON.parse(
+    formValueFromPostBody(capturedPostBody, "encrypted_payloads"),
+  );
+  const encryptionFailures = JSON.parse(
+    formValueFromPostBody(capturedPostBody, "encryption_failures"),
+  );
+
+  expect(encryptionFailures).toContain(failedRecipientId);
+  expect(encryptionFailures).not.toContain(mixedRecipientId);
+  expect(Object.keys(encryptedPayloads)).toContain(String(mixedRecipientId));
+  expect(Object.keys(encryptedPayloads)).not.toContain(
+    String(failedRecipientId),
+  );
+  expect(Object.values(encryptedPayloads).length).toBeGreaterThan(0);
+  for (const encryptedPayload of Object.values(encryptedPayloads)) {
+    expect(encryptedPayload).toContain(PGP_ARMOR_HEADER);
+    expectNoPlaintext(encryptedPayload, [broadcastPlaintext]);
+  }
+});
+
 test("logged-in account conversation stays encrypted through browser lifecycle", async ({
   browser,
 }) => {

--- a/tests/test_admin_broadcasts.py
+++ b/tests/test_admin_broadcasts.py
@@ -8,6 +8,7 @@ from flask.testing import FlaskClient
 
 from hushline.db import db
 from hushline.model import ChatKey, Message, User
+from hushline.settings.broadcast import _send_broadcast_notification_emails
 
 ARMORED_BROADCAST = (
     "-----BEGIN PGP MESSAGE-----\n" "\n" "encrypted admin message\n" "-----END PGP MESSAGE-----"
@@ -62,9 +63,8 @@ def test_broadcasts_lists_default_audience_counts(
     summary_text = " ".join(
         summary.get_text(" ", strip=True) for summary in soup.select(".broadcast-summary .metric")
     )
-    assert "Audience Users 2" in summary_text
+    assert "Audience Users 1" in summary_text
     assert "Encrypted Submissions 1" in summary_text
-    assert "Chat Key Only 1" in summary_text
     assert "Notification Emails 1" in summary_text
     nav = soup.select_one("nav.settings-tabs")
     assert nav is not None
@@ -201,7 +201,35 @@ def test_broadcasts_rejects_missing_encrypted_payloads(
     )
 
     assert response.status_code == 400
-    assert "Encrypted payloads are missing or incomplete." in response.text
+    assert "No recipient messages could be encrypted." in response.text
+    send_email.assert_not_called()
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 0
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_rejects_conflicting_encryption_failures(
+    client: FlaskClient,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    _enable_notification_email(user, "primary@example.com")
+    db.session.commit()
+    send_email = MagicMock()
+    monkeypatch.setattr("hushline.settings.broadcast.do_send_email", send_email)
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "encryption_failures": json.dumps([user.id]),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 400
+    assert "Encrypted payloads conflict with reported encryption failures." in response.text
     send_email.assert_not_called()
     assert db.session.scalar(db.select(db.func.count(Message.id))) == 0
 
@@ -217,8 +245,11 @@ def test_broadcasts_submit_encrypted_inbox_messages_for_pgp_targets(
     _enable_notification_email(user, "primary@example.com")
     _add_chat_key(user2)
     db.session.commit()
-    send_email = MagicMock()
-    monkeypatch.setattr("hushline.settings.broadcast.do_send_email", send_email)
+    queue_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._queue_broadcast_notification_emails",
+        queue_notifications,
+    )
 
     response = client.post(
         url_for("settings.broadcasts"),
@@ -235,9 +266,46 @@ def test_broadcasts_submit_encrypted_inbox_messages_for_pgp_targets(
     assert messages[0].username_id == user.primary_username.id
     assert messages[0].field_values[0].encrypted is True
     assert messages[0].field_values[0].value == ARMORED_BROADCAST
-    send_email.assert_called_once_with(
-        user, "You have a new Hush Line message! Please log in to read it."
+    queue_notifications.assert_called_once_with((user.id,))
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_submits_successes_when_some_recipients_fail_browser_encryption(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    _enable_notification_email(user, "primary@example.com")
+    user2.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    _enable_notification_email(user2, "secondary@example.com")
+    db.session.commit()
+    queue_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._queue_broadcast_notification_emails",
+        queue_notifications,
     )
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "encryption_failures": json.dumps([user2.id]),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert "Encrypted messages submitted to 1 users. Skipped 1 users" in response.text
+    messages = db.session.scalars(db.select(Message).order_by(Message.id)).all()
+    assert len(messages) == 1
+    assert messages[0].username_id == user.primary_username.id
+    assert messages[0].field_values[0].encrypted is True
+    assert messages[0].field_values[0].value == ARMORED_BROADCAST
+    queue_notifications.assert_called_once_with((user.id,))
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")
@@ -253,8 +321,11 @@ def test_broadcasts_submit_to_recipient_key_only_users(
         "-----BEGIN PGP PUBLIC KEY BLOCK-----\nrecipient\n-----END PGP PUBLIC KEY BLOCK-----"
     )
     db.session.commit()
-    send_email = MagicMock()
-    monkeypatch.setattr("hushline.settings.broadcast.do_send_email", send_email)
+    queue_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._queue_broadcast_notification_emails",
+        queue_notifications,
+    )
 
     response = client.post(
         url_for("settings.broadcasts"),
@@ -271,6 +342,40 @@ def test_broadcasts_submit_to_recipient_key_only_users(
     assert messages[0].username_id == user.primary_username.id
     assert messages[0].field_values[0].encrypted is True
     assert messages[0].field_values[0].value == ARMORED_BROADCAST
+    queue_notifications.assert_called_once_with((user.id,))
+
+
+def test_send_broadcast_notification_emails_sends_generic_email(
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _enable_notification_email(user, "primary@example.com")
+    db.session.commit()
+    send_email = MagicMock()
+    monkeypatch.setattr("hushline.settings.broadcast.do_send_email", send_email)
+
+    _send_broadcast_notification_emails((user.id,))
+
+    send_email.assert_called_once_with(
+        user, "You have a new Hush Line message! Please log in to read it."
+    )
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_excludes_chat_key_only_users_until_chat_broadcasts_exist(
+    client: FlaskClient,
+    user: User,
+) -> None:
+    _add_chat_key(user)
+    db.session.commit()
+
+    response = client.get(url_for("settings.broadcasts"))
+
+    assert response.status_code == 200
+    summary_text = BeautifulSoup(response.text, "html.parser").get_text(" ", strip=True)
+    assert "Audience Users 0" in summary_text
+    assert "Encrypted Submissions 0" in summary_text
+    assert "Chat Key Only" not in summary_text
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")


### PR DESCRIPTION
## What changed

- Updated admin broadcast client-side encryption so one malformed or incompatible recipient key does not fail the entire broadcast.
- Parse each public key independently, so a recipient with one stale key and one usable key still receives the broadcast encrypted to the usable subset.
- Added an `encryption_failures` hidden field so the browser can report recipients for whom no usable message key remained.
- Updated the server-side broadcast route to accept partial success only when every deliverable message-key recipient is accounted for by either an encrypted payload or a reported encryption failure.
- Clarified the UI audience to message-key recipients only. Chat-key-only users are no longer counted as deliverable by this inbox-message broadcast path, because chat delivery requires browser-generated chat conversation envelopes.
- Moved notification email dispatch out of the admin POST path into a post-commit background dispatch helper.
- Added Flask tests for conflict rejection, partial-success broadcast submission, chat-key-only exclusion, and notification dispatch.
- Added a Playwright E2EE regression test that verifies mixed good/bad keys on the same recipient still produce a ciphertext while an all-bad recipient is reported as skipped.

## Why

The production failure was caused by OpenPGP.js rejecting at least one stored recipient key with `Misformed armored text`. The previous client used `Promise.all` over the whole audience, so a single incompatible key rejected the full broadcast and no messages were submitted. The first fix narrowed failure to a recipient; this update narrows it further to individual keys within each recipient.

## Access model

This remains an existing admin-only feature using `user.is_admin`. There is no new Super Admin role in this PR.

## Security notes

- E2EE is preserved: plaintext stays browser-side and is cleared before submit.
- The server still rejects missing, conflicting, or incomplete encryption reports.
- Successful recipients receive normal encrypted inbox submissions and generic notification-only emails.
- Recipients with no usable message key are skipped and surfaced in the admin flash message.
- Chat-key-only broadcast delivery is intentionally not faked server-side; it needs a future client-side chat-envelope implementation to preserve chat E2EE.

## Validation

- `docker compose run --rm app poetry run pytest tests/test_admin_broadcasts.py tests/test_security_headers.py::test_admin_broadcast_page_keeps_csp_enforced -q` - passed, 16 tests.
- `npx playwright test --config=playwright.e2ee.config.js -g "admin broadcasts encrypt usable recipients and report malformed keys before POST"` - passed.
- `docker compose run --rm app poetry run mypy hushline/settings/broadcast.py tests/test_admin_broadcasts.py` - passed.
- `docker compose run --rm app poetry run ruff format --check hushline/settings/broadcast.py tests/test_admin_broadcasts.py && docker compose run --rm app poetry run ruff check hushline/settings/broadcast.py tests/test_admin_broadcasts.py --output-format full` - passed.
- `npx prettier --check assets/js/admin-broadcasts.js tests/playwright/e2ee/client-side-encryption.spec.js` - passed.
- `make audit-python` - passed, no known vulnerabilities found.
- `make audit-node-runtime` - passed, found 0 vulnerabilities.
- Earlier `make lint` run before this last update: Ruff format/check and mypy passed; final Prettier step failed on pre-existing unstaged generated files `hushline/static/js/directory_verified.js` and `hushline/static/js/settings-location.js`, which are intentionally not included in this PR.

## Manual testing

- Navigate as an admin to `/settings/broadcasts`.
- Submit a broadcast with one incompatible recipient key present.
- Verify compatible message-key recipients receive encrypted inbox messages and generic notification emails.
- Verify incompatible keys are skipped without blocking all compatible message-key recipients.