### PR TITLE
Make admin broadcasts retryable

### DIFF
--- a/assets/js/admin-broadcasts.js
+++ b/assets/js/admin-broadcasts.js
@@ -64,6 +64,21 @@ function expectedRecipientIds() {
   }
 }
 
+function ensureBroadcastIdInput(form, broadcastId) {
+  if (!broadcastId) {
+    return;
+  }
+  let input = document.getElementById("broadcast_id");
+  if (!input) {
+    input = document.createElement("input");
+    input.type = "hidden";
+    input.id = "broadcast_id";
+    input.name = "broadcast_id";
+    form.appendChild(input);
+  }
+  input.value = broadcastId;
+}
+
 async function encryptMessage(publicKeys, message) {
   const keys = Array.isArray(publicKeys) ? publicKeys : [publicKeys];
   const parsedKeys = await Promise.all(
@@ -163,7 +178,10 @@ async function submitBroadcastBatch(
   if (
     !response.ok ||
     !Number.isInteger(payload.submitted_count) ||
-    !Number.isInteger(payload.skipped_count)
+    !Number.isInteger(payload.skipped_count) ||
+    !Number.isInteger(payload.pending_count) ||
+    typeof payload.broadcast_id !== "string" ||
+    typeof payload.broadcast_complete !== "boolean"
   ) {
     throw new Error(payload.error || "Broadcast batch submission failed.");
   }
@@ -274,6 +292,7 @@ document.addEventListener("DOMContentLoaded", function () {
           completedUserIds,
           isFinalChunk,
         );
+        ensureBroadcastIdInput(form, result.broadcast_id);
         submittedCount += Number(result.submitted_count || 0);
         skippedCount += Number(result.skipped_count || 0);
         completedCount += batch.length;
@@ -310,7 +329,7 @@ document.addEventListener("DOMContentLoaded", function () {
         plaintext.value = "";
         updateStatus(
           status,
-          `Broadcast stopped after ${submittedCount} submitted and ${skippedCount} skipped. Do not retry from this page; refresh to review the current audience.`,
+          `Broadcast stopped after ${submittedCount} submitted and ${skippedCount} skipped. Refresh to resume pending recipients only.`,
         );
       } else {
         form.dataset.encryptionInProgress = "false";

--- a/assets/js/admin-broadcasts.js
+++ b/assets/js/admin-broadcasts.js
@@ -1,6 +1,8 @@
 import * as openpgp from "openpgp";
 
 const BROADCAST_BATCH_SIZE = 10;
+const BROADCAST_BATCH_RETRY_LIMIT = 4;
+const BROADCAST_BATCH_RETRY_BASE_MS = 750;
 
 function assertClientCryptoSupport() {
   if (!window.isSecureContext) {
@@ -140,6 +142,32 @@ function progressPercent(completedCount, totalCount) {
   );
 }
 
+function wait(ms) {
+  return new Promise((resolve) => {
+    window.setTimeout(resolve, ms);
+  });
+}
+
+function retryDelay(attempt) {
+  return Math.min(
+    6000,
+    BROADCAST_BATCH_RETRY_BASE_MS * 2 ** Math.max(0, attempt - 1),
+  );
+}
+
+function broadcastSubmitError(message, retryable = false) {
+  const error = new Error(message);
+  error.retryable = retryable;
+  return error;
+}
+
+function isRetryableBroadcastError(error) {
+  if (error?.retryable === true) {
+    return true;
+  }
+  return error instanceof TypeError;
+}
+
 async function submitBroadcastBatch(
   form,
   encryptedPayloads,
@@ -170,11 +198,21 @@ async function submitBroadcastBatch(
   });
   const contentType = response.headers.get("content-type") || "";
   if (response.redirected || !contentType.includes("application/json")) {
-    throw new Error(
+    throw broadcastSubmitError(
       "Broadcast session changed. Sign in again before continuing.",
     );
   }
-  const payload = await response.json();
+  let payload;
+  try {
+    payload = await response.json();
+  } catch {
+    throw broadcastSubmitError(
+      "Broadcast batch submission failed.",
+      response.status >= 500 ||
+        response.status === 408 ||
+        response.status === 429,
+    );
+  }
   if (
     !response.ok ||
     !Number.isInteger(payload.submitted_count) ||
@@ -183,9 +221,52 @@ async function submitBroadcastBatch(
     typeof payload.broadcast_id !== "string" ||
     typeof payload.broadcast_complete !== "boolean"
   ) {
-    throw new Error(payload.error || "Broadcast batch submission failed.");
+    throw broadcastSubmitError(
+      payload.error || "Broadcast batch submission failed.",
+      response.status >= 500 ||
+        response.status === 408 ||
+        response.status === 429,
+    );
   }
   return payload;
+}
+
+async function submitBroadcastBatchWithRetry(
+  form,
+  encryptedPayloads,
+  encryptionFailures,
+  expectedUserIds,
+  completedUserIds,
+  isFinalChunk,
+  status,
+  batchNumber,
+  totalBatches,
+) {
+  for (let attempt = 1; attempt <= BROADCAST_BATCH_RETRY_LIMIT; attempt += 1) {
+    try {
+      return await submitBroadcastBatch(
+        form,
+        encryptedPayloads,
+        encryptionFailures,
+        expectedUserIds,
+        completedUserIds,
+        isFinalChunk,
+      );
+    } catch (error) {
+      if (
+        attempt >= BROADCAST_BATCH_RETRY_LIMIT ||
+        !isRetryableBroadcastError(error)
+      ) {
+        throw error;
+      }
+      updateStatus(
+        status,
+        `Still sending broadcast: retrying batch ${batchNumber} of ${totalBatches}...`,
+      );
+      await wait(retryDelay(attempt));
+    }
+  }
+  throw broadcastSubmitError("Broadcast batch submission failed.");
 }
 
 document.addEventListener("DOMContentLoaded", function () {
@@ -242,6 +323,9 @@ document.addEventListener("DOMContentLoaded", function () {
 
       let completedCount = 0;
       const completedUserIds = [];
+      const totalBatches = Math.ceil(
+        recipientEntries.length / BROADCAST_BATCH_SIZE,
+      );
 
       updateStatus(status, "Sending broadcast: 1% complete...");
       for (
@@ -283,14 +367,18 @@ document.addEventListener("DOMContentLoaded", function () {
         completedUserIds.push(...batch.map((recipient) => recipient.user_id));
         const isFinalChunk =
           index + BROADCAST_BATCH_SIZE >= recipientEntries.length;
+        const batchNumber = Math.floor(index / BROADCAST_BATCH_SIZE) + 1;
         batchRequestStarted = true;
-        const result = await submitBroadcastBatch(
+        const result = await submitBroadcastBatchWithRetry(
           form,
           encryptedPayloads,
           encryptionFailures,
           expectedUserIds,
           completedUserIds,
           isFinalChunk,
+          status,
+          batchNumber,
+          totalBatches,
         );
         ensureBroadcastIdInput(form, result.broadcast_id);
         submittedCount += Number(result.submitted_count || 0);

--- a/assets/js/admin-broadcasts.js
+++ b/assets/js/admin-broadcasts.js
@@ -66,11 +66,15 @@ function expectedRecipientIds() {
   }
 }
 
+function broadcastIdInput() {
+  return document.getElementById("broadcast_id");
+}
+
 function ensureBroadcastIdInput(form, broadcastId) {
   if (!broadcastId) {
     return;
   }
-  let input = document.getElementById("broadcast_id");
+  let input = broadcastIdInput();
   if (!input) {
     input = document.createElement("input");
     input.type = "hidden";
@@ -79,6 +83,24 @@ function ensureBroadcastIdInput(form, broadcastId) {
     form.appendChild(input);
   }
   input.value = broadcastId;
+}
+
+function createBroadcastId() {
+  if (typeof window.crypto.randomUUID === "function") {
+    return window.crypto.randomUUID();
+  }
+  const bytes = new Uint8Array(16);
+  window.crypto.getRandomValues(bytes);
+  bytes[6] = (bytes[6] & 0x0f) | 0x40;
+  bytes[8] = (bytes[8] & 0x3f) | 0x80;
+  const hex = [...bytes].map((byte) => byte.toString(16).padStart(2, "0"));
+  return [
+    hex.slice(0, 4).join(""),
+    hex.slice(4, 6).join(""),
+    hex.slice(6, 8).join(""),
+    hex.slice(8, 10).join(""),
+    hex.slice(10, 16).join(""),
+  ].join("-");
 }
 
 async function encryptMessage(publicKeys, message) {
@@ -161,6 +183,10 @@ function broadcastSubmitError(message, retryable = false) {
   return error;
 }
 
+function isRetryableStatus(status) {
+  return status >= 500 || status === 408 || status === 429;
+}
+
 function isRetryableBroadcastError(error) {
   if (error?.retryable === true) {
     return true;
@@ -197,9 +223,17 @@ async function submitBroadcastBatch(
     body: formData,
   });
   const contentType = response.headers.get("content-type") || "";
-  if (response.redirected || !contentType.includes("application/json")) {
+  if (response.redirected) {
     throw broadcastSubmitError(
       "Broadcast session changed. Sign in again before continuing.",
+    );
+  }
+  if (!contentType.includes("application/json")) {
+    throw broadcastSubmitError(
+      isRetryableStatus(response.status)
+        ? "Broadcast batch submission failed."
+        : "Broadcast session changed. Sign in again before continuing.",
+      isRetryableStatus(response.status),
     );
   }
   let payload;
@@ -208,9 +242,7 @@ async function submitBroadcastBatch(
   } catch {
     throw broadcastSubmitError(
       "Broadcast batch submission failed.",
-      response.status >= 500 ||
-        response.status === 408 ||
-        response.status === 429,
+      isRetryableStatus(response.status),
     );
   }
   if (
@@ -223,9 +255,7 @@ async function submitBroadcastBatch(
   ) {
     throw broadcastSubmitError(
       payload.error || "Broadcast batch submission failed.",
-      response.status >= 500 ||
-        response.status === 408 ||
-        response.status === 429,
+      isRetryableStatus(response.status),
     );
   }
   return payload;
@@ -316,6 +346,10 @@ document.addEventListener("DOMContentLoaded", function () {
         );
       }
       assertClientCryptoSupport();
+      ensureBroadcastIdInput(
+        form,
+        broadcastIdInput()?.value || createBroadcastId(),
+      );
       const body = plaintext.value.trim();
       if (body.length < 10) {
         throw new Error("Message must be at least 10 characters.");

--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -193,10 +193,12 @@ PR descriptions for conversation workflow changes should include a threat or ris
 
 Administrative broadcasts create encrypted inbox messages in browser-side batches. Hush Line stores
 a broadcast ledger with recipient status for each eligible recipient, but it does not store the
-plaintext broadcast body. If a browser stops after some batches are submitted, the next visit to
-Settings -> Broadcasts shows the interrupted broadcast counts and limits the encryption audience to
-pending recipients only. The admin must re-enter the same message, confirm the send, and continue
-only the pending recipients.
+plaintext broadcast body. While the broadcast page remains open, transient batch submission failures
+are retried automatically and committed batches can be replayed without duplicating delivered inbox
+messages. If the browser or page stops after some batches are submitted, the next visit to Settings
+-> Broadcasts shows the interrupted broadcast counts and limits the encryption audience to pending
+recipients only. The admin must re-enter the same message, confirm the send, and continue only the
+pending recipients because the server cannot recover unstored plaintext.
 
 Resume validation must preserve two safety constraints:
 
@@ -204,9 +206,10 @@ Resume validation must preserve two safety constraints:
   server ledger has already moved earlier recipients out of pending status.
 - Refresh-based continuation may post only the pending audience rendered by the resume page.
 
-In both cases the server must reject payloads for recipients that are no longer pending or no longer
-eligible before creating additional messages. Pending recipients whose browser encryption fails are
-recorded as skipped so the ledger can complete without duplicating successful deliveries.
+In both cases the server must reject new payloads for recipients that are no longer pending or no
+longer eligible before creating additional messages, while acknowledging idempotent replays for
+recipients already recorded as submitted or skipped. Pending recipients whose browser encryption
+fails are recorded as skipped so the ledger can complete without duplicating successful deliveries.
 
 ## Manual Review Steps
 

--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -161,6 +161,7 @@ The app and public directory support more than individual profiles. Current disc
 | Admin | Search all usernames                                                                              | I can find accounts and aliases quickly in a larger deployment                                    | Settings -> Users           |
 | Admin | See aggregate usage metrics such as user count, 2FA adoption, PGP adoption, and chat-key creation | I can evaluate account-hardening posture and platform uptake                                      | Settings -> Metrics         |
 | Admin | Submit encrypted administrative updates to eligible E2EE recipients                               | I can announce security workflow changes or new account-hardening features without weakening E2EE | Settings -> Broadcasts      |
+| Admin | Resume an interrupted encrypted broadcast for pending recipients only                             | I can continue a large or interrupted announcement without duplicating delivered inbox messages   | Settings -> Broadcasts      |
 | Admin | Mark a primary account or alias as verified                                                       | Visitors can see that a staff member verified the identity behind a tip line                      | Settings -> Users           |
 | Admin | Mark one or more verified accounts as featured                                                    | Visitors see priority verified recipients at the top of the Verified directory tab                | Settings -> Users           |
 | Admin | Mark an account as cautious                                                                       | Visitors can receive a visible warning before trusting a listing                                  | Settings -> Users           |
@@ -187,6 +188,25 @@ Password changes require the active Hush Line chat key to be rewrapped in the br
 Conversation notifications are generic activity alerts. They do not include conversation plaintext or conversation ciphertext, even when the recipient has enabled message-content notifications for one-way tip intake.
 
 PR descriptions for conversation workflow changes should include a threat or risk summary, affected data paths, mitigations, validation commands, manual test steps, known risks, and follow-ups.
+
+## Administrative Broadcast Resume Workflow
+
+Administrative broadcasts create encrypted inbox messages in browser-side batches. Hush Line stores
+a broadcast ledger with recipient status for each eligible recipient, but it does not store the
+plaintext broadcast body. If a browser stops after some batches are submitted, the next visit to
+Settings -> Broadcasts shows the interrupted broadcast counts and limits the encryption audience to
+pending recipients only. The admin must re-enter the same message, confirm the send, and continue
+only the pending recipients.
+
+Resume validation must preserve two safety constraints:
+
+- Same-page continuation may post the original audience and cumulative completed IDs while the
+  server ledger has already moved earlier recipients out of pending status.
+- Refresh-based continuation may post only the pending audience rendered by the resume page.
+
+In both cases the server must reject payloads for recipients that are no longer pending or no longer
+eligible before creating additional messages. Pending recipients whose browser encryption fails are
+recorded as skipped so the ledger can complete without duplicating successful deliveries.
 
 ## Manual Review Steps
 

--- a/hushline/model/__init__.py
+++ b/hushline/model/__init__.py
@@ -1,5 +1,6 @@
 # ruff: noqa: F401
 
+from hushline.model.admin_broadcast import AdminBroadcast, AdminBroadcastRecipient
 from hushline.model.authentication_log import AuthenticationLog
 from hushline.model.chat_key import ChatKey
 from hushline.model.chat_rate_limit_attempt import ChatRateLimitAttempt

--- a/hushline/model/admin_broadcast.py
+++ b/hushline/model/admin_broadcast.py
@@ -1,0 +1,172 @@
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+from uuid import uuid4
+
+from sqlalchemy import Index, UniqueConstraint, text
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from hushline.db import db
+
+if TYPE_CHECKING:
+    from flask_sqlalchemy.model import Model
+
+    from hushline.model.message import Message
+    from hushline.model.user import User
+else:
+    Model = db.Model
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+class AdminBroadcast(Model):
+    __tablename__ = "admin_broadcasts"
+    __table_args__ = (Index("ix_admin_broadcasts_status_created_at", "status", "created_at"),)
+
+    STATUS_IN_PROGRESS = "in_progress"
+    STATUS_COMPLETED = "completed"
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    public_id: Mapped[str] = mapped_column(
+        db.String(36),
+        unique=True,
+        index=True,
+        nullable=False,
+        default=lambda: str(uuid4()),
+    )
+    admin_user_id: Mapped[int | None] = mapped_column(
+        db.ForeignKey("users.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(
+        db.String(32),
+        nullable=False,
+        default=STATUS_IN_PROGRESS,
+        server_default=STATUS_IN_PROGRESS,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        db.DateTime(timezone=True),
+        default=_utc_now,
+        server_default=text("NOW()"),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        db.DateTime(timezone=True),
+        default=_utc_now,
+        server_default=text("NOW()"),
+        nullable=False,
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(db.DateTime(timezone=True))
+
+    admin_user: Mapped["User | None"] = relationship()
+    recipients: Mapped[list["AdminBroadcastRecipient"]] = relationship(
+        back_populates="broadcast",
+        cascade="all, delete-orphan",
+        order_by="AdminBroadcastRecipient.user_id.asc()",
+    )
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+    @property
+    def pending_count(self) -> int:
+        return sum(
+            recipient.status == AdminBroadcastRecipient.STATUS_PENDING
+            for recipient in self.recipients
+        )
+
+    @property
+    def submitted_count(self) -> int:
+        return sum(
+            recipient.status == AdminBroadcastRecipient.STATUS_SUBMITTED
+            for recipient in self.recipients
+        )
+
+    @property
+    def skipped_count(self) -> int:
+        return sum(
+            recipient.status == AdminBroadcastRecipient.STATUS_SKIPPED
+            for recipient in self.recipients
+        )
+
+    def mark_updated(self) -> None:
+        self.updated_at = _utc_now()
+
+    def mark_completed_if_done(self) -> None:
+        if self.pending_count == 0:
+            now = _utc_now()
+            self.status = self.STATUS_COMPLETED
+            self.updated_at = now
+            self.completed_at = self.completed_at or now
+
+
+class AdminBroadcastRecipient(Model):
+    __tablename__ = "admin_broadcast_recipients"
+    __table_args__ = (
+        UniqueConstraint("broadcast_id", "user_id"),
+        UniqueConstraint("message_id"),
+        Index(
+            "ix_admin_broadcast_recipients_broadcast_status",
+            "broadcast_id",
+            "status",
+        ),
+    )
+
+    STATUS_PENDING = "pending"
+    STATUS_SUBMITTED = "submitted"
+    STATUS_SKIPPED = "skipped"
+
+    id: Mapped[int] = mapped_column(primary_key=True, nullable=False, autoincrement=True)
+    broadcast_id: Mapped[int] = mapped_column(
+        db.ForeignKey("admin_broadcasts.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    user_id: Mapped[int] = mapped_column(
+        db.ForeignKey("users.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    status: Mapped[str] = mapped_column(
+        db.String(32),
+        nullable=False,
+        default=STATUS_PENDING,
+        server_default=STATUS_PENDING,
+    )
+    message_id: Mapped[int | None] = mapped_column(
+        db.ForeignKey("messages.id", ondelete="SET NULL"),
+        nullable=True,
+    )
+    failure_reason: Mapped[str | None] = mapped_column(db.String(64), nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        db.DateTime(timezone=True),
+        default=_utc_now,
+        server_default=text("NOW()"),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        db.DateTime(timezone=True),
+        default=_utc_now,
+        server_default=text("NOW()"),
+        nullable=False,
+    )
+
+    broadcast: Mapped["AdminBroadcast"] = relationship(back_populates="recipients")
+    user: Mapped["User"] = relationship()
+    message: Mapped["Message | None"] = relationship()
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+
+    def mark_submitted(self, message: "Message") -> None:
+        self.status = self.STATUS_SUBMITTED
+        self.message = message
+        self.failure_reason = None
+        self.updated_at = _utc_now()
+
+    def mark_skipped(self, failure_reason: str = "encryption_failed") -> None:
+        self.status = self.STATUS_SKIPPED
+        self.failure_reason = failure_reason
+        self.updated_at = _utc_now()

--- a/hushline/settings/broadcast.py
+++ b/hushline/settings/broadcast.py
@@ -197,6 +197,10 @@ def _pending_user_ids(broadcast: AdminBroadcast) -> set[int]:
     }
 
 
+def _broadcast_user_ids(broadcast: AdminBroadcast) -> set[int]:
+    return {recipient.user_id for recipient in broadcast.recipients}
+
+
 def _broadcast_state(broadcast: AdminBroadcast | None) -> BroadcastDisplayState | None:
     if broadcast is None:
         return None
@@ -399,9 +403,10 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                         failed_user_ids = _encryption_failure_user_ids(
                             form.encryption_failures.data or ""
                         )
-                        expected_user_ids = {
+                        eligible_user_ids = {
                             user.id for user in audience.encrypted_submission_users
                         }
+                        expected_user_ids = eligible_user_ids
                         submitted_user_ids = set(encrypted_payloads)
                         expected_chunk_user_ids = _user_ids_from_json(
                             request.form.get(BROADCAST_EXPECTED_IDS_FIELD, "")
@@ -413,7 +418,16 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                         broadcast_public_id = request.form.get(BROADCAST_ID_FIELD, "")
                         active_broadcast = _load_active_broadcast_by_public_id(broadcast_public_id)
                         if chunked_broadcast and active_broadcast is not None:
-                            expected_user_ids = _pending_user_ids(active_broadcast)
+                            pending_user_ids = _pending_user_ids(active_broadcast)
+                            broadcast_user_ids = _broadcast_user_ids(active_broadcast)
+                            if expected_chunk_user_ids == broadcast_user_ids:
+                                expected_user_ids = broadcast_user_ids
+                            elif expected_chunk_user_ids == pending_user_ids:
+                                expected_user_ids = pending_user_ids
+                            else:
+                                expected_user_ids = set()
+                        else:
+                            pending_user_ids = expected_user_ids
                         if not submitted_user_ids and not (chunked_broadcast and failed_user_ids):
                             if chunked_broadcast:
                                 return _json_broadcast_error(
@@ -468,6 +482,18 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                         ).issubset(completed_chunk_user_ids):
                             return _json_broadcast_error(
                                 "Broadcast completion is missing submitted recipients."
+                            )
+                        elif chunked_broadcast and not submitted_user_ids.issubset(
+                            pending_user_ids
+                        ):
+                            return _json_broadcast_error(
+                                "Broadcast recipients are no longer pending. Refresh and try again."
+                            )
+                        elif chunked_broadcast and not submitted_user_ids.issubset(
+                            eligible_user_ids
+                        ):
+                            return _json_broadcast_error(
+                                "One or more recipients became ineligible before submission."
                             )
                         elif (
                             chunked_broadcast

--- a/hushline/settings/broadcast.py
+++ b/hushline/settings/broadcast.py
@@ -159,15 +159,12 @@ def _load_active_broadcast() -> AdminBroadcast | None:
     ).one_or_none()
 
 
-def _load_active_broadcast_by_public_id(public_id: str) -> AdminBroadcast | None:
+def _load_broadcast_by_public_id(public_id: str) -> AdminBroadcast | None:
     if not public_id:
         return None
     return db.session.scalars(
         db.select(AdminBroadcast)
-        .where(
-            AdminBroadcast.public_id == public_id,
-            AdminBroadcast.status == AdminBroadcast.STATUS_IN_PROGRESS,
-        )
+        .where(AdminBroadcast.public_id == public_id)
         .options(selectinload(AdminBroadcast.recipients))
         .limit(1)
     ).one_or_none()
@@ -199,6 +196,10 @@ def _pending_user_ids(broadcast: AdminBroadcast) -> set[int]:
 
 def _broadcast_user_ids(broadcast: AdminBroadcast) -> set[int]:
     return {recipient.user_id for recipient in broadcast.recipients}
+
+
+def _broadcast_status_user_ids(broadcast: AdminBroadcast, status: str) -> set[int]:
+    return {recipient.user_id for recipient in broadcast.recipients if recipient.status == status}
 
 
 def _broadcast_state(broadcast: AdminBroadcast | None) -> BroadcastDisplayState | None:
@@ -386,7 +387,9 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                             "Confirm before submitting these encrypted messages."
                         )
                         status_code = 400
-                    elif not audience.encrypted_submission_users:
+                    elif not audience.encrypted_submission_users and not (
+                        chunked_broadcast and request.form.get(BROADCAST_ID_FIELD, "")
+                    ):
                         if chunked_broadcast:
                             return _json_broadcast_error(
                                 "No eligible encrypted message recipients match this audience."
@@ -416,14 +419,49 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                         )
                         final_chunk = request.form.get(BROADCAST_FINAL_CHUNK_FIELD) == "1"
                         broadcast_public_id = request.form.get(BROADCAST_ID_FIELD, "")
-                        active_broadcast = _load_active_broadcast_by_public_id(broadcast_public_id)
-                        if chunked_broadcast and active_broadcast is not None:
-                            pending_user_ids = _pending_user_ids(active_broadcast)
-                            broadcast_user_ids = _broadcast_user_ids(active_broadcast)
-                            if expected_chunk_user_ids == broadcast_user_ids:
-                                expected_user_ids = broadcast_user_ids
-                            elif expected_chunk_user_ids == pending_user_ids:
-                                expected_user_ids = pending_user_ids
+                        broadcast = _load_broadcast_by_public_id(broadcast_public_id)
+                        active_broadcast = (
+                            broadcast
+                            if broadcast is not None
+                            and broadcast.status == AdminBroadcast.STATUS_IN_PROGRESS
+                            else None
+                        )
+                        completed_broadcast = (
+                            broadcast
+                            if broadcast is not None
+                            and broadcast.status == AdminBroadcast.STATUS_COMPLETED
+                            else None
+                        )
+                        submitted_broadcast_user_ids: set[int] = set()
+                        skipped_broadcast_user_ids: set[int] = set()
+                        submitted_user_ids_to_create = submitted_user_ids
+                        failed_user_ids_to_record = failed_user_ids
+                        if chunked_broadcast and broadcast is not None:
+                            pending_user_ids = _pending_user_ids(broadcast)
+                            broadcast_user_ids = _broadcast_user_ids(broadcast)
+                            submitted_broadcast_user_ids = _broadcast_status_user_ids(
+                                broadcast,
+                                AdminBroadcastRecipient.STATUS_SUBMITTED,
+                            )
+                            skipped_broadcast_user_ids = _broadcast_status_user_ids(
+                                broadcast,
+                                AdminBroadcastRecipient.STATUS_SKIPPED,
+                            )
+                            if active_broadcast is not None:
+                                submitted_user_ids_to_create = submitted_user_ids & pending_user_ids
+                                failed_user_ids_to_record = failed_user_ids & pending_user_ids
+                                if expected_chunk_user_ids == broadcast_user_ids:
+                                    expected_user_ids = broadcast_user_ids
+                                elif expected_chunk_user_ids == pending_user_ids:
+                                    expected_user_ids = pending_user_ids
+                                else:
+                                    expected_user_ids = set()
+                            elif (
+                                completed_broadcast is not None
+                                and final_chunk
+                                and expected_chunk_user_ids.issubset(broadcast_user_ids)
+                            ):
+                                expected_user_ids = expected_chunk_user_ids
                             else:
                                 expected_user_ids = set()
                         else:
@@ -446,7 +484,7 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                 "Encrypted payloads conflict with reported encryption failures."
                             )
                             status_code = 400
-                        elif chunked_broadcast and broadcast_public_id and active_broadcast is None:
+                        elif chunked_broadcast and broadcast_public_id and broadcast is None:
                             return _json_broadcast_error(
                                 "Broadcast run is no longer active. Refresh and try again."
                             )
@@ -483,13 +521,29 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                             return _json_broadcast_error(
                                 "Broadcast completion is missing submitted recipients."
                             )
-                        elif chunked_broadcast and not submitted_user_ids.issubset(
-                            pending_user_ids
+                        elif (
+                            chunked_broadcast
+                            and active_broadcast is not None
+                            and (
+                                submitted_user_ids - pending_user_ids - submitted_broadcast_user_ids
+                                or failed_user_ids - pending_user_ids - skipped_broadcast_user_ids
+                            )
                         ):
                             return _json_broadcast_error(
                                 "Broadcast recipients are no longer pending. Refresh and try again."
                             )
-                        elif chunked_broadcast and not submitted_user_ids.issubset(
+                        elif (
+                            chunked_broadcast
+                            and completed_broadcast is not None
+                            and (
+                                submitted_user_ids - submitted_broadcast_user_ids
+                                or failed_user_ids - skipped_broadcast_user_ids
+                            )
+                        ):
+                            return _json_broadcast_error(
+                                "Broadcast run is complete. Refresh and try again."
+                            )
+                        elif chunked_broadcast and not submitted_user_ids_to_create.issubset(
                             eligible_user_ids
                         ):
                             return _json_broadcast_error(
@@ -512,12 +566,26 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                             )
                             status_code = 400
                         else:
+                            if chunked_broadcast and completed_broadcast is not None:
+                                return jsonify(
+                                    {
+                                        "broadcast_id": completed_broadcast.public_id,
+                                        "broadcast_complete": True,
+                                        "pending_count": 0,
+                                        "submitted_count": len(
+                                            submitted_user_ids & submitted_broadcast_user_ids
+                                        ),
+                                        "skipped_count": len(
+                                            failed_user_ids & skipped_broadcast_user_ids
+                                        ),
+                                    }
+                                )
                             if chunked_broadcast and active_broadcast is None:
                                 active_broadcast = _create_broadcast(user.id, expected_user_ids)
                             submitted_users = [
                                 user
                                 for user in audience.encrypted_submission_users
-                                if user.id in submitted_user_ids
+                                if user.id in submitted_user_ids_to_create
                             ]
                             try:
                                 submitted_count = _submit_encrypted_broadcast_messages(
@@ -528,7 +596,7 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                 if chunked_broadcast and active_broadcast is not None:
                                     _record_broadcast_failures(
                                         active_broadcast,
-                                        failed_user_ids,
+                                        failed_user_ids_to_record,
                                     )
                                     db.session.commit()
                             except ValueError:
@@ -556,13 +624,25 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                     return _json_broadcast_error(
                                         "Broadcast run could not be recorded."
                                     )
+                                submitted_broadcast_user_ids = _broadcast_status_user_ids(
+                                    active_broadcast,
+                                    AdminBroadcastRecipient.STATUS_SUBMITTED,
+                                )
+                                skipped_broadcast_user_ids = _broadcast_status_user_ids(
+                                    active_broadcast,
+                                    AdminBroadcastRecipient.STATUS_SKIPPED,
+                                )
                                 return jsonify(
                                     {
                                         "broadcast_id": active_broadcast.public_id,
                                         "broadcast_complete": active_broadcast.pending_count == 0,
                                         "pending_count": active_broadcast.pending_count,
-                                        "submitted_count": submitted_count,
-                                        "skipped_count": skipped_count,
+                                        "submitted_count": len(
+                                            submitted_user_ids & submitted_broadcast_user_ids
+                                        ),
+                                        "skipped_count": len(
+                                            failed_user_ids & skipped_broadcast_user_ids
+                                        ),
                                     }
                                 )
                             if skipped_count:

--- a/hushline/settings/broadcast.py
+++ b/hushline/settings/broadcast.py
@@ -1,6 +1,7 @@
 import json
 from dataclasses import dataclass
 from typing import cast
+from uuid import UUID
 
 from flask import (
     Blueprint,
@@ -170,8 +171,14 @@ def _load_broadcast_by_public_id(public_id: str) -> AdminBroadcast | None:
     ).one_or_none()
 
 
-def _create_broadcast(admin_user_id: int, expected_user_ids: set[int]) -> AdminBroadcast:
+def _create_broadcast(
+    admin_user_id: int,
+    expected_user_ids: set[int],
+    public_id: str = "",
+) -> AdminBroadcast:
     broadcast = AdminBroadcast(admin_user_id=admin_user_id)
+    if public_id:
+        broadcast.public_id = public_id
     db.session.add(broadcast)
     db.session.flush()
     for user_id in sorted(expected_user_ids):
@@ -200,6 +207,16 @@ def _broadcast_user_ids(broadcast: AdminBroadcast) -> set[int]:
 
 def _broadcast_status_user_ids(broadcast: AdminBroadcast, status: str) -> set[int]:
     return {recipient.user_id for recipient in broadcast.recipients if recipient.status == status}
+
+
+def _normalized_broadcast_public_id(public_id: str) -> str:
+    value = public_id.strip()
+    if not value:
+        return ""
+    try:
+        return str(UUID(value))
+    except ValueError:
+        return ""
 
 
 def _broadcast_state(broadcast: AdminBroadcast | None) -> BroadcastDisplayState | None:
@@ -418,7 +435,13 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                             request.form.get(BROADCAST_COMPLETED_IDS_FIELD, "")
                         )
                         final_chunk = request.form.get(BROADCAST_FINAL_CHUNK_FIELD) == "1"
-                        broadcast_public_id = request.form.get(BROADCAST_ID_FIELD, "")
+                        raw_broadcast_public_id = request.form.get(BROADCAST_ID_FIELD, "")
+                        broadcast_public_id = _normalized_broadcast_public_id(
+                            raw_broadcast_public_id
+                        )
+                        invalid_broadcast_public_id = bool(
+                            raw_broadcast_public_id and not broadcast_public_id
+                        )
                         broadcast = _load_broadcast_by_public_id(broadcast_public_id)
                         active_broadcast = (
                             broadcast
@@ -484,13 +507,11 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                 "Encrypted payloads conflict with reported encryption failures."
                             )
                             status_code = 400
-                        elif chunked_broadcast and broadcast_public_id and broadcast is None:
-                            return _json_broadcast_error(
-                                "Broadcast run is no longer active. Refresh and try again."
-                            )
+                        elif chunked_broadcast and invalid_broadcast_public_id:
+                            return _json_broadcast_error("Broadcast run id is invalid.")
                         elif (
                             chunked_broadcast
-                            and not broadcast_public_id
+                            and broadcast is None
                             and _load_active_broadcast() is not None
                         ):
                             return _json_broadcast_error(
@@ -581,7 +602,11 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                     }
                                 )
                             if chunked_broadcast and active_broadcast is None:
-                                active_broadcast = _create_broadcast(user.id, expected_user_ids)
+                                active_broadcast = _create_broadcast(
+                                    user.id,
+                                    expected_user_ids,
+                                    broadcast_public_id,
+                                )
                             submitted_users = [
                                 user
                                 for user in audience.encrypted_submission_users

--- a/hushline/settings/broadcast.py
+++ b/hushline/settings/broadcast.py
@@ -23,6 +23,8 @@ from hushline.auth import admin_authentication_required
 from hushline.db import db
 from hushline.forms import Button
 from hushline.model import (
+    AdminBroadcast,
+    AdminBroadcastRecipient,
     FieldDefinition,
     FieldValue,
     Message,
@@ -36,6 +38,7 @@ BROADCAST_CHUNK_FIELD = "broadcast_chunk"
 BROADCAST_COMPLETED_IDS_FIELD = "broadcast_completed_user_ids"
 BROADCAST_EXPECTED_IDS_FIELD = "broadcast_expected_user_ids"
 BROADCAST_FINAL_CHUNK_FIELD = "broadcast_final_chunk"
+BROADCAST_ID_FIELD = "broadcast_id"
 
 
 class AdminBroadcastForm(FlaskForm):
@@ -86,6 +89,15 @@ class BroadcastAudience:
         return recipients
 
 
+@dataclass(frozen=True)
+class BroadcastDisplayState:
+    broadcast: AdminBroadcast
+    pending_user_ids: set[int]
+    submitted_count: int
+    skipped_count: int
+    pending_count: int
+
+
 def _recipient_pgp_key_exists() -> ColumnElement[bool]:
     return cast(
         ColumnElement[bool],
@@ -118,6 +130,88 @@ def _load_audience() -> BroadcastAudience:
         ).all()
     )
     return BroadcastAudience(target_users=users)
+
+
+def _load_pending_audience(pending_user_ids: set[int]) -> BroadcastAudience:
+    if not pending_user_ids:
+        return BroadcastAudience(target_users=[])
+    users = list(
+        db.session.scalars(
+            db.select(User)
+            .where(_audience_predicate(), User.id.in_(pending_user_ids))
+            .options(
+                selectinload(User.notification_recipients),
+                selectinload(User.primary_username),
+            )
+            .order_by(User.id)
+        ).all()
+    )
+    return BroadcastAudience(target_users=users)
+
+
+def _load_active_broadcast() -> AdminBroadcast | None:
+    return db.session.scalars(
+        db.select(AdminBroadcast)
+        .where(AdminBroadcast.status == AdminBroadcast.STATUS_IN_PROGRESS)
+        .options(selectinload(AdminBroadcast.recipients))
+        .order_by(AdminBroadcast.created_at.desc(), AdminBroadcast.id.desc())
+        .limit(1)
+    ).one_or_none()
+
+
+def _load_active_broadcast_by_public_id(public_id: str) -> AdminBroadcast | None:
+    if not public_id:
+        return None
+    return db.session.scalars(
+        db.select(AdminBroadcast)
+        .where(
+            AdminBroadcast.public_id == public_id,
+            AdminBroadcast.status == AdminBroadcast.STATUS_IN_PROGRESS,
+        )
+        .options(selectinload(AdminBroadcast.recipients))
+        .limit(1)
+    ).one_or_none()
+
+
+def _create_broadcast(admin_user_id: int, expected_user_ids: set[int]) -> AdminBroadcast:
+    broadcast = AdminBroadcast(admin_user_id=admin_user_id)
+    db.session.add(broadcast)
+    db.session.flush()
+    for user_id in sorted(expected_user_ids):
+        db.session.add(
+            AdminBroadcastRecipient(
+                broadcast_id=broadcast.id,
+                user_id=user_id,
+            )
+        )
+    db.session.flush()
+    db.session.refresh(broadcast, ["recipients"])
+    return broadcast
+
+
+def _pending_user_ids(broadcast: AdminBroadcast) -> set[int]:
+    return {
+        recipient.user_id
+        for recipient in broadcast.recipients
+        if recipient.status == AdminBroadcastRecipient.STATUS_PENDING
+    }
+
+
+def _broadcast_state(broadcast: AdminBroadcast | None) -> BroadcastDisplayState | None:
+    if broadcast is None:
+        return None
+    pending_user_ids = _pending_user_ids(broadcast)
+    if not pending_user_ids:
+        broadcast.mark_completed_if_done()
+        db.session.commit()
+        return None
+    return BroadcastDisplayState(
+        broadcast=broadcast,
+        pending_user_ids=pending_user_ids,
+        submitted_count=broadcast.submitted_count,
+        skipped_count=broadcast.skipped_count,
+        pending_count=len(pending_user_ids),
+    )
 
 
 def _unique_enabled_email_count(user: User) -> int:
@@ -188,11 +282,20 @@ def _message_field_for(user: User) -> FieldDefinition | None:
 
 
 def _submit_encrypted_broadcast_messages(
-    users: list[User], encrypted_payloads: dict[int, str]
+    users: list[User],
+    encrypted_payloads: dict[int, str],
+    broadcast: AdminBroadcast | None = None,
 ) -> int:
     submitted_count = 0
     submitted_notification_user_ids: list[int] = []
+    pending_recipients_by_user_id = {
+        recipient.user_id: recipient
+        for recipient in (broadcast.recipients if broadcast is not None else [])
+        if recipient.status == AdminBroadcastRecipient.STATUS_PENDING
+    }
     for user in users:
+        if broadcast is not None and user.id not in pending_recipients_by_user_id:
+            continue
         encrypted_payload = encrypted_payloads.get(user.id)
         field_definition = _message_field_for(user)
         username = user.primary_username
@@ -204,14 +307,39 @@ def _submit_encrypted_broadcast_messages(
         db.session.add(message)
         db.session.flush()
         db.session.add(FieldValue(field_definition, message, encrypted_payload, True))
+        if broadcast is not None:
+            pending_recipients_by_user_id[user.id].mark_submitted(message)
         submitted_count += 1
         submitted_notification_user_ids.append(user.id)
+
+    if broadcast is not None:
+        broadcast.mark_updated()
+        broadcast.mark_completed_if_done()
 
     if submitted_count:
         db.session.commit()
         _send_broadcast_notification_emails(tuple(submitted_notification_user_ids))
+    elif broadcast is not None:
+        db.session.commit()
 
     return submitted_count
+
+
+def _record_broadcast_failures(
+    broadcast: AdminBroadcast,
+    failed_user_ids: set[int],
+    failure_reason: str = "encryption_failed",
+) -> None:
+    if not failed_user_ids:
+        return
+    for recipient in broadcast.recipients:
+        if (
+            recipient.user_id in failed_user_ids
+            and recipient.status == AdminBroadcastRecipient.STATUS_PENDING
+        ):
+            recipient.mark_skipped(failure_reason)
+    broadcast.mark_updated()
+    broadcast.mark_completed_if_done()
 
 
 def _send_broadcast_notification_emails(user_ids: tuple[int, ...]) -> None:
@@ -282,6 +410,10 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                             request.form.get(BROADCAST_COMPLETED_IDS_FIELD, "")
                         )
                         final_chunk = request.form.get(BROADCAST_FINAL_CHUNK_FIELD) == "1"
+                        broadcast_public_id = request.form.get(BROADCAST_ID_FIELD, "")
+                        active_broadcast = _load_active_broadcast_by_public_id(broadcast_public_id)
+                        if chunked_broadcast and active_broadcast is not None:
+                            expected_user_ids = _pending_user_ids(active_broadcast)
                         if not submitted_user_ids and not (chunked_broadcast and failed_user_ids):
                             if chunked_broadcast:
                                 return _json_broadcast_error(
@@ -300,6 +432,18 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                 "Encrypted payloads conflict with reported encryption failures."
                             )
                             status_code = 400
+                        elif chunked_broadcast and broadcast_public_id and active_broadcast is None:
+                            return _json_broadcast_error(
+                                "Broadcast run is no longer active. Refresh and try again."
+                            )
+                        elif (
+                            chunked_broadcast
+                            and not broadcast_public_id
+                            and _load_active_broadcast() is not None
+                        ):
+                            return _json_broadcast_error(
+                                "An interrupted broadcast is active. Refresh to resume it."
+                            )
                         elif chunked_broadcast and expected_chunk_user_ids != expected_user_ids:
                             return _json_broadcast_error(
                                 "Broadcast audience changed. Refresh and try again."
@@ -342,6 +486,8 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                             )
                             status_code = 400
                         else:
+                            if chunked_broadcast and active_broadcast is None:
+                                active_broadcast = _create_broadcast(user.id, expected_user_ids)
                             submitted_users = [
                                 user
                                 for user in audience.encrypted_submission_users
@@ -351,7 +497,14 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                 submitted_count = _submit_encrypted_broadcast_messages(
                                     submitted_users,
                                     encrypted_payloads,
+                                    active_broadcast if chunked_broadcast else None,
                                 )
+                                if chunked_broadcast and active_broadcast is not None:
+                                    _record_broadcast_failures(
+                                        active_broadcast,
+                                        failed_user_ids,
+                                    )
+                                    db.session.commit()
                             except ValueError:
                                 db.session.rollback()
                                 form.encrypted_payloads.errors.append(
@@ -368,12 +521,20 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                     user=user,
                                     form=form,
                                     audience=audience,
+                                    active_broadcast_state=None,
                                     encryption_recipients=audience.encryption_recipients,
                                 ), status_code
                             skipped_count = len(failed_user_ids)
                             if chunked_broadcast:
+                                if active_broadcast is None:
+                                    return _json_broadcast_error(
+                                        "Broadcast run could not be recorded."
+                                    )
                                 return jsonify(
                                     {
+                                        "broadcast_id": active_broadcast.public_id,
+                                        "broadcast_complete": active_broadcast.pending_count == 0,
+                                        "pending_count": active_broadcast.pending_count,
                                         "submitted_count": submitted_count,
                                         "skipped_count": skipped_count,
                                     }
@@ -398,10 +559,31 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                     return _json_broadcast_error("Invalid broadcast submission.")
                 status_code = 400
 
+        active_broadcast_state = _broadcast_state(_load_active_broadcast())
+        if active_broadcast_state is not None:
+            audience = _load_pending_audience(active_broadcast_state.pending_user_ids)
+            renderable_pending_user_ids = {user.id for user in audience.encrypted_submission_users}
+            ineligible_pending_user_ids = (
+                active_broadcast_state.pending_user_ids - renderable_pending_user_ids
+            )
+            if ineligible_pending_user_ids:
+                _record_broadcast_failures(
+                    active_broadcast_state.broadcast,
+                    ineligible_pending_user_ids,
+                    failure_reason="ineligible",
+                )
+                db.session.commit()
+                active_broadcast_state = _broadcast_state(active_broadcast_state.broadcast)
+                if active_broadcast_state is not None:
+                    audience = _load_pending_audience(active_broadcast_state.pending_user_ids)
+                else:
+                    audience = _load_audience()
+
         return render_template(
             "settings/broadcasts.html",
             user=user,
             form=form,
             audience=audience,
+            active_broadcast_state=active_broadcast_state,
             encryption_recipients=audience.encryption_recipients,
         ), status_code

--- a/hushline/templates/settings/broadcasts.html
+++ b/hushline/templates/settings/broadcasts.html
@@ -13,9 +13,25 @@
 {% block settings_content %}
   {% set expected_recipient_ids = audience.encrypted_submission_users | map(attribute='id') | list %}
   <h3>Broadcasts</h3>
-  <p>
-    Submit an encrypted administrative update to every eligible message-key recipient.
-  </p>
+  {% if active_broadcast_state %}
+    <p>
+      Resume the interrupted broadcast for pending recipients only. Hush Line does not store
+      broadcast plaintext, so enter the same message before continuing.
+    </p>
+  {% else %}
+    <p>
+      Submit an encrypted administrative update to every eligible message-key recipient.
+    </p>
+  {% endif %}
+
+  {% if active_broadcast_state %}
+    <div class="flash-messages warning">
+      Interrupted broadcast:
+      {{ active_broadcast_state.submitted_count }} submitted,
+      {{ active_broadcast_state.skipped_count }} skipped,
+      {{ active_broadcast_state.pending_count }} pending.
+    </div>
+  {% endif %}
 
   <div class="admin-highlights broadcast-summary">
     <div class="metric">
@@ -50,6 +66,14 @@
       name="broadcast_expected_user_ids"
       value='{{ expected_recipient_ids | tojson }}'
     >
+    {% if active_broadcast_state %}
+      <input
+        type="hidden"
+        id="broadcast_id"
+        name="broadcast_id"
+        value="{{ active_broadcast_state.broadcast.public_id }}"
+      >
+    {% endif %}
     {{ field_errors(form.encrypted_payloads) }}
 
     <div class="checkbox-group">

--- a/migrations/versions/9c8f0a1d2b3c_add_admin_broadcast_ledger.py
+++ b/migrations/versions/9c8f0a1d2b3c_add_admin_broadcast_ledger.py
@@ -1,0 +1,141 @@
+"""add admin broadcast ledger
+
+Revision ID: 9c8f0a1d2b3c
+Revises: 4d2a7c9e1b64
+Create Date: 2026-06-24 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "9c8f0a1d2b3c"
+down_revision = "4d2a7c9e1b64"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "admin_broadcasts",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("public_id", sa.String(length=36), nullable=False),
+        sa.Column("admin_user_id", sa.Integer(), nullable=True),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            server_default="in_progress",
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["admin_user_id"], ["users.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("public_id"),
+    )
+    op.create_index(
+        "ix_admin_broadcasts_admin_user_id",
+        "admin_broadcasts",
+        ["admin_user_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_admin_broadcasts_public_id",
+        "admin_broadcasts",
+        ["public_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_admin_broadcasts_status_created_at",
+        "admin_broadcasts",
+        ["status", "created_at"],
+        unique=False,
+    )
+
+    op.create_table(
+        "admin_broadcast_recipients",
+        sa.Column("id", sa.Integer(), autoincrement=True, nullable=False),
+        sa.Column("broadcast_id", sa.Integer(), nullable=False),
+        sa.Column("user_id", sa.Integer(), nullable=False),
+        sa.Column(
+            "status",
+            sa.String(length=32),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column("message_id", sa.Integer(), nullable=True),
+        sa.Column("failure_reason", sa.String(length=64), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.text("NOW()"),
+            nullable=False,
+        ),
+        sa.ForeignKeyConstraint(
+            ["broadcast_id"],
+            ["admin_broadcasts.id"],
+            ondelete="CASCADE",
+        ),
+        sa.ForeignKeyConstraint(["message_id"], ["messages.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("broadcast_id", "user_id"),
+        sa.UniqueConstraint("message_id"),
+    )
+    op.create_index(
+        "ix_admin_broadcast_recipients_broadcast_id",
+        "admin_broadcast_recipients",
+        ["broadcast_id"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_admin_broadcast_recipients_broadcast_status",
+        "admin_broadcast_recipients",
+        ["broadcast_id", "status"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_admin_broadcast_recipients_user_id",
+        "admin_broadcast_recipients",
+        ["user_id"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_admin_broadcast_recipients_user_id",
+        table_name="admin_broadcast_recipients",
+    )
+    op.drop_index(
+        "ix_admin_broadcast_recipients_broadcast_status",
+        table_name="admin_broadcast_recipients",
+    )
+    op.drop_index(
+        "ix_admin_broadcast_recipients_broadcast_id",
+        table_name="admin_broadcast_recipients",
+    )
+    op.drop_table("admin_broadcast_recipients")
+    op.drop_index("ix_admin_broadcasts_status_created_at", table_name="admin_broadcasts")
+    op.drop_index("ix_admin_broadcasts_public_id", table_name="admin_broadcasts")
+    op.drop_index("ix_admin_broadcasts_admin_user_id", table_name="admin_broadcasts")
+    op.drop_table("admin_broadcasts")

--- a/tests/migrations/revision_9c8f0a1d2b3c.py
+++ b/tests/migrations/revision_9c8f0a1d2b3c.py
@@ -1,0 +1,260 @@
+from sqlalchemy import text
+from sqlalchemy.exc import IntegrityError
+
+from hushline.db import db
+
+ADMIN_USER_ID = 9801
+RECIPIENT_USER_ID = 9802
+BROADCAST_ID = 9801
+RECIPIENT_ID = 9801
+
+NEW_TABLES = ["admin_broadcasts", "admin_broadcast_recipients"]
+NEW_INDEXES = [
+    "ix_admin_broadcasts_admin_user_id",
+    "ix_admin_broadcasts_public_id",
+    "ix_admin_broadcasts_status_created_at",
+    "ix_admin_broadcast_recipients_broadcast_id",
+    "ix_admin_broadcast_recipients_broadcast_status",
+    "ix_admin_broadcast_recipients_user_id",
+]
+
+
+def _insert_user(user_id: int, *, is_admin: bool = False) -> None:
+    db.session.execute(
+        text(
+            """
+            INSERT INTO users (
+                id,
+                is_admin,
+                is_suspended,
+                password_hash,
+                session_id
+            )
+            VALUES (:user_id, :is_admin, false, '$scrypt$', :session_id)
+            """
+        ),
+        {
+            "user_id": user_id,
+            "is_admin": is_admin,
+            "session_id": f"session-{user_id}",
+        },
+    )
+    db.session.commit()
+
+
+def _insert_users() -> None:
+    _insert_user(ADMIN_USER_ID, is_admin=True)
+    _insert_user(RECIPIENT_USER_ID)
+
+
+def _insert_broadcast() -> None:
+    db.session.execute(
+        text(
+            """
+            INSERT INTO admin_broadcasts (
+                id,
+                public_id,
+                admin_user_id
+            )
+            VALUES (
+                :broadcast_id,
+                '00000000-0000-0000-0000-000000009801',
+                :admin_user_id
+            )
+            """
+        ),
+        {
+            "broadcast_id": BROADCAST_ID,
+            "admin_user_id": ADMIN_USER_ID,
+        },
+    )
+    db.session.commit()
+
+
+def _insert_recipient() -> None:
+    db.session.execute(
+        text(
+            """
+            INSERT INTO admin_broadcast_recipients (
+                id,
+                broadcast_id,
+                user_id
+            )
+            VALUES (
+                :recipient_id,
+                :broadcast_id,
+                :user_id
+            )
+            """
+        ),
+        {
+            "recipient_id": RECIPIENT_ID,
+            "broadcast_id": BROADCAST_ID,
+            "user_id": RECIPIENT_USER_ID,
+        },
+    )
+    db.session.commit()
+
+
+def _expect_integrity_error(statement: str, params: dict[str, object]) -> None:
+    try:
+        db.session.execute(text(statement), params)
+        db.session.commit()
+    except IntegrityError:
+        db.session.rollback()
+    else:
+        raise AssertionError("Expected database integrity constraint to reject invalid row")
+
+
+class UpgradeTester:
+    def load_data(self) -> None:
+        _insert_users()
+
+    def check_upgrade(self) -> None:
+        table_names = set(
+            db.session.scalars(
+                text(
+                    """
+                    SELECT table_name
+                    FROM information_schema.tables
+                    WHERE table_schema = 'public'
+                      AND table_name = ANY(:table_names)
+                    """
+                ),
+                {"table_names": NEW_TABLES},
+            ).all()
+        )
+        assert table_names == set(NEW_TABLES)
+
+        indexes = set(
+            db.session.scalars(
+                text(
+                    """
+                    SELECT indexname
+                    FROM pg_indexes
+                    WHERE schemaname = 'public'
+                      AND indexname = ANY(:index_names)
+                    """
+                ),
+                {"index_names": NEW_INDEXES},
+            ).all()
+        )
+        assert indexes == set(NEW_INDEXES)
+
+        columns = db.session.execute(
+            text(
+                """
+                SELECT table_name, column_name, is_nullable
+                FROM information_schema.columns
+                WHERE table_schema = 'public'
+                  AND table_name = ANY(:table_names)
+                ORDER BY table_name, ordinal_position
+                """
+            ),
+            {"table_names": NEW_TABLES},
+        ).all()
+        assert columns == [
+            ("admin_broadcast_recipients", "id", "NO"),
+            ("admin_broadcast_recipients", "broadcast_id", "NO"),
+            ("admin_broadcast_recipients", "user_id", "NO"),
+            ("admin_broadcast_recipients", "status", "NO"),
+            ("admin_broadcast_recipients", "message_id", "YES"),
+            ("admin_broadcast_recipients", "failure_reason", "YES"),
+            ("admin_broadcast_recipients", "created_at", "NO"),
+            ("admin_broadcast_recipients", "updated_at", "NO"),
+            ("admin_broadcasts", "id", "NO"),
+            ("admin_broadcasts", "public_id", "NO"),
+            ("admin_broadcasts", "admin_user_id", "YES"),
+            ("admin_broadcasts", "status", "NO"),
+            ("admin_broadcasts", "created_at", "NO"),
+            ("admin_broadcasts", "updated_at", "NO"),
+            ("admin_broadcasts", "completed_at", "YES"),
+        ]
+
+        _insert_broadcast()
+        _insert_recipient()
+
+        status_values = db.session.execute(
+            text(
+                """
+                SELECT
+                    b.status AS broadcast_status,
+                    r.status AS recipient_status
+                FROM admin_broadcasts b
+                JOIN admin_broadcast_recipients r ON r.broadcast_id = b.id
+                WHERE b.id = :broadcast_id
+                """
+            ),
+            {"broadcast_id": BROADCAST_ID},
+        ).one()
+        assert status_values == ("in_progress", "pending")
+
+        _expect_integrity_error(
+            """
+            INSERT INTO admin_broadcast_recipients (
+                broadcast_id,
+                user_id
+            )
+            VALUES (
+                :broadcast_id,
+                :user_id
+            )
+            """,
+            {
+                "broadcast_id": BROADCAST_ID,
+                "user_id": RECIPIENT_USER_ID,
+            },
+        )
+
+        db.session.execute(
+            text("DELETE FROM admin_broadcasts WHERE id = :broadcast_id"),
+            {"broadcast_id": BROADCAST_ID},
+        )
+        db.session.commit()
+        assert (
+            db.session.scalar(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM admin_broadcast_recipients
+                    WHERE broadcast_id = :broadcast_id
+                    """
+                ),
+                {"broadcast_id": BROADCAST_ID},
+            )
+            == 0
+        )
+
+
+class DowngradeTester:
+    def load_data(self) -> None:
+        _insert_users()
+        _insert_broadcast()
+        _insert_recipient()
+
+    def check_downgrade(self) -> None:
+        table_count = db.session.scalar(
+            text(
+                """
+                SELECT count(*)
+                FROM information_schema.tables
+                WHERE table_schema = 'public'
+                  AND table_name = ANY(:table_names)
+                """
+            ),
+            {"table_names": NEW_TABLES},
+        )
+        assert table_count == 0
+        assert (
+            db.session.scalar(
+                text(
+                    """
+                    SELECT count(*)
+                    FROM users
+                    WHERE id = ANY(:user_ids)
+                    """
+                ),
+                {"user_ids": [ADMIN_USER_ID, RECIPIENT_USER_ID]},
+            )
+            == 2
+        )

--- a/tests/test_admin_broadcasts.py
+++ b/tests/test_admin_broadcasts.py
@@ -7,7 +7,7 @@ from flask import url_for
 from flask.testing import FlaskClient
 
 from hushline.db import db
-from hushline.model import AdminBroadcast, AdminBroadcastRecipient, ChatKey, Message, User
+from hushline.model import AdminBroadcast, AdminBroadcastRecipient, ChatKey, Message, User, Username
 from hushline.settings.broadcast import _send_broadcast_notification_emails
 
 ARMORED_BROADCAST = (
@@ -36,6 +36,19 @@ def _add_chat_key(user: User) -> None:
             wrapping_algorithm="AES-GCM",
         )
     )
+
+
+def _make_broadcast_user(password: str) -> User:
+    user = User(password=password)
+    user.onboarding_complete = True
+    user.tier_id = 1
+    db.session.add(user)
+    db.session.flush()
+    username = Username(user_id=user.id, _username=f"broadcast-{user.id}", is_primary=True)
+    db.session.add(username)
+    db.session.commit()
+    username.create_default_field_defs()
+    return user
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -474,6 +487,133 @@ def test_broadcasts_resume_submits_pending_only_without_duplicate_messages(
     assert broadcast.submitted_count == 2
     send_notifications.assert_any_call((user.id,))
     send_notifications.assert_any_call((user2.id,))
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_continues_same_page_chunk_with_original_audience(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    user2.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    db.session.commit()
+    send_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._send_broadcast_notification_emails",
+        send_notifications,
+    )
+    expected_user_ids = [user.id, user2.id]
+
+    first = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps(expected_user_ids),
+            "broadcast_final_chunk": "0",
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+    broadcast_id = first.get_json()["broadcast_id"]
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps(expected_user_ids),
+            "broadcast_expected_user_ids": json.dumps(expected_user_ids),
+            "broadcast_final_chunk": "1",
+            "broadcast_id": broadcast_id,
+            "encrypted_payloads": json.dumps({str(user2.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["submitted_count"] == 1
+    assert payload["pending_count"] == 0
+    assert payload["broadcast_complete"] is True
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 2
+    broadcast = db.session.scalars(db.select(AdminBroadcast)).one()
+    assert broadcast.status == AdminBroadcast.STATUS_COMPLETED
+    assert broadcast.submitted_count == 2
+    send_notifications.assert_any_call((user.id,))
+    send_notifications.assert_any_call((user2.id,))
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_resume_rejects_payload_for_ineligible_pending_recipient(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    user_password: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user3 = _make_broadcast_user(user_password)
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    user2.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    user3.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    db.session.commit()
+    send_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._send_broadcast_notification_emails",
+        send_notifications,
+    )
+    expected_user_ids = [user.id, user2.id, user3.id]
+
+    first = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps(expected_user_ids),
+            "broadcast_final_chunk": "0",
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+    assert first.status_code == 200
+    broadcast_id = first.get_json()["broadcast_id"]
+
+    user2.is_suspended = True
+    db.session.commit()
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps(expected_user_ids),
+            "broadcast_expected_user_ids": json.dumps(expected_user_ids),
+            "broadcast_final_chunk": "1",
+            "broadcast_id": broadcast_id,
+            "encrypted_payloads": json.dumps(
+                {
+                    str(user2.id): ARMORED_BROADCAST,
+                    str(user3.id): ARMORED_BROADCAST,
+                }
+            ),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "One or more recipients became ineligible before submission."
+    }
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 1
+    broadcast = db.session.scalars(db.select(AdminBroadcast)).one()
+    assert broadcast.status == AdminBroadcast.STATUS_IN_PROGRESS
+    assert broadcast.submitted_count == 1
+    assert broadcast.pending_count == 2
+    send_notifications.assert_called_once_with((user.id,))
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")

--- a/tests/test_admin_broadcasts.py
+++ b/tests/test_admin_broadcasts.py
@@ -548,6 +548,120 @@ def test_broadcasts_continues_same_page_chunk_with_original_audience(
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_replays_committed_chunk_without_duplicate_messages(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    user2.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    db.session.commit()
+    send_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._send_broadcast_notification_emails",
+        send_notifications,
+    )
+    expected_user_ids = [user.id, user2.id]
+
+    first = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps(expected_user_ids),
+            "broadcast_final_chunk": "0",
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+    broadcast_id = first.get_json()["broadcast_id"]
+
+    replay = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps(expected_user_ids),
+            "broadcast_final_chunk": "0",
+            "broadcast_id": broadcast_id,
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert replay.status_code == 200
+    payload = replay.get_json()
+    assert payload["submitted_count"] == 1
+    assert payload["skipped_count"] == 0
+    assert payload["pending_count"] == 1
+    assert payload["broadcast_complete"] is False
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 1
+    broadcast = db.session.scalars(db.select(AdminBroadcast)).one()
+    assert broadcast.status == AdminBroadcast.STATUS_IN_PROGRESS
+    assert broadcast.submitted_count == 1
+    assert broadcast.pending_count == 1
+    send_notifications.assert_called_once_with((user.id,))
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_replays_completed_final_chunk_without_duplicate_messages(
+    client: FlaskClient,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    db.session.commit()
+    send_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._send_broadcast_notification_emails",
+        send_notifications,
+    )
+
+    first = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id]),
+            "broadcast_final_chunk": "1",
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+    broadcast_id = first.get_json()["broadcast_id"]
+
+    replay = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id]),
+            "broadcast_final_chunk": "1",
+            "broadcast_id": broadcast_id,
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert replay.status_code == 200
+    payload = replay.get_json()
+    assert payload["submitted_count"] == 1
+    assert payload["skipped_count"] == 0
+    assert payload["pending_count"] == 0
+    assert payload["broadcast_complete"] is True
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 1
+    broadcast = db.session.scalars(db.select(AdminBroadcast)).one()
+    assert broadcast.status == AdminBroadcast.STATUS_COMPLETED
+    assert broadcast.submitted_count == 1
+    send_notifications.assert_called_once_with((user.id,))
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
 def test_broadcasts_resume_rejects_payload_for_ineligible_pending_recipient(
     client: FlaskClient,
     user: User,

--- a/tests/test_admin_broadcasts.py
+++ b/tests/test_admin_broadcasts.py
@@ -7,7 +7,7 @@ from flask import url_for
 from flask.testing import FlaskClient
 
 from hushline.db import db
-from hushline.model import ChatKey, Message, User
+from hushline.model import AdminBroadcast, AdminBroadcastRecipient, ChatKey, Message, User
 from hushline.settings.broadcast import _send_broadcast_notification_emails
 
 ARMORED_BROADCAST = (
@@ -300,12 +300,24 @@ def test_broadcasts_submit_encrypted_chunk(
     )
 
     assert response.status_code == 200
-    assert response.get_json() == {"submitted_count": 1, "skipped_count": 0}
+    payload = response.get_json()
+    assert payload["submitted_count"] == 1
+    assert payload["skipped_count"] == 0
+    assert payload["pending_count"] == 0
+    assert payload["broadcast_complete"] is True
+    assert payload["broadcast_id"]
     messages = db.session.scalars(db.select(Message).order_by(Message.id)).all()
     assert len(messages) == 1
     assert messages[0].username_id == user.primary_username.id
     assert messages[0].field_values[0].encrypted is True
     assert messages[0].field_values[0].value == ARMORED_BROADCAST
+    broadcast = db.session.scalars(db.select(AdminBroadcast)).one()
+    assert broadcast.public_id == payload["broadcast_id"]
+    assert broadcast.status == AdminBroadcast.STATUS_COMPLETED
+    assert broadcast.submitted_count == 1
+    assert broadcast.skipped_count == 0
+    assert broadcast.pending_count == 0
+    assert broadcast.recipients[0].message_id == messages[0].id
     send_notifications.assert_called_once_with((user.id,))
 
 
@@ -339,9 +351,129 @@ def test_broadcasts_chunk_accepts_failure_only_batch(
     )
 
     assert response.status_code == 200
-    assert response.get_json() == {"submitted_count": 0, "skipped_count": 1}
+    payload = response.get_json()
+    assert payload["submitted_count"] == 0
+    assert payload["skipped_count"] == 1
+    assert payload["pending_count"] == 0
+    assert payload["broadcast_complete"] is True
     assert db.session.scalar(db.select(db.func.count(Message.id))) == 0
+    broadcast = db.session.scalars(db.select(AdminBroadcast)).one()
+    assert broadcast.status == AdminBroadcast.STATUS_COMPLETED
+    assert broadcast.submitted_count == 0
+    assert broadcast.skipped_count == 1
+    assert broadcast.recipients[0].status == AdminBroadcastRecipient.STATUS_SKIPPED
     send_notifications.assert_not_called()
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_refresh_resumes_interrupted_chunk_for_pending_recipients(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    user2.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    db.session.commit()
+    send_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._send_broadcast_notification_emails",
+        send_notifications,
+    )
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id, user2.id]),
+            "broadcast_final_chunk": "0",
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["submitted_count"] == 1
+    assert payload["skipped_count"] == 0
+    assert payload["pending_count"] == 1
+    assert payload["broadcast_complete"] is False
+    broadcast = db.session.scalars(db.select(AdminBroadcast)).one()
+    assert broadcast.public_id == payload["broadcast_id"]
+    assert broadcast.status == AdminBroadcast.STATUS_IN_PROGRESS
+
+    refresh = client.get(url_for("settings.broadcasts"))
+
+    assert refresh.status_code == 200
+    soup = BeautifulSoup(refresh.text, "html.parser")
+    refresh_text = soup.get_text(" ", strip=True)
+    assert "Interrupted broadcast:" in refresh_text
+    assert "1 submitted" in refresh_text
+    assert "0 skipped" in refresh_text
+    assert "1 pending" in refresh_text
+    assert soup.select_one("#broadcast_id")["value"] == broadcast.public_id
+    assert json.loads(soup.select_one("#broadcast_expected_user_ids")["value"]) == [user2.id]
+    recipients = json.loads(soup.select_one("#broadcastEncryptionRecipients").text)
+    assert [recipient["user_id"] for recipient in recipients] == [user2.id]
+    send_notifications.assert_called_once_with((user.id,))
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_resume_submits_pending_only_without_duplicate_messages(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    user2.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    db.session.commit()
+    send_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._send_broadcast_notification_emails",
+        send_notifications,
+    )
+    first = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id, user2.id]),
+            "broadcast_final_chunk": "0",
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+    broadcast_id = first.get_json()["broadcast_id"]
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user2.id]),
+            "broadcast_expected_user_ids": json.dumps([user2.id]),
+            "broadcast_final_chunk": "1",
+            "broadcast_id": broadcast_id,
+            "encrypted_payloads": json.dumps({str(user2.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["submitted_count"] == 1
+    assert payload["pending_count"] == 0
+    assert payload["broadcast_complete"] is True
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 2
+    broadcast = db.session.scalars(db.select(AdminBroadcast)).one()
+    assert broadcast.status == AdminBroadcast.STATUS_COMPLETED
+    assert broadcast.submitted_count == 2
+    send_notifications.assert_any_call((user.id,))
+    send_notifications.assert_any_call((user2.id,))
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")

--- a/tests/test_admin_broadcasts.py
+++ b/tests/test_admin_broadcasts.py
@@ -1,5 +1,6 @@
 import json
 from unittest.mock import MagicMock
+from uuid import uuid4
 
 import pytest
 from bs4 import BeautifulSoup
@@ -331,6 +332,72 @@ def test_broadcasts_submit_encrypted_chunk(
     assert broadcast.skipped_count == 0
     assert broadcast.pending_count == 0
     assert broadcast.recipients[0].message_id == messages[0].id
+    send_notifications.assert_called_once_with((user.id,))
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_uses_client_broadcast_id_for_first_chunk(
+    client: FlaskClient,
+    user: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    _enable_notification_email(user, "primary@example.com")
+    db.session.commit()
+    send_notifications = MagicMock()
+    monkeypatch.setattr(
+        "hushline.settings.broadcast._send_broadcast_notification_emails",
+        send_notifications,
+    )
+    broadcast_id = str(uuid4())
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id]),
+            "broadcast_final_chunk": "1",
+            "broadcast_id": broadcast_id,
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload["broadcast_id"] == broadcast_id
+    assert payload["submitted_count"] == 1
+    assert payload["pending_count"] == 0
+    assert payload["broadcast_complete"] is True
+    broadcast = db.session.scalars(db.select(AdminBroadcast)).one()
+    assert broadcast.public_id == broadcast_id
+    assert broadcast.status == AdminBroadcast.STATUS_COMPLETED
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 1
+    send_notifications.assert_called_once_with((user.id,))
+
+    replay = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id]),
+            "broadcast_final_chunk": "1",
+            "broadcast_id": broadcast_id,
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert replay.status_code == 200
+    replay_payload = replay.get_json()
+    assert replay_payload["broadcast_id"] == broadcast_id
+    assert replay_payload["submitted_count"] == 1
+    assert replay_payload["pending_count"] == 0
+    assert replay_payload["broadcast_complete"] is True
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 1
     send_notifications.assert_called_once_with((user.id,))
 
 


### PR DESCRIPTION
Superseded by a clean replacement PR. This branch accumulated several rounds of review churn while shaping the broadcast reliability fix; closing it so the final version can be reviewed from a fresh branch with a focused history.