### PR TITLE
Fix inbox sticky tab header offset

### DIFF
--- a/assets/js/inbox.js
+++ b/assets/js/inbox.js
@@ -37,14 +37,14 @@ document.addEventListener("DOMContentLoaded", function () {
     const updateStickyOffset = () => {
       const header = document.querySelector("header");
       const banner = document.querySelector(".banner");
-      const desktopOffset = window.matchMedia("(min-width: 641px)").matches
+      const desktopNavMargin = window.matchMedia("(min-width: 641px)").matches
         ? Number.parseFloat(
             window.getComputedStyle(document.documentElement).fontSize,
           ) || 16
         : 0;
       const headerHeight = header ? header.getBoundingClientRect().height : 0;
       const bannerHeight = banner ? banner.getBoundingClientRect().height : 0;
-      const stickyTop = headerHeight + bannerHeight + desktopOffset;
+      const stickyTop = headerHeight + bannerHeight + desktopNavMargin;
 
       inboxTabsNav.style.setProperty(
         "--inbox-tabs-top",

--- a/assets/scss/style.scss
+++ b/assets/scss/style.scss
@@ -4563,6 +4563,10 @@ h2.submit#embed-recipient-heading {
   width: 200px;
 }
 
+.banner+header+main .inbox-tabs-nav {
+  top: var(--inbox-tabs-top, calc(1rem + 105px + env(safe-area-inset-top)));
+}
+
 .inbox-tabs {
   max-width: none;
   width: 100%;
@@ -4959,6 +4963,10 @@ h2.submit#embed-recipient-heading {
     padding-left: var(--container-padding, 1.25rem);
     padding-right: var(--container-padding, 1.25rem);
     box-sizing: border-box;
+  }
+
+  .banner+header+main.inbox-main .inbox-content .inbox-tabs-nav {
+    top: var(--inbox-tabs-top, calc(105px + env(safe-area-inset-top)));
   }
 
   .settings-main .tab-list li,

--- a/tests/playwright/e2ee/inbox-sticky-tabs.spec.js
+++ b/tests/playwright/e2ee/inbox-sticky-tabs.spec.js
@@ -1,0 +1,57 @@
+const { expect, test } = require("@playwright/test");
+
+const TEST_PASSWORD = "Test-testtesttesttest-1";
+
+async function login(page, username) {
+  await page.addInitScript(() => {
+    localStorage.setItem("hasFinishedGuidance", "true");
+    sessionStorage.setItem("hushline:first-load-splash-seen", "true");
+  });
+  await page.goto("/login", { waitUntil: "networkidle" });
+  await page.fill("#username", username);
+  await page.fill("#password", TEST_PASSWORD);
+
+  await Promise.all([
+    page.waitForFunction(() => document.body?.dataset.authenticated === "true"),
+    page.locator('button[type="submit"]').click(),
+  ]);
+}
+
+test("inbox tabs keep the desktop top margin while pinned", async ({
+  page,
+}) => {
+  await page.setViewportSize({ width: 1280, height: 500 });
+  await login(page, "jerryseinfeld");
+
+  await page.goto("/inbox", { waitUntil: "networkidle" });
+  await expect(page.locator(".inbox-tabs-nav")).toBeVisible();
+  await page.evaluate(() => {
+    const messageList = document.querySelector(".message-list");
+    const spacer = document.createElement("div");
+    spacer.style.height = "900px";
+    messageList?.append(spacer);
+  });
+
+  await page.evaluate(() => window.scrollTo(0, 200));
+
+  await expect
+    .poll(() =>
+      page.evaluate(() => {
+        const header = document.querySelector("header");
+        const tabs = document.querySelector(".inbox-tabs-nav");
+
+        if (!header || !tabs) {
+          return Number.POSITIVE_INFINITY;
+        }
+
+        const headerRect = header.getBoundingClientRect();
+        const tabsRect = tabs.getBoundingClientRect();
+        const expectedMargin = Number.parseFloat(
+          window.getComputedStyle(document.documentElement).fontSize,
+        );
+
+        return Math.abs(tabsRect.top - headerRect.bottom - expectedMargin);
+      }),
+    )
+    .toBeLessThanOrEqual(1);
+});

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -934,8 +934,14 @@ def test_inbox_sticky_nav_hooks_exist() -> None:
     assert 'class="inbox-tabs-nav"' in inbox_template
     assert 'const inboxTabsNav = document.querySelector(".inbox-tabs-nav");' in inbox_js
     assert "--inbox-tabs-top" in inbox_js
+    assert "const desktopNavMargin = window.matchMedia" in inbox_js
+    assert "const stickyTop = headerHeight + bannerHeight + desktopNavMargin;" in inbox_js
+    assert "desktopOffset" not in inbox_js
     assert ".inbox-tabs-nav {" in scss
     assert "position: sticky;" in scss
+    assert "top: var(--inbox-tabs-top, calc(1rem + 65px + env(safe-area-inset-top)));" in (scss)
+    assert "top: var(--inbox-tabs-top, calc(1rem + 105px + env(safe-area-inset-top)));" in scss
+    assert "top: var(--inbox-tabs-top, calc(105px + env(safe-area-inset-top)));" in scss
     assert "flex-wrap: nowrap;" in scss
     assert "overflow-x: auto;" in scss
     assert "flex: 0 0 auto;" in scss


### PR DESCRIPTION
## What changed
- Preserve the inbox desktop sticky tab bar's intended `1rem` spacing below the global header by naming that part of the JS calculation as `desktopNavMargin`.
- Add banner-aware no-JS CSS fallbacks so inbox tabs sit below the fixed banner + header when the JS custom property is unavailable.
- Add a Playwright regression test for the scrolled inbox tab position using an unshared seeded user.
- Strengthen the frontend compatibility test around the inbox sticky hooks and fallbacks.

## Why
The inbox sticky calculation should account for the measured header/banner height plus the intended desktop nav top margin. The CSS fallback should also keep the filters usable without JavaScript by accounting for the fixed 40px banner and 65px header.

## Validation
- `npm run build:prod`
- `PLAYWRIGHT_BASE_URL=http://localhost:8080 npx playwright test --config=playwright.e2ee.config.js tests/playwright/e2ee/inbox-sticky-tabs.spec.js`
- `docker compose run --rm app poetry run pytest tests/test_frontend_compat.py::test_inbox_sticky_nav_hooks_exist`
- `make lint`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing
- Verified the scrolled inbox desktop state with Playwright: header bottom was 105px, tabs top was 121px, and root `1rem` was 16px.
- Captured local screenshots:
  - `/tmp/hushline-inbox-sticky-after-desktop-margin.png`
  - `/tmp/hushline-directory-sticky-reference.png`

## Risks / follow-ups
- Low risk; the JS-enabled behavior preserves the intended desktop spacing while adding no-JS fallback coverage.
- Local SSH signature verification is blocked by missing `gpg.ssh.allowedSignersFile`; the commit contains an SSH signature and should be verified by GitHub.