### PR TITLE
Accept encrypted custom choice submissions

### DIFF
--- a/hushline/routes/forms.py
+++ b/hushline/routes/forms.py
@@ -198,7 +198,9 @@ class DynamicMessageForm:
         def skip_invalid_choice(
             form: FlaskForm, field: RadioField | SelectField | MultiCheckboxField
         ) -> None:
-            field.errors = [error for error in field.errors if error != "Not a valid choice."]
+            field.errors = [
+                error for error in field.errors if "not a valid choice" not in error.lower()
+            ]
 
         # Add the fields to the form
         for i, field in enumerate(fields):

--- a/tests/test_routes_forms.py
+++ b/tests/test_routes_forms.py
@@ -121,6 +121,48 @@ def test_dynamic_message_form_choice_fields_select_and_multicheckbox(app: Flask)
     assert form.field_0.errors == ["another"]
 
 
+def test_dynamic_message_form_accepts_encrypted_choice_payloads(app: Flask) -> None:
+    encrypted_payload = (
+        "-----BEGIN PGP MESSAGE-----\n\n"
+        "wV4DySYCvmcevcgSAQdAexampleencryptedpayload\n"
+        "-----END PGP MESSAGE-----"
+    )
+    fields = [
+        SimpleNamespace(
+            enabled=True,
+            required=False,
+            field_type=FieldType.CHOICE_SINGLE,
+            encrypted=True,
+            label="Reason for reaching out",
+            choices=[
+                "Whistleblower Requests",
+                "Founder Request",
+                "Investor or Funder Inquiry",
+            ],
+        ),
+        SimpleNamespace(
+            enabled=True,
+            required=False,
+            field_type=FieldType.CHOICE_MULTIPLE,
+            encrypted=True,
+            label="Topics",
+            choices=["Research", "Media"],
+        ),
+    ]
+    dynamic = DynamicMessageForm(fields)  # type: ignore[arg-type]
+
+    with app.test_request_context(
+        method="POST",
+        data={
+            "field_0": encrypted_payload,
+            "field_1": encrypted_payload,
+        },
+    ):
+        form = dynamic.form(csrf_enabled=False)
+
+        assert form.validate(), form.errors
+
+
 def test_onboarding_profile_form_rejects_disallowed_language(app: Flask) -> None:
     def _mock_contains_disallowed_text(text: str | None) -> bool:
         return bool(text and "blocked-token" in text)


### PR DESCRIPTION
## What changed

- Allow encrypted custom choice fields to pass form validation when WTForms reports the submitted PGP payload as not matching the original plaintext choices.
- Add a regression test covering encrypted single-choice and multi-choice custom fields.

## Why

A paying customer hit a blocking submission error on a custom form. The browser encrypted the selected custom choice value into an armored PGP message, but server-side validation still tried to compare that encrypted payload to the plaintext choices and rejected it.

## Impact

Encrypted custom checkbox/radio/select answers can now be submitted successfully without weakening plaintext validation for non-encrypted choice fields. The change preserves the existing encrypted-field behavior and does not expose plaintext values server-side.

## Validation

- `make test TESTS=tests/test_routes_forms.py`
- `make lint`

## Manual testing

Not applicable beyond the focused regression path; this fix is covered at the dynamic form validation layer that blocked the reported submission.

## Risk and follow-up

Risk is low and scoped to filtering WTForms choice-validation errors for fields already marked as encrypted custom choice fields. Follow-up: add customer-facing troubleshooting guidance that old messages remain encrypted to the PGP key active at submission time, and key changes should be verified with a new test tip.