### PR TITLE
Fix GlobaLeaks refresh PR credentials

### DIFF
--- a/.github/workflows/globaleaks-directory-refresh.yml
+++ b/.github/workflows/globaleaks-directory-refresh.yml
@@ -19,6 +19,8 @@ jobs:
     timeout-minutes: 30
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          persist-credentials: false
 
       - name: Refresh GlobaLeaks directory listings
         run: |


### PR DESCRIPTION
## Summary
- set `persist-credentials: false` on the GlobaLeaks refresh checkout
- keep `secrets.ADMIN_PAT` for `peter-evans/create-pull-request` so generated refresh PRs can trigger required checks

## Root Cause
The scheduled GlobaLeaks refresh completed and created the refresh commit, but failed when pushing `bot/globaleaks-directory-refresh` with:

```text
fatal: could not read Username for 'https://github.com': No such device or address
```

The checkout step persisted the default checkout credentials in git config, which interfered with the PAT that `create-pull-request` needs to use for its fetch/push operations.

## Validation
- Parsed `.github/workflows/globaleaks-directory-refresh.yml` with Ruby YAML loader
- `git diff --check`