### PR TITLE
Fix locked chat PGP copy assertion

### DIFF
--- a/tests/test_conversation.py
+++ b/tests/test_conversation.py
@@ -5,6 +5,7 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
 import pytest
+from bs4 import BeautifulSoup
 from cryptography.hazmat.primitives import hashes
 from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
@@ -697,8 +698,9 @@ def test_conversation_view_shows_locked_chat_key_state(
     assert "Replies are unavailable until you have an active signing-capable" in response.text
     assert "conversation-chat-password" not in response.text
     assert "Unlock Chat" not in response.text
-    assert "Proton" not in response.text
-    assert "PGP" not in response.text
+    page_text = BeautifulSoup(response.text, "html.parser").get_text(" ", strip=True)
+    assert "Proton" not in page_text
+    assert "PGP" not in page_text
     assert url_for("conversation_presence", public_id=conversation.public_id) in response.text
 
 


### PR DESCRIPTION
## What changed

- Narrow the locked-chat test's `PGP` / `Proton` negative assertions to visible page text instead of the full HTML response.

## Why

`main` failed in `Run Linter and Tests` on the `test-with-alembic` job:

- Workflow run: https://github.com/scidsg/hushline/actions/runs/29116598788
- Failing test: `tests/test_conversation.py::test_conversation_view_shows_locked_chat_key_state`

The product behavior was correct. The test scanned the full rendered HTML for `PGP`; CI generated a random `data-chat-key-session-id` containing `LPGP`, which made the test fail even though no legacy PGP/Proton UI copy was visible to the user.

## Validation

- `env PYTEST_ADDOPTS="--alembic --skip-local-only" make test TESTS=tests/test_conversation.py::test_conversation_view_shows_locked_chat_key_state`
- `make lint`
- `make audit-python`
- `make audit-node-runtime`

## Manual testing

Not applicable; this is a test-only fix for a brittle assertion.

## Risks / follow-ups

Low risk. The assertion still verifies that legacy PGP/Proton copy is absent from visible text on the locked chat page.
