### PR TITLE
Keep active chat keys unlocked while in use

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -84,6 +84,10 @@
     }
   }
 
+  function refreshedUnlockedKeyExpiresAt(now = Date.now()) {
+    return now + unlockedKeyMaxAgeMs;
+  }
+
   function scheduleUnlockedKeyExpiry(expiresAt, lastUsedAt) {
     clearUnlockedKeyExpiryTimer();
     const now = Date.now();
@@ -192,7 +196,7 @@
     sourceDocument = document,
   ) {
     const now = Date.now();
-    const expiresAt = now + unlockedKeyMaxAgeMs;
+    const expiresAt = refreshedUnlockedKeyExpiresAt(now);
     const sessionId = chatKeySessionId(sourceDocument);
     const storedValue = JSON.stringify({
       key_version: chatKey.key_version,
@@ -252,9 +256,11 @@
         forgetUnlockedPrivateJwk();
         return null;
       }
+      const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(now);
+      stored.expires_at = refreshedExpiresAt;
       stored.last_used_at = now;
       sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
-      scheduleUnlockedKeyExpiry(expiresAt, now);
+      scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
       return normalizePrivateKeyBundle(
         stored.private_key_bundle || stored.private_jwk,
       );
@@ -294,6 +300,7 @@
       return false;
     }
 
+    const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(now);
     try {
       const stored = JSON.parse(
         sessionStorage.getItem(sessionStorageKey) || "null",
@@ -306,14 +313,15 @@
           clearChatKeyMaterial();
           return false;
         }
+        stored.expires_at = refreshedExpiresAt;
         stored.last_used_at = now;
         sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
       }
     } catch (error) {
-      // The in-memory key remains bounded by its absolute expiry.
+      // The in-memory key remains bounded by the active tab expiry timer.
     }
 
-    scheduleUnlockedKeyExpiry(unlockedChatKeyExpiresAt, now);
+    scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
     return true;
   }
 

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -88,6 +88,10 @@
     }
   }
 
+  function refreshedUnlockedKeyExpiresAt(now = Date.now()) {
+    return now + unlockedKeyMaxAgeMs;
+  }
+
   function scheduleUnlockedKeyExpiry(expiresAt, lastUsedAt) {
     clearUnlockedKeyExpiryTimer();
     const now = Date.now();
@@ -196,7 +200,7 @@
     sourceDocument = document,
   ) {
     const now = Date.now();
-    const expiresAt = now + unlockedKeyMaxAgeMs;
+    const expiresAt = refreshedUnlockedKeyExpiresAt(now);
     const sessionId = chatKeySessionId(sourceDocument);
     const storedValue = JSON.stringify({
       key_version: chatKey.key_version,
@@ -256,9 +260,11 @@
         forgetUnlockedPrivateJwk();
         return null;
       }
+      const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(now);
+      stored.expires_at = refreshedExpiresAt;
       stored.last_used_at = now;
       sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
-      scheduleUnlockedKeyExpiry(expiresAt, now);
+      scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
       return normalizePrivateKeyBundle(
         stored.private_key_bundle || stored.private_jwk,
       );
@@ -298,6 +304,7 @@
       return false;
     }
 
+    const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(now);
     try {
       const stored = JSON.parse(
         sessionStorage.getItem(sessionStorageKey) || "null",
@@ -310,14 +317,15 @@
           clearChatKeyMaterial();
           return false;
         }
+        stored.expires_at = refreshedExpiresAt;
         stored.last_used_at = now;
         sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
       }
     } catch (error) {
-      // The in-memory key remains bounded by its absolute expiry.
+      // The in-memory key remains bounded by the active tab expiry timer.
     }
 
-    scheduleUnlockedKeyExpiry(unlockedChatKeyExpiresAt, now);
+    scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
     return true;
   }
 

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -234,9 +234,11 @@ def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session(
     assert "browserStorageMaxAgeMs" not in js
     assert "const unlockedKeyMaxAgeMs = 15 * 60 * 1000;" in js
     assert "const unlockedKeyIdleTimeoutMs = 5 * 60 * 1000;" in js
+    assert "function refreshedUnlockedKeyExpiresAt(now = Date.now())" in js
     assert "expires_at: expiresAt" in js
+    assert "stored.expires_at = refreshedExpiresAt;" in js
     assert "last_used_at: now" in js
-    assert "scheduleUnlockedKeyExpiry(expiresAt, now);" in js
+    assert "scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);" in js
     assert "now - lastUsedAt > unlockedKeyIdleTimeoutMs" in js
     assert "expiresAt > now + unlockedKeyMaxAgeMs" in js
     assert 'const crossTabChannelName = "hushline:chat-key-session";' in js


### PR DESCRIPTION
## What changed

- Renew the in-tab unlocked chat key expiry whenever the key is successfully used for decrypting or signing.
- Keep the existing 5-minute idle timeout, so the key still clears when the tab is not actively using chat.
- Update the served static chat-key lifecycle bundle and frontend compatibility test to lock the sliding expiry behavior.

## Why

An open conversation could sit long enough for the hard 15-minute browser key expiry to clear the unlocked key even while the user was still on the chat. After that, messages fell back to the server-rendered “Encrypted message. Waiting for browser chat key.” placeholder and the user had to log out and back in to unlock chat again.

The user should not need to re-authenticate just because they stayed in an active chat. This keeps active visible conversations usable while preserving idle cleanup.

## Impact

Active chat usage extends the in-tab unlocked key window. If the tab becomes idle and no decrypt/sign operations touch the key for the existing idle window, key material is still cleared from memory/session storage.

## Validation

- `make test TESTS=tests/test_frontend_compat.py::test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session`
- `make lint`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

Not separately performed; this is covered by the lifecycle compatibility test and scoped source/static JS diff review.

## Known risks

This intentionally changes the previous hard 15-minute cap into a sliding active-use window. The key remains scoped to the current tab/session storage and is still cleared by the existing idle timeout, logout/reset cleanup triggers, and browser-session mismatch checks.