### PR TITLE
Preserve chat key availability with bounded renewal

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -5,7 +5,8 @@
   const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";
   const crossTabChannelName = "hushline:chat-key-session";
   const crossTabRequestTimeoutMs = 750;
-  const unlockedKeyMaxAgeMs = 15 * 60 * 1000;
+  const unlockedKeyActiveRenewalMs = 15 * 60 * 1000;
+  const unlockedKeyMaxAgeMs = 2 * 60 * 60 * 1000;
   const unlockedKeyIdleTimeoutMs = 5 * 60 * 1000;
   const conversationPollMinIntervalMs = 3000;
   const tabId = window.crypto?.randomUUID
@@ -16,6 +17,7 @@
   let unlockedChatPrivateKey = null;
   let unlockedChatSigningPrivateKey = null;
   let unlockedChatKeyExpiryTimer = null;
+  let unlockedChatKeyCreatedAt = null;
   let unlockedChatKeyExpiresAt = null;
   let unlockedChatKeyLastUsedAt = null;
   let pendingLoginPassword = null;
@@ -84,8 +86,23 @@
     }
   }
 
-  function refreshedUnlockedKeyExpiresAt(now = Date.now()) {
-    return now + unlockedKeyMaxAgeMs;
+  function unlockedKeyAbsoluteExpiresAt(createdAt) {
+    return createdAt + unlockedKeyMaxAgeMs;
+  }
+
+  function refreshedUnlockedKeyExpiresAt(createdAt, now = Date.now()) {
+    return Math.min(
+      now + unlockedKeyActiveRenewalMs,
+      unlockedKeyAbsoluteExpiresAt(createdAt),
+    );
+  }
+
+  function storedUnlockedKeyCreatedAt(stored) {
+    const createdAt = Number(stored?.created_at);
+    if (Number.isFinite(createdAt)) {
+      return createdAt;
+    }
+    return Number(stored?.expires_at) - unlockedKeyActiveRenewalMs;
   }
 
   function scheduleUnlockedKeyExpiry(expiresAt, lastUsedAt) {
@@ -196,13 +213,15 @@
     sourceDocument = document,
   ) {
     const now = Date.now();
-    const expiresAt = refreshedUnlockedKeyExpiresAt(now);
+    const expiresAt = refreshedUnlockedKeyExpiresAt(now, now);
     const sessionId = chatKeySessionId(sourceDocument);
+    unlockedChatKeyCreatedAt = now;
     const storedValue = JSON.stringify({
       key_version: chatKey.key_version,
       public_key: chatKey.public_key,
       public_signing_key: chatKey.public_signing_key || null,
       private_key_bundle: privateKeyBundle,
+      created_at: now,
       expires_at: expiresAt,
       last_used_at: now,
       session_id: sessionId,
@@ -237,16 +256,21 @@
     try {
       const stored = JSON.parse(storedValue);
       const now = Date.now();
+      const createdAt = storedUnlockedKeyCreatedAt(stored);
       const expiresAt = Number(stored.expires_at);
       const lastUsedAt = Number(stored.last_used_at);
+      const absoluteExpiresAt = unlockedKeyAbsoluteExpiresAt(createdAt);
       if (
         stored?.key_version !== chatKey.key_version ||
         stored.public_key !== chatKey.public_key ||
         (stored.public_signing_key || null) !==
           (chatKey.public_signing_key || null) ||
         !(stored.private_key_bundle || stored.private_jwk) ||
+        !Number.isFinite(createdAt) ||
+        createdAt > now ||
         !Number.isFinite(expiresAt) ||
-        expiresAt > now + unlockedKeyMaxAgeMs ||
+        expiresAt > absoluteExpiresAt ||
+        expiresAt > now + unlockedKeyActiveRenewalMs ||
         !Number.isFinite(lastUsedAt) ||
         stored.session_id !== chatKeySessionId()
       ) {
@@ -256,7 +280,9 @@
         forgetUnlockedPrivateJwk();
         return null;
       }
-      const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(now);
+      const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(createdAt, now);
+      unlockedChatKeyCreatedAt = createdAt;
+      stored.created_at = createdAt;
       stored.expires_at = refreshedExpiresAt;
       stored.last_used_at = now;
       sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
@@ -290,6 +316,7 @@
     }
 
     const now = Date.now();
+    let createdAt = unlockedChatKeyCreatedAt;
     if (
       !Number.isFinite(unlockedChatKeyExpiresAt) ||
       !Number.isFinite(unlockedChatKeyLastUsedAt) ||
@@ -300,27 +327,44 @@
       return false;
     }
 
-    const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(now);
     try {
       const stored = JSON.parse(
         sessionStorage.getItem(sessionStorageKey) || "null",
       );
       if (stored) {
+        createdAt = storedUnlockedKeyCreatedAt(stored);
         if (
+          !Number.isFinite(createdAt) ||
+          createdAt > now ||
+          unlockedKeyAbsoluteExpiresAt(createdAt) < now ||
           Number(stored.expires_at) !== unlockedChatKeyExpiresAt ||
           stored.session_id !== chatKeySessionId()
         ) {
           clearChatKeyMaterial();
           return false;
         }
+        const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(
+          createdAt,
+          now,
+        );
+        unlockedChatKeyCreatedAt = createdAt;
+        stored.created_at = createdAt;
         stored.expires_at = refreshedExpiresAt;
         stored.last_used_at = now;
         sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
+        scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
+        return true;
       }
     } catch (error) {
       // The in-memory key remains bounded by the active tab expiry timer.
     }
 
+    if (!Number.isFinite(createdAt)) {
+      clearChatKeyMaterial();
+      return false;
+    }
+    const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(createdAt, now);
+    unlockedChatKeyCreatedAt = createdAt;
     scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
     return true;
   }
@@ -1066,6 +1110,7 @@
     clearUnlockedKeyExpiryTimer();
     unlockedChatPrivateKey = null;
     unlockedChatSigningPrivateKey = null;
+    unlockedChatKeyCreatedAt = null;
     unlockedChatKeyExpiresAt = null;
     unlockedChatKeyLastUsedAt = null;
     state.status = "empty";

--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -1025,12 +1025,16 @@
         sourceDocument,
       );
       if (unlocked && !chatKey.public_signing_key) {
-        await upgradeChatKeySigningCapability(
-          chatKey,
-          password,
-          chatKeyUrl,
-          sourceDocument,
-        );
+        try {
+          await upgradeChatKeySigningCapability(
+            chatKey,
+            password,
+            chatKeyUrl,
+            sourceDocument,
+          );
+        } catch (error) {
+          return unlocked;
+        }
       }
       return unlocked;
     }

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -1029,12 +1029,16 @@
         sourceDocument,
       );
       if (unlocked && !chatKey.public_signing_key) {
-        await upgradeChatKeySigningCapability(
-          chatKey,
-          password,
-          chatKeyUrl,
-          sourceDocument,
-        );
+        try {
+          await upgradeChatKeySigningCapability(
+            chatKey,
+            password,
+            chatKeyUrl,
+            sourceDocument,
+          );
+        } catch (error) {
+          return unlocked;
+        }
       }
       return unlocked;
     }

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -9,7 +9,8 @@
   const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";
   const crossTabChannelName = "hushline:chat-key-session";
   const crossTabRequestTimeoutMs = 750;
