### PR TITLE
Guard admin deletion for Stripe subscriptions

### DIFF
--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -166,7 +166,7 @@ The app and public directory support more than individual profiles. Current disc
 | Admin | Mark an account as cautious                                                                       | Visitors can receive a visible warning before trusting a listing                                  | Settings -> Users           |
 | Admin | Suspend an account                                                                                | The platform can stop new message intake for unsafe or abusive accounts                           | Settings -> Users           |
 | Admin | Grant or remove admin privileges                                                                  | Governance tasks can be shared deliberately                                                       | Settings -> Users           |
-| Admin | Delete a primary user account                                                                     | I can remove an account and its related data when required                                        | Settings -> Users           |
+| Admin | Delete a primary user account                                                                     | I can remove an account and its related data after active Stripe subscriptions are resolved       | Settings -> Users           |
 | Admin | Delete an alias without deleting the whole user                                                   | I can remove an outdated intake endpoint while preserving the owner account                       | Settings -> Users           |
 | Admin | Preserve participant-only access to account conversations                                         | Administrators can govern accounts without becoming hidden readers of conversation ciphertext     | Admin moderation boundaries |
 

--- a/hushline/admin.py
+++ b/hushline/admin.py
@@ -7,7 +7,12 @@ from hushline.auth import admin_authentication_required
 from hushline.db import db
 from hushline.model import AccountCategory, OrganizationSetting, Tier, User, Username
 from hushline.premium import update_price
-from hushline.user_deletion import delete_user_and_related, delete_username_and_related
+from hushline.user_deletion import (
+    delete_user_and_related,
+    delete_username_and_related,
+    has_deletion_blocking_stripe_invoice,
+    has_deletion_blocking_stripe_invoice_event,
+)
 from hushline.utils import parse_bool
 
 
@@ -231,6 +236,31 @@ def create_blueprint() -> Blueprint:
             user = db.session.get(User, user_id)
             if user is None:
                 abort(404)
+
+            if user.has_deletion_blocking_stripe_subscription:
+                flash(
+                    "⛔️ This account has an active or unresolved Stripe subscription. "
+                    "Cancel the subscription and wait for Stripe to confirm cancellation "
+                    "before deleting the account.",
+                    "danger",
+                )
+                return abort(400)
+
+            if has_deletion_blocking_stripe_invoice(user):
+                flash(
+                    "⛔️ This account has draft, open, or unknown Stripe invoices. "
+                    "Resolve those invoices before deleting the account.",
+                    "danger",
+                )
+                return abort(400)
+
+            if has_deletion_blocking_stripe_invoice_event(user):
+                flash(
+                    "⛔️ This account has queued Stripe invoice webhooks. "
+                    "Wait for those events to finish before deleting the account.",
+                    "danger",
+                )
+                return abort(400)
 
             delete_user_and_related(user)
 

--- a/hushline/admin.py
+++ b/hushline/admin.py
@@ -12,6 +12,7 @@ from hushline.user_deletion import (
     delete_username_and_related,
     has_deletion_blocking_stripe_invoice,
     has_deletion_blocking_stripe_invoice_event,
+    has_deletion_blocking_stripe_subscription_event,
 )
 from hushline.utils import parse_bool
 
@@ -257,6 +258,14 @@ def create_blueprint() -> Blueprint:
             if has_deletion_blocking_stripe_invoice_event(user):
                 flash(
                     "⛔️ This account has queued Stripe invoice webhooks. "
+                    "Wait for those events to finish before deleting the account.",
+                    "danger",
+                )
+                return abort(400)
+
+            if has_deletion_blocking_stripe_subscription_event(user):
+                flash(
+                    "⛔️ This account has queued Stripe subscription webhooks. "
                     "Wait for those events to finish before deleting the account.",
                     "danger",
                 )

--- a/hushline/model/user.py
+++ b/hushline/model/user.py
@@ -312,6 +312,9 @@ class User(Model):
 
     @property
     def has_deletion_blocking_stripe_subscription(self) -> bool:
+        if self.stripe_subscription_status == StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED:
+            return False
+
         return bool(self.stripe_subscription_id)
 
     def set_free_tier(self) -> None:

--- a/hushline/model/user.py
+++ b/hushline/model/user.py
@@ -310,6 +310,10 @@ class User(Model):
             and self.stripe_subscription_status == StripeSubscriptionStatusEnum.ACTIVE
         )
 
+    @property
+    def has_deletion_blocking_stripe_subscription(self) -> bool:
+        return bool(self.stripe_subscription_id)
+
     def set_free_tier(self) -> None:
         self.tier_id = Tier.free_tier_id()
 

--- a/hushline/premium.py
+++ b/hushline/premium.py
@@ -36,6 +36,11 @@ from hushline.model import (
 TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES = {
     StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED,
 }
+REDACTED_STRIPE_EVENT_DATA = "{}"
+STRIPE_INVOICE_UPDATE_EVENT_TYPES = {
+    "invoice.updated",
+    "invoice.payment_succeeded",
+}
 
 
 def init_stripe() -> None:
@@ -188,6 +193,9 @@ def get_subscription(user: User) -> stripe.Subscription | None:
     if user.stripe_subscription_id is None:
         return None
 
+    if user.stripe_subscription_status in TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES:
+        return None
+
     return stripe.Subscription.retrieve(user.stripe_subscription_id)
 
 
@@ -231,16 +239,24 @@ def handle_subscription_updated(subscription: stripe.Subscription) -> None:
     # customer.subscription.updated
 
     # If subscription changes to cancel or unpaid, downgrade user
+    subscription_status = StripeSubscriptionStatusEnum(subscription.status)
     user = db.session.scalars(
         db.select(User).filter_by(stripe_subscription_id=subscription.id)
     ).one_or_none()
     if user:
-        subscription_status = StripeSubscriptionStatusEnum(subscription.status)
+        if (
+            user.stripe_subscription_status in TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES
+            and subscription_status not in TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES
+        ):
+            current_app.logger.info(
+                f"Ignoring stale update for terminal subscription {subscription.id}"
+            )
+            return
+
         user.stripe_subscription_status = subscription_status
 
         if subscription_status in TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES:
             user.set_free_tier()
-            user.stripe_subscription_id = None
             user.stripe_subscription_cancel_at_period_end = None
             user.stripe_subscription_current_period_end = None
             user.stripe_subscription_current_period_start = None
@@ -262,8 +278,29 @@ def handle_subscription_updated(subscription: stripe.Subscription) -> None:
             user.set_free_tier()
 
         db.session.commit()
-    else:
-        raise ValueError(f"Could not find user with subscription ID {subscription.id}")
+        return
+
+    customer_id = getattr(subscription, "customer", None)
+    if isinstance(customer_id, str):
+        customer_user = db.session.scalars(
+            db.select(User).filter_by(stripe_customer_id=customer_id)
+        ).one_or_none()
+        if customer_user is None:
+            current_app.logger.info(
+                f"Ignoring subscription update for deleted customer {customer_id}"
+            )
+            return
+        if (
+            customer_user.stripe_subscription_id is None
+            and customer_user.stripe_subscription_status
+            in TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES
+        ):
+            current_app.logger.info(
+                f"Ignoring stale update for terminal subscription {subscription.id}"
+            )
+            return
+
+    raise ValueError(f"Could not find user with subscription ID {subscription.id}")
 
 
 def handle_subscription_deleted(subscription: stripe.Subscription) -> None:
@@ -274,14 +311,35 @@ def handle_subscription_deleted(subscription: stripe.Subscription) -> None:
     ).one_or_none()
     if user:
         user.set_free_tier()
+        if user.stripe_subscription_status in TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES:
+            db.session.commit()
+            return
+
         user.stripe_subscription_id = None
         user.stripe_subscription_status = None
         user.stripe_subscription_cancel_at_period_end = None
         user.stripe_subscription_current_period_end = None
         user.stripe_subscription_current_period_start = None
         db.session.commit()
-    else:
-        raise ValueError(f"Could not find user with subscription ID {subscription.id}")
+        return
+
+    customer_id = getattr(subscription, "customer", None)
+    if isinstance(customer_id, str):
+        customer_user = db.session.scalars(
+            db.select(User).filter_by(stripe_customer_id=customer_id)
+        ).one_or_none()
+        if customer_user is None:
+            current_app.logger.info(
+                f"Ignoring subscription delete for deleted customer {customer_id}"
+            )
+            return
+        if customer_user.stripe_subscription_status in TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES:
+            current_app.logger.info(
+                f"Ignoring stale delete for terminal subscription {subscription.id}"
+            )
+            return
+
+    raise ValueError(f"Could not find user with subscription ID {subscription.id}")
 
 
 def handle_invoice_created(invoice: stripe.Invoice) -> None:
@@ -318,17 +376,53 @@ def _sync_invoice(stripe_invoice: StripeInvoice, invoice: stripe.Invoice) -> Non
         stripe_invoice.hosted_invoice_url = receipt_url
 
 
+def _invoice_id_from_stripe_event_data(event_data: str) -> str | None:
+    try:
+        event = json.loads(event_data)
+    except json.JSONDecodeError:
+        return None
+
+    invoice_id = event.get("data", {}).get("object", {}).get("id")
+    if isinstance(invoice_id, str):
+        return invoice_id
+
+    return None
+
+
+def _redact_stripe_invoice_event_payloads(invoice_id: str) -> None:
+    events = db.session.scalars(
+        db.select(StripeEvent).where(StripeEvent.event_type.in_(STRIPE_INVOICE_UPDATE_EVENT_TYPES))
+    )
+    for event in events:
+        if _invoice_id_from_stripe_event_data(event.event_data) == invoice_id:
+            event.event_data = REDACTED_STRIPE_EVENT_DATA
+
+
 def handle_invoice_updated(invoice: stripe.Invoice) -> None:
     # invoice.updated
 
+    invoice_id = getattr(invoice, "id", None)
     stripe_invoice = db.session.scalars(
-        db.select(StripeInvoice).filter_by(invoice_id=invoice.id)
+        db.select(StripeInvoice).filter_by(invoice_id=invoice_id)
     ).one_or_none()
     if stripe_invoice:
         _sync_invoice(stripe_invoice, invoice)
         db.session.commit()
     else:
-        raise ValueError(f"Could not find invoice with ID {invoice.id}")
+        customer_id = getattr(invoice, "customer", None)
+        if isinstance(customer_id, str):
+            user = db.session.scalars(
+                db.select(User).filter_by(stripe_customer_id=customer_id)
+            ).one_or_none()
+            if user is None:
+                current_app.logger.info(
+                    f"Ignoring invoice update for deleted customer {customer_id}"
+                )
+                if isinstance(invoice_id, str):
+                    _redact_stripe_invoice_event_payloads(invoice_id)
+                return
+
+        raise ValueError(f"Could not find invoice with ID {invoice_id}")
 
 
 async def worker(app: Flask) -> None:

--- a/hushline/premium.py
+++ b/hushline/premium.py
@@ -33,6 +33,10 @@ from hushline.model import (
     User,
 )
 
+TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES = {
+    StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED,
+}
+
 
 def init_stripe() -> None:
     stripe.api_key = current_app.config["STRIPE_SECRET_KEY"]
@@ -231,7 +235,18 @@ def handle_subscription_updated(subscription: stripe.Subscription) -> None:
         db.select(User).filter_by(stripe_subscription_id=subscription.id)
     ).one_or_none()
     if user:
