### PR TITLE
Reject incomplete final broadcast batches

### DIFF
--- a/hushline/settings/broadcast.py
+++ b/hushline/settings/broadcast.py
@@ -676,6 +676,16 @@ def register_broadcast_routes(bp: Blueprint) -> None:
                                 "Broadcast batches are incomplete. Refresh and try again."
                             )
                         elif (
+                            chunked_broadcast
+                            and final_chunk
+                            and completed_broadcast is None
+                            and (submitted_user_ids_to_create | failed_user_ids_to_record)
+                            != pending_user_ids
+                        ):
+                            return _json_broadcast_error(
+                                "Final broadcast batch must include every pending recipient."
+                            )
+                        elif (
                             not chunked_broadcast
                             and submitted_user_ids | failed_user_ids != expected_user_ids
                         ):

--- a/tests/test_admin_broadcasts.py
+++ b/tests/test_admin_broadcasts.py
@@ -942,6 +942,41 @@ def test_broadcasts_final_chunk_rejects_incomplete_completion(
 
 
 @pytest.mark.usefixtures("_authenticated_admin_user")
+def test_broadcasts_final_chunk_rejects_client_claimed_completion_without_payloads(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    user.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    user2.pgp_key = "-----BEGIN PGP PUBLIC KEY BLOCK-----\nkey\n-----END PGP PUBLIC KEY BLOCK-----"
+    db.session.commit()
+    send_email = MagicMock()
+    monkeypatch.setattr("hushline.settings.broadcast.do_send_email", send_email)
+
+    response = client.post(
+        url_for("settings.broadcasts"),
+        data={
+            "broadcast_chunk": "1",
+            "broadcast_completed_user_ids": json.dumps([user.id, user2.id]),
+            "broadcast_expected_user_ids": json.dumps([user.id, user2.id]),
+            "broadcast_final_chunk": "1",
+            "encrypted_payloads": json.dumps({str(user.id): ARMORED_BROADCAST}),
+            "confirm_send": "y",
+            "send_broadcast": "Send Broadcast",
+        },
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {
+        "error": "Final broadcast batch must include every pending recipient."
+    }
+    assert db.session.scalar(db.select(db.func.count(Message.id))) == 0
+    assert db.session.scalar(db.select(db.func.count(AdminBroadcast.id))) == 0
+    send_email.assert_not_called()
+
+
+@pytest.mark.usefixtures("_authenticated_admin_user")
 def test_broadcasts_chunk_rejects_stale_expected_audience(
     client: FlaskClient,
     user: User,


### PR DESCRIPTION
### Motivation
- Fix an integrity bug in chunked admin broadcasts where the server trusted a client-supplied `broadcast_completed_user_ids` value for final-chunk completion, allowing a final request to claim the whole audience while submitting only a subset of payloads.
- Threat/risk: an authenticated admin (or same-origin attacker controlling an admin session) could cause a broadcast to be accepted as complete while persisting messages for only a subset of recipients, breaking delivery guarantees for operational/security notices. Affected data path: admin broadcast delivery and encrypted inbox submissions.
- Preserve existing chunking workflow while ensuring the final chunk cannot be used to silently omit pending recipients.

### Description
- Add server-side final-chunk validation in `hushline/settings/broadcast.py` so that when a chunked final request is received for a non-completed run the union of `submitted_user_ids_to_create` and `failed_user_ids_to_record` must equal the server-side `pending_user_ids`, otherwise return a JSON error `"Final broadcast batch must include every pending recipient."`.
- Add a regression test `test_broadcasts_final_chunk_rejects_client_claimed_completion_without_payloads` in `tests/test_admin_broadcasts.py` that asserts a client claiming completion for all recipients while submitting payloads for only one is rejected and that no messages or broadcast records are persisted.
- Keep behavior-preserving changes elsewhere in the handler; the new check runs only for chunked final batches that are not already completed by the server.

### Testing
- Ran static/format checks on the changed files with `poetry run ruff format --check hushline/settings/broadcast.py tests/test_admin_broadcasts.py && poetry run ruff check hushline/settings/broadcast.py tests/test_admin_broadcasts.py`, which passed. The specific linter invocation on the modified files passed.
- Added and attempted to run the focused regression suite via `poetry run pytest tests/test_admin_broadcasts.py -q`, but the run was blocked by the environment being unable to resolve the required `postgres` hostname (`psycopg.OperationalError: [Errno -3] Temporary failure in name resolution`), so the new test could not be executed here.
- `make lint`, `make audit-python`, and `make audit-node-runtime` could not be executed in this environment because `docker` is unavailable; these checks should be run in CI and locally per repository PR requirements before merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d48d64200833087bb2d0d284981ae)