### PR TITLE
Use signing-capable chat keys from settings rotation

### DIFF
--- a/assets/js/settings.js
+++ b/assets/js/settings.js
@@ -220,14 +220,6 @@ document.addEventListener("DOMContentLoaded", function () {
   });
 });
 
-function bytesToBase64(bytes) {
-  let binary = "";
-  bytes.forEach((byte) => {
-    binary += String.fromCharCode(byte);
-  });
-  return btoa(binary);
-}
-
 async function provisionChatKey(form) {
   const passwordInput = form.querySelector("#chat-key-password");
   const status = document.getElementById("chat-key-provision-status");
@@ -242,101 +234,21 @@ async function provisionChatKey(form) {
     }
   }
 
-  if (!window.crypto?.subtle) {
-    status.textContent = "This browser cannot create a chat key.";
+  if (!window.HushLineChatKeys?.provisionChatKey) {
+    status.textContent = "Chat key tools are unavailable. Reload and try again.";
     return;
   }
 
   submitButton.disabled = true;
   status.textContent =
     action === "rotate" ? "Rotating chat key..." : "Creating chat key...";
-  let privateJwk = null;
 
   try {
-    const textEncoder = new TextEncoder();
-    const salt = window.crypto.getRandomValues(new Uint8Array(16));
-    const iv = window.crypto.getRandomValues(new Uint8Array(12));
-    const keyPair = await window.crypto.subtle.generateKey(
-      {
-        name: "ECDH",
-        namedCurve: "P-256",
-      },
-      true,
-      ["deriveKey"],
+    await window.HushLineChatKeys.provisionChatKey(
+      form.dataset.chatKeyUrl,
+      passwordInput.value,
+      document,
     );
-    const publicJwk = await window.crypto.subtle.exportKey(
-      "jwk",
-      keyPair.publicKey,
-    );
-    privateJwk = await window.crypto.subtle.exportKey("jwk", keyPair.privateKey);
-    const passwordKey = await window.crypto.subtle.importKey(
-      "raw",
-      textEncoder.encode(passwordInput.value),
-      "PBKDF2",
-      false,
-      ["deriveKey"],
-    );
-    const wrappingKey = await window.crypto.subtle.deriveKey(
-      {
-        name: "PBKDF2",
-        salt,
-        iterations: 310000,
-        hash: "SHA-256",
-      },
-      passwordKey,
-      {
-        name: "AES-GCM",
-        length: 256,
-      },
-      false,
-      ["encrypt"],
-    );
-    const encryptedBytes = new Uint8Array(
-      await window.crypto.subtle.encrypt(
-        {
-          name: "AES-GCM",
-          iv,
-        },
-        wrappingKey,
-        textEncoder.encode(JSON.stringify(privateJwk)),
-      ),
-    );
-    const payload = {
-      public_key: JSON.stringify(publicJwk),
-      encrypted_private_key: JSON.stringify({
-        algorithm: "AES-GCM",
-        iv: bytesToBase64(iv),
-        ciphertext: bytesToBase64(encryptedBytes),
-      }),
-      kdf_algorithm: "PBKDF2-SHA-256",
-      kdf_params: {
-        iterations: 310000,
-        hash: "SHA-256",
-      },
-      kdf_salt: bytesToBase64(salt),
-      wrapping_algorithm: "AES-GCM",
-    };
-    const headers = {
-      Accept: "application/json",
-      "Content-Type": "application/json",
-    };
-    if (form.dataset.csrfToken) {
-      headers["X-CSRFToken"] = form.dataset.csrfToken;
-    }
-
-    const response = await fetch(form.dataset.chatKeyUrl, {
-      method: "POST",
-      credentials: "same-origin",
-      headers,
-      body: JSON.stringify(payload),
-    });
-    if (!response.ok) {
-      throw new Error(
-        action === "rotate"
-          ? "Chat key rotation failed"
-          : "Chat key creation failed",
-      );
-    }
     status.textContent =
       action === "rotate"
         ? "Chat key rotated. Old conversations encrypted to earlier keys are no longer readable."
@@ -348,7 +260,6 @@ async function provisionChatKey(form) {
         ? "Chat key rotation failed."
         : "Chat key creation failed.";
   } finally {
-    privateJwk = null;
     passwordInput.value = "";
     submitButton.disabled = false;
   }

--- a/hushline/chat_key_lifecycle.py
+++ b/hushline/chat_key_lifecycle.py
@@ -169,7 +169,9 @@ def validate_chat_key_payload(payload: Any, *, current_user_id: int) -> tuple[di
         return {}, "public_key is required."
     if not _valid_public_jwk(public_key, expected_use="agreement"):
         return {}, "public_key must be a P-256 ECDH public JWK."
-    if public_signing_key and not _valid_public_jwk(public_signing_key, expected_use="signing"):
+    if not public_signing_key:
+        return {}, "public_signing_key is required."
+    if not _valid_public_jwk(public_signing_key, expected_use="signing"):
         return {}, "public_signing_key must be a P-256 ECDSA public JWK."
     if not encrypted_private_key:
         return {}, "encrypted_private_key is required."

--- a/hushline/templates/settings/encryption.html
+++ b/hushline/templates/settings/encryption.html
@@ -25,8 +25,9 @@
       </p>
     {% else %}
       <p class="meta">
-        This chat key predates signed conversation envelopes. Rotate it to sign
-        new conversation replies from this account.
+        This chat key predates signed conversation envelopes. Sign out and back
+        in, or rotate it here, to enable signed conversation replies from this
+        account.
       </p>
     {% endif %}
     {% if chat_key_history %}

--- a/poetry.lock
+++ b/poetry.lock
@@ -2188,14 +2188,14 @@ files = [
 
 [[package]]
 name = "soupsieve"
-version = "2.6"
+version = "2.8.4"
 description = "A modern CSS selector implementation for Beautiful Soup."
 optional = false
-python-versions = ">=3.8"
+python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "soupsieve-2.6-py3-none-any.whl", hash = "sha256:e72c4ff06e4fb6e4b5a9f0f55fe6e81514581fca1515028625d0f299c602ccc9"},
-    {file = "soupsieve-2.6.tar.gz", hash = "sha256:e2e68417777af359ec65daac1057404a3c8a5455bb8abc36f1a9866ab1a51abb"},
+    {file = "soupsieve-2.8.4-py3-none-any.whl", hash = "sha256:e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"},
+    {file = "soupsieve-2.8.4.tar.gz", hash = "sha256:e121fd02e975c695e4e9e8774a5ee35d74714b59307868dcc5319ad2d9e3328e"},
 ]
 
 [[package]]

--- a/tests/test_chat_keys.py
+++ b/tests/test_chat_keys.py
@@ -90,6 +90,7 @@ def test_forbidden_secret_field_detection_recurses_through_nested_lists() -> Non
             "public_signing_key must be a P-256 ECDSA public JWK.",
         ),
         ({"public_key": ""}, "public_key is required."),
+        ({"public_signing_key": ""}, "public_signing_key is required."),
         ({"encrypted_private_key": ""}, "encrypted_private_key is required."),
         ({"kdf_algorithm": ""}, "kdf_algorithm is required."),
         ({"kdf_salt": ""}, "kdf_salt is required."),
@@ -315,6 +316,18 @@ def test_chat_key_payload_rejects_plaintext_private_key_material(
 
     assert response.status_code == 400
     assert "Plaintext chat key material is not accepted." in response.text
+    assert db.session.scalars(db.select(ChatKey)).all() == []
+
+
+@pytest.mark.usefixtures("_authenticated_user")
+def test_chat_key_post_requires_signing_public_key(client: FlaskClient) -> None:
+    payload = _chat_key_payload()
+    payload.pop("public_signing_key")
+
+    response = client.post(url_for("settings.chat_key"), json=payload)
+
+    assert response.status_code == 400
+    assert "public_signing_key is required." in response.text
     assert db.session.scalars(db.select(ChatKey)).all() == []
 
 
@@ -598,6 +611,15 @@ def test_chat_key_lifecycle_js_exposes_unlock_rewrap_and_cleanup() -> None:
     assert 'document.visibilityState === "visible"' in lifecycle_source
     assert "document.body?.dataset.authenticated" in lifecycle_source
     assert "Log out and log back in to unlock chat" not in lifecycle_js
+
+
+def test_settings_chat_key_rotation_uses_signing_capable_provisioner() -> None:
+    settings_js = (ROOT / "assets/js/settings.js").read_text(encoding="utf-8")
+
+    assert "HushLineChatKeys?.provisionChatKey" in settings_js
+    assert "HushLineChatKeys.provisionChatKey" in settings_js
+    assert "This browser cannot create a chat key." not in settings_js
+    assert "bytesToBase64" not in settings_js
 
 
 @pytest.mark.usefixtures("_pgp_user")

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -198,12 +198,13 @@ def test_chat_key_lifecycle_upgrades_legacy_keys_with_signing_material() -> None
         assert "if (!publicSigningKey || !privateKeyBundle.signing_private_jwk)" in lifecycle_js
 
 
-def test_settings_chat_key_provisioning_generates_decryptable_ecdh_key() -> None:
+def test_settings_chat_key_provisioning_uses_shared_lifecycle_provisioner() -> None:
     js = (ROOT / "assets/js/settings.js").read_text(encoding="utf-8")
 
-    assert 'name: "ECDH"' in js
-    assert '["deriveKey"]' in js
-    assert '["deriveBits"]' not in js
+    assert "HushLineChatKeys?.provisionChatKey" in js
+    assert "HushLineChatKeys.provisionChatKey" in js
+    assert 'name: "ECDH"' not in js
+    assert "bytesToBase64" not in js
     assert 'form.dataset.chatKeyAction === "rotate"' in js
     assert "confirm(form.dataset.confirmMessage)" in js
     assert "Rotating chat key..." in js

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -538,6 +538,9 @@ def test_change_password_rewraps_active_chat_key(
     data["rewrapped_chat_key"] = json.dumps(
         {
             "public_key": '{"kty":"EC","crv":"P-256","x":"public-chat","y":"key"}',
+            "public_signing_key": (
+                '{"kty":"EC","crv":"P-256","x":"signing-public-chat","y":"signing-key"}'
+            ),
             "encrypted_private_key": (
                 '{"algorithm":"AES-GCM","iv":"bmV3LWl2LTEyMzQ1","ciphertext":"cmV3cmFwcGVk"}'
             ),
@@ -567,6 +570,9 @@ def test_change_password_rewraps_active_chat_key(
     assert keys[0].recovery_state == "rewrapped"
     assert keys[1].disabled_at is None
     assert keys[1].public_key == '{"kty":"EC","crv":"P-256","x":"public-chat","y":"key"}'
+    assert keys[1].public_signing_key == (
+        '{"kty":"EC","crv":"P-256","x":"signing-public-chat","y":"signing-key"}'
+    )
     assert keys[1].encrypted_private_key == (
         '{"algorithm":"AES-GCM","iv":"bmV3LWl2LTEyMzQ1","ciphertext":"cmV3cmFwcGVk"}'
     )


### PR DESCRIPTION
## What changed

- Settings-page chat key creation and rotation now delegates to the shared `HushLineChatKeys.provisionChatKey` lifecycle code.
- The chat-key API now rejects provisioning payloads without `public_signing_key`.
- The legacy-key Settings copy now tells users they can sign out and back in or rotate the key to enable signed replies.
- Updated `soupsieve` from `2.6` to `2.8.4` after dependency audit found CVE-2026-49476 and CVE-2026-49477.

## Why

A user could rotate their Hush Line chat key from Settings and still end up with an active legacy key that could decrypt messages but could not sign conversation envelopes. That left replies disabled with the message that the user needed an active signing-capable chat key, even after rotation to a newer key version.

Root cause: `assets/js/settings.js` had an older standalone chat-key provisioning path that generated only ECDH key material and posted no signing public key. The newer login lifecycle already created signing-capable key bundles, but Settings was bypassing it.

## User impact

After this change, rotating a legacy chat key from Settings creates a signing-capable key. Existing users with the affected state should be able to sign out and back in for automatic upgrade, or rotate from Settings after this deploy.

## Security notes

Affected data paths: browser chat-key provisioning, `/settings/chat-key.json`, and two-way conversation reply signing readiness.

This keeps private key material client-side and password-wrapped as before. Server-side validation prevents future clients from creating non-signing active chat keys through the provisioning endpoint.

## Validation

- `npm run build:prod` completed with the existing Sass legacy JS API deprecation warning
- `make test TESTS=tests/test_chat_keys.py`
- `make test TESTS=tests/test_frontend_compat.py::test_settings_chat_key_provisioning_uses_shared_lifecycle_provisioner`
- `make lint`
- `make audit-node-runtime`
- `make audit-python`

## Manual testing

Manual browser submission was not run for this PR. The changed Settings handler is covered by source-level frontend compatibility tests, and the endpoint behavior is covered by focused chat-key tests.

## Risks / follow-ups

- Rotating a chat key still makes old conversations encrypted to earlier chat keys unreadable; the existing confirmation remains in place.
- CI should run the broader regression suite before merge.