### PR TITLE
Upgrade legacy chat keys for replies

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -576,6 +576,31 @@
       true,
       ["deriveKey"],
     );
+    const signingKeyMaterial = await createSigningKeyMaterial();
+    const publicJwk = await window.crypto.subtle.exportKey(
+      "jwk",
+      keyPair.publicKey,
+    );
+    const privateKeyBundle = {
+      ecdh_private_jwk: await window.crypto.subtle.exportKey(
+        "jwk",
+        keyPair.privateKey,
+      ),
+      signing_private_jwk: signingKeyMaterial.signingPrivateJwk,
+    };
+    const wrapped = await encryptPrivateKeyBundle(privateKeyBundle, password);
+
+    return {
+      privateKeyBundle,
+      payload: {
+        public_key: JSON.stringify(publicJwk),
+        public_signing_key: JSON.stringify(signingKeyMaterial.publicSigningJwk),
+        ...wrapped,
+      },
+    };
+  }
+
+  async function createSigningKeyMaterial() {
     const signingKeyPair = await window.crypto.subtle.generateKey(
       {
         name: "ECDSA",
@@ -584,33 +609,15 @@
       true,
       ["sign", "verify"],
     );
-    const publicJwk = await window.crypto.subtle.exportKey(
-      "jwk",
-      keyPair.publicKey,
-    );
-    const publicSigningJwk = await window.crypto.subtle.exportKey(
-      "jwk",
-      signingKeyPair.publicKey,
-    );
-    const privateKeyBundle = {
-      ecdh_private_jwk: await window.crypto.subtle.exportKey(
+    return {
+      publicSigningJwk: await window.crypto.subtle.exportKey(
         "jwk",
-        keyPair.privateKey,
+        signingKeyPair.publicKey,
       ),
-      signing_private_jwk: await window.crypto.subtle.exportKey(
+      signingPrivateJwk: await window.crypto.subtle.exportKey(
         "jwk",
         signingKeyPair.privateKey,
       ),
-    };
-    const wrapped = await encryptPrivateKeyBundle(privateKeyBundle, password);
-
-    return {
-      privateKeyBundle,
-      payload: {
-        public_key: JSON.stringify(publicJwk),
-        public_signing_key: JSON.stringify(publicSigningJwk),
-        ...wrapped,
-      },
     };
   }
 
@@ -619,13 +626,22 @@
     let privateKeyBundle = null;
     try {
       privateKeyBundle = await decryptPrivateKeyBundle(chatKey, oldPassword);
+      let publicSigningKey = chatKey.public_signing_key || null;
+      if (!publicSigningKey || !privateKeyBundle.signing_private_jwk) {
+        const signingKeyMaterial = await createSigningKeyMaterial();
+        privateKeyBundle = {
+          ...privateKeyBundle,
+          signing_private_jwk: signingKeyMaterial.signingPrivateJwk,
+        };
+        publicSigningKey = JSON.stringify(signingKeyMaterial.publicSigningJwk);
+      }
       const wrapped = await encryptPrivateKeyBundle(
         privateKeyBundle,
         newPassword,
       );
       return {
         public_key: chatKey.public_key,
-        public_signing_key: chatKey.public_signing_key || null,
+        public_signing_key: publicSigningKey,
         recovery_state: "available",
         ...wrapped,
       };
@@ -924,6 +940,69 @@
     return chatKey;
   }
 
+  async function upgradeChatKeySigningCapability(
+    chatKey,
+    password,
+    sourceDocument = document,
+  ) {
+    if (!chatKey || chatKey.public_signing_key) {
+      return chatKey;
+    }
+
+    let privateKeyBundle = null;
+    try {
+      privateKeyBundle = await decryptPrivateKeyBundle(chatKey, password);
+      const signingKeyMaterial = await createSigningKeyMaterial();
+      const upgradedPrivateKeyBundle = {
+        ...privateKeyBundle,
+        signing_private_jwk: signingKeyMaterial.signingPrivateJwk,
+      };
+      const wrapped = await encryptPrivateKeyBundle(
+        upgradedPrivateKeyBundle,
+        password,
+      );
+      const headers = {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      };
+      const csrfToken = csrfTokenFromDocument(sourceDocument);
+      if (csrfToken) {
+        headers["X-CSRFToken"] = csrfToken;
+      }
+
+      const response = await fetch(chatKeyUrl, {
+        method: "POST",
+        credentials: "same-origin",
+        headers,
+        body: JSON.stringify({
+          public_key: chatKey.public_key,
+          public_signing_key: JSON.stringify(
+            signingKeyMaterial.publicSigningJwk,
+          ),
+          recovery_state: "available",
+          ...wrapped,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error("Chat key signing upgrade failed.");
+      }
+
+      const responsePayload = await response.json();
+      const upgradedChatKey = responsePayload.chat_key;
+      if (!upgradedChatKey) {
+        throw new Error("Upgraded chat key was unavailable.");
+      }
+      await restoreUnlockedChatKeyFromBundle(
+        upgradedChatKey,
+        upgradedPrivateKeyBundle,
+        sourceDocument,
+      );
+      return upgradedChatKey;
+    } finally {
+      privateKeyBundle = null;
+    }
+  }
+
   async function ensureChatKeyUnlockedAfterAuth(
     password,
     sourceDocument = document,
@@ -931,7 +1010,23 @@
     const chatKeyUrl = chatKeyUrlFromCurrentOrigin();
     const chatKey = await fetchChatKey(chatKeyUrl);
     if (chatKey) {
-      return unlockFromPassword(chatKey, password, sourceDocument);
+      const unlocked = await unlockFromPassword(
+        chatKey,
+        password,
+        sourceDocument,
+      );
+      if (unlocked && !chatKey.public_signing_key) {
+        try {
+          await upgradeChatKeySigningCapability(
+            chatKey,
+            password,
+            sourceDocument,
+          );
+        } catch (error) {
+          return unlocked;
+        }
+      }
+      return unlocked;
     }
     await provisionChatKey(chatKeyUrl, password, sourceDocument);
     return true;

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -580,6 +580,31 @@
       true,
       ["deriveKey"],
     );
+    const signingKeyMaterial = await createSigningKeyMaterial();
+    const publicJwk = await window.crypto.subtle.exportKey(
+      "jwk",
+      keyPair.publicKey,
+    );
+    const privateKeyBundle = {
+      ecdh_private_jwk: await window.crypto.subtle.exportKey(
+        "jwk",
+        keyPair.privateKey,
+      ),
+      signing_private_jwk: signingKeyMaterial.signingPrivateJwk,
+    };
+    const wrapped = await encryptPrivateKeyBundle(privateKeyBundle, password);
+
+    return {
+      privateKeyBundle,
+      payload: {
+        public_key: JSON.stringify(publicJwk),
+        public_signing_key: JSON.stringify(signingKeyMaterial.publicSigningJwk),
+        ...wrapped,
+      },
+    };
+  }
+
+  async function createSigningKeyMaterial() {
     const signingKeyPair = await window.crypto.subtle.generateKey(
       {
         name: "ECDSA",
@@ -588,33 +613,15 @@
       true,
       ["sign", "verify"],
     );
-    const publicJwk = await window.crypto.subtle.exportKey(
-      "jwk",
-      keyPair.publicKey,
-    );
-    const publicSigningJwk = await window.crypto.subtle.exportKey(
-      "jwk",
-      signingKeyPair.publicKey,
-    );
-    const privateKeyBundle = {
-      ecdh_private_jwk: await window.crypto.subtle.exportKey(
+    return {
+      publicSigningJwk: await window.crypto.subtle.exportKey(
         "jwk",
-        keyPair.privateKey,
+        signingKeyPair.publicKey,
       ),
-      signing_private_jwk: await window.crypto.subtle.exportKey(
+      signingPrivateJwk: await window.crypto.subtle.exportKey(
         "jwk",
         signingKeyPair.privateKey,
       ),
-    };
-    const wrapped = await encryptPrivateKeyBundle(privateKeyBundle, password);
-
-    return {
-      privateKeyBundle,
-      payload: {
-        public_key: JSON.stringify(publicJwk),
-        public_signing_key: JSON.stringify(publicSigningJwk),
-        ...wrapped,
-      },
     };
   }
 
@@ -623,13 +630,22 @@
     let privateKeyBundle = null;
     try {
       privateKeyBundle = await decryptPrivateKeyBundle(chatKey, oldPassword);
+      let publicSigningKey = chatKey.public_signing_key || null;
+      if (!publicSigningKey || !privateKeyBundle.signing_private_jwk) {
+        const signingKeyMaterial = await createSigningKeyMaterial();
+        privateKeyBundle = {
+          ...privateKeyBundle,
+          signing_private_jwk: signingKeyMaterial.signingPrivateJwk,
+        };
+        publicSigningKey = JSON.stringify(signingKeyMaterial.publicSigningJwk);
+      }
       const wrapped = await encryptPrivateKeyBundle(
         privateKeyBundle,
         newPassword,
       );
       return {
         public_key: chatKey.public_key,
-        public_signing_key: chatKey.public_signing_key || null,
+        public_signing_key: publicSigningKey,
         recovery_state: "available",
         ...wrapped,
       };
@@ -928,6 +944,69 @@
     return chatKey;
   }
 
+  async function upgradeChatKeySigningCapability(
+    chatKey,
+    password,
+    sourceDocument = document,
+  ) {
+    if (!chatKey || chatKey.public_signing_key) {
+      return chatKey;
+    }
+
+    let privateKeyBundle = null;
+    try {
+      privateKeyBundle = await decryptPrivateKeyBundle(chatKey, password);
+      const signingKeyMaterial = await createSigningKeyMaterial();
+      const upgradedPrivateKeyBundle = {
+        ...privateKeyBundle,
+        signing_private_jwk: signingKeyMaterial.signingPrivateJwk,
+      };
+      const wrapped = await encryptPrivateKeyBundle(
+        upgradedPrivateKeyBundle,
+        password,
+      );
+      const headers = {
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      };
+      const csrfToken = csrfTokenFromDocument(sourceDocument);
+      if (csrfToken) {
+        headers["X-CSRFToken"] = csrfToken;
+      }
+
+      const response = await fetch(chatKeyUrl, {
+        method: "POST",
+        credentials: "same-origin",
+        headers,
+        body: JSON.stringify({
+          public_key: chatKey.public_key,
+          public_signing_key: JSON.stringify(
+            signingKeyMaterial.publicSigningJwk,
+          ),
+          recovery_state: "available",
+          ...wrapped,
+        }),
+      });
+      if (!response.ok) {
+        throw new Error("Chat key signing upgrade failed.");
+      }
+
+      const responsePayload = await response.json();
+      const upgradedChatKey = responsePayload.chat_key;
+      if (!upgradedChatKey) {
+        throw new Error("Upgraded chat key was unavailable.");
+      }
+      await restoreUnlockedChatKeyFromBundle(
+        upgradedChatKey,
+        upgradedPrivateKeyBundle,
+        sourceDocument,
+      );
+      return upgradedChatKey;
+    } finally {
+      privateKeyBundle = null;
+    }
+  }
+
   async function ensureChatKeyUnlockedAfterAuth(
     password,
     sourceDocument = document,
@@ -935,7 +1014,23 @@
     const chatKeyUrl = chatKeyUrlFromCurrentOrigin();
     const chatKey = await fetchChatKey(chatKeyUrl);
     if (chatKey) {
-      return unlockFromPassword(chatKey, password, sourceDocument);
+      const unlocked = await unlockFromPassword(
+        chatKey,
+        password,
+        sourceDocument,
+      );
+      if (unlocked && !chatKey.public_signing_key) {
+        try {
+          await upgradeChatKeySigningCapability(
+            chatKey,
+            password,
+            sourceDocument,
+          );
+        } catch (error) {
+          return unlocked;
+        }
+      }
+      return unlocked;
     }
     await provisionChatKey(chatKeyUrl, password, sourceDocument);
     return true;

--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -487,6 +487,43 @@ def test_chat_key_rotation_versions_new_key_and_disables_old_key(
 
 
 @pytest.mark.usefixtures("_authenticated_user")
+def test_chat_key_signing_upgrade_preserves_chat_public_key(
+    client: FlaskClient, user: User
+) -> None:
+    public_key = '{"kty":"EC","crv":"P-256","x":"legacy","y":"key"}'
+    legacy_key = ChatKey(
+        user=user,
+        key_version=1,
+        public_key=public_key,
+        encrypted_private_key="legacy-wrapped-private-chat-key",
+        kdf_algorithm="PBKDF2-SHA-256",
+        kdf_params={"iterations": 310000},
+        kdf_salt="salt",
+        wrapping_algorithm="AES-GCM",
+    )
+    db.session.add(legacy_key)
+    db.session.commit()
+
+    response = client.post(
+        url_for("settings.chat_key"),
+        json=_chat_key_payload(public_key=public_key),
+    )
+
+    assert response.status_code == 201
+    keys = db.session.scalars(
+        db.select(ChatKey).filter_by(user_id=user.id).order_by(ChatKey.key_version.asc())
+    ).all()
+    assert [key.key_version for key in keys] == [1, 2]
+    assert keys[0].disabled_at is not None
+    assert keys[0].recovery_state == "rotated"
+    assert keys[1].disabled_at is None
+    assert keys[1].public_key == public_key
+    assert keys[1].public_signing_key == _chat_key_payload()["public_signing_key"]
+    assert user.chat_public_key == public_key
+    assert user.chat_public_signing_key == _chat_key_payload()["public_signing_key"]
+
+
+@pytest.mark.usefixtures("_authenticated_user")
 def test_chat_key_get_returns_only_authenticated_users_key(
     client: FlaskClient, user: User, user2: User
 ) -> None:

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -181,6 +181,23 @@ def test_chat_key_lifecycle_imports_private_key_for_message_decryption() -> None
     assert "decryptChatCiphertext" in js
 
 
+def test_chat_key_lifecycle_upgrades_legacy_keys_with_signing_material() -> None:
+    js = (ROOT / "assets/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
+    static_js = (ROOT / "hushline/static/js/chat-key-lifecycle.js").read_text(encoding="utf-8")
+
+    for lifecycle_js in (js, static_js):
+        assert "async function createSigningKeyMaterial()" in lifecycle_js
+        assert "async function upgradeChatKeySigningCapability(" in lifecycle_js
+        assert (
+            "privateKeyBundle = await decryptPrivateKeyBundle(chatKey, password);" in lifecycle_js
+        )
+        assert "public_key: chatKey.public_key" in lifecycle_js
+        assert "signing_private_jwk: signingKeyMaterial.signingPrivateJwk" in lifecycle_js
+        assert "if (unlocked && !chatKey.public_signing_key)" in lifecycle_js
+        assert "await upgradeChatKeySigningCapability(" in lifecycle_js
+        assert "if (!publicSigningKey || !privateKeyBundle.signing_private_jwk)" in lifecycle_js
+
+
 def test_settings_chat_key_provisioning_generates_decryptable_ecdh_key() -> None:
     js = (ROOT / "assets/js/settings.js").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## What changed

- Automatically adds signing material to legacy Hush Line chat keys after a successful login unlock.
- Adds signing material during password-change rewrap if the existing chat key bundle lacks it.
- Preserves the existing ECDH chat public key during the signing upgrade so old conversation history remains decryptable.
- Adds regression coverage for the backend signing upgrade and frontend lifecycle behavior.

## Why

Some conversations could show rotated-key warnings and still block replies with "Replies are unavailable until every participant has an active signing-capable Hush Line chat key." Users should not need a separate chat setup step after login or password rewrap when the browser can safely upgrade the existing chat key.

## Validation

- `docker compose -p hushline run --rm --no-deps -v /tmp/hushline-chat-key-signing:/app app poetry run pytest tests/test_chat_keys.py tests/test_frontend_compat.py`
- `docker compose -p hushline run --rm --no-deps -v /tmp/hushline-chat-key-signing:/app app sh -lc 'poetry run ruff format --check && poetry run ruff check --output-format full && poetry run mypy --no-incremental . && prettier --ignore-path /dev/null --check ./*.md ./docs ./.github/workflows/* ./hushline/data/*.json ./hushline/static/manifest.json ./hushline/static/no-js.js ./package.json ./playwright.e2ee.config.js ./tests/playwright ./hushline/static/js/directory_verified.js ./hushline/static/js/settings-location.js'`

## Manual testing

Not run manually; this is covered by focused chat-key route tests and frontend lifecycle source checks.

## Risks

Low. The upgrade only runs after the user successfully unlocks the existing chat key with their password, preserves the ECDH key used to decrypt existing chat history, and stores the upgraded private bundle through the existing chat-key rewrap endpoint.
