### PR TITLE
Prevent chat thread scroll jumps

### DIFF
--- a/assets/js/chat-key-lifecycle.js
+++ b/assets/js/chat-key-lifecycle.js
@@ -1001,8 +1001,8 @@
     ).toString();
   }
 
-  function jsonFromScript(id, fallback) {
-    const script = document.getElementById(id);
+  function jsonFromScript(id, fallback, sourceDocument = document) {
+    const script = sourceDocument.getElementById(id);
     if (!script?.textContent) {
       return fallback;
     }
@@ -1198,7 +1198,6 @@
       return false;
     }
 
-    const shouldScroll = scroll || conversationThreadIsNearBottom();
     const response = await fetch(window.location.href, {
       cache: "no-store",
       credentials: "same-origin",
@@ -1229,30 +1228,34 @@
       return false;
     }
 
+    await decryptConversationMessages(nextDocument);
+    const shouldScroll = scroll || conversationThreadIsNearBottom();
+    const previousScrollTop = thread.scrollTop;
     currentCopies.textContent = nextCopies.textContent;
     thread.replaceChildren(
       ...Array.from(nextThread.children).map((child) => {
         return document.importNode(child, true);
       }),
     );
-    await decryptConversationMessages();
-    if (shouldScroll) {
-      scrollConversationThreadToLatest("smooth");
-    }
+    thread.scrollTop = shouldScroll ? thread.scrollHeight : previousScrollTop;
     return true;
   }
 
-  async function decryptConversationMessages() {
-    const copies = jsonFromScript("conversationMessageCopies", []);
+  async function decryptConversationMessages(sourceDocument = document) {
+    const copies = jsonFromScript(
+      "conversationMessageCopies",
+      [],
+      sourceDocument,
+    );
     for (const copy of copies) {
       if (!copy.encrypted_payload) {
         continue;
       }
 
-      const messageElement = document.querySelector(
+      const messageElement = sourceDocument.querySelector(
         `[data-conversation-message-id="${copy.message_id}"] .conversation-message-body`,
       );
-      const messageContainer = document.querySelector(
+      const messageContainer = sourceDocument.querySelector(
         `[data-conversation-message-id="${copy.message_id}"]`,
       );
       const messageTimeElement = messageContainer?.querySelector(

--- a/hushline/static/js/chat-key-lifecycle.js
+++ b/hushline/static/js/chat-key-lifecycle.js
@@ -1005,8 +1005,8 @@
     ).toString();
   }
 
-  function jsonFromScript(id, fallback) {
-    const script = document.getElementById(id);
+  function jsonFromScript(id, fallback, sourceDocument = document) {
+    const script = sourceDocument.getElementById(id);
     if (!script?.textContent) {
       return fallback;
     }
@@ -1202,7 +1202,6 @@
       return false;
     }
 
-    const shouldScroll = scroll || conversationThreadIsNearBottom();
     const response = await fetch(window.location.href, {
       cache: "no-store",
       credentials: "same-origin",
@@ -1233,30 +1232,34 @@
       return false;
     }
 
+    await decryptConversationMessages(nextDocument);
+    const shouldScroll = scroll || conversationThreadIsNearBottom();
+    const previousScrollTop = thread.scrollTop;
     currentCopies.textContent = nextCopies.textContent;
     thread.replaceChildren(
       ...Array.from(nextThread.children).map((child) => {
         return document.importNode(child, true);
       }),
     );
-    await decryptConversationMessages();
-    if (shouldScroll) {
-      scrollConversationThreadToLatest("smooth");
-    }
+    thread.scrollTop = shouldScroll ? thread.scrollHeight : previousScrollTop;
     return true;
   }
 
-  async function decryptConversationMessages() {
-    const copies = jsonFromScript("conversationMessageCopies", []);
+  async function decryptConversationMessages(sourceDocument = document) {
+    const copies = jsonFromScript(
+      "conversationMessageCopies",
+      [],
+      sourceDocument,
+    );
     for (const copy of copies) {
       if (!copy.encrypted_payload) {
         continue;
       }
 
-      const messageElement = document.querySelector(
+      const messageElement = sourceDocument.querySelector(
         `[data-conversation-message-id="${copy.message_id}"] .conversation-message-body`,
       );
-      const messageContainer = document.querySelector(
+      const messageContainer = sourceDocument.querySelector(
         `[data-conversation-message-id="${copy.message_id}"]`,
       );
       const messageTimeElement = messageContainer?.querySelector(

--- a/tests/test_frontend_compat.py
+++ b/tests/test_frontend_compat.py
@@ -514,6 +514,13 @@ def test_conversation_replies_and_polling_update_thread_in_place() -> None:
     assert "bindConversationPolling(root);" in js
     assert "window.setInterval(refreshIfVisible, intervalMs);" in js
     assert "thread.replaceChildren(" in js
+    assert "await decryptConversationMessages(nextDocument);" in js
+    assert "const previousScrollTop = thread.scrollTop;" in js
+    assert "thread.scrollTop = shouldScroll ? thread.scrollHeight : previousScrollTop;" in js
+    assert js.index("await decryptConversationMessages(nextDocument);") < js.index(
+        "thread.replaceChildren("
+    )
+    assert 'scrollConversationThreadToLatest("smooth")' not in js
     assert "currentCopies.textContent = nextCopies.textContent;" in js
     assert "conversationMessagesSignature(nextDocument)" in js
     assert 'getElementById("conversationMessageCopies")?.textContent' in js
@@ -527,6 +534,9 @@ def test_conversation_replies_and_polling_update_thread_in_place() -> None:
     assert "bindConversationPolling(root);" in static_js
     assert "window.setInterval(refreshIfVisible, intervalMs);" in static_js
     assert "thread.replaceChildren(" in static_js
+    assert "await decryptConversationMessages(nextDocument);" in static_js
+    assert "previousScrollTop" in static_js
+    assert 'scrollConversationThreadToLatest("smooth")' not in static_js
     assert 'getElementById("conversationMessageCopies")?.textContent' in static_js
     assert "window.location.reload()" not in static_js
     assert "thread.scrollTo({" in static_js


### PR DESCRIPTION
## What changed

- decrypt refreshed conversation markup in the detached response document before it reaches the visible thread
- replace the visible message list only once the refreshed messages are ready
- restore the exact prior scroll position for readers viewing older messages
- keep readers pinned to the newest message when they were already near the bottom or just sent a reply
- add compatibility assertions that lock in the off-screen decrypt and synchronous scroll restoration behavior

## Why

Conversation polling previously replaced the live thread with encrypted placeholders, then decrypted it asynchronously and smooth-scrolled back to the latest message. That intermediate render reset the thread to the top and caused the visible top-to-bottom jump whenever a message was sent or received.

## User impact

New messages now appear without the conversation flashing to the top. People reading earlier messages keep their position, while people following the latest messages remain at the bottom.

## Security and privacy

This does not change message encryption, key handling, server data paths, or CSP. E2EE decryption still happens client-side; refreshed markup is now decrypted while detached from the visible DOM before the atomic swap.

## Validation

- `make lint`
- focused frontend compatibility and CSP tests: 2 passed
- Playwright E2EE browser lifecycle test: 1 passed
- `make test`: 2,333 passed, 1 deselected, 1 xfailed; 99% coverage
- CI-style coverage after the documented fresh-volume recovery: 2,329 passed, 5 skipped, 1 xfailed; 99% coverage
- `make audit-python`: no known vulnerabilities
- `make audit-node-runtime`: 0 vulnerabilities
- `git diff --check`

The first CI-style coverage attempt encountered the repository-documented Postgres shared-memory exhaustion after the full suite. After resetting volumes and reseeding as prescribed, the exact command passed.

## Manual testing

- Open a conversation with enough messages to scroll.
- While at the bottom, send a reply and receive/poll a new reply; confirm the thread remains at the newest message without flashing to the top.
- Scroll upward, allow a new reply to arrive, and confirm the reading position is preserved.
- Confirm messages remain decrypted through send, receive, polling, and refresh.

## Risks and follow-ups

Risk is limited to client-side conversation refresh rendering and scroll restoration. The existing browser E2EE lifecycle path and CSP checks pass. No known follow-up is required.