-        user.stripe_subscription_status = StripeSubscriptionStatusEnum(subscription.status)
+        subscription_status = StripeSubscriptionStatusEnum(subscription.status)
+        user.stripe_subscription_status = subscription_status
+
+        if subscription_status in TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES:
+            user.set_free_tier()
+            user.stripe_subscription_id = None
+            user.stripe_subscription_cancel_at_period_end = None
+            user.stripe_subscription_current_period_end = None
+            user.stripe_subscription_current_period_start = None
+            db.session.commit()
+            return
+
         user.stripe_subscription_cancel_at_period_end = subscription.cancel_at_period_end
         user.stripe_subscription_current_period_end = datetime.fromtimestamp(
             subscription.current_period_end

--- a/hushline/premium.py
+++ b/hushline/premium.py
@@ -389,16 +389,14 @@ def _invoice_id_from_stripe_event_data(event_data: str) -> str | None:
     return None
 
 
-def _redact_stripe_invoice_event_payloads(invoice_id: str) -> None:
-    events = db.session.scalars(
-        db.select(StripeEvent).where(StripeEvent.event_type.in_(STRIPE_INVOICE_UPDATE_EVENT_TYPES))
-    )
-    for event in events:
-        if _invoice_id_from_stripe_event_data(event.event_data) == invoice_id:
-            event.event_data = REDACTED_STRIPE_EVENT_DATA
+def _redact_stripe_event_payload(stripe_event: StripeEvent | None) -> None:
+    if stripe_event is not None:
+        stripe_event.event_data = REDACTED_STRIPE_EVENT_DATA
 
 
-def handle_invoice_updated(invoice: stripe.Invoice) -> None:
+def handle_invoice_updated(
+    invoice: stripe.Invoice, stripe_event: StripeEvent | None = None
+) -> None:
     # invoice.updated
 
     invoice_id = getattr(invoice, "id", None)
@@ -418,8 +416,7 @@ def handle_invoice_updated(invoice: stripe.Invoice) -> None:
                 current_app.logger.info(
                     f"Ignoring invoice update for deleted customer {customer_id}"
                 )
-                if isinstance(invoice_id, str):
-                    _redact_stripe_invoice_event_payloads(invoice_id)
+                _redact_stripe_event_payload(stripe_event)
                 return
 
         raise ValueError(f"Could not find invoice with ID {invoice_id}")
@@ -496,7 +493,7 @@ async def worker(app: Flask) -> None:
                     if event.type == "invoice.created":
                         handle_invoice_created(invoice)
                     elif event.type in ["invoice.updated", "invoice.payment_succeeded"]:
-                        handle_invoice_updated(invoice)
+                        handle_invoice_updated(invoice, stripe_event)
 
             except (
                 json.JSONDecodeError,

--- a/hushline/premium.py
+++ b/hushline/premium.py
@@ -214,13 +214,21 @@ def get_business_price_string() -> str:
     return business_price
 
 
-def handle_subscription_created(subscription: stripe.Subscription) -> None:
+def handle_subscription_created(
+    subscription: stripe.Subscription, stripe_event: StripeEvent | None = None
+) -> None:
     # customer.subscription.created
 
     user = db.session.scalars(
         db.select(User).filter_by(stripe_customer_id=subscription.customer)
     ).one_or_none()
     if user:
+        if user.stripe_subscription_status in TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES:
+            current_app.logger.info(
+                f"Ignoring stale created event for terminal subscription {subscription.id}"
+            )
+            return
+
         user.stripe_subscription_id = subscription.id
         user.stripe_subscription_status = StripeSubscriptionStatusEnum(subscription.status)
         user.stripe_subscription_cancel_at_period_end = subscription.cancel_at_period_end
@@ -232,10 +240,20 @@ def handle_subscription_created(subscription: stripe.Subscription) -> None:
         )
         db.session.commit()
     else:
+        customer_id = getattr(subscription, "customer", None)
+        if stripe_event is not None and isinstance(customer_id, str):
+            current_app.logger.info(
+                f"Ignoring subscription create for deleted customer {customer_id}"
+            )
+            _redact_stripe_event_payload(stripe_event)
+            return
+
         raise ValueError(f"Could not find user with customer ID {subscription.customer}")
 
 
-def handle_subscription_updated(subscription: stripe.Subscription) -> None:
+def handle_subscription_updated(
+    subscription: stripe.Subscription, stripe_event: StripeEvent | None = None
+) -> None:
     # customer.subscription.updated
 
     # If subscription changes to cancel or unpaid, downgrade user
@@ -289,6 +307,7 @@ def handle_subscription_updated(subscription: stripe.Subscription) -> None:
             current_app.logger.info(
                 f"Ignoring subscription update for deleted customer {customer_id}"
             )
+            _redact_stripe_event_payload(stripe_event)
             return
         if (
             customer_user.stripe_subscription_id is None
@@ -303,7 +322,9 @@ def handle_subscription_updated(subscription: stripe.Subscription) -> None:
     raise ValueError(f"Could not find user with subscription ID {subscription.id}")
 
 
-def handle_subscription_deleted(subscription: stripe.Subscription) -> None:
+def handle_subscription_deleted(
+    subscription: stripe.Subscription, stripe_event: StripeEvent | None = None
+) -> None:
     # customer.subscription.deleted
 
     user = db.session.scalars(
@@ -332,6 +353,7 @@ def handle_subscription_deleted(subscription: stripe.Subscription) -> None:
             current_app.logger.info(
                 f"Ignoring subscription delete for deleted customer {customer_id}"
             )
+            _redact_stripe_event_payload(stripe_event)
             return
         if customer_user.stripe_subscription_status in TERMINAL_NON_BILLING_SUBSCRIPTION_STATUSES:
             current_app.logger.info(
@@ -342,12 +364,26 @@ def handle_subscription_deleted(subscription: stripe.Subscription) -> None:
     raise ValueError(f"Could not find user with subscription ID {subscription.id}")
 
 
-def handle_invoice_created(invoice: stripe.Invoice) -> None:
+def handle_invoice_created(
+    invoice: stripe.Invoice, stripe_event: StripeEvent | None = None
+) -> None:
     # invoice.created
 
     try:
         new_invoice = StripeInvoice(invoice)
     except ValueError as e:
+        customer_id = getattr(invoice, "customer", None)
+        if stripe_event is not None and isinstance(customer_id, str):
+            user = db.session.scalars(
+                db.select(User).filter_by(stripe_customer_id=customer_id)
+            ).one_or_none()
+            if user is None:
+                current_app.logger.info(
+                    f"Ignoring invoice create for deleted customer {customer_id}"
+                )
+                _redact_stripe_event_payload(stripe_event)
+                return
+
         current_app.logger.error(f"Error creating invoice: {e}")
         return
 
@@ -480,18 +516,18 @@ async def worker(app: Flask) -> None:
                         event.data.object, current_app.config["STRIPE_SECRET_KEY"]
                     )
                     if event.type == "customer.subscription.created":
-                        handle_subscription_created(subscription)
+                        handle_subscription_created(subscription, stripe_event)
                     elif event.type == "customer.subscription.updated":
-                        handle_subscription_updated(subscription)
+                        handle_subscription_updated(subscription, stripe_event)
                     elif event.type == "customer.subscription.deleted":
-                        handle_subscription_deleted(subscription)
+                        handle_subscription_deleted(subscription, stripe_event)
                 # invoice events
                 elif event.type.startswith("invoice."):
                     invoice: stripe.Invoice = stripe.Invoice.construct_from(
                         event.data.object, current_app.config["STRIPE_SECRET_KEY"]
                     )
                     if event.type == "invoice.created":
-                        handle_invoice_created(invoice)
+                        handle_invoice_created(invoice, stripe_event)
                     elif event.type in ["invoice.updated", "invoice.payment_succeeded"]:
                         handle_invoice_updated(invoice, stripe_event)
 

--- a/hushline/settings/admin.py
+++ b/hushline/settings/admin.py
@@ -12,6 +12,11 @@ from sqlalchemy.orm import joinedload
 from hushline.auth import admin_authentication_required
 from hushline.db import db
 from hushline.model import AccountCategory, User, Username
+from hushline.user_deletion import (
+    deletion_blocking_stripe_invoice_counts_by_user_ids,
+    deletion_blocking_stripe_invoice_event_counts_by_user_ids,
+    stripe_invoice_counts_by_user_ids,
+)
 
 ADMIN_USERNAMES_PER_PAGE = 20
 
@@ -62,6 +67,14 @@ def register_admin_routes(bp: Blueprint) -> None:
                 username_query.limit(ADMIN_USERNAMES_PER_PAGE).offset(page_offset)
             ).all()
         )
+        user_ids = {username.user_id for username in all_usernames}
+        stripe_invoice_counts_by_user_id = stripe_invoice_counts_by_user_ids(user_ids)
+        deletion_blocking_stripe_invoice_counts_by_user_id = (
+            deletion_blocking_stripe_invoice_counts_by_user_ids(user_ids)
+        )
+        deletion_blocking_stripe_invoice_event_counts_by_user_id = (
+            deletion_blocking_stripe_invoice_event_counts_by_user_ids(user_ids)
+        )
 
         page_start = page_offset + 1 if username_count else 0
         page_end = min(page_offset + len(all_usernames), username_count)
@@ -79,5 +92,12 @@ def register_admin_routes(bp: Blueprint) -> None:
             admin_total_pages=total_pages,
             admin_page_start=page_start,
             admin_page_end=page_end,
+            stripe_invoice_counts_by_user_id=stripe_invoice_counts_by_user_id,
+            deletion_blocking_stripe_invoice_counts_by_user_id=(
+                deletion_blocking_stripe_invoice_counts_by_user_id
+            ),
+            deletion_blocking_stripe_invoice_event_counts_by_user_id=(
+                deletion_blocking_stripe_invoice_event_counts_by_user_id
+            ),
             csrf_token=generate_csrf(),
         )

--- a/hushline/settings/admin.py
+++ b/hushline/settings/admin.py
@@ -15,6 +15,7 @@ from hushline.model import AccountCategory, User, Username
 from hushline.user_deletion import (
     deletion_blocking_stripe_invoice_counts_by_user_ids,
     deletion_blocking_stripe_invoice_event_counts_by_user_ids,
+    deletion_blocking_stripe_subscription_event_counts_by_user_ids,
     stripe_invoice_counts_by_user_ids,
 )
 
@@ -75,6 +76,9 @@ def register_admin_routes(bp: Blueprint) -> None:
         deletion_blocking_stripe_invoice_event_counts_by_user_id = (
             deletion_blocking_stripe_invoice_event_counts_by_user_ids(user_ids)
         )
+        deletion_blocking_stripe_subscription_event_counts_by_user_id = (
+            deletion_blocking_stripe_subscription_event_counts_by_user_ids(user_ids)
+        )
 
         page_start = page_offset + 1 if username_count else 0
         page_end = min(page_offset + len(all_usernames), username_count)
@@ -98,6 +102,9 @@ def register_admin_routes(bp: Blueprint) -> None:
             ),
             deletion_blocking_stripe_invoice_event_counts_by_user_id=(
                 deletion_blocking_stripe_invoice_event_counts_by_user_id
+            ),
+            deletion_blocking_stripe_subscription_event_counts_by_user_id=(
+                deletion_blocking_stripe_subscription_event_counts_by_user_id
             ),
             csrf_token=generate_csrf(),
         )

