### PR TITLE
Allow replies to legacy chat-key recipients

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -1421,7 +1421,7 @@
     }
     if (root.dataset.canCompose !== "true") {
       setConversationStatus(
-        "Replies are unavailable until every participant has an active signing-capable Hush Line chat key.",
+        "Replies are unavailable until you have an active signing-capable Hush Line chat key and every participant has an active chat key.",
       );
       return;
     }

--- a/hushline/routes/message.py
+++ b/hushline/routes/message.py
@@ -108,6 +108,28 @@ def _conversation_active_participants(thread: Conversation) -> list[Conversation
     ]
 
 
+def _conversation_encryption_capable_participant_ids(thread: Conversation) -> set[str]:
+    return {
+        str(thread_participant.id)
+        for thread_participant in thread.participants
+        if (
+            thread_participant.deleted_at is None
+            and thread_participant.user
+            and thread_participant.user.active_chat_key
+            and thread_participant.user.chat_public_key
+        )
+    }
+
+
+def _participant_can_sign_replies(participant: ConversationParticipant) -> bool:
+    return bool(
+        participant.user
+        and participant.user.active_chat_key
+        and participant.user.chat_public_key
+        and participant.user.chat_public_signing_key
+    )
+
+
 def _locked_conversation_participants(thread: Conversation) -> list[ConversationParticipant]:
     return list(
         db.session.scalars(
@@ -670,7 +692,6 @@ def register_message_routes(app: Flask) -> None:
                 and thread_participant.user
                 and thread_participant.user.active_chat_key
                 and thread_participant.user.chat_public_key
-                and thread_participant.user.chat_public_signing_key
             )
         ]
         participant_signing_public_keys = [
@@ -696,9 +717,11 @@ def register_message_routes(app: Flask) -> None:
             )
         ]
         active_participants = _conversation_active_participants(thread)
-        can_compose = len(active_participants) == len(thread.participants) and len(
-            participant_public_keys
-        ) == len(thread.participants)
+        can_compose = (
+            len(active_participants) == len(thread.participants)
+            and len(participant_public_keys) == len(thread.participants)
+            and _participant_can_sign_replies(participant)
+        )
         conversation_message_form = ConversationMessageForm()
         delete_conversation_form = DeleteConversationForm()
 
@@ -774,24 +797,18 @@ def register_message_routes(app: Flask) -> None:
         if not isinstance(encrypted_copies, dict):
             return jsonify({"error": "Invalid encrypted message payload."}), 400
 
-        reply_capable_participant_ids = {
-            str(thread_participant.id)
-            for thread_participant in thread.participants
-            if (
-                thread_participant.deleted_at is None
-                and thread_participant.user
-                and thread_participant.user.active_chat_key
-                and thread_participant.user.chat_public_key
-                and thread_participant.user.chat_public_signing_key
-            )
-        }
+        encryption_capable_participant_ids = _conversation_encryption_capable_participant_ids(
+            thread
+        )
         active_participants = _conversation_active_participants(thread)
-        if len(active_participants) != len(thread.participants) or len(
-            reply_capable_participant_ids
-        ) != len(thread.participants):
+        if (
+            len(active_participants) != len(thread.participants)
+            or len(encryption_capable_participant_ids) != len(thread.participants)
+            or not _participant_can_sign_replies(participant)
+        ):
             return jsonify({"error": "Conversation replies are unavailable."}), 400
 
-        if set(encrypted_copies.keys()) != reply_capable_participant_ids:
+        if set(encrypted_copies.keys()) != encryption_capable_participant_ids:
             return jsonify({"error": "Invalid encrypted message payload."}), 400
 
         if not all(_is_chat_ciphertext_envelope(value) for value in encrypted_copies.values()):

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -1425,7 +1425,7 @@
     }
     if (root.dataset.canCompose !== "true") {
       setConversationStatus(
-        "Replies are unavailable until every participant has an active signing-capable Hush Line chat key.",
+        "Replies are unavailable until you have an active signing-capable Hush Line chat key and every participant has an active chat key.",
       );
       return;
     }

--- a/hushline/templates/conversation.html
+++ b/hushline/templates/conversation.html
@@ -186,8 +186,8 @@
       ) }}
       {% if not can_compose %}
         <p id="conversation-compose-unavailable" class="meta">
-          Replies are unavailable until every participant has an active signing-capable
-          Hush Line chat key.
+          Replies are unavailable until you have an active signing-capable Hush Line
+          chat key and every participant has an active chat key.
         </p>
       {% endif %}
     </form>