-  const unlockedKeyMaxAgeMs = 15 * 60 * 1000;
+  const unlockedKeyActiveRenewalMs = 15 * 60 * 1000;
+  const unlockedKeyMaxAgeMs = 2 * 60 * 60 * 1000;
   const unlockedKeyIdleTimeoutMs = 5 * 60 * 1000;
   const conversationPollMinIntervalMs = 3000;
   const tabId = window.crypto?.randomUUID
@@ -20,6 +21,7 @@
   let unlockedChatPrivateKey = null;
   let unlockedChatSigningPrivateKey = null;
   let unlockedChatKeyExpiryTimer = null;
+  let unlockedChatKeyCreatedAt = null;
   let unlockedChatKeyExpiresAt = null;
   let unlockedChatKeyLastUsedAt = null;
   let pendingLoginPassword = null;
@@ -88,8 +90,23 @@
     }
   }
 
-  function refreshedUnlockedKeyExpiresAt(now = Date.now()) {
-    return now + unlockedKeyMaxAgeMs;
+  function unlockedKeyAbsoluteExpiresAt(createdAt) {
+    return createdAt + unlockedKeyMaxAgeMs;
+  }
+
+  function refreshedUnlockedKeyExpiresAt(createdAt, now = Date.now()) {
+    return Math.min(
+      now + unlockedKeyActiveRenewalMs,
+      unlockedKeyAbsoluteExpiresAt(createdAt),
+    );
+  }
+
+  function storedUnlockedKeyCreatedAt(stored) {
+    const createdAt = Number(stored?.created_at);
+    if (Number.isFinite(createdAt)) {
+      return createdAt;
+    }
+    return Number(stored?.expires_at) - unlockedKeyActiveRenewalMs;
   }
 
   function scheduleUnlockedKeyExpiry(expiresAt, lastUsedAt) {
@@ -200,13 +217,15 @@
     sourceDocument = document,
   ) {
     const now = Date.now();
-    const expiresAt = refreshedUnlockedKeyExpiresAt(now);
+    const expiresAt = refreshedUnlockedKeyExpiresAt(now, now);
     const sessionId = chatKeySessionId(sourceDocument);
+    unlockedChatKeyCreatedAt = now;
     const storedValue = JSON.stringify({
       key_version: chatKey.key_version,
       public_key: chatKey.public_key,
       public_signing_key: chatKey.public_signing_key || null,
       private_key_bundle: privateKeyBundle,
+      created_at: now,
       expires_at: expiresAt,
       last_used_at: now,
       session_id: sessionId,
@@ -241,16 +260,21 @@
     try {
       const stored = JSON.parse(storedValue);
       const now = Date.now();
+      const createdAt = storedUnlockedKeyCreatedAt(stored);
       const expiresAt = Number(stored.expires_at);
       const lastUsedAt = Number(stored.last_used_at);
+      const absoluteExpiresAt = unlockedKeyAbsoluteExpiresAt(createdAt);
       if (
         stored?.key_version !== chatKey.key_version ||
         stored.public_key !== chatKey.public_key ||
         (stored.public_signing_key || null) !==
           (chatKey.public_signing_key || null) ||
         !(stored.private_key_bundle || stored.private_jwk) ||
+        !Number.isFinite(createdAt) ||
+        createdAt > now ||
         !Number.isFinite(expiresAt) ||
-        expiresAt > now + unlockedKeyMaxAgeMs ||
+        expiresAt > absoluteExpiresAt ||
+        expiresAt > now + unlockedKeyActiveRenewalMs ||
         !Number.isFinite(lastUsedAt) ||
         stored.session_id !== chatKeySessionId()
       ) {
@@ -260,7 +284,9 @@
         forgetUnlockedPrivateJwk();
         return null;
       }
-      const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(now);
+      const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(createdAt, now);
+      unlockedChatKeyCreatedAt = createdAt;
+      stored.created_at = createdAt;
       stored.expires_at = refreshedExpiresAt;
       stored.last_used_at = now;
       sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
@@ -294,6 +320,7 @@
     }
 
     const now = Date.now();
+    let createdAt = unlockedChatKeyCreatedAt;
     if (
       !Number.isFinite(unlockedChatKeyExpiresAt) ||
       !Number.isFinite(unlockedChatKeyLastUsedAt) ||
@@ -304,27 +331,44 @@
       return false;
     }
 
-    const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(now);
     try {
       const stored = JSON.parse(
         sessionStorage.getItem(sessionStorageKey) || "null",
       );
       if (stored) {
+        createdAt = storedUnlockedKeyCreatedAt(stored);
         if (
+          !Number.isFinite(createdAt) ||
+          createdAt > now ||
+          unlockedKeyAbsoluteExpiresAt(createdAt) < now ||
           Number(stored.expires_at) !== unlockedChatKeyExpiresAt ||
           stored.session_id !== chatKeySessionId()
         ) {
           clearChatKeyMaterial();
           return false;
         }
+        const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(
+          createdAt,
+          now,
+        );
+        unlockedChatKeyCreatedAt = createdAt;
+        stored.created_at = createdAt;
         stored.expires_at = refreshedExpiresAt;
         stored.last_used_at = now;
         sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
+        scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
+        return true;
       }
     } catch (error) {
       // The in-memory key remains bounded by the active tab expiry timer.
     }
 
+    if (!Number.isFinite(createdAt)) {
+      clearChatKeyMaterial();
+      return false;
+    }
+    const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(createdAt, now);
+    unlockedChatKeyCreatedAt = createdAt;
     scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
     return true;
   }
@@ -1070,6 +1114,7 @@
     clearUnlockedKeyExpiryTimer();
     unlockedChatPrivateKey = null;
     unlockedChatSigningPrivateKey = null;
+    unlockedChatKeyCreatedAt = null;
     unlockedChatKeyExpiresAt = null;
     unlockedChatKeyLastUsedAt = null;
     state.status = "empty";

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -195,10 +195,16 @@ def test_chat_key_lifecycle_upgrades_legacy_keys_with_signing_material() -> None
         assert "public_key: chatKey.public_key" in lifecycle_js
         assert "signing_private_jwk: signingKeyMaterial.signingPrivateJwk" in lifecycle_js
         assert "if (unlocked && !chatKey.public_signing_key)" in lifecycle_js
-        assert "await upgradeChatKeySigningCapability(" in lifecycle_js
-        assert "chatKeyUrl,\n          sourceDocument," in lifecycle_js
+        assert (
+            "await upgradeChatKeySigningCapability(\n"
+            "            chatKey,\n"
+            "            password,\n"
+            "            chatKeyUrl,\n"
+            "            sourceDocument,\n"
+            "          );" in lifecycle_js
+        )
         assert "return unlocked;" in lifecycle_js
-        assert "catch (error) {\n          return unlocked;" not in lifecycle_js
+        assert "catch (error) {\n          return unlocked;" in lifecycle_js
         assert "if (!publicSigningKey || !privateKeyBundle.signing_private_jwk)" in lifecycle_js
 
 

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -239,15 +239,27 @@ def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session(
     assert 'const sessionStorageKey = "hushline:chat-private-jwk";' in js
     assert 'const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";' in js
     assert "browserStorageMaxAgeMs" not in js
-    assert "const unlockedKeyMaxAgeMs = 15 * 60 * 1000;" in js
+    assert "const unlockedKeyActiveRenewalMs = 15 * 60 * 1000;" in js
+    assert "const unlockedKeyMaxAgeMs = 2 * 60 * 60 * 1000;" in js
     assert "const unlockedKeyIdleTimeoutMs = 5 * 60 * 1000;" in js
-    assert "function refreshedUnlockedKeyExpiresAt(now = Date.now())" in js
+    assert "function unlockedKeyAbsoluteExpiresAt(createdAt)" in js
+    assert "function refreshedUnlockedKeyExpiresAt(createdAt, now = Date.now())" in js
+    assert "function storedUnlockedKeyCreatedAt(stored)" in js
+    assert "unlockedKeyAbsoluteExpiresAt(createdAt)" in js
+    assert "return Number(stored?.expires_at) - unlockedKeyActiveRenewalMs;" in js
+    assert "now + unlockedKeyActiveRenewalMs" in js
+    assert "let unlockedChatKeyCreatedAt = null;" in js
+    assert "created_at: now" in js
     assert "expires_at: expiresAt" in js
+    assert "stored.created_at = createdAt;" in js
+    assert "unlockedChatKeyCreatedAt = createdAt;" in js
+    assert "unlockedChatKeyCreatedAt = null;" in js
     assert "stored.expires_at = refreshedExpiresAt;" in js
     assert "last_used_at: now" in js
     assert "scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);" in js
     assert "now - lastUsedAt > unlockedKeyIdleTimeoutMs" in js
-    assert "expiresAt > now + unlockedKeyMaxAgeMs" in js
+    assert "expiresAt > absoluteExpiresAt" in js
+    assert "expiresAt > now + unlockedKeyActiveRenewalMs" in js
     assert 'const crossTabChannelName = "hushline:chat-key-session";' in js
     assert "new BroadcastChannel(crossTabChannelName)" in js
     assert "function chatKeySessionId(sourceDocument = document)" in js


### PR DESCRIPTION
## What changed

- Keep the already-unlocked legacy chat key available when automatic signing-key upgrade fails during login or 2FA completion.
- Replace unbounded active chat-key renewal with a bounded lifecycle:
  - 5-minute idle timeout remains.
  - 15-minute active renewal windows remain.
  - A 2-hour absolute cap now bounds both in-memory and `sessionStorage` key material.
- Store and validate the unlock creation timestamp so repeated message decryption/signing cannot keep key material resident forever.
- Update frontend compatibility tests for the legacy-upgrade fallback and bounded key lifetime behavior.

## Why

Two release-blocking lifecycle issues were found:

- A legacy chat key can be successfully decrypted before its signing material is upgraded. If the upgrade request then fails, propagating that error into the login handler causes `clearChatKeyMaterial()` to run and strands the user with locked chat material.
- #2334 fixed the bad active-chat UX by making key expiry sliding, but it removed the effective absolute lifetime. Visible active conversations could keep refreshing unlocked key material indefinitely.

This keeps chat usable during active sessions without allowing indefinite browser key residency.

## Security / privacy impact

- Affected path: authenticated login, 2FA completion, and browser chat-key lifecycle for existing chat keys.
- Data touched: in-memory/session-scoped browser chat key material only.
- Mitigations:
  - Successful legacy unlock remains usable even if the best-effort signing upgrade path fails.
  - Active renewal is capped by an original unlock timestamp.
  - Existing entries without `created_at` are migrated from their current expiry minus the 15-minute renewal window.
  - Idle cleanup still clears key material after 5 minutes without use.

## Validation

- `make test TESTS=tests/test_frontend_compat.py::test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session`
- `make test TESTS=tests/test_frontend_compat.py::test_chat_key_lifecycle_upgrades_legacy_keys_with_signing_material`
- `make lint`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

Not run in-browser for this small lifecycle guard; covered by focused frontend compatibility tests for both source and served static JS.

## Risks / follow-ups

Replying still depends on the existing server-side signing-capable key requirements. Active sessions are now more reliable than the original 15-minute hard stop but still intentionally expire at the 2-hour absolute cap.