--- a/hushline/settings/delete_account.py
+++ b/hushline/settings/delete_account.py
@@ -15,6 +15,7 @@ from hushline.user_deletion import (
     delete_user_and_related,
     has_deletion_blocking_stripe_invoice,
     has_deletion_blocking_stripe_invoice_event,
+    has_deletion_blocking_stripe_subscription_event,
 )
 
 
@@ -49,6 +50,13 @@ def register_delete_account_routes(bp: Blueprint) -> None:
                 if has_deletion_blocking_stripe_invoice_event(user):
                     flash(
                         "⛔️ Your account has queued Stripe invoice webhooks. "
+                        "Wait for those events to finish before deleting your account."
+                    )
+                    return abort(400)
+
+                if has_deletion_blocking_stripe_subscription_event(user):
+                    flash(
+                        "⛔️ Your account has queued Stripe subscription webhooks. "
                         "Wait for those events to finish before deleting your account."
                     )
                     return abort(400)

--- a/hushline/settings/delete_account.py
+++ b/hushline/settings/delete_account.py
@@ -11,7 +11,11 @@ from werkzeug.wrappers.response import Response
 from hushline.auth import authentication_required
 from hushline.db import db
 from hushline.model import User
-from hushline.user_deletion import delete_user_and_related
+from hushline.user_deletion import (
+    delete_user_and_related,
+    has_deletion_blocking_stripe_invoice,
+    has_deletion_blocking_stripe_invoice_event,
+)
 
 
 def register_delete_account_routes(bp: Blueprint) -> None:
@@ -26,6 +30,28 @@ def register_delete_account_routes(bp: Blueprint) -> None:
                     if admin_count == 1:
                         flash("⛔️ You cannot delete the only admin account.")
                         return abort(400)
+
+                if user.has_deletion_blocking_stripe_subscription:
+                    flash(
+                        "⛔️ Your account has an active or unresolved Stripe subscription. "
+                        "Cancel the subscription and wait for Stripe to confirm cancellation "
+                        "before deleting your account."
+                    )
+                    return abort(400)
+
+                if has_deletion_blocking_stripe_invoice(user):
+                    flash(
+                        "⛔️ Your account has draft, open, or unknown Stripe invoices. "
+                        "Resolve those invoices before deleting your account."
+                    )
+                    return abort(400)
+
+                if has_deletion_blocking_stripe_invoice_event(user):
+                    flash(
+                        "⛔️ Your account has queued Stripe invoice webhooks. "
+                        "Wait for those events to finish before deleting your account."
+                    )
+                    return abort(400)
 
                 delete_user_and_related(user)
             else:

--- a/hushline/templates/settings/admin.html
+++ b/hushline/templates/settings/admin.html
@@ -84,7 +84,8 @@
         {% set stripe_invoice_count = stripe_invoice_counts_by_user_id.get(username.user.id, 0) %}
         {% set deletion_blocking_stripe_invoice_count = deletion_blocking_stripe_invoice_counts_by_user_id.get(username.user.id, 0) %}
         {% set deletion_blocking_stripe_invoice_event_count = deletion_blocking_stripe_invoice_event_counts_by_user_id.get(username.user.id, 0) %}
-        {% set has_deletion_blocking_stripe_billing = username.user.has_deletion_blocking_stripe_subscription or deletion_blocking_stripe_invoice_count or deletion_blocking_stripe_invoice_event_count %}
+        {% set deletion_blocking_stripe_subscription_event_count = deletion_blocking_stripe_subscription_event_counts_by_user_id.get(username.user.id, 0) %}
+        {% set has_deletion_blocking_stripe_billing = username.user.has_deletion_blocking_stripe_subscription or deletion_blocking_stripe_invoice_count or deletion_blocking_stripe_invoice_event_count or deletion_blocking_stripe_subscription_event_count %}
         {% if username.is_primary and (stripe_invoice_count or has_deletion_blocking_stripe_billing) %}
           <p class="meta">
             Stripe Billing:
@@ -99,6 +100,11 @@
             {% if deletion_blocking_stripe_invoice_event_count %}
               {{ deletion_blocking_stripe_invoice_event_count }} queued invoice
               webhook{{ "" if deletion_blocking_stripe_invoice_event_count == 1 else "s" }};
+              deletion disabled.
+            {% endif %}
+            {% if deletion_blocking_stripe_subscription_event_count %}
+              {{ deletion_blocking_stripe_subscription_event_count }} queued subscription
+              webhook{{ "" if deletion_blocking_stripe_subscription_event_count == 1 else "s" }};
               deletion disabled.
             {% endif %}
             {% if stripe_invoice_count %}

--- a/hushline/templates/settings/admin.html
+++ b/hushline/templates/settings/admin.html
@@ -81,6 +81,32 @@
         <p class="meta">
           Account Category: {{ username.user.account_category_label or "None" }}
         </p>
+        {% set stripe_invoice_count = stripe_invoice_counts_by_user_id.get(username.user.id, 0) %}
+        {% set deletion_blocking_stripe_invoice_count = deletion_blocking_stripe_invoice_counts_by_user_id.get(username.user.id, 0) %}
+        {% set deletion_blocking_stripe_invoice_event_count = deletion_blocking_stripe_invoice_event_counts_by_user_id.get(username.user.id, 0) %}
+        {% set has_deletion_blocking_stripe_billing = username.user.has_deletion_blocking_stripe_subscription or deletion_blocking_stripe_invoice_count or deletion_blocking_stripe_invoice_event_count %}
+        {% if username.is_primary and (stripe_invoice_count or has_deletion_blocking_stripe_billing) %}
+          <p class="meta">
+            Stripe Billing:
+            {% if username.user.has_deletion_blocking_stripe_subscription %}
+              Active or unresolved subscription; deletion disabled.
+            {% endif %}
+            {% if deletion_blocking_stripe_invoice_count %}
+              {{ deletion_blocking_stripe_invoice_count }} draft, open, or unknown
+              invoice{{ "" if deletion_blocking_stripe_invoice_count == 1 else "s" }};
+              deletion disabled.
+            {% endif %}
+            {% if deletion_blocking_stripe_invoice_event_count %}
+              {{ deletion_blocking_stripe_invoice_event_count }} queued invoice
+              webhook{{ "" if deletion_blocking_stripe_invoice_event_count == 1 else "s" }};
+              deletion disabled.
+            {% endif %}
+            {% if stripe_invoice_count %}
+              {{ stripe_invoice_count }} invoice{{ "" if stripe_invoice_count == 1 else "s" }}
+              associated; deleting this user also deletes stored invoice receipt records.
+            {% endif %}
+          </p>
+        {% endif %}
         <div class="tableActions">
             {% if user_verification_enabled %}
             <form
@@ -164,12 +190,13 @@
             method="POST"
             class="formBody"
           >
+            {% set delete_disabled = session.get('user_id') == username.user.id or (username.is_primary and has_deletion_blocking_stripe_billing) %}
             <input type="hidden" name="csrf_token" value="{{ csrf_token }}" />
             <button
               type="submit"
               class="btn-danger {% if username.is_primary %}delete-user-button{% else %}delete-username-button{% endif %}"
               data-username="{{ username.username }}"
-              {% if session.get('user_id') == username.user.id %}disabled{% endif %}
+              {% if delete_disabled %}disabled{% endif %}
             >
               {{ "Delete User" if username.is_primary else "Delete Alias" }}
             </button>

--- a/hushline/user_deletion.py
+++ b/hushline/user_deletion.py
@@ -30,9 +30,10 @@ DELETION_BLOCKING_STRIPE_INVOICE_EVENT_TYPES = {
     "invoice.updated",
     "invoice.payment_succeeded",
 }
-STRIPE_INVOICE_EVENT_SCRUB_TYPES = {
-    "invoice.created",
-    *DELETION_BLOCKING_STRIPE_INVOICE_EVENT_TYPES,
+DELETION_BLOCKING_STRIPE_SUBSCRIPTION_EVENT_TYPES = {
+    "customer.subscription.created",
+    "customer.subscription.updated",
+    "customer.subscription.deleted",
 }
 REDACTED_STRIPE_EVENT_DATA = "{}"
 
@@ -71,18 +72,105 @@ def deletion_blocking_stripe_invoice_counts_by_user_ids(user_ids: set[int]) -> d
     }
 
 
-def _invoice_id_from_stripe_event_data(event_data: str) -> str | None:
+def _stripe_event_object_from_data(event_data: str) -> dict[str, object]:
     try:
         event = json.loads(event_data)
     except json.JSONDecodeError:
-        return None
+        return {}
 
     event_object = event.get("data", {}).get("object", {})
+    if isinstance(event_object, dict):
+        return event_object
+
+    return {}
+
+
+def _invoice_id_from_stripe_event_data(event_data: str) -> str | None:
+    event_object = _stripe_event_object_from_data(event_data)
     invoice_id = event_object.get("id")
     if isinstance(invoice_id, str):
         return invoice_id
 
     return None
+
+
+def _subscription_ids_from_stripe_event_data(event_data: str) -> tuple[str | None, str | None]:
+    event_object = _stripe_event_object_from_data(event_data)
+    customer_id = event_object.get("customer")
+    subscription_id = event_object.get("id")
+
+    return (
+        customer_id if isinstance(customer_id, str) else None,
+        subscription_id if isinstance(subscription_id, str) else None,
+    )
+
+
+def _stripe_user_ids_by_customer_or_subscription_id(
+    user_ids: set[int],
+) -> tuple[dict[str, int], dict[str, int]]:
+    if not user_ids:
+        return {}, {}
+
+    customer_user_ids: dict[str, int] = {}
+    subscription_user_ids: dict[str, int] = {}
+    for user_id, customer_id, subscription_id in db.session.execute(
+        db.select(User.id, User.stripe_customer_id, User.stripe_subscription_id).where(
+            User.id.in_(user_ids)
+        )
+    ):
+        if isinstance(customer_id, str):
+            customer_user_ids[customer_id] = user_id
+        if isinstance(subscription_id, str):
+            subscription_user_ids[subscription_id] = user_id
+
+    return customer_user_ids, subscription_user_ids
+
+
+def _stripe_event_matches_subscription_ids(
+    event_data: str,
+    customer_ids: set[str],
+    subscription_ids: set[str],
+) -> bool:
+    customer_id, subscription_id = _subscription_ids_from_stripe_event_data(event_data)
+
+    return bool(
+        (customer_id is not None and customer_id in customer_ids)
+        or (subscription_id is not None and subscription_id in subscription_ids)
+    )
+
+
+def _is_processed_stripe_event(event: StripeEvent) -> bool:
+    return event.status not in DELETION_BLOCKING_STRIPE_INVOICE_EVENT_STATUSES
+
+
+def deletion_blocking_stripe_subscription_event_counts_by_user_ids(
+    user_ids: set[int],
+) -> dict[int, int]:
+    customer_user_ids, subscription_user_ids = _stripe_user_ids_by_customer_or_subscription_id(
+        user_ids
+    )
+    if not customer_user_ids and not subscription_user_ids:
+        return {}
+
+    counts_by_user_id: dict[int, int] = {}
+    event_data_rows = db.session.scalars(
+        db.select(StripeEvent.event_data)
+        .where(StripeEvent.event_type.in_(DELETION_BLOCKING_STRIPE_SUBSCRIPTION_EVENT_TYPES))
+        .where(StripeEvent.status.in_(DELETION_BLOCKING_STRIPE_INVOICE_EVENT_STATUSES))
+    )
+    for event_data in event_data_rows:
+        customer_id, subscription_id = _subscription_ids_from_stripe_event_data(event_data)
+        user_id = None
+        if customer_id is not None:
+            user_id = customer_user_ids.get(customer_id)
+        if user_id is None and subscription_id is not None:
+            user_id = subscription_user_ids.get(subscription_id)
+        if user_id is None:
+            continue
+
+        counts_by_user_id[user_id] = counts_by_user_id.get(user_id, 0) + 1
+
+    return counts_by_user_id
 
 
 def deletion_blocking_stripe_invoice_event_counts_by_user_ids(
@@ -138,18 +226,49 @@ def has_deletion_blocking_stripe_invoice_event(user: User) -> bool:
     )
 
 