--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -693,10 +693,7 @@ def test_conversation_view_shows_locked_chat_key_state(
     assert "JavaScript is required for end-to-end encrypted chat." in response.text
     assert "server-side chat fallback for conversations" in response.text
     assert "Encrypted message. Waiting for browser chat key." in response.text
-    assert (
-        "Replies are unavailable until every participant has an active signing-capable"
-        in response.text
-    )
+    assert "Replies are unavailable until you have an active signing-capable" in response.text
     assert "conversation-chat-password" not in response.text
     assert "Unlock Chat" not in response.text
     assert "Proton" not in response.text
@@ -755,8 +752,44 @@ def test_conversation_view_disables_composer_when_participant_key_cannot_sign(
     assert participant_keys_match is not None
     participant_keys = json.loads(participant_keys_match.group(1))
     assert [participant_key["participant_id"] for participant_key in participant_keys] == [
-        _participant_for(conversation, user2).id
+        _participant_for(conversation, user).id,
+        _participant_for(conversation, user2).id,
     ]
+
+
+def test_conversation_view_allows_signing_sender_to_reply_to_legacy_recipient(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(
+        user,
+        '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}',
+        public_signing_key=_SENDER_PUBLIC_SIGNING_KEY,
+    )
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    response = client.get(url_for("conversation", public_id=conversation.public_id))
+
+    assert response.status_code == 200
+    assert 'data-can-compose="true"' in response.text
+    assert "conversation-compose-unavailable" not in response.text
+    participant_keys_match = re.search(
+        r'<script id="conversationParticipantPublicKeys" type="application/json">\s*'
+        r"([\s\S]*?)</script>",
+        response.text,
+    )
+    assert participant_keys_match is not None
+    participant_keys = json.loads(participant_keys_match.group(1))
+    recipient_key = next(
+        participant_key
+        for participant_key in participant_keys
+        if participant_key["participant_id"] == _participant_for(conversation, user2).id
+    )
+    assert recipient_key["public_key"] == '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}'
+    assert recipient_key["public_signing_key"] is None
 
 
 def test_conversation_view_exposes_historical_signing_keys_for_initial_message_verification(
@@ -1309,6 +1342,36 @@ def test_participant_can_append_encrypted_conversation_message(
     for encrypted_copy in messages[-1].encrypted_copies:
         assert "ECDH-P256-AES-GCM" in encrypted_copy.encrypted_payload
         assert plaintext not in encrypted_copy.encrypted_payload
+
+
+def test_signing_participant_can_append_reply_to_legacy_recipient(
+    client: FlaskClient,
+    user: User,
+    user2: User,
+) -> None:
+    _add_chat_key(
+        user,
+        '{"kty":"EC","crv":"P-256","x":"sender","y":"key"}',
+        public_signing_key=_SENDER_PUBLIC_SIGNING_KEY,
+    )
+    _add_chat_key(user2, '{"kty":"EC","crv":"P-256","x":"recipient","y":"key"}')
+    conversation = _make_conversation(user, user2)
+    _authenticate_as(client, user)
+
+    response = client.post(
+        url_for("append_conversation_message", public_id=conversation.public_id),
+        json={"encrypted_copies": _reply_copies_for(conversation, user, "legacy-recipient")},
+    )
+
+    assert response.status_code == 201
+    message = db.session.scalars(
+        db.select(ConversationMessage)
+        .where(ConversationMessage.conversation_id == conversation.id)
+        .order_by(ConversationMessage.id.desc())
+    ).first()
+    assert message is not None
+    assert message.sender_participant.user_id == user.id
+    assert len(message.encrypted_copies) == 2
 
 
 @patch("hushline.routes.message.send_email_to_user_recipients")


### PR DESCRIPTION
## What changed
- Allows a signing-capable participant to reply when another active participant has a legacy encryption-only chat key.
- Keeps reply submission blocked when the sender lacks an active signing-capable chat key.
- Updates disabled-composer copy to distinguish sender signing capability from participant encryption capability.

## Why
Wellnest could decrypt the verification conversation but could not reply because the gate required every participant, including Hush Line Admin, to have a signing-capable key. Only the sender needs signing capability for the outgoing reply; recipients need active encryption-capable chat keys so encrypted copies can be delivered.

## Validation
- No open Dependabot PRs at time of work.
- make test TESTS=tests/test_conversation.py
- make test TESTS=tests/test_frontend_compat.py
- make lint

## Manual testing
- Not run separately; covered by focused conversation route tests for the legacy-recipient reply path and disabled composer state.

## Security and privacy notes
- Affected data path: end-to-end encrypted conversation replies.
- The change does not weaken sender authentication: append still requires the current participant to have an active signing-capable chat key and verifies the submitted signature.
- Recipients remain required to have active encryption-capable chat keys before replies are accepted.

## Known risks or follow-ups
- Existing conversations where the sender still has a legacy encryption-only key remain reply-disabled until that sender rotates to a signing-capable key.