### PR TITLE
Fix docs screenshot archive checkout

### DIFF
--- a/.github/workflows/publish-docs-screenshots.yml
+++ b/.github/workflows/publish-docs-screenshots.yml
@@ -224,17 +224,18 @@ jobs:
           chmod 700 "$GIT_ASKPASS"
           export GIT_ASKPASS GIT_TERMINAL_PROMPT=0
 
-          git clone \
-            --depth 1 \
-            --filter=blob:none \
-            --single-branch \
-            --branch "${SCREENSHOTS_DEFAULT_BRANCH}" \
-            "https://github.com/${SCREENSHOTS_REPOSITORY}.git" \
-            /tmp/hushline-screenshots
+          mkdir -p /tmp/hushline-screenshots
           cd /tmp/hushline-screenshots
+          git init
+          git remote add origin "https://github.com/${SCREENSHOTS_REPOSITORY}.git"
           git sparse-checkout init --no-cone
           git sparse-checkout set README.md badge-docs-screenshots.json releases/latest "releases/${RELEASE_KEY}"
-          git checkout -B "${SCREENSHOTS_DEFAULT_BRANCH}" "origin/${SCREENSHOTS_DEFAULT_BRANCH}"
+          git fetch \
+            --depth 1 \
+            --filter=blob:none \
+            origin \
+            "${SCREENSHOTS_DEFAULT_BRANCH}"
+          git checkout -B "${SCREENSHOTS_DEFAULT_BRANCH}" FETCH_HEAD
 
           mkdir -p "releases/${RELEASE_KEY}" "releases/latest"
           rsync -a --delete "${SCREENSHOT_ROOT}/" "releases/${RELEASE_KEY}/"
@@ -245,7 +246,7 @@ jobs:
           {"schemaVersion":1,"label":"docs screenshots","message":"${RELEASE_KEY}","color":"blue"}
           EOF
 
-          git add README.md badge-docs-screenshots.json releases
+          git add -A -- README.md badge-docs-screenshots.json "releases/${RELEASE_KEY}" releases/latest
           if git diff --cached --quiet; then
             echo "No screenshot archive changes to publish."
             exit 0

--- a/tests/test_workflow_pr_head_qualification.py
+++ b/tests/test_workflow_pr_head_qualification.py
@@ -145,16 +145,25 @@ def test_screenshots_archive_workflow_publishes_directly_without_pr_flow() -> No
     )
     assert "--depth 1" in archive_section
     assert "--filter=blob:none" in archive_section
-    assert "--single-branch" in archive_section
+    assert "--single-branch" not in archive_section
+    assert "git init" in archive_section
+    assert (
+        'git remote add origin "https://github.com/${SCREENSHOTS_REPOSITORY}.git"'
+        in archive_section
+    )
     assert "git sparse-checkout init --no-cone" in archive_section
     assert (
         "git sparse-checkout set README.md badge-docs-screenshots.json releases/latest "
         '"releases/${RELEASE_KEY}"' in archive_section
     )
     assert (
-        'git checkout -B "${SCREENSHOTS_DEFAULT_BRANCH}" "origin/${SCREENSHOTS_DEFAULT_BRANCH}"'
-        in archive_section
+        "git fetch \\\n"
+        "            --depth 1 \\\n"
+        "            --filter=blob:none \\\n"
+        "            origin \\\n"
+        '            "${SCREENSHOTS_DEFAULT_BRANCH}"' in archive_section
     )
+    assert 'git checkout -B "${SCREENSHOTS_DEFAULT_BRANCH}" FETCH_HEAD' in archive_section
     assert 'GIT_ASKPASS="${RUNNER_TEMP}/hushline-screenshots-git-askpass.sh"' in archive_section
     assert '"https://github.com/${SCREENSHOTS_REPOSITORY}.git"' in archive_section
     assert "x-access-token:${SCREENSHOTS_PUSH_TOKEN}@github.com" not in archive_section


### PR DESCRIPTION
## Summary
- avoid materializing the full `hushline-screenshots` archive before sparse checkout is configured
- fetch only the default branch tip and checkout the sparse paths needed for `latest` and the current release
- stage only the updated release paths instead of the entire `releases` tree

## Root cause
The v0.7.13 docs screenshot capture succeeded, but the publish job hung during `git clone` of `scidsg/hushline-screenshots`. The clone attempted to update 364,203 files before sparse checkout ran, then GitHub cancelled the job before the website publish step.

## Validation
- `ruby -e "require 'yaml'; YAML.load_file('/Users/scidsg/hushline/.github/workflows/publish-docs-screenshots.yml'); puts 'yaml ok'"`
- `git -C /Users/scidsg/hushline diff --check`
- local smoke test confirmed the empty-repo sparse checkout sequence materializes only README, badge JSON, `releases/latest`, and the target release directory