+def has_deletion_blocking_stripe_subscription_event(user: User) -> bool:
+    if user.id is None:
+        return False
+
+    return bool(
+        deletion_blocking_stripe_subscription_event_counts_by_user_ids({user.id}).get(user.id, 0)
+    )
+
+
 def _redact_processed_stripe_invoice_events(invoice_ids: set[str]) -> None:
     if not invoice_ids:
         return
 
     events = db.session.scalars(
-        db.select(StripeEvent)
-        .where(StripeEvent.event_type.in_(STRIPE_INVOICE_EVENT_SCRUB_TYPES))
-        .where(~StripeEvent.status.in_(DELETION_BLOCKING_STRIPE_INVOICE_EVENT_STATUSES))
+        db.select(StripeEvent).where(StripeEvent.event_type.like("invoice.%"))
     )
     for event in events:
+        if not _is_processed_stripe_event(event):
+            continue
+
         invoice_id = _invoice_id_from_stripe_event_data(event.event_data)
         if invoice_id in invoice_ids:
+            event.event_data = REDACTED_STRIPE_EVENT_DATA
+
+
+def _redact_processed_stripe_subscription_events(
+    customer_ids: set[str],
+    subscription_ids: set[str],
+) -> None:
+    if not customer_ids and not subscription_ids:
+        return
+
+    events = db.session.scalars(
+        db.select(StripeEvent).where(StripeEvent.event_type.like("customer.subscription.%"))
+    )
+    for event in events:
+        if not _is_processed_stripe_event(event):
+            continue
+        if _stripe_event_matches_subscription_ids(
+            event.event_data,
+            customer_ids,
+            subscription_ids,
+        ):
             event.event_data = REDACTED_STRIPE_EVENT_DATA
 
 
@@ -159,6 +278,10 @@ def delete_user_and_related(user: User) -> None:
     username_ids = [username.id for username in usernames]
     stripe_invoice_ids = set(
         db.session.scalars(db.select(StripeInvoice.invoice_id).filter_by(user_id=user.id)).all()
+    )
+    stripe_customer_ids = {user.stripe_customer_id} if user.stripe_customer_id else set()
+    stripe_subscription_ids = (
+        {user.stripe_subscription_id} if user.stripe_subscription_id else set()
     )
 
     # Delete all FieldValue entries related to the user's usernames
@@ -185,6 +308,7 @@ def delete_user_and_related(user: User) -> None:
     db.session.execute(db.delete(AuthenticationLog).filter_by(user_id=user.id))
     db.session.execute(db.delete(NotificationRecipient).filter_by(user_id=user.id))
     _redact_processed_stripe_invoice_events(stripe_invoice_ids)
+    _redact_processed_stripe_subscription_events(stripe_customer_ids, stripe_subscription_ids)
     db.session.execute(db.delete(StripeInvoice).filter_by(user_id=user.id))
 
     # Delete username and finally the user

--- a/hushline/user_deletion.py
+++ b/hushline/user_deletion.py
@@ -1,3 +1,7 @@
+import json
+
+from sqlalchemy import or_
+
 from hushline.db import db
 from hushline.model import (
     AuthenticationLog,
@@ -6,9 +10,127 @@ from hushline.model import (
     Message,
     MessageStatusText,
     NotificationRecipient,
+    StripeEvent,
+    StripeEventStatusEnum,
+    StripeInvoice,
+    StripeInvoiceStatusEnum,
     User,
     Username,
 )
+
+DELETION_BLOCKING_STRIPE_INVOICE_STATUSES = {
+    StripeInvoiceStatusEnum.DRAFT,
+    StripeInvoiceStatusEnum.OPEN,
+}
+DELETION_BLOCKING_STRIPE_INVOICE_EVENT_STATUSES = {
+    StripeEventStatusEnum.PENDING,
+    StripeEventStatusEnum.IN_PROGRESS,
+}
+DELETION_BLOCKING_STRIPE_INVOICE_EVENT_TYPES = {
+    "invoice.updated",
+    "invoice.payment_succeeded",
+}
+
+
+def stripe_invoice_counts_by_user_ids(user_ids: set[int]) -> dict[int, int]:
+    if not user_ids:
+        return {}
+
+    return {
+        user_id: invoice_count
+        for user_id, invoice_count in db.session.execute(
+            db.select(StripeInvoice.user_id, db.func.count(StripeInvoice.id))
+            .where(StripeInvoice.user_id.in_(user_ids))
+            .group_by(StripeInvoice.user_id)
+        )
+    }
+
+
+def deletion_blocking_stripe_invoice_counts_by_user_ids(user_ids: set[int]) -> dict[int, int]:
+    if not user_ids:
+        return {}
+
+    return {
+        user_id: invoice_count
+        for user_id, invoice_count in db.session.execute(
+            db.select(StripeInvoice.user_id, db.func.count(StripeInvoice.id))
+            .where(StripeInvoice.user_id.in_(user_ids))
+            .where(
+                or_(
+                    StripeInvoice.status.is_(None),
+                    StripeInvoice.status.in_(DELETION_BLOCKING_STRIPE_INVOICE_STATUSES),
+                )
+            )
+            .group_by(StripeInvoice.user_id)
+        )
+    }
+
+
+def _invoice_id_from_stripe_event_data(event_data: str) -> str | None:
+    try:
+        event = json.loads(event_data)
+    except json.JSONDecodeError:
+        return None
+
+    event_object = event.get("data", {}).get("object", {})
+    invoice_id = event_object.get("id")
+    if isinstance(invoice_id, str):
+        return invoice_id
+
+    return None
+
+
+def deletion_blocking_stripe_invoice_event_counts_by_user_ids(
+    user_ids: set[int],
+) -> dict[int, int]:
+    if not user_ids:
+        return {}
+
+    invoice_users_by_invoice_id = {
+        invoice_id: user_id
+        for user_id, invoice_id in db.session.execute(
+            db.select(StripeInvoice.user_id, StripeInvoice.invoice_id).where(
+                StripeInvoice.user_id.in_(user_ids)
+            )
+        )
+    }
+    if not invoice_users_by_invoice_id:
+        return {}
+
+    counts_by_user_id: dict[int, int] = {}
+    event_data_rows = db.session.scalars(
+        db.select(StripeEvent.event_data)
+        .where(StripeEvent.event_type.in_(DELETION_BLOCKING_STRIPE_INVOICE_EVENT_TYPES))
+        .where(StripeEvent.status.in_(DELETION_BLOCKING_STRIPE_INVOICE_EVENT_STATUSES))
+    )
+    for event_data in event_data_rows:
+        invoice_id = _invoice_id_from_stripe_event_data(event_data)
+        if invoice_id is None:
+            continue
+
+        user_id = invoice_users_by_invoice_id.get(invoice_id)
+        if user_id is None:
+            continue
+
+        counts_by_user_id[user_id] = counts_by_user_id.get(user_id, 0) + 1
+
+    return counts_by_user_id
+
+
+def has_deletion_blocking_stripe_invoice(user: User) -> bool:
+    if user.id is None:
+        return False
+
+    return bool(deletion_blocking_stripe_invoice_counts_by_user_ids({user.id}).get(user.id, 0))
+
+
+def has_deletion_blocking_stripe_invoice_event(user: User) -> bool:
+    if user.id is None:
+        return False
+
+    return bool(
+        deletion_blocking_stripe_invoice_event_counts_by_user_ids({user.id}).get(user.id, 0)
+    )
 
 
 def delete_user_and_related(user: User) -> None:
@@ -39,6 +161,7 @@ def delete_user_and_related(user: User) -> None:
     db.session.execute(db.delete(MessageStatusText).filter_by(user_id=user.id))
     db.session.execute(db.delete(AuthenticationLog).filter_by(user_id=user.id))
     db.session.execute(db.delete(NotificationRecipient).filter_by(user_id=user.id))
+    db.session.execute(db.delete(StripeInvoice).filter_by(user_id=user.id))
 
     # Delete username and finally the user
     db.session.execute(db.delete(Username).filter_by(user_id=user.id))

--- a/hushline/user_deletion.py
+++ b/hushline/user_deletion.py
@@ -30,6 +30,7 @@ DELETION_BLOCKING_STRIPE_INVOICE_EVENT_TYPES = {
     "invoice.updated",
     "invoice.payment_succeeded",
 }
+REDACTED_STRIPE_EVENT_DATA = "{}"
 
 
 def stripe_invoice_counts_by_user_ids(user_ids: set[int]) -> dict[int, int]:
@@ -133,10 +134,28 @@ def has_deletion_blocking_stripe_invoice_event(user: User) -> bool:
     )
 
 
+def _redact_processed_stripe_invoice_events(invoice_ids: set[str]) -> None:
+    if not invoice_ids:
+        return
+
+    events = db.session.scalars(
+        db.select(StripeEvent)
+        .where(StripeEvent.event_type.in_(DELETION_BLOCKING_STRIPE_INVOICE_EVENT_TYPES))
+        .where(~StripeEvent.status.in_(DELETION_BLOCKING_STRIPE_INVOICE_EVENT_STATUSES))
+    )
+    for event in events:
+        invoice_id = _invoice_id_from_stripe_event_data(event.event_data)
+        if invoice_id in invoice_ids:
+            event.event_data = REDACTED_STRIPE_EVENT_DATA
+
+
 def delete_user_and_related(user: User) -> None:
     # Delete field values and definitions
     usernames = db.session.scalars(db.select(Username).filter_by(user_id=user.id)).all()
     username_ids = [username.id for username in usernames]
