### PR TITLE
Fix legacy chat key signing upgrade URL

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -943,6 +943,7 @@
   async function upgradeChatKeySigningCapability(
     chatKey,
     password,
+    chatKeyUrl,
     sourceDocument = document,
   ) {
     if (!chatKey || chatKey.public_signing_key) {
@@ -1016,7 +1017,12 @@
         sourceDocument,
       );
       if (unlocked && !chatKey.public_signing_key) {
-        await upgradeChatKeySigningCapability(chatKey, password, sourceDocument);
+        await upgradeChatKeySigningCapability(
+          chatKey,
+          password,
+          chatKeyUrl,
+          sourceDocument,
+        );
       }
       return unlocked;
     }

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -947,6 +947,7 @@
   async function upgradeChatKeySigningCapability(
     chatKey,
     password,
+    chatKeyUrl,
     sourceDocument = document,
   ) {
     if (!chatKey || chatKey.public_signing_key) {
@@ -1020,7 +1021,12 @@
         sourceDocument,
       );
       if (unlocked && !chatKey.public_signing_key) {
-        await upgradeChatKeySigningCapability(chatKey, password, sourceDocument);
+        await upgradeChatKeySigningCapability(
+          chatKey,
+          password,
+          chatKeyUrl,
+          sourceDocument,
+        );
       }
       return unlocked;
     }

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -196,6 +196,7 @@ def test_chat_key_lifecycle_upgrades_legacy_keys_with_signing_material() -> None
         assert "signing_private_jwk: signingKeyMaterial.signingPrivateJwk" in lifecycle_js
         assert "if (unlocked && !chatKey.public_signing_key)" in lifecycle_js
         assert "await upgradeChatKeySigningCapability(" in lifecycle_js
+        assert "chatKeyUrl,\n          sourceDocument," in lifecycle_js
         assert "return unlocked;" in lifecycle_js
         assert "catch (error) {\n          return unlocked;" not in lifecycle_js
         assert "if (!publicSigningKey || !privateKeyBundle.signing_private_jwk)" in lifecycle_js


### PR DESCRIPTION
### Motivation
- The helper `upgradeChatKeySigningCapability()` called `fetch(chatKeyUrl)` but did not have `chatKeyUrl` in scope, causing a `ReferenceError` and preventing automatic upgrade of legacy chat keys that lack `public_signing_key` during login.

### Description
- Add a `chatKeyUrl` parameter to `upgradeChatKeySigningCapability()` in both `assets/js/chat-key-lifecycle.js` and the served copy `hushline/static/js/chat-key-lifecycle.js` and forward the computed `chatKeyUrl` from `ensureChatKeyUnlockedAfterAuth()` so the POST is sent to the correct endpoint.
- Update `tests/test_frontend_compat.py` to assert that the upgrade call forwards `chatKeyUrl` in the lifecycle JavaScript, without changing the existing upgrade logic or error handling.
- Preserve existing behavior for keys that already have `public_signing_key` and avoid other behavioral changes.

### Testing
- Ran `pytest tests/test_frontend_compat.py::test_chat_key_lifecycle_upgrades_legacy_keys_with_signing_material` which passed.
- Ran `git diff --check` which passed in this environment and verified no whitespace/diff errors.
- `make lint`, `make audit-python`, and `make audit-node-runtime` could not be executed here because Docker is not available in the runtime environment and must be rerun in CI or a local environment with Docker.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a5132e9207083308702f3d580575f5a)