### PR TITLE
Validate encrypted choice payload shape

### DIFF
--- a/hushline/routes/forms.py
+++ b/hushline/routes/forms.py
@@ -25,6 +25,9 @@ from hushline.model import (
 from hushline.routes.common import valid_username
 
 PASSWORD_MAX_LENGTH = 128
+ENCRYPTED_CHOICE_MAX_LENGTH = 10240
+PGP_MESSAGE_BEGIN = "-----BEGIN PGP MESSAGE-----"
+PGP_MESSAGE_END = "-----END PGP MESSAGE-----"
 
 
 # https://wtforms.readthedocs.io/en/3.2.x/specific_problems/#specialty-field-tricks
@@ -194,13 +197,42 @@ class DynamicMessageForm:
 
         self.F = F
 
-        # Custom validator to skip choice validation while keeping other validations
+        def is_pgp_message(value: str) -> bool:
+            stripped_value = value.strip()
+            return (
+                len(value) <= ENCRYPTED_CHOICE_MAX_LENGTH
+                and stripped_value.startswith(PGP_MESSAGE_BEGIN)
+                and stripped_value.endswith(PGP_MESSAGE_END)
+            )
+
+        def submitted_values_are_valid_encrypted_choices(
+            field: RadioField | SelectField | MultiCheckboxField,
+        ) -> bool:
+            if field.data in (None, ""):
+                return True
+
+            submitted_values = field.data if isinstance(field.data, list) else [field.data]
+            choice_values = {
+                str(choice[0] if isinstance(choice, (list, tuple)) else choice)
+                for choice in field.choices
+            }
+
+            return all(
+                value in choice_values or (isinstance(value, str) and is_pgp_message(value))
+                for value in submitted_values
+            )
+
+        # Custom validator to skip choice validation for client-side encrypted PGP
+        # payloads while keeping other validations. Do not suppress invalid choice
+        # errors for arbitrary invalid values, because MultiCheckboxField length
+        # validation applies to list cardinality rather than each submitted value.
         def skip_invalid_choice(
             form: FlaskForm, field: RadioField | SelectField | MultiCheckboxField
         ) -> None:
-            field.errors = [
-                error for error in field.errors if "not a valid choice" not in error.lower()
-            ]
+            if submitted_values_are_valid_encrypted_choices(field):
+                field.errors = [
+                    error for error in field.errors if "not a valid choice" not in error.lower()
+                ]
 
         # Add the fields to the form
         for i, field in enumerate(fields):

--- a/tests/test_routes_forms.py
+++ b/tests/test_routes_forms.py
@@ -7,6 +7,7 @@ from wtforms.validators import Length
 
 from hushline.model import FieldType
 from hushline.routes.forms import (
+    ENCRYPTED_CHOICE_MAX_LENGTH,
     DynamicMessageForm,
     LoginForm,
     OnboardingProfileForm,
@@ -161,6 +162,43 @@ def test_dynamic_message_form_accepts_encrypted_choice_payloads(app: Flask) -> N
         form = dynamic.form(csrf_enabled=False)
 
         assert form.validate(), form.errors
+
+
+def test_dynamic_message_form_rejects_invalid_encrypted_choice_values(app: Flask) -> None:
+    oversized_pgp_payload = (
+        "-----BEGIN PGP MESSAGE-----\n"
+        + "a" * ENCRYPTED_CHOICE_MAX_LENGTH
+        + "\n-----END PGP MESSAGE-----"
+    )
+    fields = [
+        SimpleNamespace(
+            enabled=True,
+            required=False,
+            field_type=FieldType.CHOICE_MULTIPLE,
+            encrypted=True,
+            label="Topics",
+            choices=["Research", "Media"],
+        ),
+    ]
+    dynamic = DynamicMessageForm(fields)  # type: ignore[arg-type]
+
+    with app.test_request_context(
+        method="POST",
+        data={"field_0": "not-a-choice-or-pgp"},
+    ):
+        form = dynamic.form(csrf_enabled=False)
+
+        assert not form.validate()
+        assert "not a valid choice" in form.field_0.errors[0].lower()
+
+    with app.test_request_context(
+        method="POST",
+        data={"field_0": oversized_pgp_payload},
+    ):
+        form = dynamic.form(csrf_enabled=False)
+
+        assert not form.validate()
+        assert "not a valid choice" in form.field_0.errors[0].lower()
 
 
 def test_onboarding_profile_form_rejects_disallowed_language(app: Flask) -> None:


### PR DESCRIPTION
### Motivation
- A change that suppressed WTForms "not a valid choice" errors for encrypted choice fields allowed arbitrary non-choice values to bypass per-value size limits for `CHOICE_MULTIPLE` fields because `MultiCheckboxField`/`SelectMultipleField` `Length` validation applies to list cardinality rather than each item's length. 
- The goal is to preserve the ability to accept client-side PGP-encrypted choice payloads while preventing attackers from submitting oversized or arbitrary invalid values that force unnecessary PGP/DB encryption and storage work.

### Description
- Add `ENCRYPTED_CHOICE_MAX_LENGTH` and PGP boundary constants and implement `is_pgp_message` to detect bounded PGP-armored payloads. 
- Add `submitted_values_are_valid_encrypted_choices` which returns true only when every submitted value is either a configured choice or a bounded PGP message, and keep empty/None submissions allowed. 
- Update the `skip_invalid_choice` validator to suppress invalid-choice errors only when `submitted_values_are_valid_encrypted_choices` permits it. 
- Add regression tests in `tests/test_routes_forms.py` that assert encrypted payload acceptance and rejection of arbitrary invalid or oversized PGP-looking payloads.

### Testing
- Ran formatter and static checks with `poetry run ruff format` and `poetry run ruff check` for the modified files, and they passed. 
- Attempted to run focused tests with `poetry run pytest tests/test_routes_forms.py`, but pytest setup failed due to the test environment being unable to resolve the `postgres` host, causing test setup errors; some unrelated tests did run locally before the setup failure. 
- Executed a focused Flask/WTF validation script that exercises valid PGP payloads, an arbitrary invalid value, and an oversized PGP-looking payload; the script validated the intended behavior and passed. 
- Environment-level checks `make lint`, `make audit-python`, and `make audit-node-runtime` could not run in this environment because Docker is unavailable, and an attempted GPG-signed commit was replaced with an unsigned local commit due to missing signing key.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a513463a2f483308a1ea1ec7d537759)