+    stripe_invoice_ids = set(
+        db.session.scalars(db.select(StripeInvoice.invoice_id).filter_by(user_id=user.id)).all()
+    )
 
     # Delete all FieldValue entries related to the user's usernames
     db.session.execute(
@@ -161,6 +180,7 @@ def delete_user_and_related(user: User) -> None:
     db.session.execute(db.delete(MessageStatusText).filter_by(user_id=user.id))
     db.session.execute(db.delete(AuthenticationLog).filter_by(user_id=user.id))
     db.session.execute(db.delete(NotificationRecipient).filter_by(user_id=user.id))
+    _redact_processed_stripe_invoice_events(stripe_invoice_ids)
     db.session.execute(db.delete(StripeInvoice).filter_by(user_id=user.id))
 
     # Delete username and finally the user

--- a/hushline/user_deletion.py
+++ b/hushline/user_deletion.py
@@ -30,6 +30,10 @@ DELETION_BLOCKING_STRIPE_INVOICE_EVENT_TYPES = {
     "invoice.updated",
     "invoice.payment_succeeded",
 }
+STRIPE_INVOICE_EVENT_SCRUB_TYPES = {
+    "invoice.created",
+    *DELETION_BLOCKING_STRIPE_INVOICE_EVENT_TYPES,
+}
 REDACTED_STRIPE_EVENT_DATA = "{}"
 
 
@@ -140,7 +144,7 @@ def _redact_processed_stripe_invoice_events(invoice_ids: set[str]) -> None:
 
     events = db.session.scalars(
         db.select(StripeEvent)
-        .where(StripeEvent.event_type.in_(DELETION_BLOCKING_STRIPE_INVOICE_EVENT_TYPES))
+        .where(StripeEvent.event_type.in_(STRIPE_INVOICE_EVENT_SCRUB_TYPES))
         .where(~StripeEvent.status.in_(DELETION_BLOCKING_STRIPE_INVOICE_EVENT_STATUSES))
     )
     for event in events:

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -424,11 +424,20 @@ def test_delete_user_scrubs_processed_stripe_invoice_events(
     client: FlaskClient, user: User
 ) -> None:
     invoice = _add_stripe_invoice(user, "inv_processed_event_delete_user")
-    event = _add_stripe_invoice_event(
+    created_event = _add_stripe_invoice_event(
         invoice.invoice_id,
+        event_type="invoice.created",
         status=StripeEventStatusEnum.FINISHED,
     )
-    event.event_data = json.dumps(
+    updated_event = StripeEvent(
+        MagicMock(
+            id="evt_inv_processed_event_delete_user_updated",
+            created=2,
+            type="invoice.updated",
+        )
+    )
+    updated_event.status = StripeEventStatusEnum.FINISHED
+    event_data = json.dumps(
         {
             "data": {
                 "object": {
@@ -438,14 +447,20 @@ def test_delete_user_scrubs_processed_stripe_invoice_events(
             }
         }
     )
+    created_event.event_data = event_data
+    updated_event.event_data = event_data
+    db.session.add(updated_event)
     db.session.commit()
 
     response = client.post(url_for("admin.delete_user", user_id=user.id))
     assert response.status_code == 302
 
-    refreshed_event = db.session.get(StripeEvent, event.id)
-    assert refreshed_event is not None
-    assert refreshed_event.event_data == "{}"
+    refreshed_created_event = db.session.get(StripeEvent, created_event.id)
+    refreshed_updated_event = db.session.get(StripeEvent, updated_event.id)
+    assert refreshed_created_event is not None
+    assert refreshed_created_event.event_data == "{}"
+    assert refreshed_updated_event is not None
+    assert refreshed_updated_event.event_data == "{}"
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -420,6 +420,35 @@ def test_delete_user_removes_stripe_invoices(client: FlaskClient, user: User) ->
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")
+def test_delete_user_scrubs_processed_stripe_invoice_events(
+    client: FlaskClient, user: User
+) -> None:
+    invoice = _add_stripe_invoice(user, "inv_processed_event_delete_user")
+    event = _add_stripe_invoice_event(
+        invoice.invoice_id,
+        status=StripeEventStatusEnum.FINISHED,
+    )
+    event.event_data = json.dumps(
+        {
+            "data": {
+                "object": {
+                    "id": invoice.invoice_id,
+                    "hosted_invoice_url": "https://stripe.com/receipt",
+                }
+            }
+        }
+    )
+    db.session.commit()
+
+    response = client.post(url_for("admin.delete_user", user_id=user.id))
+    assert response.status_code == 302
+
+    refreshed_event = db.session.get(StripeEvent, event.id)
+    assert refreshed_event is not None
+    assert refreshed_event.event_data == "{}"
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
 def test_delete_user_with_active_stripe_subscription_blocked(
     client: FlaskClient, user: User
 ) -> None:
@@ -433,6 +462,20 @@ def test_delete_user_with_active_stripe_subscription_blocked(
 
     assert db.session.get(User, user.id) is not None
     assert db.session.get(StripeInvoice, invoice.id) is not None
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_delete_user_with_incomplete_expired_subscription_id_allowed(
+    client: FlaskClient, user: User
+) -> None:
+    user.stripe_subscription_id = "sub_expired_checkout_delete_user"
+    user.stripe_subscription_status = StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
+    db.session.commit()
+
+    response = client.post(url_for("admin.delete_user", user_id=user.id))
+    assert response.status_code == 302
+
+    assert db.session.get(User, user.id) is None
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,3 +1,7 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 from bs4 import BeautifulSoup
 from flask import Flask, url_for
@@ -9,6 +13,11 @@ from hushline.db import db
 from hushline.model import (
     AccountCategory,
     ChatKey,
+    StripeEvent,
+    StripeEventStatusEnum,
+    StripeInvoice,
+    StripeInvoiceStatusEnum,
+    StripeSubscriptionStatusEnum,
     Tier,
     User,
     Username,
@@ -51,6 +60,38 @@ def test_admin_settings_includes_user_search(app: Flask, client: FlaskClient) ->
     assert account_category_form.select_one('select[name="account_category"]') is not None
     assert account_category_form.find_parent(class_="tableActions") is None
     assert "Update Category" not in response.text
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_admin_settings_discloses_stripe_billing_state(client: FlaskClient, user: User) -> None:
+    _add_stripe_invoice(user, "inv_admin_billing_state", StripeInvoiceStatusEnum.OPEN)
+    user.stripe_subscription_id = "sub_admin_billing_state"
+    user.stripe_subscription_status = StripeSubscriptionStatusEnum.ACTIVE
+    db.session.commit()
+
+    response = client.get(url_for("settings.admin"), follow_redirects=True)
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+    user_card = next(
+        (
+            card
+            for card in soup.select("#admin-users-list .user")
+            if card.find("h5", string=user.primary_username.username)
+        ),
+        None,
+    )
+    assert user_card is not None
+    user_text = " ".join(user_card.get_text(" ", strip=True).split())
+
+    assert "Stripe Billing: Active or unresolved subscription; deletion disabled." in user_text
+    assert "1 draft, open, or unknown invoice; deletion disabled." in user_text
+    assert (
+        "1 invoice associated; deleting this user also deletes stored invoice receipt records."
+        in user_text
+    )
+    delete_button = user_card.select_one("button.delete-user-button")
+    assert delete_button is not None
+    assert delete_button.has_attr("disabled")
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")
@@ -121,6 +162,55 @@ def _create_admin_list_user(username: str, display_name: str | None = None) -> U
     )
     db.session.commit()
     return user
+
+
+def _add_stripe_invoice(
+    user: User,
+    invoice_id: str = "inv_delete_user",
+    status: StripeInvoiceStatusEnum = StripeInvoiceStatusEnum.PAID,
+) -> StripeInvoice:
+    user.stripe_customer_id = f"cus_{invoice_id}"
+    business_tier = Tier.business_tier()
+    assert business_tier is not None
+    db.session.commit()
+
+    invoice = StripeInvoice(
+        SimpleNamespace(
+            id=invoice_id,
+            customer=user.stripe_customer_id,
+            hosted_invoice_url="https://example.com/invoice",
+            total=2000,
+            status=status.value,
+            created=None,
+            lines=SimpleNamespace(
+                data=[
+                    SimpleNamespace(plan=SimpleNamespace(product=business_tier.stripe_product_id))
+                ]
+            ),
+        )
+    )
+    db.session.add(invoice)
+    db.session.commit()
+    return invoice
+
+
+def _add_stripe_invoice_event(
+    invoice_id: str,
+    event_type: str = "invoice.updated",
+    status: StripeEventStatusEnum = StripeEventStatusEnum.PENDING,
+) -> StripeEvent:
+    event = StripeEvent(
+        MagicMock(
+            id=f"evt_{invoice_id}",
+            created=1,
+            type=event_type,
+        )
+    )
+    event.event_data = json.dumps({"data": {"object": {"id": invoice_id}}})
+    event.status = status
+    db.session.add(event)
+    db.session.commit()
+    return event
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")
@@ -315,6 +405,101 @@ def test_delete_user_removes_user(client: FlaskClient, user: User) -> None:
 
     deleted_user = db.session.get(User, user.id)
     assert deleted_user is None
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_delete_user_removes_stripe_invoices(client: FlaskClient, user: User) -> None:
+    invoice = _add_stripe_invoice(user)
+    invoice_id = invoice.id
+
+    response = client.post(url_for("admin.delete_user", user_id=user.id))
+    assert response.status_code == 302
+
+    assert db.session.get(User, user.id) is None
+    assert db.session.get(StripeInvoice, invoice_id) is None
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_delete_user_with_active_stripe_subscription_blocked(
+    client: FlaskClient, user: User
+) -> None:
+    invoice = _add_stripe_invoice(user, "inv_blocked_delete_user")
+    user.stripe_subscription_id = "sub_blocked_delete_user"
+    user.stripe_subscription_status = StripeSubscriptionStatusEnum.ACTIVE
+    db.session.commit()
+
+    response = client.post(url_for("admin.delete_user", user_id=user.id))
+    assert response.status_code == 400
+
+    assert db.session.get(User, user.id) is not None
+    assert db.session.get(StripeInvoice, invoice.id) is not None
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_delete_user_with_canceled_stripe_subscription_id_blocked(
+    client: FlaskClient, user: User
+) -> None:
+    user.stripe_subscription_id = "sub_canceled_but_not_deleted"
+    user.stripe_subscription_status = StripeSubscriptionStatusEnum.CANCELED
+    db.session.commit()
+
+    response = client.post(url_for("admin.delete_user", user_id=user.id))
+    assert response.status_code == 400
+
+    assert db.session.get(User, user.id) is not None
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_delete_user_with_open_stripe_invoice_blocked(client: FlaskClient, user: User) -> None:
+    invoice = _add_stripe_invoice(user, "inv_open_delete_user", StripeInvoiceStatusEnum.OPEN)
+
+    response = client.post(url_for("admin.delete_user", user_id=user.id))
+    assert response.status_code == 400
+
+    assert db.session.get(User, user.id) is not None
+    assert db.session.get(StripeInvoice, invoice.id) is not None
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_delete_user_with_queued_stripe_invoice_event_blocked(
+    client: FlaskClient, user: User
+) -> None:
+    invoice = _add_stripe_invoice(user, "inv_pending_event_delete_user")
+    event = _add_stripe_invoice_event(invoice.invoice_id)
+
+    response = client.post(url_for("admin.delete_user", user_id=user.id))
+    assert response.status_code == 400
+
+    assert db.session.get(User, user.id) is not None
+    assert db.session.get(StripeInvoice, invoice.id) is not None
+    assert db.session.get(StripeEvent, event.id) is not None
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_admin_settings_discloses_queued_stripe_invoice_event(
+    client: FlaskClient, user: User
+) -> None:
+    invoice = _add_stripe_invoice(user, "inv_admin_pending_event")
+    _add_stripe_invoice_event(invoice.invoice_id)
+
+    response = client.get(url_for("settings.admin"), follow_redirects=True)
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+    user_card = next(
+        (
+            card
+            for card in soup.select("#admin-users-list .user")
+            if card.find("h5", string=user.primary_username.username)
+        ),
+        None,
+    )
+    assert user_card is not None
+    user_text = " ".join(user_card.get_text(" ", strip=True).split())
+
+    assert "1 queued invoice webhook; deletion disabled." in user_text
+    delete_button = user_card.select_one("button.delete-user-button")
+    assert delete_button is not None
+    assert delete_button.has_attr("disabled")
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -213,6 +213,36 @@ def _add_stripe_invoice_event(
     return event
 
 
+def _add_stripe_subscription_event(
+    user: User,
+    event_type: str = "customer.subscription.created",
+    status: StripeEventStatusEnum = StripeEventStatusEnum.PENDING,
+) -> StripeEvent:
+    user.stripe_customer_id = user.stripe_customer_id or "cus_subscription_event"
+    user.stripe_subscription_id = user.stripe_subscription_id or "sub_subscription_event"
+    event = StripeEvent(
+        MagicMock(
+            id=f"evt_{event_type.replace('.', '_')}_{user.id}",
+            created=1,
+            type=event_type,
+        )
+    )
+    event.event_data = json.dumps(
+        {
+            "data": {
+                "object": {
+                    "id": user.stripe_subscription_id,
+                    "customer": user.stripe_customer_id,
+                }
+            }
+        }
+    )
+    event.status = status
+    db.session.add(event)
+    db.session.commit()
+    return event
+
+
 @pytest.mark.usefixtures("_authenticated_admin_user")
 def test_admin_settings_paginates_usernames(client: FlaskClient) -> None:
     for index in range(25):
@@ -437,6 +467,14 @@ def test_delete_user_scrubs_processed_stripe_invoice_events(
         )
     )
     updated_event.status = StripeEventStatusEnum.FINISHED
+    finalized_event = StripeEvent(
+        MagicMock(
+            id="evt_inv_processed_event_delete_user_finalized",
+            created=3,
+            type="invoice.finalized",
+        )
+    )
+    finalized_event.status = StripeEventStatusEnum.FINISHED
     event_data = json.dumps(
         {
             "data": {
@@ -449,7 +487,8 @@ def test_delete_user_scrubs_processed_stripe_invoice_events(
     )
     created_event.event_data = event_data
     updated_event.event_data = event_data
-    db.session.add(updated_event)
+    finalized_event.event_data = event_data
+    db.session.add_all([updated_event, finalized_event])
     db.session.commit()
 
     response = client.post(url_for("admin.delete_user", user_id=user.id))
@@ -457,10 +496,35 @@ def test_delete_user_scrubs_processed_stripe_invoice_events(
 
     refreshed_created_event = db.session.get(StripeEvent, created_event.id)
     refreshed_updated_event = db.session.get(StripeEvent, updated_event.id)
+    refreshed_finalized_event = db.session.get(StripeEvent, finalized_event.id)
     assert refreshed_created_event is not None
     assert refreshed_created_event.event_data == "{}"
     assert refreshed_updated_event is not None
     assert refreshed_updated_event.event_data == "{}"
+    assert refreshed_finalized_event is not None
+    assert refreshed_finalized_event.event_data == "{}"
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_delete_user_scrubs_processed_stripe_subscription_events(
+    client: FlaskClient, user: User
+) -> None:
+    user.stripe_customer_id = "cus_processed_subscription_event"
+    user.stripe_subscription_id = "sub_processed_subscription_event"
+    user.stripe_subscription_status = StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
+    db.session.commit()
+    event = _add_stripe_subscription_event(
+        user,
+        event_type="customer.subscription.updated",
+        status=StripeEventStatusEnum.FINISHED,
+    )
+
+    response = client.post(url_for("admin.delete_user", user_id=user.id))
+    assert response.status_code == 302
+
+    refreshed_event = db.session.get(StripeEvent, event.id)
+    assert refreshed_event is not None
+    assert refreshed_event.event_data == "{}"
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")
@@ -534,6 +598,23 @@ def test_delete_user_with_queued_stripe_invoice_event_blocked(
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")
+def test_delete_user_with_queued_stripe_subscription_event_blocked(
+    client: FlaskClient, user: User
+) -> None:
+    invoice = _add_stripe_invoice(user, "inv_pending_subscription_event_delete_user")
+    event = _add_stripe_subscription_event(user)
+    user.stripe_subscription_id = None
+    db.session.commit()
+
+    response = client.post(url_for("admin.delete_user", user_id=user.id))
+    assert response.status_code == 400
+
+    assert db.session.get(User, user.id) is not None
+    assert db.session.get(StripeInvoice, invoice.id) is not None
+    assert db.session.get(StripeEvent, event.id) is not None
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
 def test_admin_settings_discloses_queued_stripe_invoice_event(
     client: FlaskClient, user: User
 ) -> None:
@@ -555,6 +636,32 @@ def test_admin_settings_discloses_queued_stripe_invoice_event(
     user_text = " ".join(user_card.get_text(" ", strip=True).split())
 
     assert "1 queued invoice webhook; deletion disabled." in user_text
+    delete_button = user_card.select_one("button.delete-user-button")
+    assert delete_button is not None
+    assert delete_button.has_attr("disabled")
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
+def test_admin_settings_discloses_queued_stripe_subscription_event(
+    client: FlaskClient, user: User
+) -> None:
+    _add_stripe_subscription_event(user)
+
+    response = client.get(url_for("settings.admin"), follow_redirects=True)
+    assert response.status_code == 200
+    soup = BeautifulSoup(response.text, "html.parser")
+    user_card = next(
+        (
+            card
+            for card in soup.select("#admin-users-list .user")
+            if card.find("h5", string=user.primary_username.username)
+        ),
+        None,
+    )
+    assert user_card is not None
+    user_text = " ".join(user_card.get_text(" ", strip=True).split())
+
+    assert "1 queued subscription webhook; deletion disabled." in user_text
     delete_button = user_card.select_one("button.delete-user-button")
     assert delete_button is not None
     assert delete_button.has_attr("disabled")

--- a/tests/test_delete_account.py
+++ b/tests/test_delete_account.py
@@ -67,6 +67,31 @@ def _add_stripe_invoice_event(
     return event
 
 
+def _add_stripe_subscription_event(user: User) -> StripeEvent:
+    user.stripe_customer_id = "cus_pending_subscription_event_delete_account"
+    event = StripeEvent(
+        MagicMock(
+            id="evt_pending_subscription_event_delete_account",
+            created=1,
+            type="customer.subscription.created",
+        )
+    )
+    event.event_data = json.dumps(
+        {
+            "data": {
+                "object": {
+                    "id": "sub_pending_subscription_event_delete_account",
+                    "customer": user.stripe_customer_id,
+                }
+            }
+        }
+    )
+    event.status = StripeEventStatusEnum.PENDING
+    db.session.add(event)
+    db.session.commit()
+    return event
+
+
 @pytest.mark.usefixtures("_authenticated_user")
 def test_delete_account(client: FlaskClient, user: User) -> None:
     user.email = "primary@example.com"
@@ -134,6 +159,19 @@ def test_delete_account_with_queued_stripe_invoice_event_blocked(
 
     assert db.session.get(User, user.id) is not None
     assert db.session.get(StripeInvoice, invoice.id) is not None
+    assert db.session.get(StripeEvent, event.id) is not None
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_delete_account_with_queued_stripe_subscription_event_blocked(
+    client: FlaskClient, user: User
+) -> None:
+    event = _add_stripe_subscription_event(user)
+
+    response = client.post(url_for("settings.delete_account"))
+    assert response.status_code == 400
+
+    assert db.session.get(User, user.id) is not None
     assert db.session.get(StripeEvent, event.id) is not None
 
 

--- a/tests/test_delete_account.py
+++ b/tests/test_delete_account.py
@@ -98,6 +98,20 @@ def test_delete_account_with_stripe_subscription_blocked(client: FlaskClient, us
 
 
 @pytest.mark.usefixtures("_authenticated_user")
+def test_delete_account_with_incomplete_expired_subscription_id_allowed(
+    client: FlaskClient, user: User
+) -> None:
+    user.stripe_subscription_id = "sub_expired_checkout_delete_account"
+    user.stripe_subscription_status = StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
+    db.session.commit()
+
+    response = client.post(url_for("settings.delete_account"))
+    assert response.status_code == 302
+
+    assert db.session.get(User, user.id) is None
+
+
+@pytest.mark.usefixtures("_authenticated_user")
 def test_delete_account_with_open_stripe_invoice_blocked(client: FlaskClient, user: User) -> None:
     invoice = _add_stripe_invoice(user, "inv_open_delete_account", StripeInvoiceStatusEnum.OPEN)
 

--- a/tests/test_delete_account.py
+++ b/tests/test_delete_account.py
@@ -1,11 +1,70 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
 import pytest
 from flask import url_for
 from flask.testing import FlaskClient
 
 from hushline.db import db
 from hushline.model import (
+    StripeEvent,
+    StripeEventStatusEnum,
+    StripeInvoice,
+    StripeInvoiceStatusEnum,
+    StripeSubscriptionStatusEnum,
+    Tier,
     User,
 )
+
+
+def _add_stripe_invoice(
+    user: User,
+    invoice_id: str = "inv_delete_account",
+    status: StripeInvoiceStatusEnum = StripeInvoiceStatusEnum.PAID,
+) -> StripeInvoice:
+    user.stripe_customer_id = f"cus_{invoice_id}"
+    business_tier = Tier.business_tier()
+    assert business_tier is not None
+    db.session.commit()
+
+    invoice = StripeInvoice(
+        SimpleNamespace(
+            id=invoice_id,
+            customer=user.stripe_customer_id,
+            hosted_invoice_url="https://example.com/invoice",
+            total=2000,
+            status=status.value,
+            created=None,
+            lines=SimpleNamespace(
+                data=[
+                    SimpleNamespace(plan=SimpleNamespace(product=business_tier.stripe_product_id))
+                ]
+            ),
+        )
+    )
+    db.session.add(invoice)
+    db.session.commit()
+    return invoice
+
+
+def _add_stripe_invoice_event(
+    invoice_id: str,
+    event_type: str = "invoice.updated",
+    status: StripeEventStatusEnum = StripeEventStatusEnum.PENDING,
+) -> StripeEvent:
+    event = StripeEvent(
+        MagicMock(
+            id=f"evt_{invoice_id}",
+            created=1,
+            type=event_type,
+        )
+    )
+    event.event_data = json.dumps({"data": {"object": {"id": invoice_id}}})
+    event.status = status
+    db.session.add(event)
+    db.session.commit()
+    return event
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -24,6 +83,44 @@ def test_delete_account(client: FlaskClient, user: User) -> None:
     # Make sure the user is deleted
     user_count = db.session.query(User).filter_by(id=user.id).count()
     assert user_count == 0
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_delete_account_with_stripe_subscription_blocked(client: FlaskClient, user: User) -> None:
+    user.stripe_subscription_id = "sub_delete_account"
+    user.stripe_subscription_status = StripeSubscriptionStatusEnum.CANCELED
+    db.session.commit()
+
+    response = client.post(url_for("settings.delete_account"))
+    assert response.status_code == 400
+
+    assert db.session.get(User, user.id) is not None
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_delete_account_with_open_stripe_invoice_blocked(client: FlaskClient, user: User) -> None:
+    invoice = _add_stripe_invoice(user, "inv_open_delete_account", StripeInvoiceStatusEnum.OPEN)
+
+    response = client.post(url_for("settings.delete_account"))
+    assert response.status_code == 400
+
+    assert db.session.get(User, user.id) is not None
+    assert db.session.get(StripeInvoice, invoice.id) is not None
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_delete_account_with_queued_stripe_invoice_event_blocked(
+    client: FlaskClient, user: User
+) -> None:
+    invoice = _add_stripe_invoice(user, "inv_pending_event_delete_account")
+    event = _add_stripe_invoice_event(invoice.invoice_id)
+
+    response = client.post(url_for("settings.delete_account"))
+    assert response.status_code == 400
+
+    assert db.session.get(User, user.id) is not None
+    assert db.session.get(StripeInvoice, invoice.id) is not None
+    assert db.session.get(StripeEvent, event.id) is not None
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")

--- a/tests/test_premium.py
+++ b/tests/test_premium.py
@@ -310,6 +310,29 @@ def test_handle_subscription_updated_downgrade(app: Flask, user: User) -> None:
     assert user.is_free_tier
 
 
+def test_handle_subscription_updated_incomplete_expired_clears_subscription_id(
+    app: Flask, user: User
+) -> None:
+    user.stripe_subscription_id = "sub_123"
+    user.stripe_subscription_cancel_at_period_end = True
+    user.stripe_subscription_current_period_end = datetime.now() + timedelta(days=30)
+    user.stripe_subscription_current_period_start = datetime.now()
+    db.session.commit()
+
+    subscription = MagicMock()
+    subscription.id = "sub_123"
+    subscription.status = StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED.value
+
+    handle_subscription_updated(subscription)
+
+    assert user.is_free_tier
+    assert user.stripe_subscription_id is None
+    assert user.stripe_subscription_status == StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
+    assert user.stripe_subscription_cancel_at_period_end is None
+    assert user.stripe_subscription_current_period_end is None
+    assert user.stripe_subscription_current_period_start is None
+
+
 def test_handle_subscription_updated_raises_for_missing_subscription(app: Flask) -> None:
     subscription = MagicMock()
     subscription.id = "sub_missing"

--- a/tests/test_premium.py
+++ b/tests/test_premium.py
@@ -310,7 +310,7 @@ def test_handle_subscription_updated_downgrade(app: Flask, user: User) -> None:
     assert user.is_free_tier
 
 
-def test_handle_subscription_updated_incomplete_expired_clears_subscription_id(
+def test_handle_subscription_updated_incomplete_expired_retains_subscription_tombstone(
     app: Flask, user: User
 ) -> None:
     user.stripe_subscription_id = "sub_123"
@@ -326,11 +326,44 @@ def test_handle_subscription_updated_incomplete_expired_clears_subscription_id(
     handle_subscription_updated(subscription)
 
     assert user.is_free_tier
-    assert user.stripe_subscription_id is None
+    assert user.stripe_subscription_id == "sub_123"
     assert user.stripe_subscription_status == StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
     assert user.stripe_subscription_cancel_at_period_end is None
     assert user.stripe_subscription_current_period_end is None
     assert user.stripe_subscription_current_period_start is None
+
+
+def test_handle_subscription_updated_ignores_stale_update_after_incomplete_expired(
+    app: Flask, user: User
+) -> None:
+    user.stripe_subscription_id = "sub_123"
+    user.stripe_subscription_status = StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
+    db.session.commit()
+
+    subscription = MagicMock()
+    subscription.id = "sub_123"
+    subscription.status = StripeSubscriptionStatusEnum.INCOMPLETE.value
+    subscription.cancel_at_period_end = False
+    subscription.current_period_end = int((datetime.now() + timedelta(days=30)).timestamp())
+    subscription.current_period_start = int(datetime.now().timestamp())
+
+    handle_subscription_updated(subscription)
+
+    assert user.is_free_tier
+    assert user.stripe_subscription_id == "sub_123"
+    assert user.stripe_subscription_status == StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
+
+
+def test_handle_subscription_updated_ignores_deleted_customer(app: Flask) -> None:
+    subscription = MagicMock()
+    subscription.id = "sub_deleted"
+    subscription.customer = "cus_deleted"
+    subscription.status = StripeSubscriptionStatusEnum.INCOMPLETE.value
+    subscription.cancel_at_period_end = False
+    subscription.current_period_end = int((datetime.now() + timedelta(days=30)).timestamp())
+    subscription.current_period_start = int(datetime.now().timestamp())
+
+    handle_subscription_updated(subscription)
 
 
 def test_handle_subscription_updated_raises_for_missing_subscription(app: Flask) -> None:
@@ -356,6 +389,29 @@ def test_handle_subscription_deleted(app: Flask, user: User) -> None:
 
     assert user.is_free_tier
     assert user.stripe_subscription_id is None
+
+
+def test_handle_subscription_deleted_keeps_terminal_tombstone(app: Flask, user: User) -> None:
+    user.stripe_subscription_id = "sub_123"
+    user.stripe_subscription_status = StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
+    db.session.commit()
+
+    subscription = MagicMock()
+    subscription.id = "sub_123"
+
+    handle_subscription_deleted(subscription)
+
+    assert user.is_free_tier
+    assert user.stripe_subscription_id == "sub_123"
+    assert user.stripe_subscription_status == StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
+
+
+def test_handle_subscription_deleted_ignores_deleted_customer(app: Flask) -> None:
+    subscription = MagicMock()
+    subscription.id = "sub_deleted"
+    subscription.customer = "cus_deleted"
+
+    handle_subscription_deleted(subscription)
 
 
 def test_handle_subscription_deleted_raises_for_missing_subscription(app: Flask) -> None:
@@ -670,6 +726,36 @@ def test_handle_invoice_updated_raises_for_missing_invoice(app: Flask) -> None:
         handle_invoice_updated(
             MagicMock(id="inv_missing", status=StripeInvoiceStatusEnum.PAID.value, total=1)
         )
+
+
+def test_handle_invoice_updated_ignores_deleted_customer_and_scrubs_event(app: Flask) -> None:
+    event = StripeEvent(MagicMock(id="evt_deleted_invoice", created=1, type="invoice.updated"))
+    event.event_data = json.dumps(
+        {
+            "data": {
+                "object": {
+                    "id": "inv_deleted",
+                    "hosted_invoice_url": "https://stripe.com/receipt",
+                }
+            }
+        }
+    )
+    event.status = StripeEventStatusEnum.IN_PROGRESS
+    db.session.add(event)
+    db.session.commit()
+
+    handle_invoice_updated(
+        MagicMock(
+            id="inv_deleted",
+            customer="cus_deleted",
+            status=StripeInvoiceStatusEnum.PAID.value,
+            total=1,
+        )
+    )
+
+    refreshed_event = db.session.get(StripeEvent, event.id)
+    assert refreshed_event is not None
+    assert refreshed_event.event_data == "{}"
 
 
 @pytest.mark.usefixtures("_authenticated_user")

--- a/tests/test_premium.py
+++ b/tests/test_premium.py
@@ -265,6 +265,56 @@ def test_handle_subscription_created(app: Flask, user: User) -> None:
     assert not user.is_business_tier
 
 
+def test_handle_subscription_created_ignores_stale_terminal_tombstone(
+    app: Flask, user: User
+) -> None:
+    user.stripe_customer_id = "cus_123"
+    user.stripe_subscription_id = "sub_123"
+    user.stripe_subscription_status = StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
+    db.session.commit()
+
+    subscription = MagicMock()
+    subscription.customer = "cus_123"
+    subscription.id = "sub_123"
+    subscription.status = StripeSubscriptionStatusEnum.INCOMPLETE.value
+    subscription.cancel_at_period_end = False
+    subscription.current_period_end = int((datetime.now() + timedelta(days=30)).timestamp())
+    subscription.current_period_start = int(datetime.now().timestamp())
+
+    handle_subscription_created(subscription)
+
+    assert user.stripe_subscription_id == "sub_123"
+    assert user.stripe_subscription_status == StripeSubscriptionStatusEnum.INCOMPLETE_EXPIRED
+
+
+def test_handle_subscription_created_redacts_deleted_customer_event(app: Flask) -> None:
+    event = StripeEvent(
+        MagicMock(
+            id="evt_deleted_subscription_created", created=1, type="customer.subscription.created"
+        )
+    )
+    event.event_data = json.dumps(
+        {"data": {"object": {"id": "sub_deleted", "customer": "cus_deleted"}}}
+    )
+    event.status = StripeEventStatusEnum.IN_PROGRESS
+    db.session.add(event)
+    db.session.commit()
+
+    subscription = MagicMock()
+    subscription.customer = "cus_deleted"
+    subscription.id = "sub_deleted"
+    subscription.status = StripeSubscriptionStatusEnum.INCOMPLETE.value
+    subscription.cancel_at_period_end = False
+    subscription.current_period_end = int((datetime.now() + timedelta(days=30)).timestamp())
+    subscription.current_period_start = int(datetime.now().timestamp())
+
+    handle_subscription_created(subscription, event)
+
+    refreshed_event = db.session.get(StripeEvent, event.id)
+    assert refreshed_event is not None
+    assert refreshed_event.event_data == "{}"
+
+
 def test_handle_subscription_created_raises_for_missing_user(app: Flask) -> None:
     subscription = MagicMock()
     subscription.customer = "missing"
@@ -366,6 +416,34 @@ def test_handle_subscription_updated_ignores_deleted_customer(app: Flask) -> Non
     handle_subscription_updated(subscription)
 
 
+def test_handle_subscription_updated_redacts_deleted_customer_event(app: Flask) -> None:
+    event = StripeEvent(
+        MagicMock(
+            id="evt_deleted_subscription_updated", created=1, type="customer.subscription.updated"
+        )
+    )
+    event.event_data = json.dumps(
+        {"data": {"object": {"id": "sub_deleted", "customer": "cus_deleted"}}}
+    )
+    event.status = StripeEventStatusEnum.IN_PROGRESS
+    db.session.add(event)
+    db.session.commit()
+
+    subscription = MagicMock()
+    subscription.id = "sub_deleted"
+    subscription.customer = "cus_deleted"
+    subscription.status = StripeSubscriptionStatusEnum.INCOMPLETE.value
+    subscription.cancel_at_period_end = False
+    subscription.current_period_end = int((datetime.now() + timedelta(days=30)).timestamp())
+    subscription.current_period_start = int(datetime.now().timestamp())
+
+    handle_subscription_updated(subscription, event)
+
+    refreshed_event = db.session.get(StripeEvent, event.id)
+    assert refreshed_event is not None
+    assert refreshed_event.event_data == "{}"
+
+
 def test_handle_subscription_updated_raises_for_missing_subscription(app: Flask) -> None:
     subscription = MagicMock()
     subscription.id = "sub_missing"
@@ -446,6 +524,34 @@ def test_handle_invoice_created(app: Flask, user: User) -> None:
 def test_handle_invoice_created_value_error_is_handled(app: Flask, mocker: MockFixture) -> None:
     mocker.patch("hushline.premium.StripeInvoice", side_effect=ValueError("bad invoice"))
     handle_invoice_created(MagicMock())
+
+
+def test_handle_invoice_created_redacts_deleted_customer_event(app: Flask) -> None:
+    event = StripeEvent(
+        MagicMock(id="evt_deleted_invoice_created", created=1, type="invoice.created")
+    )
+    event.event_data = json.dumps(
+        {"data": {"object": {"id": "inv_deleted", "customer": "cus_deleted"}}}
+    )
+    event.status = StripeEventStatusEnum.IN_PROGRESS
+    db.session.add(event)
+    db.session.commit()
+
+    handle_invoice_created(
+        MagicMock(
+            id="inv_deleted",
+            customer="cus_deleted",
+            hosted_invoice_url="https://stripe.com/receipt",
+            total=2000,
+            status=StripeInvoiceStatusEnum.OPEN.value,
+            lines=MagicMock(data=[MagicMock(plan=MagicMock(product="prod_123"))]),
+        ),
+        event,
+    )
+
+    refreshed_event = db.session.get(StripeEvent, event.id)
+    assert refreshed_event is not None
+    assert refreshed_event.event_data == "{}"
 
 
 def test_handle_invoice_updated(app: Flask, user: User) -> None:
@@ -1457,7 +1563,9 @@ async def test_worker_processes_subscription_created_event(app: Flask, mocker: M
 
     db.session.refresh(pending)
     assert pending.status == StripeEventStatusEnum.FINISHED
-    handle_created.assert_called_once_with(subscription_obj)
+    handle_created.assert_called_once()
+    assert handle_created.call_args.args[0] is subscription_obj
+    assert isinstance(handle_created.call_args.args[1], StripeEvent)
 
 
 @pytest.mark.asyncio()
@@ -1574,8 +1682,12 @@ async def test_worker_processes_subscription_updated_and_deleted_events(
     db.session.refresh(pending_deleted)
     assert pending_updated.status == StripeEventStatusEnum.FINISHED
     assert pending_deleted.status == StripeEventStatusEnum.FINISHED
-    handle_updated.assert_called_once_with(subscription_obj)
-    handle_deleted.assert_called_once_with(subscription_obj)
+    handle_updated.assert_called_once()
+    assert handle_updated.call_args.args[0] is subscription_obj
+    assert isinstance(handle_updated.call_args.args[1], StripeEvent)
+    handle_deleted.assert_called_once()
+    assert handle_deleted.call_args.args[0] is subscription_obj
+    assert isinstance(handle_deleted.call_args.args[1], StripeEvent)
 
 
 @pytest.mark.asyncio()
@@ -1611,7 +1723,9 @@ async def test_worker_processes_invoice_created_event(app: Flask, mocker: MockFi
 
     db.session.refresh(pending)
     assert pending.status == StripeEventStatusEnum.FINISHED
-    handle_invoice_created_mock.assert_called_once_with(invoice_obj)
+    handle_invoice_created_mock.assert_called_once()
+    assert handle_invoice_created_mock.call_args.args[0] is invoice_obj
+    assert isinstance(handle_invoice_created_mock.call_args.args[1], StripeEvent)
 
 
 @pytest.mark.asyncio()

--- a/tests/test_premium.py
+++ b/tests/test_premium.py
@@ -730,6 +730,9 @@ def test_handle_invoice_updated_raises_for_missing_invoice(app: Flask) -> None:
 
 def test_handle_invoice_updated_ignores_deleted_customer_and_scrubs_event(app: Flask) -> None:
     event = StripeEvent(MagicMock(id="evt_deleted_invoice", created=1, type="invoice.updated"))
+    pending_event = StripeEvent(
+        MagicMock(id="evt_deleted_invoice_pending", created=2, type="invoice.updated")
+    )
     event.event_data = json.dumps(
         {
             "data": {
@@ -740,8 +743,10 @@ def test_handle_invoice_updated_ignores_deleted_customer_and_scrubs_event(app: F
             }
         }
     )
+    pending_event.event_data = event.event_data
     event.status = StripeEventStatusEnum.IN_PROGRESS
-    db.session.add(event)
+    pending_event.status = StripeEventStatusEnum.PENDING
+    db.session.add_all([event, pending_event])
     db.session.commit()
 
     handle_invoice_updated(
@@ -750,12 +755,16 @@ def test_handle_invoice_updated_ignores_deleted_customer_and_scrubs_event(app: F
             customer="cus_deleted",
             status=StripeInvoiceStatusEnum.PAID.value,
             total=1,
-        )
+        ),
+        event,
     )
 
     refreshed_event = db.session.get(StripeEvent, event.id)
+    refreshed_pending_event = db.session.get(StripeEvent, pending_event.id)
     assert refreshed_event is not None
     assert refreshed_event.event_data == "{}"
+    assert refreshed_pending_event is not None
+    assert "https://stripe.com/receipt" in refreshed_pending_event.event_data
 
 
 @pytest.mark.usefixtures("_authenticated_user")
@@ -1643,4 +1652,6 @@ async def test_worker_processes_invoice_payment_succeeded_event(
 
     db.session.refresh(pending)
     assert pending.status == StripeEventStatusEnum.FINISHED
-    handle_invoice_updated_mock.assert_called_once_with(invoice_obj)
+    handle_invoice_updated_mock.assert_called_once()
+    assert handle_invoice_updated_mock.call_args.args[0] is invoice_obj
+    assert isinstance(handle_invoice_updated_mock.call_args.args[1], StripeEvent)


### PR DESCRIPTION
## What changed

- Block admin deletion and self-deletion when the target user has active/unresolved Stripe billing state: remaining non-terminal subscription ids, draft/open/unknown invoices, queued invoice webhooks, or queued subscription webhooks.
- Treat terminal `incomplete_expired` checkout subscriptions as deletion-safe tombstones while keeping enough local state for delayed Stripe subscription webhooks to be recognized and ignored safely.
- Show Stripe billing state in the admin Users list, including invoice count, queued invoice webhook count, queued subscription webhook count, and disabled deletion when Stripe cleanup is unresolved.
- Delete historical terminal Stripe invoice records with the account when no Stripe billing state blocks deletion.
- Scrub retained processed Stripe webhook payloads associated with deleted billing records, including all matching `invoice.%` events and matching `customer.subscription.%` events.
- Pass the current `StripeEvent` into delayed invoice-created and subscription webhook handlers so deleted-customer paths can redact the current payload before the worker marks the event finished.
- Ignore stale `customer.subscription.created` retries after a terminal non-billing subscription tombstone is already recorded.
- Update the canonical admin delete use case to include the Stripe subscription precondition.

## Why

Deleting a user with Stripe invoice history could raise a 500 because `stripe_invoices.user_id` was not cleaned up before deleting the user. Accounts with unresolved subscriptions, non-terminal invoices, queued invoice events, or queued subscription events also should not be removed until billing has been canceled/resolved and confirmed by local Stripe webhook state.

The webhook handling changes keep Stripe processing from marking valid delayed events as errors after an account has been deliberately deleted, while redacting retained processed webhook payloads that would otherwise keep billing/customer metadata after the local user and invoice rows are gone.

## Validation

- `docker compose -p hushline run --rm --no-deps app poetry run pytest tests/test_admin.py::test_delete_user_removes_stripe_invoices tests/test_admin.py::test_delete_user_scrubs_processed_stripe_invoice_events tests/test_admin.py::test_delete_user_scrubs_processed_stripe_subscription_events tests/test_admin.py::test_delete_user_with_active_stripe_subscription_blocked tests/test_admin.py::test_delete_user_with_incomplete_expired_subscription_id_allowed tests/test_admin.py::test_delete_user_with_canceled_stripe_subscription_id_blocked tests/test_admin.py::test_delete_user_with_open_stripe_invoice_blocked tests/test_admin.py::test_delete_user_with_queued_stripe_invoice_event_blocked tests/test_admin.py::test_delete_user_with_queued_stripe_subscription_event_blocked tests/test_admin.py::test_admin_settings_discloses_stripe_invoice_count tests/test_admin.py::test_admin_settings_discloses_unresolved_stripe_invoice tests/test_admin.py::test_admin_settings_discloses_queued_stripe_invoice_event tests/test_admin.py::test_admin_settings_discloses_queued_stripe_subscription_event tests/test_delete_account.py::test_delete_account_with_stripe_subscription_blocked tests/test_delete_account.py::test_delete_account_with_incomplete_expired_subscription_id_allowed tests/test_delete_account.py::test_delete_account_with_open_stripe_invoice_blocked tests/test_delete_account.py::test_delete_account_with_queued_stripe_invoice_event_blocked tests/test_delete_account.py::test_delete_account_with_queued_stripe_subscription_event_blocked tests/test_premium.py::test_handle_subscription_created tests/test_premium.py::test_handle_subscription_created_ignores_stale_terminal_tombstone tests/test_premium.py::test_handle_subscription_created_redacts_deleted_customer_event tests/test_premium.py::test_handle_subscription_created_raises_for_missing_user tests/test_premium.py::test_handle_subscription_updated tests/test_premium.py::test_handle_subscription_updated_incomplete_expired_retains_subscription_tombstone tests/test_premium.py::test_handle_subscription_updated_ignores_stale_update_after_incomplete_expired tests/test_premium.py::test_handle_subscription_updated_ignores_deleted_customer tests/test_premium.py::test_handle_subscription_updated_redacts_deleted_customer_event tests/test_premium.py::test_handle_subscription_updated_raises_for_missing_subscription tests/test_premium.py::test_handle_subscription_deleted tests/test_premium.py::test_handle_subscription_deleted_keeps_terminal_tombstone tests/test_premium.py::test_handle_subscription_deleted_ignores_deleted_customer tests/test_premium.py::test_handle_subscription_deleted_raises_for_missing_subscription tests/test_premium.py::test_handle_invoice_created tests/test_premium.py::test_handle_invoice_created_value_error_is_handled tests/test_premium.py::test_handle_invoice_created_redacts_deleted_customer_event tests/test_premium.py::test_handle_invoice_updated tests/test_premium.py::test_handle_invoice_updated_raises_for_missing_invoice tests/test_premium.py::test_handle_invoice_updated_ignores_deleted_customer_and_scrubs_event tests/test_premium.py::test_worker_processes_subscription_created_event tests/test_premium.py::test_worker_processes_subscription_updated_and_deleted_events tests/test_premium.py::test_worker_processes_invoice_created_event tests/test_premium.py::test_worker_processes_invoice_payment_succeeded_event tests/test_premium.py::test_worker_marks_event_error_when_handler_raises -q` (`39 passed`)
- `docker compose -p hushline run --rm --no-deps app poetry run ruff check --output-format full hushline/admin.py hushline/model/user.py hushline/premium.py hushline/settings/admin.py hushline/settings/delete_account.py hushline/user_deletion.py tests/test_admin.py tests/test_delete_account.py tests/test_premium.py`
- `docker compose -p hushline run --rm --no-deps app poetry run mypy --no-incremental hushline/admin.py hushline/model/user.py hushline/premium.py hushline/settings/admin.py hushline/settings/delete_account.py hushline/user_deletion.py tests/test_admin.py tests/test_delete_account.py tests/test_premium.py`

## Manual testing

Not manually exercised in the browser. The admin route, self-delete route, Stripe subscription handlers, Stripe invoice webhook worker paths, and rendered admin Users list are covered by focused tests.

## Known risks / follow-ups

- Full `make lint` previously passed Ruff and mypy, then failed on unrelated pre-existing dirty static JS formatting in `hushline/static/js/directory_verified.js` and `hushline/static/js/settings-location.js`, which are not included in this PR.
- No open Dependabot PRs or Dependabot alerts were found before this work.