### PR TITLE
Chunk admin broadcast submissions

### DIFF
--- a/assets/js/admin-broadcasts.js
+++ b/assets/js/admin-broadcasts.js
@@ -1,5 +1,7 @@
 import * as openpgp from "openpgp";
 
+const BROADCAST_BATCH_SIZE = 10;
+
 function assertClientCryptoSupport() {
   if (!window.isSecureContext) {
     throw new Error("Encryption requires a secure browser context.");
@@ -49,6 +51,19 @@ function recipients() {
   }
 }
 
+function expectedRecipientIds() {
+  const input = document.getElementById("broadcast_expected_user_ids");
+  if (!input?.value) {
+    return [];
+  }
+  try {
+    const parsed = JSON.parse(input.value);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
 async function encryptMessage(publicKeys, message) {
   const keys = Array.isArray(publicKeys) ? publicKeys : [publicKeys];
   const parsedKeys = await Promise.all(
@@ -92,9 +107,73 @@ function setButtonsDisabled(form, disabled) {
     });
 }
 
+function updateStatus(status, message) {
+  if (!status) {
+    return;
+  }
+  status.hidden = false;
+  status.textContent = message;
+}
+
+function progressPercent(completedCount, totalCount) {
+  if (totalCount <= 0) {
+    return 100;
+  }
+  return Math.min(
+    99,
+    Math.max(1, Math.floor((completedCount / totalCount) * 100)),
+  );
+}
+
+async function submitBroadcastBatch(
+  form,
+  encryptedPayloads,
+  encryptionFailures,
+  expectedUserIds,
+  completedUserIds,
+  isFinalChunk,
+) {
+  const formData = new FormData(form);
+  formData.set("broadcast_chunk", "1");
+  formData.set("encrypted_payloads", JSON.stringify(encryptedPayloads));
+  formData.set("encryption_failures", JSON.stringify(encryptionFailures));
+  formData.set("broadcast_expected_user_ids", JSON.stringify(expectedUserIds));
+  formData.set(
+    "broadcast_completed_user_ids",
+    JSON.stringify(completedUserIds),
+  );
+  formData.set("broadcast_final_chunk", isFinalChunk ? "1" : "0");
+  formData.set("send_broadcast", "Submit Messages");
+
+  const response = await fetch(form.action || window.location.href, {
+    method: form.method || "POST",
+    credentials: "same-origin",
+    headers: {
+      Accept: "application/json",
+    },
+    body: formData,
+  });
+  const contentType = response.headers.get("content-type") || "";
+  if (response.redirected || !contentType.includes("application/json")) {
+    throw new Error(
+      "Broadcast session changed. Sign in again before continuing.",
+    );
+  }
+  const payload = await response.json();
+  if (
+    !response.ok ||
+    !Number.isInteger(payload.submitted_count) ||
+    !Number.isInteger(payload.skipped_count)
+  ) {
+    throw new Error(payload.error || "Broadcast batch submission failed.");
+  }
+  return payload;
+}
+
 document.addEventListener("DOMContentLoaded", function () {
   const form = document.querySelector("form[data-admin-broadcast-form='true']");
   const plaintext = document.getElementById("broadcast_plaintext");
+  const status = document.getElementById("broadcast_status");
   if (!form || !plaintext) {
     return;
   }
@@ -116,6 +195,7 @@ document.addEventListener("DOMContentLoaded", function () {
       "input[name='encryption_failures']",
     );
     const recipientEntries = recipients();
+    const expectedUserIds = expectedRecipientIds();
     if (!payloadTarget || !failureTarget || recipientEntries.length === 0) {
       alert("No users with PGP message keys match this audience.");
       return;
@@ -124,53 +204,118 @@ document.addEventListener("DOMContentLoaded", function () {
     form.dataset.encryptionInProgress = "true";
     setButtonsDisabled(form, true);
 
+    let submittedCount = 0;
+    let skippedCount = 0;
+    let batchRequestStarted = false;
     try {
+      if (
+        typeof window.fetch !== "function" ||
+        typeof window.FormData === "undefined"
+      ) {
+        throw new Error(
+          "Batch submission requires Fetch and FormData support.",
+        );
+      }
       assertClientCryptoSupport();
       const body = plaintext.value.trim();
       if (body.length < 10) {
         throw new Error("Message must be at least 10 characters.");
       }
 
-      const encryptedPayloads = {};
-      const encryptionFailures = [];
-      await Promise.all(
-        recipientEntries.map(async (recipient) => {
-          try {
-            encryptedPayloads[recipient.user_id] = await encryptMessage(
-              recipient.public_keys,
-              body,
-            );
-          } catch (error) {
-            encryptionFailures.push(recipient.user_id);
-            console.error(
-              `Broadcast encryption failed for user ${recipient.user_id}.`,
-              error,
-            );
-          }
-        }),
-      );
-      if (Object.keys(encryptedPayloads).length === 0) {
+      let completedCount = 0;
+      const completedUserIds = [];
+
+      updateStatus(status, "Sending broadcast: 1% complete...");
+      for (
+        let index = 0;
+        index < recipientEntries.length;
+        index += BROADCAST_BATCH_SIZE
+      ) {
+        const batch = recipientEntries.slice(
+          index,
+          index + BROADCAST_BATCH_SIZE,
+        );
+        const encryptedPayloads = {};
+        const encryptionFailures = [];
+
+        await Promise.all(
+          batch.map(async (recipient) => {
+            try {
+              encryptedPayloads[recipient.user_id] = await encryptMessage(
+                recipient.public_keys,
+                body,
+              );
+            } catch (error) {
+              encryptionFailures.push(recipient.user_id);
+              console.error(
+                `Broadcast encryption failed for user ${recipient.user_id}.`,
+                error,
+              );
+            }
+          }),
+        );
+
+        if (
+          Object.keys(encryptedPayloads).length === 0 &&
+          encryptionFailures.length === 0
+        ) {
+          throw new Error("No recipient messages could be encrypted.");
+        }
+
+        completedUserIds.push(...batch.map((recipient) => recipient.user_id));
+        const isFinalChunk =
+          index + BROADCAST_BATCH_SIZE >= recipientEntries.length;
+        batchRequestStarted = true;
+        const result = await submitBroadcastBatch(
+          form,
+          encryptedPayloads,
+          encryptionFailures,
+          expectedUserIds,
+          completedUserIds,
+          isFinalChunk,
+        );
+        submittedCount += Number(result.submitted_count || 0);
+        skippedCount += Number(result.skipped_count || 0);
+        completedCount += batch.length;
+        updateStatus(
+          status,
+          `Sending broadcast: ${progressPercent(
+            completedCount,
+            recipientEntries.length,
+          )}% complete...`,
+        );
+      }
+
+      if (submittedCount === 0) {
         throw new Error("No recipient messages could be encrypted.");
       }
-      payloadTarget.value = JSON.stringify(encryptedPayloads);
-      failureTarget.value = JSON.stringify(encryptionFailures);
-      plaintext.value = "";
 
-      const submitIntent = document.createElement("input");
-      submitIntent.type = "hidden";
-      submitIntent.name = "send_broadcast";
-      submitIntent.value = "Submit Messages";
-      form.appendChild(submitIntent);
-      form.submit();
+      plaintext.value = "";
+      payloadTarget.value = "";
+      failureTarget.value = "";
+      updateStatus(
+        status,
+        skippedCount
+          ? `Broadcast sent to ${submittedCount} users. Skipped ${skippedCount} users whose keys could not be used.`
+          : `Broadcast sent to ${submittedCount} users.`,
+      );
     } catch (error) {
       console.error("Broadcast encryption failed.", error);
       alert(
-        `Message encryption failed: ${error.message} No messages were submitted.`,
+        `Message encryption failed: ${error.message} No more messages were submitted.`,
       );
       payloadTarget.value = "";
       failureTarget.value = "";
-      form.dataset.encryptionInProgress = "false";
-      setButtonsDisabled(form, false);
+      if (batchRequestStarted) {
+        plaintext.value = "";
+        updateStatus(
+          status,
+          `Broadcast stopped after ${submittedCount} submitted and ${skippedCount} skipped. Do not retry from this page; refresh to review the current audience.`,
+        );
+      } else {
+        form.dataset.encryptionInProgress = "false";
+        setButtonsDisabled(form, false);
+      }
     }
   });
 });

--- a/hushline/settings/broadcast.py
+++ b/hushline/settings/broadcast.py
@@ -5,6 +5,7 @@ from typing import cast
 from flask import (
     Blueprint,
     flash,
+    jsonify,
     redirect,
     render_template,
     request,
@@ -31,6 +32,10 @@ from hushline.model import (
 from hushline.routes.common import do_send_email
 
 BROADCAST_SEND_SUBMIT = "send_broadcast"
+BROADCAST_CHUNK_FIELD = "broadcast_chunk"
+BROADCAST_COMPLETED_IDS_FIELD = "broadcast_completed_user_ids"
+BROADCAST_EXPECTED_IDS_FIELD = "broadcast_expected_user_ids"
+BROADCAST_FINAL_CHUNK_FIELD = "broadcast_final_chunk"
 
 
 class AdminBroadcastForm(FlaskForm):
@@ -152,20 +157,24 @@ def _encrypted_payloads_by_user(raw_payloads: str) -> dict[int, str]:
 
 
 def _encryption_failure_user_ids(raw_failures: str) -> set[int]:
+    return _user_ids_from_json(raw_failures)
+
+
+def _user_ids_from_json(raw_user_ids: str) -> set[int]:
     try:
-        failures = json.loads(raw_failures)
+        user_ids = json.loads(raw_user_ids)
     except json.JSONDecodeError:
         return set()
-    if not isinstance(failures, list):
+    if not isinstance(user_ids, list):
         return set()
 
-    failed_user_ids: set[int] = set()
-    for user_id in failures:
+    parsed_user_ids: set[int] = set()
+    for user_id in user_ids:
         try:
-            failed_user_ids.add(int(user_id))
+            parsed_user_ids.add(int(user_id))
         except (TypeError, ValueError):
             continue
-    return failed_user_ids
+    return parsed_user_ids
 
 
 def _message_field_for(user: User) -> FieldDefinition | None:
@@ -219,24 +228,37 @@ def _send_broadcast_notification_emails(user_ids: tuple[int, ...]) -> None:
         do_send_email(user, notification_body)
 
 
+def _json_broadcast_error(message: str) -> tuple[Response, int]:
+    return jsonify({"error": message}), 400
+
+
 def register_broadcast_routes(bp: Blueprint) -> None:
     @bp.route("/broadcasts", methods=["GET", "POST"])
     @admin_authentication_required
-    def broadcasts() -> tuple[str, int] | Response:
+    def broadcasts() -> tuple[str, int] | tuple[Response, int] | Response:
         user = db.session.scalars(db.select(User).filter_by(id=session["user_id"])).one()
         form = AdminBroadcastForm()
         status_code = 200
         audience = _load_audience()
 
         if request.method == "POST":
+            chunked_broadcast = request.form.get(BROADCAST_CHUNK_FIELD) == "1"
             if form.validate():
                 if BROADCAST_SEND_SUBMIT in request.form:
                     if not form.confirm_send.data:
+                        if chunked_broadcast:
+                            return _json_broadcast_error(
+                                "Confirm before submitting these encrypted messages."
+                            )
                         form.confirm_send.errors.append(
                             "Confirm before submitting these encrypted messages."
                         )
                         status_code = 400
                     elif not audience.encrypted_submission_users:
+                        if chunked_broadcast:
+                            return _json_broadcast_error(
+                                "No eligible encrypted message recipients match this audience."
+                            )
                         flash(
                             "No eligible encrypted message recipients match this audience.",
                             "error",
@@ -253,17 +275,68 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                             user.id for user in audience.encrypted_submission_users
                         }
                         submitted_user_ids = set(encrypted_payloads)
-                        if not submitted_user_ids:
+                        expected_chunk_user_ids = _user_ids_from_json(
+                            request.form.get(BROADCAST_EXPECTED_IDS_FIELD, "")
+                        )
+                        completed_chunk_user_ids = _user_ids_from_json(
+                            request.form.get(BROADCAST_COMPLETED_IDS_FIELD, "")
+                        )
+                        final_chunk = request.form.get(BROADCAST_FINAL_CHUNK_FIELD) == "1"
+                        if not submitted_user_ids and not (chunked_broadcast and failed_user_ids):
+                            if chunked_broadcast:
+                                return _json_broadcast_error(
+                                    "No recipient messages could be encrypted."
+                                )
                             form.encrypted_payloads.errors.append(
                                 "No recipient messages could be encrypted."
                             )
                             status_code = 400
                         elif submitted_user_ids & failed_user_ids:
+                            if chunked_broadcast:
+                                return _json_broadcast_error(
+                                    "Encrypted payloads conflict with reported encryption failures."
+                                )
                             form.encrypted_payloads.errors.append(
                                 "Encrypted payloads conflict with reported encryption failures."
                             )
                             status_code = 400
-                        elif submitted_user_ids | failed_user_ids != expected_user_ids:
+                        elif chunked_broadcast and expected_chunk_user_ids != expected_user_ids:
+                            return _json_broadcast_error(
+                                "Broadcast audience changed. Refresh and try again."
+                            )
+                        elif not (submitted_user_ids | failed_user_ids).issubset(expected_user_ids):
+                            if chunked_broadcast:
+                                return _json_broadcast_error(
+                                    "Encrypted payloads include unknown recipients."
+                                )
+                            form.encrypted_payloads.errors.append(
+                                "Encrypted payloads include unknown recipients."
+                            )
+                            status_code = 400
+                        elif chunked_broadcast and not completed_chunk_user_ids.issubset(
+                            expected_user_ids
+                        ):
+                            return _json_broadcast_error(
+                                "Broadcast completion includes unknown recipients."
+                            )
+                        elif chunked_broadcast and not (
+                            submitted_user_ids | failed_user_ids
+                        ).issubset(completed_chunk_user_ids):
+                            return _json_broadcast_error(
+                                "Broadcast completion is missing submitted recipients."
+                            )
+                        elif (
+                            chunked_broadcast
+                            and final_chunk
+                            and completed_chunk_user_ids != expected_user_ids
+                        ):
+                            return _json_broadcast_error(
+                                "Broadcast batches are incomplete. Refresh and try again."
+                            )
+                        elif (
+                            not chunked_broadcast
+                            and submitted_user_ids | failed_user_ids != expected_user_ids
+                        ):
                             form.encrypted_payloads.errors.append(
                                 "Encrypted payloads are missing or incomplete."
                             )
@@ -285,6 +358,11 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                     "One or more recipients became ineligible before submission."
                                 )
                                 status_code = 400
+                                if chunked_broadcast:
+                                    return _json_broadcast_error(
+                                        "One or more recipients became ineligible "
+                                        "before submission."
+                                    )
                                 return render_template(
                                     "settings/broadcasts.html",
                                     user=user,
@@ -293,6 +371,13 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                     encryption_recipients=audience.encryption_recipients,
                                 ), status_code
                             skipped_count = len(failed_user_ids)
+                            if chunked_broadcast:
+                                return jsonify(
+                                    {
+                                        "submitted_count": submitted_count,
+                                        "skipped_count": skipped_count,
+                                    }
+                                )
                             if skipped_count:
                                 flash(
                                     (
@@ -309,6 +394,8 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                 )
                             return redirect(url_for(".broadcasts"))
             else:
+                if chunked_broadcast:
+                    return _json_broadcast_error("Invalid broadcast submission.")
                 status_code = 400
 
         return render_template(

--- a/hushline/templates/settings/broadcasts.html
+++ b/hushline/templates/settings/broadcasts.html
@@ -11,6 +11,7 @@
 {% endmacro %}
 
 {% block settings_content %}
+  {% set expected_recipient_ids = audience.encrypted_submission_users | map(attribute='id') | list %}
   <h3>Broadcasts</h3>
   <p>
     Submit an encrypted administrative update to every eligible message-key recipient.
@@ -43,6 +44,12 @@
     ></textarea>
     {{ form.encrypted_payloads }}
     {{ form.encryption_failures }}
+    <input
+      type="hidden"
+      id="broadcast_expected_user_ids"
+      name="broadcast_expected_user_ids"
+      value='{{ expected_recipient_ids | tojson }}'
+    >
     {{ field_errors(form.encrypted_payloads) }}
 
     <div class="checkbox-group">
@@ -50,6 +57,15 @@
       {{ form.confirm_send.label }}
     </div>
     {{ field_errors(form.confirm_send) }}
+
+    <div
+      id="broadcast_status"
+      class="flash-messages"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+      hidden
+    ></div>
 
     <div class="tableActions">
       {{ form.send(class="btn-danger") }}

--- a/tests/playwright/e2ee/client-side-encryption.spec.js
+++ b/tests/playwright/e2ee/client-side-encryption.spec.js
@@ -223,7 +223,7 @@ test("admin broadcasts encrypt usable recipients and report malformed keys befor
 }) => {
   const broadcastPlaintext =
     "P0 frontend e2ee admin broadcast sentinel for chat launch";
-  let capturedPostBody = null;
+  const capturedPostBodies = [];
   const dialogs = [];
 
   page.on("dialog", async (dialog) => {
@@ -235,7 +235,7 @@ test("admin broadcasts encrypt usable recipients and report malformed keys befor
       request.method() === "POST" &&
       request.url().endsWith("/settings/broadcasts")
     ) {
-      capturedPostBody = request.postData() || "";
+      capturedPostBodies.push(request.postData() || "");
     }
   });
 
@@ -286,7 +286,22 @@ test("admin broadcasts encrypt usable recipients and report malformed keys befor
     page.locator("[name='send_broadcast']").click(),
   ]);
 
+  await expect(page.locator("#broadcast_status")).toContainText(
+    "Broadcast sent to",
+  );
   expect(dialogs).toEqual([]);
+  const capturedPostBody = capturedPostBodies.find((postBody) => {
+    const encryptedPayloads = JSON.parse(
+      formValueFromPostBody(postBody, "encrypted_payloads") || "{}",
+    );
+    const encryptionFailures = JSON.parse(
+      formValueFromPostBody(postBody, "encryption_failures") || "[]",
+    );
+    return (
+      Object.keys(encryptedPayloads).includes(String(mixedRecipientId)) ||
+      encryptionFailures.includes(failedRecipientId)
+    );
+  });
   expect(capturedPostBody).toBeTruthy();
   expect(capturedPostBody).not.toContain(broadcastPlaintext);
 

--- a/tests/test_admin_broadcasts.py
+++ b/tests/test_admin_broadcasts.py
@@ -69,6 +69,8 @@ def test_broadcasts_lists_default_audience_counts(
     nav = soup.select_one("nav.settings-tabs")
     assert nav is not None
     assert nav.find("a", href=url_for("settings.broadcasts")) is not None
+    status = soup.select_one("#broadcast_status[role='status'][aria-live='polite']")
+    assert status is not None
     assert soup.find("select", {"name": "audience"}) is None
     assert soup.find("input", {"name": "subject"}) is None
     assert soup.find("textarea", {"name": "body"}) is None
@@ -267,6 +269,176 @@ def test_broadcasts_submit_encrypted_inbox_messages_for_pgp_targets(
     assert messages[0].field_values[0].encrypted is True
     assert messages[0].field_values[0].value == ARMORED_BROADCAST
     send_notifications.assert_called_once_with((user.id,))
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_submit_encrypted_chunk(
+    client: FlaskClient,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    _enable_notification_email(user, "primary@example.com")
+    db.session.commit()
+    send_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._send_broadcast_notification_emails",
+        send_notifications,
+    )
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id]),
+            "broadcast_final_chunk": "1",
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"submitted_count": 1, "skipped_count": 0}
+    messages = db.session.scalars(db.select(Message).order_by(Message.id)).all()
+    assert len(messages) == 1
+    assert messages[0].username_id == user.primary_username.id
+    assert messages[0].field_values[0].encrypted is True
+    assert messages[0].field_values[0].value == ARMORED_BROADCAST
+    send_notifications.assert_called_once_with((user.id,))
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_chunk_accepts_failure_only_batch(
+    client: FlaskClient,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    _enable_notification_email(user, "primary@example.com")
+    db.session.commit()
+    send_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._send_broadcast_notification_emails",
+        send_notifications,
+    )
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id]),
+            "broadcast_final_chunk": "1",
+            "encrypted_payloads": json.dumps({}),
+            "encryption_failures": json.dumps([user.id]),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {"submitted_count": 0, "skipped_count": 1}
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 0
+    send_notifications.assert_not_called()
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_chunk_rejects_unknown_recipients(
+    client: FlaskClient,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    _enable_notification_email(user, "primary@example.com")
+    db.session.commit()
+    send_email = MagicMock()
+    monkeypatch.setattr("hushline.settings.broadcast.do_send_email", send_email)
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id + 1000]),
+            "broadcast_expected_user_ids": json.dumps([user.id]),
+            "broadcast_final_chunk": "1",
+            "encrypted_payloads": json.dumps({str(user.id + 1000): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Encrypted payloads include unknown recipients."}
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 0
+    send_email.assert_not_called()
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_final_chunk_rejects_incomplete_completion(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    user2.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    db.session.commit()
+    send_email = MagicMock()
+    monkeypatch.setattr("hushline.settings.broadcast.do_send_email", send_email)
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id, user2.id]),
+            "broadcast_final_chunk": "1",
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Broadcast batches are incomplete. Refresh and try again."
+    }
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 0
+    send_email.assert_not_called()
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_chunk_rejects_stale_expected_audience(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    user2.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    db.session.commit()
+    send_email = MagicMock()
+    monkeypatch.setattr("hushline.settings.broadcast.do_send_email", send_email)
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id]),
+            "broadcast_final_chunk": "1",
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {"error": "Broadcast audience changed. Refresh and try again."}
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 0
+    send_email.assert_not_called()
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")


### PR DESCRIPTION
## What changed

- Changed admin broadcast sending from one large encrypted form POST to small browser-driven batches of 10 recipients.
- Added a live status region that reports progress while the browser encrypts and submits batches, then shows the final sent/skipped counts.
- Added a server-side chunk mode that accepts partial encrypted payloads or failure reports only for currently eligible broadcast recipients.
- Added expected/completed recipient tracking so the final chunk must account for the full server-side eligible audience.
- Hardened batch response handling so redirects, non-JSON responses, and missing count payloads fail instead of being treated as success.
- Prevented duplicate-prone full restarts after any batch request has started; the UI clears the plaintext and tells the admin to refresh/review instead.
- Preserved the existing full-form validation path for non-batched submissions.
- Added Flask coverage for encrypted chunks, failure-only chunks, stale/incomplete chunk rejection, unknown recipient rejection, and the live status region.
- Updated the Playwright E2EE broadcast test to exercise the chunked submit path while still verifying plaintext does not leave the browser.

## Why

A real broadcast with a normal-length admin message hit `413: Request Entity Too Large` because the browser encrypted the message separately for every recipient and submitted every armored ciphertext in one hidden field. Batching keeps each request small without weakening E2EE or raising proxy/body limits.

## Security notes

- E2EE is preserved: plaintext still stays in the browser and each stored message is still an armored PGP ciphertext.
- The server still rejects malformed ciphertext, conflicting success/failure reports, unknown recipient IDs, stale audiences, and incomplete final chunks.
- Chunked delivery is not a single transaction across the whole audience; if a later batch fails, earlier successful batches may already be committed. The live status and error message make that visible to the admin and prevent immediate duplicate resubmission.

## Validation

- `docker compose run --rm app poetry run pytest tests/test_admin_broadcasts.py tests/test_security_headers.py::test_admin_broadcast_page_keeps_csp_enforced -q` - passed, 21 tests.
- `npx playwright test --config=playwright.e2ee.config.js -g "admin broadcasts encrypt usable recipients and report malformed keys before POST"` - passed.
- `docker compose run --rm app poetry run mypy hushline/settings/broadcast.py tests/test_admin_broadcasts.py` - passed.
- `docker compose run --rm app poetry run ruff format --check hushline/settings/broadcast.py tests/test_admin_broadcasts.py && docker compose run --rm app poetry run ruff check hushline/settings/broadcast.py tests/test_admin_broadcasts.py --output-format full` - passed.
- `npx prettier --check assets/js/admin-broadcasts.js tests/playwright/e2ee/client-side-encryption.spec.js` - passed.
- `make audit-python` - passed, no known vulnerabilities found.
- `make audit-node-runtime` - passed, found 0 vulnerabilities.
- `make lint` - Ruff format/check and mypy passed; final Prettier step failed on pre-existing unstaged generated files `hushline/static/js/directory_verified.js` and `hushline/static/js/settings-location.js`, which are intentionally not included in this PR.

## Manual testing

- Navigate as an admin to `/settings/broadcasts`.
- Send the chat-launch announcement broadcast.
- Verify the live status advances through `Sending broadcast: N% complete...` and finishes with sent/skipped counts.
- Verify compatible recipients receive encrypted inbox messages and incompatible keys are skipped without producing a 413.