### PR TITLE
Keep encrypted chats available for the browser session

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -5,9 +5,6 @@
   const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";
   const crossTabChannelName = "hushline:chat-key-session";
   const crossTabRequestTimeoutMs = 750;
-  const unlockedKeyActiveRenewalMs = 15 * 60 * 1000;
-  const unlockedKeyMaxAgeMs = 2 * 60 * 60 * 1000;
-  const unlockedKeyIdleTimeoutMs = 5 * 60 * 1000;
   const conversationPollMinIntervalMs = 3000;
   const tabId = window.crypto?.randomUUID
     ? window.crypto.randomUUID()
@@ -16,10 +13,6 @@
   let crossTabSharingBound = false;
   let unlockedChatPrivateKey = null;
   let unlockedChatSigningPrivateKey = null;
-  let unlockedChatKeyExpiryTimer = null;
-  let unlockedChatKeyCreatedAt = null;
-  let unlockedChatKeyExpiresAt = null;
-  let unlockedChatKeyLastUsedAt = null;
   let pendingLoginPassword = null;
   const state = {
     status: "empty",
@@ -77,51 +70,6 @@
 
   function chatKeySessionId(sourceDocument = document) {
     return sourceDocument.body?.dataset.chatKeySessionId || "";
-  }
-
-  function clearUnlockedKeyExpiryTimer() {
-    if (unlockedChatKeyExpiryTimer) {
-      window.clearTimeout(unlockedChatKeyExpiryTimer);
-      unlockedChatKeyExpiryTimer = null;
-    }
-  }
-
-  function unlockedKeyAbsoluteExpiresAt(createdAt) {
-    return createdAt + unlockedKeyMaxAgeMs;
-  }
-
-  function refreshedUnlockedKeyExpiresAt(createdAt, now = Date.now()) {
-    return Math.min(
-      now + unlockedKeyActiveRenewalMs,
-      unlockedKeyAbsoluteExpiresAt(createdAt),
-    );
-  }
-
-  function storedUnlockedKeyCreatedAt(stored) {
-    const createdAt = Number(stored?.created_at);
-    if (Number.isFinite(createdAt)) {
-      return createdAt;
-    }
-    return Number(stored?.expires_at) - unlockedKeyActiveRenewalMs;
-  }
-
-  function scheduleUnlockedKeyExpiry(expiresAt, lastUsedAt) {
-    clearUnlockedKeyExpiryTimer();
-    const now = Date.now();
-    const normalizedExpiresAt = Number(expiresAt);
-    const normalizedLastUsedAt = Number(lastUsedAt);
-    unlockedChatKeyExpiresAt = normalizedExpiresAt;
-    unlockedChatKeyLastUsedAt = normalizedLastUsedAt;
-    const idleExpiresAt = normalizedLastUsedAt + unlockedKeyIdleTimeoutMs;
-    const nextExpiry = Math.min(normalizedExpiresAt, idleExpiresAt);
-    if (!Number.isFinite(nextExpiry) || nextExpiry <= now) {
-      clearChatKeyMaterial();
-      return;
-    }
-    unlockedChatKeyExpiryTimer = window.setTimeout(
-      clearChatKeyMaterial,
-      nextExpiry - now,
-    );
   }
 
   async function deriveWrappingKey(password, salt, kdfParams, usages) {
@@ -212,22 +160,15 @@
     chatKey,
     sourceDocument = document,
   ) {
-    const now = Date.now();
-    const expiresAt = refreshedUnlockedKeyExpiresAt(now, now);
     const sessionId = chatKeySessionId(sourceDocument);
-    unlockedChatKeyCreatedAt = now;
     const storedValue = JSON.stringify({
       key_version: chatKey.key_version,
       public_key: chatKey.public_key,
       public_signing_key: chatKey.public_signing_key || null,
       private_key_bundle: privateKeyBundle,
-      created_at: now,
-      expires_at: expiresAt,
-      last_used_at: now,
       session_id: sessionId,
     });
 
-    scheduleUnlockedKeyExpiry(expiresAt, now);
     try {
       sessionStorage.setItem(sessionStorageKey, storedValue);
     } catch (error) {
@@ -255,38 +196,16 @@
 
     try {
       const stored = JSON.parse(storedValue);
-      const now = Date.now();
-      const createdAt = storedUnlockedKeyCreatedAt(stored);
-      const expiresAt = Number(stored.expires_at);
-      const lastUsedAt = Number(stored.last_used_at);
-      const absoluteExpiresAt = unlockedKeyAbsoluteExpiresAt(createdAt);
       if (
         stored?.key_version !== chatKey.key_version ||
         stored.public_key !== chatKey.public_key ||
         (stored.public_signing_key || null) !==
           (chatKey.public_signing_key || null) ||
         !(stored.private_key_bundle || stored.private_jwk) ||
-        !Number.isFinite(createdAt) ||
-        createdAt > now ||
-        !Number.isFinite(expiresAt) ||
-        expiresAt > absoluteExpiresAt ||
-        expiresAt > now + unlockedKeyActiveRenewalMs ||
-        !Number.isFinite(lastUsedAt) ||
         stored.session_id !== chatKeySessionId()
       ) {
         return null;
       }
-      if (now > expiresAt || now - lastUsedAt > unlockedKeyIdleTimeoutMs) {
-        forgetUnlockedPrivateJwk();
-        return null;
-      }
-      const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(createdAt, now);
-      unlockedChatKeyCreatedAt = createdAt;
-      stored.created_at = createdAt;
-      stored.expires_at = refreshedExpiresAt;
-      stored.last_used_at = now;
-      sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
-      scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
       return normalizePrivateKeyBundle(
         stored.private_key_bundle || stored.private_jwk,
       );
@@ -311,62 +230,7 @@
   }
 
   function touchUnlockedChatKeyUse() {
-    if (!unlockedChatPrivateKey && !unlockedChatSigningPrivateKey) {
-      return false;
-    }
-
-    const now = Date.now();
-    let createdAt = unlockedChatKeyCreatedAt;
-    if (
-      !Number.isFinite(unlockedChatKeyExpiresAt) ||
-      !Number.isFinite(unlockedChatKeyLastUsedAt) ||
-      now > unlockedChatKeyExpiresAt ||
-      now - unlockedChatKeyLastUsedAt > unlockedKeyIdleTimeoutMs
-    ) {
-      clearChatKeyMaterial();
-      return false;
-    }
-
-    try {
-      const stored = JSON.parse(
-        sessionStorage.getItem(sessionStorageKey) || "null",
-      );
-      if (stored) {
-        createdAt = storedUnlockedKeyCreatedAt(stored);
-        if (
-          !Number.isFinite(createdAt) ||
-          createdAt > now ||
-          unlockedKeyAbsoluteExpiresAt(createdAt) < now ||
-          Number(stored.expires_at) !== unlockedChatKeyExpiresAt ||
-          stored.session_id !== chatKeySessionId()
-        ) {
-          clearChatKeyMaterial();
-          return false;
-        }
-        const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(
-          createdAt,
-          now,
-        );
-        unlockedChatKeyCreatedAt = createdAt;
-        stored.created_at = createdAt;
-        stored.expires_at = refreshedExpiresAt;
-        stored.last_used_at = now;
-        sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
-        scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
-        return true;
-      }
-    } catch (error) {
-      // The in-memory key remains bounded by the active tab expiry timer.
-    }
-
-    if (!Number.isFinite(createdAt)) {
-      clearChatKeyMaterial();
-      return false;
-    }
-    const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(createdAt, now);
-    unlockedChatKeyCreatedAt = createdAt;
-    scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
-    return true;
+    return Boolean(unlockedChatPrivateKey || unlockedChatSigningPrivateKey);
   }
 
   async function restoreUnlockedChatKeyFromBundle(
@@ -1107,12 +971,8 @@
         state.status === "unlocked",
     );
     forgetUnlockedPrivateJwk();
-    clearUnlockedKeyExpiryTimer();
     unlockedChatPrivateKey = null;
     unlockedChatSigningPrivateKey = null;
-    unlockedChatKeyCreatedAt = null;
-    unlockedChatKeyExpiresAt = null;
-    unlockedChatKeyLastUsedAt = null;
     state.status = "empty";
     state.keyVersion = null;
     state.lastError = null;

--- a/assets/js/client-side-encryption.js
+++ b/assets/js/client-side-encryption.js
@@ -332,9 +332,7 @@ function rememberedPrivateKeyBundleForChatKey(chatKey) {
       stored.public_key !== chatKey.public_key ||
       (stored.public_signing_key || null) !==
         (chatKey.public_signing_key || null) ||
-      !(stored.private_key_bundle || stored.private_jwk) ||
-      !stored.expires_at ||
-      Date.now() > Number(stored.expires_at)
+      !(stored.private_key_bundle || stored.private_jwk)
     ) {
       return null;
     }

--- a/docs/USE-CASES.md
+++ b/docs/USE-CASES.md
@@ -177,6 +177,8 @@ Two-way conversations are for logged-in Hush Line account holders who submit to 
 
 Hush Line chat keys are browser-generated in-app conversation keys. They are separate from PGP keys used for message intake, exports, and notification email compatibility. Proton Key Lookup imports public PGP keys only; Hush Line must not ask users to export, paste, or upload Proton Mail private keys or any other external private key for account conversations.
 
+An unlocked Hush Line chat key remains available only in the authenticated browser tab's session storage so active conversations and page refreshes continue to work without another unlock. Hush Line clears that browser key material on logout, password reset, account deletion, or another explicit authentication cleanup; a changed server chat-key session identifier also prevents a stored key from being restored.
+
 New account conversation replies require all participants to have active chat keys with public encryption keys and public signing keys. If any participant only has legacy chat-key material, the conversation remains readable where possible, but composing new replies is unavailable until all participants have signing-capable chat keys.
 
 Conversation plaintext is not stored by the server. Conversation messages are stored as per-participant encrypted payloads, and only conversation participants can open the route or append replies. Administrators may manage accounts and trust states, but admin status alone does not grant conversation access.

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -9,9 +9,6 @@
   const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";
   const crossTabChannelName = "hushline:chat-key-session";
   const crossTabRequestTimeoutMs = 750;
-  const unlockedKeyActiveRenewalMs = 15 * 60 * 1000;
-  const unlockedKeyMaxAgeMs = 2 * 60 * 60 * 1000;
-  const unlockedKeyIdleTimeoutMs = 5 * 60 * 1000;
   const conversationPollMinIntervalMs = 3000;
   const tabId = window.crypto?.randomUUID
     ? window.crypto.randomUUID()
@@ -20,10 +17,6 @@
   let crossTabSharingBound = false;
   let unlockedChatPrivateKey = null;
   let unlockedChatSigningPrivateKey = null;
-  let unlockedChatKeyExpiryTimer = null;
-  let unlockedChatKeyCreatedAt = null;
-  let unlockedChatKeyExpiresAt = null;
-  let unlockedChatKeyLastUsedAt = null;
   let pendingLoginPassword = null;
   const state = {
     status: "empty",
@@ -81,51 +74,6 @@
 
   function chatKeySessionId(sourceDocument = document) {
     return sourceDocument.body?.dataset.chatKeySessionId || "";
-  }
-
-  function clearUnlockedKeyExpiryTimer() {
-    if (unlockedChatKeyExpiryTimer) {
-      window.clearTimeout(unlockedChatKeyExpiryTimer);
-      unlockedChatKeyExpiryTimer = null;
-    }
-  }
-
-  function unlockedKeyAbsoluteExpiresAt(createdAt) {
-    return createdAt + unlockedKeyMaxAgeMs;
-  }
-
-  function refreshedUnlockedKeyExpiresAt(createdAt, now = Date.now()) {
-    return Math.min(
-      now + unlockedKeyActiveRenewalMs,
-      unlockedKeyAbsoluteExpiresAt(createdAt),
-    );
-  }
-
-  function storedUnlockedKeyCreatedAt(stored) {
-    const createdAt = Number(stored?.created_at);
-    if (Number.isFinite(createdAt)) {
-      return createdAt;
-    }
-    return Number(stored?.expires_at) - unlockedKeyActiveRenewalMs;
-  }
-
-  function scheduleUnlockedKeyExpiry(expiresAt, lastUsedAt) {
-    clearUnlockedKeyExpiryTimer();
-    const now = Date.now();
-    const normalizedExpiresAt = Number(expiresAt);
-    const normalizedLastUsedAt = Number(lastUsedAt);
-    unlockedChatKeyExpiresAt = normalizedExpiresAt;
-    unlockedChatKeyLastUsedAt = normalizedLastUsedAt;
-    const idleExpiresAt = normalizedLastUsedAt + unlockedKeyIdleTimeoutMs;
-    const nextExpiry = Math.min(normalizedExpiresAt, idleExpiresAt);
-    if (!Number.isFinite(nextExpiry) || nextExpiry <= now) {
-      clearChatKeyMaterial();
-      return;
-    }
-    unlockedChatKeyExpiryTimer = window.setTimeout(
-      clearChatKeyMaterial,
-      nextExpiry - now,
-    );
   }
 
   async function deriveWrappingKey(password, salt, kdfParams, usages) {
@@ -216,22 +164,15 @@
     chatKey,
     sourceDocument = document,
   ) {
-    const now = Date.now();
-    const expiresAt = refreshedUnlockedKeyExpiresAt(now, now);
     const sessionId = chatKeySessionId(sourceDocument);
-    unlockedChatKeyCreatedAt = now;
     const storedValue = JSON.stringify({
       key_version: chatKey.key_version,
       public_key: chatKey.public_key,
       public_signing_key: chatKey.public_signing_key || null,
       private_key_bundle: privateKeyBundle,
-      created_at: now,
-      expires_at: expiresAt,
-      last_used_at: now,
       session_id: sessionId,
     });
 
-    scheduleUnlockedKeyExpiry(expiresAt, now);
     try {
       sessionStorage.setItem(sessionStorageKey, storedValue);
     } catch (error) {
@@ -259,38 +200,16 @@
 
     try {
       const stored = JSON.parse(storedValue);
-      const now = Date.now();
-      const createdAt = storedUnlockedKeyCreatedAt(stored);
-      const expiresAt = Number(stored.expires_at);
-      const lastUsedAt = Number(stored.last_used_at);
-      const absoluteExpiresAt = unlockedKeyAbsoluteExpiresAt(createdAt);
       if (
         stored?.key_version !== chatKey.key_version ||
         stored.public_key !== chatKey.public_key ||
         (stored.public_signing_key || null) !==
           (chatKey.public_signing_key || null) ||
         !(stored.private_key_bundle || stored.private_jwk) ||
-        !Number.isFinite(createdAt) ||
-        createdAt > now ||
-        !Number.isFinite(expiresAt) ||
-        expiresAt > absoluteExpiresAt ||
-        expiresAt > now + unlockedKeyActiveRenewalMs ||
-        !Number.isFinite(lastUsedAt) ||
         stored.session_id !== chatKeySessionId()
       ) {
         return null;
       }
-      if (now > expiresAt || now - lastUsedAt > unlockedKeyIdleTimeoutMs) {
-        forgetUnlockedPrivateJwk();
-        return null;
-      }
-      const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(createdAt, now);
-      unlockedChatKeyCreatedAt = createdAt;
-      stored.created_at = createdAt;
-      stored.expires_at = refreshedExpiresAt;
-      stored.last_used_at = now;
-      sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
-      scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
       return normalizePrivateKeyBundle(
         stored.private_key_bundle || stored.private_jwk,
       );
@@ -315,62 +234,7 @@
   }
 
   function touchUnlockedChatKeyUse() {
-    if (!unlockedChatPrivateKey && !unlockedChatSigningPrivateKey) {
-      return false;
-    }
-
-    const now = Date.now();
-    let createdAt = unlockedChatKeyCreatedAt;
-    if (
-      !Number.isFinite(unlockedChatKeyExpiresAt) ||
-      !Number.isFinite(unlockedChatKeyLastUsedAt) ||
-      now > unlockedChatKeyExpiresAt ||
-      now - unlockedChatKeyLastUsedAt > unlockedKeyIdleTimeoutMs
-    ) {
-      clearChatKeyMaterial();
-      return false;
-    }
-
-    try {
-      const stored = JSON.parse(
-        sessionStorage.getItem(sessionStorageKey) || "null",
-      );
-      if (stored) {
-        createdAt = storedUnlockedKeyCreatedAt(stored);
-        if (
-          !Number.isFinite(createdAt) ||
-          createdAt > now ||
-          unlockedKeyAbsoluteExpiresAt(createdAt) < now ||
-          Number(stored.expires_at) !== unlockedChatKeyExpiresAt ||
-          stored.session_id !== chatKeySessionId()
-        ) {
-          clearChatKeyMaterial();
-          return false;
-        }
-        const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(
-          createdAt,
-          now,
-        );
-        unlockedChatKeyCreatedAt = createdAt;
-        stored.created_at = createdAt;
-        stored.expires_at = refreshedExpiresAt;
-        stored.last_used_at = now;
-        sessionStorage.setItem(sessionStorageKey, JSON.stringify(stored));
-        scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
-        return true;
-      }
-    } catch (error) {
-      // The in-memory key remains bounded by the active tab expiry timer.
-    }
-
-    if (!Number.isFinite(createdAt)) {
-      clearChatKeyMaterial();
-      return false;
-    }
-    const refreshedExpiresAt = refreshedUnlockedKeyExpiresAt(createdAt, now);
-    unlockedChatKeyCreatedAt = createdAt;
-    scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);
-    return true;
+    return Boolean(unlockedChatPrivateKey || unlockedChatSigningPrivateKey);
   }
 
   async function restoreUnlockedChatKeyFromBundle(
@@ -1111,12 +975,8 @@
         state.status === "unlocked",
     );
     forgetUnlockedPrivateJwk();
-    clearUnlockedKeyExpiryTimer();
     unlockedChatPrivateKey = null;
     unlockedChatSigningPrivateKey = null;
-    unlockedChatKeyCreatedAt = null;
-    unlockedChatKeyExpiresAt = null;
-    unlockedChatKeyLastUsedAt = null;
     state.status = "empty";
     state.keyVersion = null;
     state.lastError = null;

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -140,6 +140,8 @@ def test_client_side_encryption_prepares_chat_conversation_copies() -> None:
     assert "await signChatEnvelope(envelope, signingKey)" in js
     assert "signingPrivateKeyForChatKey" in js
     assert 'const sessionStorageKey = "hushline:chat-private-jwk";' in js
+    assert "stored.expires_at" not in js
+    assert "Date.now() > Number(stored.expires_at)" not in js
     assert 'getChatPublicKey("recipientChatPublicKey")' in js
     assert 'getChatKeyDescriptor("recipientChatKey")' in js
     assert "!recipientChatKey?.public_signing_key" in js
@@ -239,27 +241,15 @@ def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session(
     assert 'const sessionStorageKey = "hushline:chat-private-jwk";' in js
     assert 'const legacyBrowserStorageKey = "hushline:chat-private-jwk:browser-session";' in js
     assert "browserStorageMaxAgeMs" not in js
-    assert "const unlockedKeyActiveRenewalMs = 15 * 60 * 1000;" in js
-    assert "const unlockedKeyMaxAgeMs = 2 * 60 * 60 * 1000;" in js
-    assert "const unlockedKeyIdleTimeoutMs = 5 * 60 * 1000;" in js
-    assert "function unlockedKeyAbsoluteExpiresAt(createdAt)" in js
-    assert "function refreshedUnlockedKeyExpiresAt(createdAt, now = Date.now())" in js
-    assert "function storedUnlockedKeyCreatedAt(stored)" in js
-    assert "unlockedKeyAbsoluteExpiresAt(createdAt)" in js
-    assert "return Number(stored?.expires_at) - unlockedKeyActiveRenewalMs;" in js
-    assert "now + unlockedKeyActiveRenewalMs" in js
-    assert "let unlockedChatKeyCreatedAt = null;" in js
-    assert "created_at: now" in js
-    assert "expires_at: expiresAt" in js
-    assert "stored.created_at = createdAt;" in js
-    assert "unlockedChatKeyCreatedAt = createdAt;" in js
-    assert "unlockedChatKeyCreatedAt = null;" in js
-    assert "stored.expires_at = refreshedExpiresAt;" in js
-    assert "last_used_at: now" in js
-    assert "scheduleUnlockedKeyExpiry(refreshedExpiresAt, now);" in js
-    assert "now - lastUsedAt > unlockedKeyIdleTimeoutMs" in js
-    assert "expiresAt > absoluteExpiresAt" in js
-    assert "expiresAt > now + unlockedKeyActiveRenewalMs" in js
+    assert "unlockedKeyActiveRenewalMs" not in js
+    assert "unlockedKeyMaxAgeMs" not in js
+    assert "unlockedKeyIdleTimeoutMs" not in js
+    assert "scheduleUnlockedKeyExpiry" not in js
+    assert "expires_at" not in js
+    assert "last_used_at" not in js
+    assert "unlockedKeyIdleTimeoutMs" not in static_js
+    assert "scheduleUnlockedKeyExpiry" not in static_js
+    assert "expires_at" not in static_js
     assert 'const crossTabChannelName = "hushline:chat-key-session";' in js
     assert "new BroadcastChannel(crossTabChannelName)" in js
     assert "function chatKeySessionId(sourceDocument = document)" in js
@@ -277,6 +267,7 @@ def test_chat_key_lifecycle_restores_unlocked_key_for_authenticated_tab_session(
     assert "restoreUnlockedChatKeyFromOtherTab" in js
     assert "async function signingPrivateKeyForChatKey(chatKey)" in js
     assert "function touchUnlockedChatKeyUse()" in js
+    assert "return Boolean(unlockedChatPrivateKey || unlockedChatSigningPrivateKey);" in js
     assert "if (!touchUnlockedChatKeyUse())" in js
     assert "function updateConversationLockedAfterKeyClear()" in js
     assert "setConversationComposeEnabled(false);" in js


### PR DESCRIPTION
## What changed

- Keep an unlocked Hush Line chat key in the authenticated tab's `sessionStorage` for the browser session instead of deleting it after an idle or absolute timer.
- Restore conversations and initial-message signing from that session-scoped key even when an older stored record contains expired lifecycle timestamps.
- Preserve key-version, public-key, signing-key, and server chat-key session-ID validation.
- Preserve explicit cleanup on logout, password reset, account deletion, and other authentication cleanup paths.
- Regenerate the served chat-key lifecycle bundle and document the browser-session behavior.
- Update compatibility coverage to prevent timer-driven chat-key expiry from returning.

## Why

The browser deliberately cleared the only unlocked E2EE private-key material after five minutes without a decrypt/sign operation and after a two-hour absolute limit. Merely viewing the conversation, typing, polling, or keeping the tab active did not count as key use. The expiry callback disabled the composer and deleted the `sessionStorage` copy; after refresh, the browser could only render `Encrypted message. Waiting for browser chat key.`

That lifecycle made a healthy authenticated chat fail during ordinary use. The browser session is the correct usability boundary: refreshes continue to work, while the private key remains browser-only and is never sent to or stored by the server.

## User impact

- The composer no longer disables itself because a browser timer elapsed.
- Refreshing an authenticated conversation continues to decrypt its messages without another login or unlock.
- Message bodies and replies remain end-to-end encrypted; the server still receives only per-participant ciphertext.

## Security and privacy impact

### Threat / risk summary

This intentionally lengthens unlocked private-key residency from a timer-bounded window to the current browser tab session. A script executing in the same origin could therefore access that key for longer. The application already treats same-origin script execution as security-critical and enforces a restrictive CSP.

### Affected data paths

- Browser-only ECDH and ECDSA private JWK bundles used to decrypt and sign account conversations.
- `sessionStorage` restoration used by conversation pages and signed initial-message submission.
- No server persistence, API payload, ciphertext format, key derivation, signing, or encryption behavior changes.

### Mitigations

- Key material remains in `sessionStorage`, never `localStorage` or server storage.
- Restoration still requires exact key version/public-key/signing-key matches and the current server-generated chat-key session ID.
- Logout, password reset, account deletion, and explicit authentication cleanup still remove key material.
- CSP/security-header regression tests remain enforced and pass.

## Validation

- `make lint`
- `make test` — 2,333 passed, 1 deselected, 1 expected xfail; 99% coverage
- `make test TESTS='tests/test_frontend_compat.py tests/test_security_headers.py'` — 65 passed
- `docker compose run --rm app poetry run pytest --cov hushline --cov-report term-missing -q --skip-local-only` — 2,329 passed, 5 skipped, 1 expected xfail; 99% coverage
- Browser E2E: `logged-in account conversation stays encrypted through browser lifecycle` — 1 passed
- `make audit-python` — no known vulnerabilities
- `make audit-node-runtime` — 0 vulnerabilities

The first CI-style coverage attempt hit the documented local Postgres shared-memory condition (`No space left on device`). After `docker compose down -v --remove-orphans`, the exact rerun passed.

## Manual testing

Not separately performed by hand. The browser E2E test logs in both participants, submits an encrypted initial message, opens and decrypts the conversation, sends an encrypted reply, refreshes, and verifies the reply still decrypts.

Suggested manual verification:

1. Log in and open an account conversation.
2. Leave the conversation open beyond the former five-minute idle boundary and verify the composer remains enabled.
3. Refresh and verify existing messages decrypt without showing the waiting-for-key placeholder.
4. Send a reply and verify it appears without a page refresh.

## Risks / follow-ups

- Browser key material now remains available until the tab session ends or an explicit cleanup/session-ID boundary occurs. This is the intended tradeoff to make authenticated E2EE chat reliable.
- The screenshots described during diagnosis were not present in the checkout, but the reported UI sequence mapped directly to the timer cleanup path and is covered by the lifecycle regression assertions and browser E2E flow.
