### PR TITLE
[codex] Use workflow token for public record refresh PR

### DIFF
--- a/.github/workflows/public-record-quarterly-refresh.yml
+++ b/.github/workflows/public-record-quarterly-refresh.yml
@@ -21,6 +21,8 @@ jobs:
       REFRESH_REPORT_DIR: .github/tmp/public-record-refresh
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Refresh public-record listings
         run: |
@@ -65,7 +67,7 @@ jobs:
       - name: Create or update refresh PR
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
         with:
-          token: ${{ github.token }}
+          token: ${{ secrets.ADMIN_PAT }}
           branch: bot/public-record-quarterly-refresh
           delete-branch: true
           commit-message: "Refresh public-record law firm listings"

--- a/.github/workflows/public-record-quarterly-refresh.yml
+++ b/.github/workflows/public-record-quarterly-refresh.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Create or update refresh PR
         uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676
         with:
-          token: ${{ secrets.ADMIN_PAT }}
+          token: ${{ github.token }}
           branch: bot/public-record-quarterly-refresh
           delete-branch: true
           commit-message: "Refresh public-record law firm listings"


### PR DESCRIPTION
## Summary
- Update the quarterly public-record refresh workflow to use `${{ github.token }}` when creating the generated refresh PR.
- Keep the existing same-repo PR branch, commit message, report body, and file allowlist unchanged.

## Root Cause
The July 1, 2026 scheduled run completed the public-record refresh and uploaded its report, then failed in `peter-evans/create-pull-request` while pushing `bot/public-record-quarterly-refresh`:

```text
fatal: could not read Username for 'https://github.com': No such device or address
```

The workflow already grants `contents: write` and `pull-requests: write`, so the refresh PR can use the built-in workflow token instead of depending on the long-lived `ADMIN_PAT` secret.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('/Users/scidsg/hushline/.github/workflows/public-record-quarterly-refresh.yml'); puts 'yaml ok'"`
- `git diff --check`

## Follow-up
After this merges, rerun `Quarterly Public Record Refresh` manually to publish the generated refresh PR for the July 2026 data drift.